### PR TITLE
Add PodDisruptionBudget management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ GIT_COMMIT?=$(shell git rev-parse HEAD)
 DATE=$(shell date +%Y-%m-%d/%H:%M:%S )
 GOMOD?="-mod=vendor"
 LDFLAGS= -ldflags "-w -X ${BUILDINFOPKG}.Tag=${TAG} -X ${BUILDINFOPKG}.Commit=${GIT_COMMIT} -X ${BUILDINFOPKG}.Version=${VERSION} -X ${BUILDINFOPKG}.BuildTime=${DATE} -s"
+KIND_CLUSTER_NAME="kind"
 
 export GO111MODULE=on
 
@@ -37,7 +38,7 @@ ${ARTIFACT}: ${SOURCES}
 container:
 	./bin/operator-sdk build $(PREFIX):$(TAG)
     ifeq ($(KINDPUSH), true)
-	 kind load docker-image $(PREFIX):$(TAG)
+	 kind load docker-image --name $(KIND_CLUSTER_NAME) $(PREFIX):$(TAG)
     endif
 
 container-ci:

--- a/chart/datadog-operator/templates/role.yaml
+++ b/chart/datadog-operator/templates/role.yaml
@@ -35,6 +35,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
   - datadoghq.com
   resources:
   - 'datadogagentdeployments'

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -35,8 +35,14 @@ rules:
   - roles.rbac.authorization.k8s.io
   - authorization.k8s.io
   resources:
-  - 'roles'
-  - 'rolebindings'
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
   verbs:
   - '*'
 - apiGroups:

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -12,9 +12,13 @@ $ make test
 # linter validation
 $ make validate
 
-# e2e test
-$ make KINDPUSH=true e2e
-
 # build you own docker image
 $ make TAG=latest container
+
+# build your own docker image and push it in a local Kind cluster
+# KIND_CLUSTER_NAME can be omitted if you use Kind default cluster name (i.e. "kind")
+$ make TAG=latest KINDPUSH=true KIND_CLUSTER_NAME="mycluster-local" container
+
+# e2e test
+$ make e2e
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,7 +10,10 @@ Find the Datadog Operator Helm chart in `/chart/datadog-operator`:
 $ DD_NAMESPACE="datadog"
 $ DD_NAMEOP="ddoperator"
 $ kubectl create ns $DD_NAMESPACE
+$ # Helm v2
 $ helm install --name $DD_NAMEOP -n $DD_NAMESPACE ./chart/datadog-operator
