### PR TITLE
Correct symlink in helm chart broken due to CRD rename

### DIFF
--- a/chart/datadog-operator/templates/datadoghq.com_datadogagentdeployments_crd.yaml
+++ b/chart/datadog-operator/templates/datadoghq.com_datadogagentdeployments_crd.yaml
@@ -1,1 +1,0 @@
-../../../deploy/crds/datadoghq.com_datadogagentdeployments_crd.yaml

--- a/chart/datadog-operator/templates/datadoghq.com_datadogagents_crd.yaml
+++ b/chart/datadog-operator/templates/datadoghq.com_datadogagents_crd.yaml
@@ -1,0 +1,1 @@
+../../../deploy/crds/datadoghq.com_datadogagents_crd.yaml


### PR DESCRIPTION
### What does this PR do?

When CRD was renamed (`DatadogAgentDeployment` => `DatadogAgent`) the symlink in the helm chart didn't get updated, this updates the chart with the correct symlink target.

