### PR TITLE
Reconcile() updates now MetricsForwarder.Status in DatadogAgentStatus

### DIFF
--- a/pkg/controller/datadogagent/datadogagent_controller.go
+++ b/pkg/controller/datadogagent/datadogagent_controller.go
@@ -306,6 +306,7 @@ func (r *ReconcileDatadogAgent) updateStatusIfNeeded(logger logr.Logger, agentde
 
 	// get metrics forwarder status
 	if metricsCondition := r.forwarders.MetricsForwarderStatusForObj(agentdeployment); metricsCondition != nil {
+		logger.V(1).Info("metrics conditions status not available")
 		condition.SetDatadogAgentStatusCondition(newStatus, metricsCondition)
 	}
 

--- a/pkg/controller/datadogagent/datadogagent_controller.go
+++ b/pkg/controller/datadogagent/datadogagent_controller.go
@@ -76,6 +76,7 @@ type metricForwardersManager interface {
 	Unregister(datadog.MonitoredObject)
 	ProcessError(datadog.MonitoredObject, error)
 	ProcessEvent(datadog.MonitoredObject, datadog.Event)
+	MetricsForwarderStatusForObj(obj datadog.MonitoredObject) *datadoghqv1alpha1.DatadogAgentCondition
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -298,9 +299,14 @@ func (r *ReconcileDatadogAgent) updateStatusIfNeeded(logger logr.Logger, agentde
 	now := metav1.NewTime(time.Now())
 	condition.UpdateDatadogAgentStatusConditionsFailure(newStatus, now, datadoghqv1alpha1.ConditionTypeReconcileError, currentError)
 	if currentError == nil {
-		condition.UpdateDatadogAgentStatusCondition(newStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionTrue, "DatadogAgent reconcile ok", false)
+		condition.UpdateDatadogAgentStatusConditions(newStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionTrue, "DatadogAgent reconcile ok", false)
 	} else {
-		condition.UpdateDatadogAgentStatusCondition(newStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionFalse, "DatadogAgent reconcile error", false)
+		condition.UpdateDatadogAgentStatusConditions(newStatus, now, datadoghqv1alpha1.ConditionTypeActive, corev1.ConditionFalse, "DatadogAgent reconcile error", false)
+	}
+
+	// get metrics forwarder status
+	if metricsCondition := r.forwarders.MetricsForwarderStatusForObj(agentdeployment); metricsCondition != nil {
+		condition.SetDatadogAgentStatusCondition(newStatus, metricsCondition)
 	}
 
 	if !apiequality.Semantic.DeepEqual(&agentdeployment.Status, newStatus) {

--- a/pkg/controller/datadogagent/datadogagent_controller_test.go
+++ b/pkg/controller/datadogagent/datadogagent_controller_test.go
@@ -1984,6 +1984,10 @@ func (dummyManager) ProcessError(datadog.MonitoredObject, error) {
 func (dummyManager) ProcessEvent(datadog.MonitoredObject, datadog.Event) {
 }
 
+func (dummyManager) MetricsForwarderStatusForObj(obj datadog.MonitoredObject) *datadoghqv1alpha1.DatadogAgentCondition {
+	return nil
+}
+
 func createClusterChecksRunnerDependencies(c client.Client, dda *datadoghqv1alpha1.DatadogAgent) {
 	_ = c.Create(context.TODO(), buildClusterChecksRunnerPDB(dda))
 }

--- a/pkg/controller/datadogagent/secret.go
+++ b/pkg/controller/datadogagent/secret.go
@@ -44,7 +44,7 @@ func (r *ReconcileDatadogAgent) manageClusterAgentSecret(logger logr.Logger, dda
 			}
 			// return error since the secret didn't exist and we are not responsible to create it.
 			err = fmt.Errorf("Secret %s didn't exist", secretName)
-			condition.UpdateDatadogAgentStatusCondition(newStatus, now, datadoghqv1alpha1.ConditionTypeSecretError, corev1.ConditionTrue, fmt.Sprintf("%v", err), false)
+			condition.UpdateDatadogAgentStatusConditions(newStatus, now, datadoghqv1alpha1.ConditionTypeSecretError, corev1.ConditionTrue, fmt.Sprintf("%v", err), false)
 		}
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/utils/condition/condition.go
+++ b/pkg/controller/utils/condition/condition.go
@@ -17,27 +17,44 @@ import (
 // UpdateDatadogAgentStatusConditionsFailure used to update the failure StatusConditions
 func UpdateDatadogAgentStatusConditionsFailure(status *datadoghqv1alpha1.DatadogAgentStatus, now metav1.Time, conditionType datadoghqv1alpha1.DatadogAgentConditionType, err error) {
 	if err != nil {
-		UpdateDatadogAgentStatusCondition(status, now, conditionType, corev1.ConditionTrue, fmt.Sprintf("%v", err), false)
+		UpdateDatadogAgentStatusConditions(status, now, conditionType, corev1.ConditionTrue, fmt.Sprintf("%v", err), false)
 	} else {
-		UpdateDatadogAgentStatusCondition(status, now, conditionType, corev1.ConditionFalse, "", false)
+		UpdateDatadogAgentStatusConditions(status, now, conditionType, corev1.ConditionFalse, "", false)
 	}
 }
 
-// UpdateDatadogAgentStatusCondition used to update a specific DatadogAgentConditionType
-func UpdateDatadogAgentStatusCondition(status *datadoghqv1alpha1.DatadogAgentStatus, now metav1.Time, t datadoghqv1alpha1.DatadogAgentConditionType, conditionStatus corev1.ConditionStatus, desc string, writeFalseIfNotExist bool) {
+// UpdateDatadogAgentStatusConditions used to update a specific DatadogAgentConditionType in conditions
+func UpdateDatadogAgentStatusConditions(status *datadoghqv1alpha1.DatadogAgentStatus, now metav1.Time, t datadoghqv1alpha1.DatadogAgentConditionType, conditionStatus corev1.ConditionStatus, desc string, writeFalseIfNotExist bool) {
 	idConditionComplete := getIndexForConditionType(status, t)
 	if idConditionComplete >= 0 {
-		if status.Conditions[idConditionComplete].Status != conditionStatus {
-			status.Conditions[idConditionComplete].LastTransitionTime = now
-			status.Conditions[idConditionComplete].Status = conditionStatus
-		}
-		status.Conditions[idConditionComplete].LastUpdateTime = now
-		status.Conditions[idConditionComplete].Message = desc
+		UpdateDatadogAgentStatusCondition(&status.Conditions[idConditionComplete], now, t, conditionStatus,desc)
 	} else if conditionStatus == corev1.ConditionTrue || writeFalseIfNotExist {
 		// Only add if the condition is True
 		status.Conditions = append(status.Conditions, NewDatadogAgentStatusCondition(t, conditionStatus, now, "", desc))
 	}
 }
+
+// UpdateDatadogAgentStatusCondition used to update a specific DatadogAgentConditionType
+func UpdateDatadogAgentStatusCondition(condition *datadoghqv1alpha1.DatadogAgentCondition, now metav1.Time, t datadoghqv1alpha1.DatadogAgentConditionType, conditionStatus corev1.ConditionStatus, desc string) *datadoghqv1alpha1.DatadogAgentCondition {
+	if condition.Status != conditionStatus {
+		condition.LastTransitionTime = now
+		condition.Status = conditionStatus
+	}
+	condition.LastUpdateTime = now
+	condition.Message = desc
+	return condition
+}
+
+// SetDatadogAgentStatusCondition use to set a condition
+func SetDatadogAgentStatusCondition(status *datadoghqv1alpha1.DatadogAgentStatus, condition *datadoghqv1alpha1.DatadogAgentCondition) {
+	idConditionComplete := getIndexForConditionType(status, condition.Type)
+	if idConditionComplete >= 0 {
+		status.Conditions[idConditionComplete] = *condition
+	} else {
+		status.Conditions = append(status.Conditions, *condition)
+	}
+}
+
 
 // NewDatadogAgentStatusCondition returns new DatadogAgentCondition instance
 func NewDatadogAgentStatusCondition(conditionType datadoghqv1alpha1.DatadogAgentConditionType, conditionStatus corev1.ConditionStatus, now metav1.Time, reason, message string) datadoghqv1alpha1.DatadogAgentCondition {

--- a/pkg/controller/utils/datadog/forwarders_manager.go
+++ b/pkg/controller/utils/datadog/forwarders_manager.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/DataDog/datadog-operator/pkg/secrets"
-
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
 )
 
@@ -100,7 +99,7 @@ func (f *ForwardersManager) ProcessEvent(obj MonitoredObject, event Event) {
 	forwarder.eventChan <- event
 }
 
-// MetricsForwarderStatusForObj used to retrieve the Metrics forwarder status for a give object
+// MetricsForwarderStatusForObj used to retrieve the Metrics forwarder status for a given object
 func (f *ForwardersManager) MetricsForwarderStatusForObj(obj MonitoredObject) *datadoghqv1alpha1.DatadogAgentCondition {
 	id := getObjID(obj)
 	forwarder, err := f.getForwarder(id)

--- a/pkg/controller/utils/datadog/forwarders_manager.go
+++ b/pkg/controller/utils/datadog/forwarders_manager.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/DataDog/datadog-operator/pkg/secrets"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
 )
 
 // ForwardersManager is a collection of metricsForwarder per DatadogAgent
@@ -96,6 +98,17 @@ func (f *ForwardersManager) ProcessEvent(obj MonitoredObject, event Event) {
 		return
 	}
 	forwarder.eventChan <- event
+}
+
+// MetricsForwarderStatusForObj used to retrieve the Metrics forwarder status for a give object
+func (f *ForwardersManager) MetricsForwarderStatusForObj(obj MonitoredObject) *datadoghqv1alpha1.DatadogAgentCondition {
+	id := getObjID(obj)
+	forwarder, err := f.getForwarder(id)
+	if err != nil {
+		// forwarder not present yet
+		return nil
+	}
+	return forwarder.getStatus()
 }
 
 // stopAllForwarders stops the running metricsForwarder goroutines

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -590,8 +590,6 @@ func (mf *metricsForwarder) updateStatusIfNeeded(dda *datadoghqv1alpha1.DatadogA
 		description = "Datadog metrics forwarding error"
 	}
 
-	mf.Lock()
-	defer mf.Unlock()
 	oldStatus := mf.getStatus()
 	if oldStatus == nil {
 		newStatus := condition.NewDatadogAgentStatusCondition(datadoghqv1alpha1.ConditionTypeActiveDatadogMetrics, conditionStatus, now, "", description)


### PR DESCRIPTION
### What does this PR do?

Avoid race condition update of the DatadogAgentStatus. 

### Motivation

before 2 differents goroutine may update the DatadogAgentStatus at the same time. that leads to concurrent update errors. 

### Additional Notes

Anything else we should know when reviewing?

