### PR TITLE
[operator] fix multi status update in reconcile()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TAG_HASH=${LAST_TAG}_$(shell git rev-parse --short HEAD)
 VERSION?=$(if $(GIT_TAG),$(GIT_TAG),$(TAG_HASH))
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 DATE=$(shell date +%Y-%m-%d/%H:%M:%S )
-GOMOD="-mod=vendor"
+GOMOD?="-mod=vendor"
 LDFLAGS= -ldflags "-w -X ${BUILDINFOPKG}.Tag=${TAG} -X ${BUILDINFOPKG}.Commit=${GIT_COMMIT} -X ${BUILDINFOPKG}.Version=${VERSION} -X ${BUILDINFOPKG}.BuildTime=${DATE} -s"
 
 export GO111MODULE=on
@@ -58,7 +58,7 @@ clean:
 
 validate: bin/golangci-lint bin/wwhrd
 	./bin/golangci-lint run ./...
-	./hack/verify-license.sh
+	./hack/verify-license.sh > /dev/null
 
 generate:
 	operator-sdk generate k8s
@@ -87,4 +87,7 @@ bin/wwhrd:
 license: bin/wwhrd
 	./hack/license.sh
 
-.PHONY: vendor build push clean test e2e validate local-load install-tools list container container-ci license
+license-verify: bin/wwhrd
+	./hack/verify-license.sh
+
+.PHONY: vendor build push clean test e2e validate local-load install-tools list container container-ci license license-verify

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,6 +19,8 @@ spec:
           command:
           - datadog-operator
           imagePullPolicy: IfNotPresent
+          args:
+            - --zap-level=debug
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-operator
 go 1.13
 
 require (
-	github.com/datadog/extendeddaemonset v0.1.6
+	github.com/datadog/extendeddaemonset v0.1.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
 	github.com/operator-framework/operator-sdk v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cyphar/filepath-securejoin v0.0.0-20170720062807-ae69057f2299/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
 github.com/d2g/dhcp4client v0.0.0-20170829104524-6e570ed0a266/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
+github.com/datadog/extendeddaemonset v0.1.0 h1:RTzNYfP1LJ2THM16gm03xiPhk/r8vsMHTDPJ6wdlHYs=
+github.com/datadog/extendeddaemonset v0.1.0/go.mod h1:2UmsvnB5oUFGQW1UkpX6gaC6XoqglnQNBrvgWuR9RJA=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/hack/verify-license.sh
+++ b/hack/verify-license.sh
@@ -5,9 +5,10 @@ set -o nounset
 set -o pipefail
 set -e
 
-cd $(dirname $0)/..
+ROOT=$(git rev-parse --show-toplevel)
+cd $ROOT
 
-make license
+make license 2>&1
 
 DIFF=$(git --no-pager diff LICENSE-3rdparty.csv)
 if [[ "${DIFF}x" != "x" ]]

--- a/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
+++ b/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
@@ -48,13 +48,13 @@ func (r *ReconcileDatadogAgentDeployment) reconcileClusterChecksRunner(logger lo
 				// Create and attach a ClusterChecksRunner Deployment
 				var result reconcile.Result
 				result, err = r.createNewClusterChecksRunnerDeployment(logger, dad, newStatus)
-				return r.updateStatusIfNeeded(logger, dad, newStatus, result, err)
+				return result, err
 			}
-			return r.updateStatusIfNeeded(logger, dad, newStatus, reconcile.Result{}, err)
+			return reconcile.Result{}, err
 		}
 
 		result, err := r.updateClusterChecksRunnerDeployment(logger, dad, ClusterChecksRunnerDeployment, newStatus)
-		return r.updateStatusIfNeeded(logger, dad, newStatus, result, err)
+		return result, err
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/datadogagentdeployment/clusterchecksrunner_rbac.go
+++ b/pkg/controller/datadogagentdeployment/clusterchecksrunner_rbac.go
@@ -60,12 +60,12 @@ func (r *ReconcileDatadogAgentDeployment) cleanupClusterChecksRunnerRbacResource
 	rbacResourcesName := getClusterChecksRunnerRbacResourcesName(dad)
 
 	// Delete Cluster Role Binding
-	if result, err := cleanupClusterRoleBinding(r.client, rbacResourcesName); err != nil {
+	if result, err := r.cleanupClusterRoleBinding(logger, r.client, dad, rbacResourcesName); err != nil {
 		return result, err
 	}
 
 	// Delete Service Account
-	if result, err := cleanupServiceAccount(r.client, rbacResourcesName); err != nil {
+	if result, err := r.cleanupServiceAccount(logger, r.client, dad, rbacResourcesName); err != nil {
 		return result, err
 	}
 

--- a/test/e2e/utils/new.go
+++ b/test/e2e/utils/new.go
@@ -9,6 +9,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,8 +39,15 @@ func NewDatadogAgentDeployment(ns, name, image string, options *NewDatadogAgentD
 			AppKey: "sgfggtdhfghfghfghfgbdfdgs",
 		},
 		Agent: &datadoghqv1alpha1.DatadogAgentDeploymentSpecAgentSpec{
-			Image:              datadoghqv1alpha1.ImageConfig{},
-			Config:             datadoghqv1alpha1.NodeAgentConfig{},
+			Image: datadoghqv1alpha1.ImageConfig{},
+			Config: datadoghqv1alpha1.NodeAgentConfig{
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("0"),
+						v1.ResourceMemory: resource.MustParse("0"),
+					},
+				},
+			},
 			DeploymentStrategy: &datadoghqv1alpha1.DaemonSetDeploymentcStrategy{},
 			Apm:                datadoghqv1alpha1.APMSpec{},
 			Log:                datadoghqv1alpha1.LogSpec{},

--- a/test/e2e/utils/wait.go
+++ b/test/e2e/utils/wait.go
@@ -63,13 +63,6 @@ func WaitForFuncOnExtendedDaemonSet(t *testing.T, client framework.FrameworkClie
 		}
 
 		ok, err := f(extendeddaemonset)
-		if ok {
-			// Update ExtendedDaemonSet status if created
-			err := client.Update(context.TODO(), extendeddaemonset)
-			if err != nil {
-				return false, err
-			}
-		}
 		t.Logf("Waiting for condition function to be true ok for %s ExtendedDaemonSet (%t/%v)\n", name, ok, err)
 		return ok, err
 	})
@@ -93,13 +86,6 @@ func WaitForFuncOnDaemonSet(t *testing.T, client framework.FrameworkClient, name
 		}
 
 		ok, err := f(daemonset)
-		if ok {
-			// Update DaemonSet status if created
-			err := client.Update(context.TODO(), daemonset)
-			if err != nil {
-				return false, err
-			}
-		}
 		t.Logf("Waiting for condition function to be true ok for %s DaemonSet (%t/%v)\n", name, ok, err)
 		return ok, err
 	})


### PR DESCRIPTION
### What does this PR do?

* fix `go.mod`
* Only update status if needed in the main reconcile() fonction
* Refactor reconcile() sub fonction call
* An Operator logs streaming in e2e test
* Improve `make validate` output

