### PR TITLE
Provide config settings for custom names for Agent daemonset and DCA deployment

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagentdeployments_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagentdeployments_crd.yaml
@@ -1893,6 +1893,9 @@ spec:
                     to the datadog.yaml config file See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6
                     for more details.
                   type: string
+                daemonsetName:
+                  description: Name of the Daemonset to create or upgrade from
+                  type: string
                 deploymentStrategy:
                   description: Update strategy configuration for the DaemonSet
                   properties:
@@ -4260,6 +4263,9 @@ spec:
                         type: object
                       type: array
                   type: object
+                deploymentName:
+                  description: Name of the deployment to upgrade from or to create
+                  type: string
                 image:
                   description: The container image of the Datadog Cluster Agent
                   properties:

--- a/deploy/crds/datadoghq.com_datadogagentdeployments_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagentdeployments_crd.yaml
@@ -4992,6 +4992,10 @@ spec:
                           type: object
                       type: object
                   type: object
+                deploymentName:
+                  description: Name of the cluster checks deployment to create or
+                    migrate from
+                  type: string
                 image:
                   description: The container image of the Datadog Cluster Agent
                   properties:

--- a/deploy/crds/datadoghq.com_datadogagentdeployments_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagentdeployments_crd.yaml
@@ -1894,7 +1894,7 @@ spec:
                     for more details.
                   type: string
                 daemonsetName:
-                  description: Name of the Daemonset to create or upgrade from
+                  description: Name of the Daemonset to create or migrate from
                   type: string
                 deploymentStrategy:
                   description: Update strategy configuration for the DaemonSet
@@ -4264,7 +4264,8 @@ spec:
                       type: array
                   type: object
                 deploymentName:
-                  description: Name of the deployment to upgrade from or to create
+                  description: Name of the Cluster Agent Deployment to create or migrate
+                    from
                   type: string
                 image:
                   description: The container image of the Datadog Cluster Agent
@@ -5145,6 +5146,10 @@ spec:
                   type: integer
                 currentHash:
                   type: string
+                daemonsetName:
+                  description: DaemonsetName corresponds to the name of the created
+                    DaemonSet
+                  type: string
                 desired:
                   format: int32
                   type: integer
@@ -5175,6 +5180,10 @@ spec:
                   format: int32
                   type: integer
                 currentHash:
+                  type: string
+                deploymentName:
+                  description: DeploymentName corresponds to the name of the Cluster
+                    Agent Deployment
                   type: string
                 generatedToken:
                   description: GeneratedToken corresponds to the generated token if
@@ -5219,6 +5228,10 @@ spec:
                   format: int32
                   type: integer
                 currentHash:
+                  type: string
+                deploymentName:
+                  description: DeploymentName corresponds to the name of the Cluster
+                    Agent Deployment
                   type: string
                 generatedToken:
                   description: GeneratedToken corresponds to the generated token if