+$ # Helm v3
+$ helm install $DD_NAMEOP -n $DD_NAMESPACE ./chart/datadog-operator
 ```
 
 ## Deploy the Datadog Agents with the operator

--- a/examples/datadog-agent-with-clusteragent.yaml
+++ b/examples/datadog-agent-with-clusteragent.yaml
@@ -19,5 +19,3 @@ spec:
     config:
       metricsProviderEnabled: true
     replicas: 2
-
-  

--- a/examples/datadog-agent-with-dca-clusterchecksrunner.yaml
+++ b/examples/datadog-agent-with-dca-clusterchecksrunner.yaml
@@ -23,6 +23,3 @@ spec:
   clusterChecksRunner:
     image: 
       name: "datadog/agent:latest"
-
-
-  

--- a/examples/datadog-agent-with-tolerations.yaml
+++ b/examples/datadog-agent-with-tolerations.yaml
@@ -11,5 +11,3 @@ spec:
     config:
       tolerations:
        - operator: Exists
-
-  

--- a/examples/datadog-agent.yaml
+++ b/examples/datadog-agent.yaml
@@ -8,5 +8,3 @@ spec:
   agent:
     image: 
       name: "datadog/agent:latest"
-
-  

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,7 @@ github.com/operator-framework/operator-registry v1.0.4/go.mod h1:hve6YwcjM2nGVls
 github.com/operator-framework/operator-registry v1.1.1/go.mod h1:7D4WEwL+EKti5npUh4/u64DQhawCBRugp8Ql20duUb4=
 github.com/operator-framework/operator-sdk v0.12.0 h1:9eAD1L8e6pPCpFCAacBUVf2eloDkRuVm29GTCOktLqQ=
 github.com/operator-framework/operator-sdk v0.12.0/go.mod h1:mW8isQxiXlLCVf2E+xqflkQAVLOTbiqjndKdkKIrR0M=
+github.com/operator-framework/operator-sdk v0.13.0 h1:AWiKOl6ZeAyQgbGVoD8fNd+eCbFuRWgr4hciaaOEBmE=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/controller/datadogagentdeployment/clusteragent.go
+++ b/pkg/controller/datadogagentdeployment/clusteragent.go
@@ -180,7 +180,7 @@ func newClusterAgentDeploymentFromInstance(logger logr.Logger, agentdeployment *
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					datadoghqv1alpha1.AgentDeploymentNameLabelKey:      agentdeployment.Name,
-					datadoghqv1alpha1.AgentDeploymentComponentLabelKey: "cluster-agent",
+					datadoghqv1alpha1.AgentDeploymentComponentLabelKey: datadoghqv1alpha1.DefaultClusterAgentResourceSuffix,
 				},
 			},
 		},
@@ -201,6 +201,11 @@ func (r *ReconcileDatadogAgentDeployment) manageClusterAgentDependencies(logger 
 	}
 
 	result, err = r.manageMetricsServerService(logger, dad, newStatus)
+	if shouldReturn(result, err) {
+		return result, err
+	}
+
+	result, err = r.manageClusterAgentPDB(logger, dad, newStatus)
 	if shouldReturn(result, err) {
 		return result, err
 	}

--- a/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
+++ b/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
@@ -180,7 +180,11 @@ func newClusterChecksRunnerDeploymentFromInstance(logger logr.Logger, agentdeplo
 }
 
 func (r *ReconcileDatadogAgentDeployment) manageClusterChecksRunnerDependencies(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentDeployment, newStatus *datadoghqv1alpha1.DatadogAgentDeploymentStatus) (reconcile.Result, error) {
-	result, err := r.manageClusterChecksRunnerRBACs(logger, dad)
+	result, err := r.manageClusterChecksRunnerPDB(logger, dad, newStatus)
+	if shouldReturn(result, err) {
+		return result, err
+	}
+	result, err = r.manageClusterChecksRunnerRBACs(logger, dad)
 	if shouldReturn(result, err) {
 		return result, err
 	}

--- a/pkg/controller/datadogagentdeployment/datadogagentdeployment_controller.go
+++ b/pkg/controller/datadogagentdeployment/datadogagentdeployment_controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/pflag"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -155,6 +156,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to secondary resource ClusterRoleBinding and requeue the owner DatadogAgentDeployment
 	err = c.Watch(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &datadoghqv1alpha1.DatadogAgentDeployment{},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to secondary resource PodDisruptionBudget and requeue the owner DatadogAgentDeployment
+	err = c.Watch(&source.Kind{Type: &policyv1.PodDisruptionBudget{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &datadoghqv1alpha1.DatadogAgentDeployment{},
 	})

--- a/pkg/controller/datadogagentdeployment/poddisruptionbudget.go
+++ b/pkg/controller/datadogagentdeployment/poddisruptionbudget.go
@@ -1,0 +1,165 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package datadogagentdeployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1beta1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	pdbMinAvailableInstances = 1
+)
+
+type (
+	pdbBuilder func(dad *datadoghqv1alpha1.DatadogAgentDeployment) *policyv1.PodDisruptionBudget
+)
+
+func (r *ReconcileDatadogAgentDeployment) manageClusterAgentPDB(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentDeployment, newStatus *datadoghqv1alpha1.DatadogAgentDeploymentStatus) (reconcile.Result, error) {
+	cleanUpCondition := dad.Spec.ClusterAgent == nil
+	return r.managePDB(logger, dad, newStatus, getClusterAgentPDBName(dad), buildClusterAgentPDB, cleanUpCondition)
+}
+
+func (r *ReconcileDatadogAgentDeployment) manageClusterChecksRunnerPDB(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentDeployment, newStatus *datadoghqv1alpha1.DatadogAgentDeploymentStatus) (reconcile.Result, error) {
+	cleanUpCondition := !needClusterChecksRunner(dad)
+	return r.managePDB(logger, dad, newStatus, getClusterChecksRunnerPDBName(dad), buildClusterChecksRunnerPDB, cleanUpCondition)
+}
+
+func (r *ReconcileDatadogAgentDeployment) managePDB(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentDeployment, newStatus *datadoghqv1alpha1.DatadogAgentDeploymentStatus, pdbName string, builder pdbBuilder, cleanUp bool) (reconcile.Result, error) {
+	if cleanUp {
+		return r.cleanupPDB(logger, dad, newStatus, pdbName)
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: dad.Namespace, Name: pdbName}, pdb)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.createPDB(logger, dad, newStatus, builder)
+		}
+		return reconcile.Result{}, err
+	}
+
+	return r.updateIfNeededPDB(logger, dad, pdb, newStatus, builder)
+}
+
+func (r *ReconcileDatadogAgentDeployment) createPDB(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentDeployment, newStatus *datadoghqv1alpha1.DatadogAgentDeploymentStatus, builder pdbBuilder) (reconcile.Result, error) {
+	newPdb := builder(dad)
+	// Set DatadogAgentDeployment instance  instance as the owner and controller
+	if err := controllerutil.SetControllerReference(dad, newPdb, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+	if err := r.client.Create(context.TODO(), newPdb); err != nil {
+		return reconcile.Result{}, err
+	}
+	logger.Info("Create PDB", "name", newPdb.Name)
+	r.recorder.Event(dad, corev1.EventTypeNormal, "Create PDB", fmt.Sprintf("%s/%s", newPdb.Namespace, newPdb.Name))
+
+	return reconcile.Result{Requeue: true}, nil
+}
+
+func (r *ReconcileDatadogAgentDeployment) updateIfNeededPDB(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentDeployment, currentPDB *policyv1.PodDisruptionBudget, newStatus *datadoghqv1alpha1.DatadogAgentDeploymentStatus, builder pdbBuilder) (reconcile.Result, error) {
+	if !ownedByDatadogOperator(currentPDB.OwnerReferences) {
+		return reconcile.Result{}, nil
+	}
+	newPDB := builder(dad)
+	result := reconcile.Result{}
+	if !(apiequality.Semantic.DeepEqual(newPDB.Spec, currentPDB.Spec) &&
+		apiequality.Semantic.DeepEqual(newPDB.Labels, currentPDB.Labels) &&
+		apiequality.Semantic.DeepEqual(newPDB.Annotations, currentPDB.Annotations)) {
+
+		updatedPDB := currentPDB.DeepCopy()
+		updatedPDB.Labels = newPDB.Labels
+		updatedPDB.Annotations = newPDB.Annotations
+		updatedPDB.Spec = newPDB.Spec
+
+		if err := r.client.Update(context.TODO(), updatedPDB); err != nil {
+			return reconcile.Result{}, err
+		}
+		r.recorder.Event(dad, corev1.EventTypeNormal, "Update PDB", fmt.Sprintf("%s/%s", updatedPDB.Namespace, updatedPDB.Name))
+		result.Requeue = true
+	}
+
+	return result, nil
+}
+
+func (r *ReconcileDatadogAgentDeployment) cleanupPDB(logger logr.Logger, dad *datadoghqv1alpha1.DatadogAgentDeployment, newStatus *datadoghqv1alpha1.DatadogAgentDeploymentStatus, pdbName string) (reconcile.Result, error) {
+	pdb := &policyv1.PodDisruptionBudget{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: dad.Namespace, Name: pdbName}, pdb)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+	if ownedByDatadogOperator(pdb.OwnerReferences) {
+		err = r.client.Delete(context.TODO(), pdb)
+	}
+
+	return reconcile.Result{}, err
+}
+
+func buildClusterAgentPDB(dad *datadoghqv1alpha1.DatadogAgentDeployment) *policyv1.PodDisruptionBudget {
+	labels := getDefaultLabels(dad, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dad))
+	annotations := getDefaultAnnotations(dad)
+	metadata := metav1.ObjectMeta{
+		Name:        getClusterAgentPDBName(dad),
+		Namespace:   dad.Namespace,
+		Labels:      labels,
+		Annotations: annotations,
+	}
+	matchLabels := map[string]string{
+		datadoghqv1alpha1.AgentDeploymentNameLabelKey:      dad.Name,
+		datadoghqv1alpha1.AgentDeploymentComponentLabelKey: datadoghqv1alpha1.DefaultClusterAgentResourceSuffix,
+	}
+
+	return buildPDB(metadata, matchLabels, pdbMinAvailableInstances)
+}
+
+func buildClusterChecksRunnerPDB(dad *datadoghqv1alpha1.DatadogAgentDeployment) *policyv1.PodDisruptionBudget {
+	labels := getDefaultLabels(dad, datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix, getAgentVersion(dad))
+	annotations := getDefaultAnnotations(dad)
+	metadata := metav1.ObjectMeta{
+		Name:        getClusterChecksRunnerPDBName(dad),
+		Namespace:   dad.Namespace,
+		Labels:      labels,
+		Annotations: annotations,
+	}
+	matchLabels := map[string]string{
+		datadoghqv1alpha1.AgentDeploymentNameLabelKey:      dad.Name,
+		datadoghqv1alpha1.AgentDeploymentComponentLabelKey: datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix,
+	}
+
+	return buildPDB(metadata, matchLabels, pdbMinAvailableInstances)
+}
+
+func buildPDB(metadata metav1.ObjectMeta, matchLabels map[string]string, minAvailable int) *policyv1.PodDisruptionBudget {
+	minAvailableStr := intstr.FromInt(pdbMinAvailableInstances)
+
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metadata,
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailableStr,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+		},
+	}
+
+	return pdb
+}

--- a/pkg/controller/datadogagentdeployment/utils.go
+++ b/pkg/controller/datadogagentdeployment/utils.go
@@ -880,6 +880,14 @@ func getClusterAgentVersion(dad *datadoghqv1alpha1.DatadogAgentDeployment) strin
 	return ""
 }
 
+func getClusterAgentPDBName(dad *datadoghqv1alpha1.DatadogAgentDeployment) string {
+	return fmt.Sprintf("%s-%s", dad.Name, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix)
+}
+
+func getClusterChecksRunnerPDBName(dad *datadoghqv1alpha1.DatadogAgentDeployment) string {
+	return fmt.Sprintf("%s-%s", dad.Name, datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix)
+}
+
 func getMetricsServerServiceName(dad *datadoghqv1alpha1.DatadogAgentDeployment) string {
 	return fmt.Sprintf("%s-%s", dad.Name, datadoghqv1alpha1.DefaultMetricsServerResourceSuffix)
 }


### PR DESCRIPTION
### What does this PR do?

Add management of PDB for Cluster Agent and Cluster Checks Runner.

### Additional Notes

Currently the PDB configuration is static and automatically created if corresponding component should exist. We set MinAvailable to 1 for both currently, which should be enough for our use cases (though for cluster checks runner we might want to implement something smarter eventually)
