### PR TITLE
[Fix] Update CR status after disabling cluster agent and clc runners

### DIFF
--- a/pkg/controller/datadogagentdeployment/clusteragent.go
+++ b/pkg/controller/datadogagentdeployment/clusteragent.go
@@ -231,6 +231,7 @@ func (r *ReconcileDatadogAgentDeployment) cleanupClusterAgent(logger logr.Logger
 	if err := r.client.Delete(context.TODO(), clusterAgentDeployment); err != nil {
 		return reconcile.Result{}, err
 	}
+	newStatus.ClusterAgent = nil
 	return reconcile.Result{Requeue: true}, nil
 }
 

--- a/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
+++ b/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
@@ -205,6 +205,7 @@ func (r *ReconcileDatadogAgentDeployment) cleanupClusterChecksRunner(logger logr
 	if err := r.client.Delete(context.TODO(), ClusterChecksRunnerDeployment); err != nil {
 		return reconcile.Result{}, err
 	}
+	newStatus.ClusterChecksRunner = nil
 	return reconcile.Result{Requeue: true}, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Update status after deleting the cluster agent or the cluster check runners

### Motivation

Keep the `DatadogAgentDeployment` status up-to-date

### Additional Notes

Anything else we should know when reviewing?

