### PR TITLE
Make component synchronization more robust

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -169,9 +169,10 @@ func NewExtendedDaemonSet(ns, name string, options *NewExtendedDaemonSetOptions)
 
 // NewDeploymentOptions set of option for the Deployment creation
 type NewDeploymentOptions struct {
-	CreationTime *time.Time
-	Annotations  map[string]string
-	Labels       map[string]string
+	CreationTime           *time.Time
+	Annotations            map[string]string
+	Labels                 map[string]string
+	ForceAvailableReplicas *int32
 }
 
 // NewClusterAgentDeployment return new Cluster Agent Deployment instance for testing purpose
@@ -201,6 +202,9 @@ func NewClusterAgentDeployment(ns, name string, options *NewDeploymentOptions) *
 			for key, value := range options.Labels {
 				dca.Labels[key] = value
 			}
+		}
+		if options.ForceAvailableReplicas != nil {
+			dca.Status.AvailableReplicas = *options.ForceAvailableReplicas
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

- Do not create Agent DaemonSet / CLC Runner deployments until the Cluster Agent has at least 1 available replica

### Motivation

Better component synchronization: Make sure the Cluster Agent is ready before creating Agent DaemonSet / CLC Runner deployments

### Additional Notes

Anything else we should know when reviewing?

