### PR TITLE
Add proper status in `get dad` display

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
@@ -504,6 +504,22 @@ type ImageConfig struct {
 	PullSecrets *[]corev1.LocalObjectReference `json:"pullSecrets,omitempty"`
 }
 
+// DatadogAgentDeploymentState type representing the ClusterAgent as a DaemonSet deployment state
+type DatadogAgentDeploymentState string
+
+const (
+	// DatadogAgentDeploymentStateProgressing the deployment is running properly
+	DatadogAgentDeploymentStateProgressing DatadogAgentDeploymentState = "Progressing"
+	// DatadogAgentDeploymentStateRunning the deployment is running properly
+	DatadogAgentDeploymentStateRunning DatadogAgentDeploymentState = "Running"
+	// DatadogAgentDeploymentStateUpdating the deployment is currently under a rolling update
+	DatadogAgentDeploymentStateUpdating DatadogAgentDeploymentState = "Updating"
+	// DatadogAgentDeploymentStateCanary the deployment is currently under a canary testing (EDS only)
+	DatadogAgentDeploymentStateCanary DatadogAgentDeploymentState = "Canary"
+	// DatadogAgentDeploymentStateFailed the current state of the deployment is considered as Failed
+	DatadogAgentDeploymentStateFailed DatadogAgentDeploymentState = "Failed"
+)
+
 // DatadogAgentDeploymentStatus defines the observed state of DatadogAgentDeployment
 // +k8s:openapi-gen=true
 type DatadogAgentDeploymentStatus struct {
@@ -533,22 +549,10 @@ type DatadogAgentDeploymentAgentStatus struct {
 	Available int32 `json:"available"`
 	UpToDate  int32 `json:"upToDate"`
 
-	State       DatadogAgentDeploymentAgentState `json:"state,omitempty"`
-	LastUpdate  *metav1.Time                     `json:"lastUpdate,omitempty"`
-	CurrentHash string                           `json:"currentHash,omitempty"`
+	State       string       `json:"state,omitempty"`
+	LastUpdate  *metav1.Time `json:"lastUpdate,omitempty"`
+	CurrentHash string       `json:"currentHash,omitempty"`
 }
-
-// DatadogAgentDeploymentAgentState type representing the Agent as a DaemonSet deployment state
-type DatadogAgentDeploymentAgentState string
-
-const (
-	// DatadogAgentDeploymentAgentStateCanary the Agent deployment currently runs a new version with a Canary deployment
-	DatadogAgentDeploymentAgentStateCanary DatadogAgentDeploymentAgentState = "Canary"
-	// DatadogAgentDeploymentAgentStateRunning the  Agent deployment is currently running
-	DatadogAgentDeploymentAgentStateRunning DatadogAgentDeploymentAgentState = "Running"
-	// DatadogAgentDeploymentAgentStateFailed the current state of the  Agent deployment is considered as Failed
-	DatadogAgentDeploymentAgentStateFailed DatadogAgentDeploymentAgentState = "Failed"
-)
 
 // DatadogAgentDeploymentDeploymentStatus type representing the Cluster Agent Deployment status
 // +k8s:openapi-gen=true
@@ -584,20 +588,8 @@ type DatadogAgentDeploymentDeploymentStatus struct {
 	GeneratedToken string `json:"generatedToken,omitempty"`
 
 	// State corresponds to the ClusterAgent deployment state
-	State DatadogAgentDeploymentDeploymentState `json:"state,omitempty"`
+	State string `json:"state,omitempty"`
 }
-
-// DatadogAgentDeploymentDeploymentState type representing the ClusterAgent as a DaemonSet deployment state
-type DatadogAgentDeploymentDeploymentState string
-
-const (
-	// DatadogAgentDeploymentDeploymentStateStarted the Cluster-Agent deployment has been started
-	DatadogAgentDeploymentDeploymentStateStarted DatadogAgentDeploymentDeploymentState = "Started"
-	// DatadogAgentDeploymentDeploymentStateRunning the Cluster-Agent deployment is running properly
-	DatadogAgentDeploymentDeploymentStateRunning DatadogAgentDeploymentDeploymentState = "Running"
-	// DatadogAgentDeploymentDeploymentStateFailed the current state of the Cluster-Agent deployment is considered as Failed
-	DatadogAgentDeploymentDeploymentStateFailed DatadogAgentDeploymentDeploymentState = "Failed"
-)
 
 // DatadogAgentDeploymentCondition describes the state of a DatadogAgentDeployment at a certain point.
 // +k8s:openapi-gen=true

--- a/pkg/controller/datadogagentdeployment/clusteragent.go
+++ b/pkg/controller/datadogagentdeployment/clusteragent.go
@@ -92,12 +92,12 @@ func (r *ReconcileDatadogAgentDeployment) createNewClusterAgentDeployment(logger
 	logger.Info("Creating a new Cluster Agent Deployment", "deployment.Namespace", newDCA.Namespace, "deployment.Name", newDCA.Name, "agentdeployment.Status.ClusterAgent.CurrentHash", hash)
 	newStatus.ClusterAgent = &datadoghqv1alpha1.DatadogAgentDeploymentDeploymentStatus{}
 	err = r.client.Create(context.TODO(), newDCA)
+	now := metav1.NewTime(time.Now())
 	if err != nil {
-		newStatus.ClusterAgent.State = datadoghqv1alpha1.DatadogAgentDeploymentDeploymentStateFailed
+		updateStatusWithClusterAgent(nil, newStatus, &now)
 		return reconcile.Result{}, err
 	}
-	now := metav1.NewTime(time.Now())
-	newStatus.ClusterAgent.State = datadoghqv1alpha1.DatadogAgentDeploymentDeploymentStateStarted
+
 	updateStatusWithClusterAgent(newDCA, newStatus, &now)
 	r.recorder.Event(agentdeployment, corev1.EventTypeNormal, "Create Cluster Agent Deployment", fmt.Sprintf("%s/%s", newDCA.Namespace, newDCA.Name))
 	return reconcile.Result{}, nil

--- a/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
+++ b/pkg/controller/datadogagentdeployment/clusterchecksrunner.go
@@ -80,12 +80,12 @@ func (r *ReconcileDatadogAgentDeployment) createNewClusterChecksRunnerDeployment
 	logger.Info("Creating a new Cluster Checks Runner Deployment", "deployment.Namespace", newDCAW.Namespace, "deployment.Name", newDCAW.Name, "agentdeployment.Status.ClusterAgent.CurrentHash", hash)
 	newStatus.ClusterChecksRunner = &datadoghqv1alpha1.DatadogAgentDeploymentDeploymentStatus{}
 	err = r.client.Create(context.TODO(), newDCAW)
+	now := metav1.NewTime(time.Now())
 	if err != nil {
-		newStatus.ClusterAgent.State = datadoghqv1alpha1.DatadogAgentDeploymentDeploymentStateFailed
+		updateStatusWithClusterChecksRunner(nil, newStatus, &now)
 		return reconcile.Result{}, err
 	}
-	now := metav1.NewTime(time.Now())
-	newStatus.ClusterChecksRunner.State = datadoghqv1alpha1.DatadogAgentDeploymentDeploymentStateStarted
+
 	updateStatusWithClusterChecksRunner(newDCAW, newStatus, &now)
 	r.recorder.Event(agentdeployment, corev1.EventTypeNormal, "Create Cluster Checks Runner Deployment", fmt.Sprintf("%s/%s", newDCAW.Namespace, newDCAW.Name))
 	return reconcile.Result{}, nil

--- a/pkg/controller/datadogagentdeployment/datadogagentdeployment_controller.go
+++ b/pkg/controller/datadogagentdeployment/datadogagentdeployment_controller.go
@@ -189,8 +189,6 @@ type ReconcileDatadogAgentDeployment struct {
 
 // Reconcile reads that state of the cluster for a DatadogAgentDeployment object and makes changes based on the state read
 // and what is in the DatadogAgentDeployment.Spec
-// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
-// a Pod as an example
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.


### PR DESCRIPTION
### What does this PR do?

Actually compute status and displays it in `kubectl get dad` output.
Currently it's implemented for the Deployments and (Extended)DaemonSets we have.

```
NAME            ACTIVE   AGENT                 CLUSTER-AGENT     CLUSTER-CHECKS-RUNNER   AGE
datadog-agent   True     Progressing (1/0/1)   Running (2/2/2)   Progressing (2/0/2)     24h
```

I've changed existing statuses and put all supported objects to have the same status:
- Progressing (is deployed, but no pod ready)
- Running (is deployed, with at least 1 pod ready)
- Updating (rolling update on-going, i.e. number of requested != number of uptodate PODs)
- Failed (creation of the target resource failed or Kubernetes reported a failed state - only for Deployments)

The numbers are Requested / Ready / Uptodate.

### Additional Notes

Flagging the PR as WIP as we need to agree on the different statuses and conditions to display them.
So feel free to make proposals if you don't agree with the statuses/conditions!