### PR TITLE
Activate kubelet check

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -60,6 +60,10 @@ const (
 	DDProcessAgentEnabled           = "DD_PROCESS_AGENT_ENABLED"
 	DDEnableMetadataCollection      = "DD_ENABLE_METADATA_COLLECTION"
 
+	// Env var used by the Datadog Agent container entrypoint
+	// to add kubelet config provider and listener
+	KubernetesEnvvarName = "KUBERNETES"
+
 	// Datadog volume names and mount paths
 	ConfdVolumeName           = "confd"
 	ConfdVolumePath           = "/conf.d"

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -59,6 +59,7 @@ const (
 	DDAPMEnabled                    = "DD_APM_ENABLED"
 	DDProcessAgentEnabled           = "DD_PROCESS_AGENT_ENABLED"
 	DDEnableMetadataCollection      = "DD_ENABLE_METADATA_COLLECTION"
+	DDKubeletHost                   = "DD_KUBERNETES_KUBELET_HOST"
 
 	// Env var used by the Datadog Agent container entrypoint
 	// to add kubelet config provider and listener

--- a/pkg/controller/datadogagentdeployment/agent_test.go
+++ b/pkg/controller/datadogagentdeployment/agent_test.go
@@ -57,6 +57,10 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 	}
 	defaultEnvVars := []corev1.EnvVar{
 		{
+			Name:  "KUBERNETES",
+			Value: "yes",
+		},
+		{
 			Name:  "DD_CLUSTER_NAME",
 			Value: "",
 		},

--- a/pkg/controller/datadogagentdeployment/agent_test.go
+++ b/pkg/controller/datadogagentdeployment/agent_test.go
@@ -57,6 +57,14 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 	}
 	defaultEnvVars := []corev1.EnvVar{
 		{
+			Name: "DD_KUBERNETES_KUBELET_HOST",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: FieldPathStatusHostIP,
+				},
+			},
+		},
+		{
 			Name:  "KUBERNETES",
 			Value: "yes",
 		},

--- a/pkg/controller/datadogagentdeployment/const.go
+++ b/pkg/controller/datadogagentdeployment/const.go
@@ -6,6 +6,9 @@
 package datadogagentdeployment
 
 const (
-	// FieldPathSpecNodeName use as FieldPath for seleting the NodeName
+	// FieldPathSpecNodeName used as FieldPath for seleting the NodeName
 	FieldPathSpecNodeName = "spec.nodeName"
+
+	// FieldPathStatusHostIP used as FieldPath to retrieve the host ip
+	FieldPathStatusHostIP = "status.hostIP"
 )

--- a/pkg/controller/datadogagentdeployment/utils.go
+++ b/pkg/controller/datadogagentdeployment/utils.go
@@ -131,6 +131,10 @@ func getEnvVarsForAgent(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentD
 
 	envVars := []corev1.EnvVar{
 		{
+			Name:  datadoghqv1alpha1.KubernetesEnvvarName,
+			Value: "yes",
+		},
+		{
 			Name:  datadoghqv1alpha1.DDClusterName,
 			Value: spec.ClusterName,
 		},

--- a/pkg/controller/datadogagentdeployment/utils.go
+++ b/pkg/controller/datadogagentdeployment/utils.go
@@ -131,6 +131,14 @@ func getEnvVarsForAgent(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentD
 
 	envVars := []corev1.EnvVar{
 		{
+			Name: datadoghqv1alpha1.DDKubeletHost,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: FieldPathStatusHostIP,
+				},
+			},
+		},
+		{
 			Name:  datadoghqv1alpha1.KubernetesEnvvarName,
 			Value: "yes",
 		},


### PR DESCRIPTION
### What does this PR do?

- Adds the `KUBERNETES=yes` environment variable to the Agent's container.
- Adds the `DD_KUBERNETES_KUBELET_HOST` env var to retrieve kubelet host using the downward API 

### Motivation

The `KUBERNETES` env var is required to configure the config `kubelet` check via the [entrypoint script](https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/entrypoint/50-kubernetes.sh#L3).

### Additional Notes

Anything else we should know when reviewing?

