### PR TITLE
Mount the directory containing the docker socket instead of the socket itself

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -88,8 +88,8 @@ const (
 	CgroupsVolumeReadOnly              = true
 	SystemProbeSocketVolumeName        = "sysprobe-socket-dir"
 	SystemProbeSocketVolumePath        = "/opt/datadog-agent/run"
-	CriSockerVolumeName                = "runtimesocket"
-	CriSockerVolumeReadOnly            = true
+	CriSocketVolumeName                = "runtimesocketdir"
+	CriSocketVolumeReadOnly            = true
 	DogstatsdSockerVolumeName          = "dsdsocket"
 	DogstatsdSockerVolumePath          = "/var/run/datadog"
 	PointerVolumeName                  = "pointerdir"
@@ -111,6 +111,7 @@ const (
 	AgentCustomConfigVolumeName        = "custom-datadog-yaml"
 	AgentCustomConfigVolumePath        = "/etc/datadog-agent/datadog.yaml"
 	AgentCustomConfigVolumeSubPath     = "datadog.yaml"
+	HostCriSocketPathPrefix            = "/host"
 
 	DefaultSystemProbeSecCompRootPath = "/var/lib/kubelet/seccomp"
 	DefaultAppArmorProfileName        = "unconfined"

--- a/pkg/controller/datadogagent/agent.go
+++ b/pkg/controller/datadogagent/agent.go
@@ -387,7 +387,7 @@ func buildAgentConfigurationConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*cor
 	// Maybe later we can implement that directly verifies against Agent configuration?
 	m := make(map[interface{}]interface{})
 	if err := yaml.Unmarshal([]byte(dda.Spec.Agent.CustomConfig), m); err != nil {
-		return nil, fmt.Errorf("unable to parse YAML from 'Agent.CustomConfig' field: %w", err)
+		return nil, fmt.Errorf("unable to parse YAML from 'Agent.CustomConfig' field: %v", err)
 	}
 
 	configMap := &corev1.ConfigMap{

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -92,10 +92,10 @@ func defaultVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: "runtimesocket",
+			Name: "runtimesocketdir",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/run/docker.sock",
+					Path: "/var/run",
 				},
 			},
 		},
@@ -129,8 +129,8 @@ func defaultMountVolume() []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 		{
-			Name:      "runtimesocket",
-			MountPath: "/var/run/docker.sock",
+			Name:      "runtimesocketdir",
+			MountPath: "/host/var/run",
 			ReadOnly:  true,
 		},
 	}
@@ -224,7 +224,7 @@ func defaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_CRI_SOCKET_PATH",
-			Value: "/var/run/docker.sock",
+			Value: "/host/var/run/docker.sock",
 		},
 	}
 }
@@ -462,10 +462,10 @@ func Test_newExtendedDaemonSetFromInstance_CustomConfigMaps(t *testing.T) {
 			},
 		},
 		{
-			Name: "runtimesocket",
+			Name: "runtimesocketdir",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/run/docker.sock",
+					Path: "/var/run",
 				},
 			},
 		},
@@ -578,10 +578,10 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 			},
 		},
 		{
-			Name: "runtimesocket",
+			Name: "runtimesocketdir",
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/run/docker.sock",
+					Path: "/var/run",
 				},
 			},
 		},
@@ -618,8 +618,8 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 			ReadOnly:  true,
 		},
 		{
-			Name:      "runtimesocket",
-			MountPath: "/var/run/docker.sock",
+			Name:      "runtimesocketdir",
+			MountPath: "/host/var/run",
 			ReadOnly:  true,
 		},
 	}

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -523,7 +524,7 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 	if dda.Spec.Agent.Config.CriSocket != nil && dda.Spec.Agent.Config.CriSocket.CriSocketPath != nil {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDCriSocketPath,
-			Value: *dda.Spec.Agent.Config.CriSocket.CriSocketPath,
+			Value: filepath.Join(datadoghqv1alpha1.HostCriSocketPathPrefix, *dda.Spec.Agent.Config.CriSocket.CriSocketPath),
 		})
 	}
 
@@ -608,10 +609,10 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 			path = *dda.Spec.Agent.Config.CriSocket.CriSocketPath
 		}
 		criVolume := corev1.Volume{
-			Name: datadoghqv1alpha1.CriSockerVolumeName,
+			Name: datadoghqv1alpha1.CriSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: path,
+					Path: filepath.Dir(path),
 				},
 			},
 		}
@@ -767,8 +768,8 @@ func getVolumeMountsForAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []corev1.
 	// Cri socket volume
 	if *spec.Agent.Config.CriSocket.UseCriSocketVolume {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      datadoghqv1alpha1.CriSockerVolumeName,
-			MountPath: *spec.Agent.Config.CriSocket.CriSocketPath,
+			Name:      datadoghqv1alpha1.CriSocketVolumeName,
+			MountPath: filepath.Join(datadoghqv1alpha1.HostCriSocketPathPrefix, filepath.Dir(*spec.Agent.Config.CriSocket.CriSocketPath)),
 			ReadOnly:  true,
 		})
 	}
@@ -831,8 +832,8 @@ func getVolumeMountsForProcessAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []
 	// Cri socket volume
 	if *spec.Agent.Config.CriSocket.UseCriSocketVolume {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      datadoghqv1alpha1.CriSockerVolumeName,
-			MountPath: *spec.Agent.Config.CriSocket.CriSocketPath,
+			Name:      datadoghqv1alpha1.CriSocketVolumeName,
+			MountPath: filepath.Join(datadoghqv1alpha1.HostCriSocketPathPrefix, filepath.Dir(*spec.Agent.Config.CriSocket.CriSocketPath)),
 			ReadOnly:  true,
 		})
 	}


### PR DESCRIPTION
This is to handle the cases where the docker daemon is restarted.
In this case, the docker daemon will recreate its docker socket.
On k8s context, the containers will not be restarted.
And, if the agent container bind-mounted directly the socket, the container would still have access to the old socket instead of the one of the new docker daemon.
As a consequence, with a bind-mount of the socket directly, a docker restart disconnects the agent from docker forever; until the agent POD is destroyed and recreated.

On the other hand, if we bind-mount the directory containing the socket, when the daemon recreates a new socket following a restart, it will be visible from the agent container. The agent will be disconnected from the old socket, and it will reconnect on the new one.