### PR TITLE
Rename a couple of vars to avoid golint warnings

### DIFF
--- a/pkg/controller/datadogagentdeployment/utils.go
+++ b/pkg/controller/datadogagentdeployment/utils.go
@@ -355,7 +355,7 @@ func getEnvVarsForSystemProbe(dad *datadoghqv1alpha1.DatadogAgentDeployment) ([]
 	return envVars, nil
 }
 
-func getEnvVarsCommon(dad *datadoghqv1alpha1.DatadogAgentDeployment, needApiKey bool) ([]corev1.EnvVar, error) {
+func getEnvVarsCommon(dad *datadoghqv1alpha1.DatadogAgentDeployment, needAPIKey bool) ([]corev1.EnvVar, error) {
 
 	envVars := []corev1.EnvVar{
 		{
@@ -384,7 +384,7 @@ func getEnvVarsCommon(dad *datadoghqv1alpha1.DatadogAgentDeployment, needApiKey 
 		},
 	}
 
-	if needApiKey {
+	if needAPIKey {
 		var apiKeyEnvVar corev1.EnvVar
 		if dad.Spec.Credentials.APIKeyExistingSecret != "" {
 			apiKeyEnvVar = corev1.EnvVar{

--- a/test/e2e/datadogagentdeployment_test.go
+++ b/test/e2e/datadogagentdeployment_test.go
@@ -38,11 +38,11 @@ var (
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 60
 
-	dd_api_key = ""
+	ddAPIKey = ""
 )
 
 func init() {
-	dd_api_key = os.Getenv("DD_API_KEY")
+	ddAPIKey = os.Getenv("DD_API_KEY")
 }
 
 func TestDatadogAgentDeployment(t *testing.T) {
@@ -67,7 +67,7 @@ func DeploymentDaemonset(t *testing.T) {
 	name := "foo"
 	options := &utils.NewDatadogAgentDeploymentOptions{
 		UseEDS: false,
-		APIKey: dd_api_key,
+		APIKey: ddAPIKey,
 	}
 
 	agentdeployment := utils.NewDatadogAgentDeployment(namespace, name, fmt.Sprintf("datadog/agent:%s", "6.14.0"), options)


### PR DESCRIPTION
### What does this PR do?

Rename a couple of variables to avoid linting warnings in vscode (by default it uses `golint`)

### Motivation

Warning free bliss :)

```
$ golint pkg/controller/... test/...                                                                                                                                                                                         (kind-kind/default)
pkg/controller/datadogagentdeployment/utils.go:358:70: func parameter needApiKey should be needAPIKey
test/e2e/datadogagentdeployment_test.go:41:2: don't use underscores in Go names; var dd_api_key should be ddAPIKey
```