--- a/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
@@ -87,7 +87,7 @@ type DatadogAgentDeploymentSpecAgentSpec struct {
 	// The container image of the Datadog Agent
 	Image ImageConfig `json:"image"`
 
-	// Name of the Daemonset to create or upgrade from
+	// Name of the Daemonset to create or migrate from
 	// +optional
 	DaemonsetName string `json:"daemonsetName,omitempty"`
 
@@ -411,7 +411,8 @@ type DatadogAgentDeploymentSpecClusterAgentSpec struct {
 	// The container image of the Datadog Cluster Agent
 	Image ImageConfig `json:"image"`
 
-	// Name of the deployment to upgrade from or to create
+	// Name of the Cluster Agent Deployment to create or migrate from
+	// +optional
 	DeploymentName string `json:"deploymentName,omitempty"`
 
 	// Cluster Agent configuration
@@ -576,6 +577,9 @@ type DatadogAgentDeploymentAgentStatus struct {
 	State       string       `json:"state,omitempty"`
 	LastUpdate  *metav1.Time `json:"lastUpdate,omitempty"`
 	CurrentHash string       `json:"currentHash,omitempty"`
+
+	// DaemonsetName corresponds to the name of the created DaemonSet
+	DaemonsetName string `json:"daemonsetName,omitempty"`
 }
 
 // DatadogAgentDeploymentDeploymentStatus type representing the Cluster Agent Deployment status
@@ -613,6 +617,9 @@ type DatadogAgentDeploymentDeploymentStatus struct {
 
 	// State corresponds to the ClusterAgent deployment state
 	State string `json:"state,omitempty"`
+
+	// DeploymentName corresponds to the name of the Cluster Agent Deployment
+	DeploymentName string `json:"deploymentName,omitempty"`
 }
 
 // DatadogAgentDeploymentCondition describes the state of a DatadogAgentDeployment at a certain point.

--- a/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
@@ -485,6 +485,10 @@ type DatadogAgentDeploymentSpecClusterChecksRunnerSpec struct {
 	// The container image of the Datadog Cluster Agent
 	Image ImageConfig `json:"image"`
 
+	// Name of the cluster checks deployment to create or migrate from
+	// +optional
+	DeploymentName string `json:"deploymentName,omitempty"`
+
 	// Agent configuration
 	Config ClusterChecksRunnerConfig `json:"config,omitempty"`
 

--- a/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagentdeployment_types.go
@@ -87,6 +87,10 @@ type DatadogAgentDeploymentSpecAgentSpec struct {
 	// The container image of the Datadog Agent
 	Image ImageConfig `json:"image"`
 
+	// Name of the Daemonset to create or upgrade from
+	// +optional
+	DaemonsetName string `json:"daemonsetName,omitempty"`
+
 	// Agent configuration
 	Config NodeAgentConfig `json:"config,omitempty"`
 
@@ -406,6 +410,9 @@ type DogstatsdConfig struct {
 type DatadogAgentDeploymentSpecClusterAgentSpec struct {
 	// The container image of the Datadog Cluster Agent
 	Image ImageConfig `json:"image"`
+
+	// Name of the deployment to upgrade from or to create
+	DeploymentName string `json:"deploymentName,omitempty"`
 
 	// Cluster Agent configuration
 	Config ClusterAgentConfig `json:"config,omitempty"`

--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -46,6 +46,8 @@ type NewDatadogAgentDeploymentOptions struct {
 	ClusterAgentVolumes        []corev1.Volume
 	ClusterAgentVolumeMounts   []corev1.VolumeMount
 	CustomConfig               string
+	AgentDaemonsetName         string
+	ClusterAgentDeploymentName string
 }
 
 // NewDefaultedDatadogAgentDeployment returns an initialized and defaulted DatadogAgentDeployment for testing purpose
@@ -91,6 +93,9 @@ func NewDefaultedDatadogAgentDeployment(ns, name string, options *NewDatadogAgen
 				ad.Annotations[key] = value
 			}
 		}
+
+		ad.Spec.Agent.DaemonsetName = options.AgentDaemonsetName
+
 		if options.Status != nil {
 			ad.Status = *options.Status
 		}
@@ -107,6 +112,7 @@ func NewDefaultedDatadogAgentDeployment(ns, name string, options *NewDatadogAgen
 				Rbac: datadoghqv1alpha1.RbacConfig{
 					Create: datadoghqv1alpha1.NewBoolPointer(true),
 				},
+				DeploymentName: options.ClusterAgentDeploymentName,
 			}
 			if options.MetricsServerEnabled {
 				ad.Spec.ClusterAgent.Config.MetricsProviderEnabled = datadoghqv1alpha1.NewBoolPointer(true)

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -491,6 +491,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentDeploymentAgentStatus(ref co
 							Format: "",
 						},
 					},
+					"daemonsetName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DaemonsetName corresponds to the name of the created DaemonSet",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"desired", "current", "ready", "available", "upToDate"},
 			},
@@ -619,6 +626,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentDeploymentDeploymentStatus(r
 					"state": {
 						SchemaProps: spec.SchemaProps{
 							Description: "State corresponds to the ClusterAgent deployment state",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"deploymentName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DeploymentName corresponds to the name of the Cluster Agent Deployment",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -759,7 +773,7 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentDeploymentSpecAgentSpec(ref 
 					},
 					"daemonsetName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the Daemonset to create or upgrade from",
+							Description: "Name of the Daemonset to create or migrate from",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -849,7 +863,7 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentDeploymentSpecClusterAgentSp
 					},
 					"deploymentName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of the deployment to upgrade from or to create",
+							Description: "Name of the Cluster Agent Deployment to create or migrate from",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -948,6 +948,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentDeploymentSpecClusterChecksR
 							Ref:         ref("./pkg/apis/datadoghq/v1alpha1.ImageConfig"),
 						},
 					},
+					"deploymentName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the cluster checks deployment to create or migrate from",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Agent configuration",

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -757,6 +757,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentDeploymentSpecAgentSpec(ref 
 							Ref:         ref("./pkg/apis/datadoghq/v1alpha1.ImageConfig"),
 						},
 					},
+					"daemonsetName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the Daemonset to create or upgrade from",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Agent configuration",
@@ -838,6 +845,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentDeploymentSpecClusterAgentSp
 						SchemaProps: spec.SchemaProps{
 							Description: "The container image of the Datadog Cluster Agent",
 							Ref:         ref("./pkg/apis/datadoghq/v1alpha1.ImageConfig"),
+						},
+					},
+					"deploymentName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the deployment to upgrade from or to create",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"config": {

--- a/pkg/controller/datadogagentdeployment/agent.go
+++ b/pkg/controller/datadogagentdeployment/agent.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
-
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +22,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	edsdatadoghqv1alpha1 "github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
 )
 

--- a/pkg/controller/datadogagentdeployment/agent.go
+++ b/pkg/controller/datadogagentdeployment/agent.go
@@ -34,7 +34,7 @@ func (r *ReconcileDatadogAgentDeployment) reconcileAgent(logger logr.Logger, dad
 	}
 
 	nameNamespace := types.NamespacedName{
-		Name:      dad.ObjectMeta.Name,
+		Name:      daemonsetName(dad),
 		Namespace: dad.ObjectMeta.Namespace,
 	}
 	// check if EDS or DS already exist
@@ -342,6 +342,13 @@ func newDaemonSetFromInstance(logger logr.Logger, agentdeployment *datadoghqv1al
 	return ds, hash, nil
 }
 
+func daemonsetName(agentdeployment *datadoghqv1alpha1.DatadogAgentDeployment) string {
+	if agentdeployment.Spec.Agent.DaemonsetName != "" {
+		return agentdeployment.Spec.Agent.DaemonsetName
+	}
+	return agentdeployment.Name
+}
+
 func newDaemonsetObjectMetaData(agentdeployment *datadoghqv1alpha1.DatadogAgentDeployment) metav1.ObjectMeta {
 	labels := getDefaultLabels(agentdeployment, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(agentdeployment))
 	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = agentdeployment.Name
@@ -352,7 +359,7 @@ func newDaemonsetObjectMetaData(agentdeployment *datadoghqv1alpha1.DatadogAgentD
 	annotations := map[string]string{}
 
 	return metav1.ObjectMeta{
-		Name:        agentdeployment.Name,
+		Name:        daemonsetName(agentdeployment),
 		Namespace:   agentdeployment.Namespace,
 		Labels:      labels,
 		Annotations: annotations,

--- a/pkg/controller/datadogagentdeployment/agent.go
+++ b/pkg/controller/datadogagentdeployment/agent.go
@@ -33,6 +33,10 @@ func (r *ReconcileDatadogAgentDeployment) reconcileAgent(logger logr.Logger, dad
 		return result, err
 	}
 
+	if newStatus.Agent != nil && newStatus.Agent.DaemonsetName != "" && newStatus.Agent.DaemonsetName != daemonsetName(dad) {
+		return result, fmt.Errorf("Datadog agent DaemonSet cannot be renamed once created")
+	}
+
 	nameNamespace := types.NamespacedName{
 		Name:      daemonsetName(dad),
 		Namespace: dad.ObjectMeta.Namespace,

--- a/pkg/controller/datadogagentdeployment/agent_test.go
+++ b/pkg/controller/datadogagentdeployment/agent_test.go
@@ -469,6 +469,7 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 	tests := []struct {
 		name            string
 		agentdeployment *datadoghqv1alpha1.DatadogAgentDeployment
+		selector        *metav1.LabelSelector
 		want            *edsdatadoghqv1alpha1.ExtendedDaemonSet
 		wantErr         bool
 	}{
@@ -679,7 +680,12 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 		{
 			name:            "with user daemonset name and selector",
 			agentdeployment: daemonsetNameAgentDeployment,
-			wantErr:         false,
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "datadog-monitoring",
+				},
+			},
+			wantErr: false,
 			want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
@@ -727,7 +733,7 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reqLogger := log.WithValues("test:", tt.name)
-			got, _, err := newExtendedDaemonSetFromInstance(reqLogger, tt.agentdeployment)
+			got, _, err := newExtendedDaemonSetFromInstance(reqLogger, tt.agentdeployment, tt.selector)
 			if tt.wantErr {
 				assert.Error(t, err, "newExtendedDaemonSetFromInstance() expected an error")
 			} else {

--- a/pkg/controller/datadogagentdeployment/agent_test.go
+++ b/pkg/controller/datadogagentdeployment/agent_test.go
@@ -457,6 +457,15 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 
 	userMountsAgentHash, _ := comparison.GenerateMD5ForSpec(userMountsAgentDeployment.Spec)
 
+	daemonsetNameAgentDeployment := test.NewDefaultedDatadogAgentDeployment("bar", "foo",
+		&test.NewDatadogAgentDeploymentOptions{
+			UseEDS:              true,
+			ClusterAgentEnabled: true,
+			AgentDaemonsetName:  "custom-agent-daemonset",
+		})
+
+	daemonsetNameAgentHash, _ := comparison.GenerateMD5ForSpec(daemonsetNameAgentDeployment.Spec)
+
 	tests := []struct {
 		name            string
 		agentdeployment *datadoghqv1alpha1.DatadogAgentDeployment
@@ -662,6 +671,52 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 							Annotations: make(map[string]string),
 						},
 						Spec: *customConfigMapCustomDatadogYamlSpec,
+					},
+					Strategy: getDefaultEDSStrategy(),
+				},
+			},
+		},
+		{
+			name:            "with user daemonset name and selector",
+			agentdeployment: daemonsetNameAgentDeployment,
+			wantErr:         false,
+			want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "bar",
+					Name:      "custom-agent-daemonset",
+					Labels: map[string]string{
+						"agentdeployment.datadoghq.com/name":      "foo",
+						"agentdeployment.datadoghq.com/component": "agent",
+						"app.kubernetes.io/instance":              "agent",
+						"app.kubernetes.io/managed-by":            "datadog-operator",
+						"app.kubernetes.io/name":                  "datadog-agent-deployment",
+						"app.kubernetes.io/part-of":               "foo",
+						"app.kubernetes.io/version":               "",
+					},
+					Annotations: map[string]string{"agentdeployment.datadoghq.com/agentspechash": daemonsetNameAgentHash},
+				},
+				Spec: edsdatadoghqv1alpha1.ExtendedDaemonSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "datadog-monitoring",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "foo",
+							Namespace:    "bar",
+							Labels: map[string]string{
+								"agentdeployment.datadoghq.com/name":      "foo",
+								"agentdeployment.datadoghq.com/component": "agent",
+								"app.kubernetes.io/instance":              "agent",
+								"app.kubernetes.io/managed-by":            "datadog-operator",
+								"app.kubernetes.io/name":                  "datadog-agent-deployment",
+								"app.kubernetes.io/part-of":               "foo",
+								"app.kubernetes.io/version":               "",
+								"app":                                     "datadog-monitoring",
+							},
+						},
+						Spec: defaultPodSpec,
 					},
 					Strategy: getDefaultEDSStrategy(),
 				},

