### PR TITLE
Add Pod Disruption Budget to the Datadog operator

### DIFF
--- a/chart/datadog-operator/templates/pod_disruption_budget.yaml
+++ b/chart/datadog-operator/templates/pod_disruption_budget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "datadog-operator.fullname" . }}
+  labels:
+{{ include "datadog-operator.labels" . | indent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "datadog-operator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
### What does this PR do?

Add Pod Disruption Budget to the Datadog operator.

### Motivation

Ensure that there is always a `datadog-operator` instance up and running.
Even when the cluster autoscaler is scaling down the cluster for example.