--- a/pkg/controller/datadogagentdeployment/clusteragent.go
+++ b/pkg/controller/datadogagentdeployment/clusteragent.go
@@ -49,6 +49,12 @@ func (r *ReconcileDatadogAgentDeployment) reconcileClusterAgent(logger logr.Logg
 		}
 	}
 
+	if newStatus.ClusterAgent != nil &&
+		newStatus.ClusterAgent.DeploymentName != "" &&
+		newStatus.ClusterAgent.DeploymentName != getClusterAgentName(dad) {
+		return result, fmt.Errorf("Datadog cluster agent Deployment cannot be renamed once created")
+	}
+
 	nsName := types.NamespacedName{
 		Name:      getClusterAgentName(dad),
 		Namespace: dad.Namespace,

--- a/pkg/controller/datadogagentdeployment/clusteragent.go
+++ b/pkg/controller/datadogagentdeployment/clusteragent.go
@@ -378,6 +378,9 @@ func getEnvVarsForClusterAgent(logger logr.Logger, dad *datadoghqv1alpha1.Datado
 }
 
 func getClusterAgentName(dad *datadoghqv1alpha1.DatadogAgentDeployment) string {
+	if dad.Spec.ClusterAgent != nil && dad.Spec.ClusterAgent.DeploymentName != "" {
+		return dad.Spec.ClusterAgent.DeploymentName
+	}
 	return fmt.Sprintf("%s-%s", dad.Name, "cluster-agent")
 }
 

--- a/pkg/controller/datadogagentdeployment/utils.go
+++ b/pkg/controller/datadogagentdeployment/utils.go
@@ -1072,6 +1072,7 @@ func updateDaemonSetStatus(ds *appsv1.DaemonSet, dsStatus *datadoghqv1alpha1.Dat
 	}
 
 	dsStatus.State = fmt.Sprintf("%v (%d/%d/%d)", deploymentState, dsStatus.Desired, dsStatus.Ready, dsStatus.UpToDate)
+	dsStatus.DaemonsetName = ds.ObjectMeta.Name
 	return dsStatus
 }
 
@@ -1102,6 +1103,7 @@ func updateExtendedDaemonSetStatus(eds *edsdatadoghqv1alpha1.ExtendedDaemonSet, 
 	}
 
 	dsStatus.State = fmt.Sprintf("%v (%d/%d/%d)", deploymentState, dsStatus.Desired, dsStatus.Ready, dsStatus.UpToDate)
+	dsStatus.DaemonsetName = eds.ObjectMeta.Name
 	return dsStatus
 }
 
@@ -1144,6 +1146,7 @@ func updateDeploymentStatus(dep *appsv1.Deployment, depStatus *datadoghqv1alpha1
 	}
 
 	depStatus.State = fmt.Sprintf("%v (%d/%d/%d)", deploymentState, depStatus.Replicas, depStatus.ReadyReplicas, depStatus.UpdatedReplicas)
+	depStatus.DeploymentName = dep.ObjectMeta.Name
 	return depStatus
 }
 

--- a/pkg/controller/datadogagentdeployment/utils.go
+++ b/pkg/controller/datadogagentdeployment/utils.go
@@ -37,11 +37,17 @@ func init() {
 }
 
 // newAgentPodTemplate generates a PodTemplate from a DatadogAgentDeployment spec
-func newAgentPodTemplate(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgentDeployment) (*corev1.PodTemplateSpec, error) {
+func newAgentPodTemplate(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgentDeployment, selector *metav1.LabelSelector) (*corev1.PodTemplateSpec, error) {
 	// copy Agent Spec to configure Agent Pod Template
 	labels := getDefaultLabels(agentdeployment, "agent", getAgentVersion(agentdeployment))
 	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = agentdeployment.Name
 	labels[datadoghqv1alpha1.AgentDeploymentComponentLabelKey] = "agent"
+
+	if selector != nil {
+		for key, val := range selector.MatchLabels {
+			labels[key] = val
+		}
+	}
 
 	annotations := getDefaultAnnotations(agentdeployment)
 	if isSystemProbeEnabled(agentdeployment) {


### PR DESCRIPTION
### What does this PR do?

- Allow customizing `daemonsetName` for agent's DaemonSet or ExtendedDaemonSet.
- Allow customizing `deploymentName` for cluster agent's deployment.

These can be used to "migrate" from existing helm-created resources.

### Motivation

Providing a path to migrate from helm-provisioned Datadog agent deployments.

