### PR TITLE
[WIP] Add missing fields in DatadogAgent CRD

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -53,6 +53,18 @@ spec:
               description: The desired state of the Agent as an extended daemonset
                 Contains the Node Agent configuration and deployment strategy
               properties:
+                additionalAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: AdditionalAnnotations provide annotations that will
+                    be added to the Agent Pods.
+                  type: object
+                additionalLabels:
+                  additionalProperties:
+                    type: string
+                  description: AdditionalLabels provide labels that will be added
+                    to the cluster checks runner Pods.
+                  type: object
                 apm:
                   description: Trace Agent configuration
                   properties:
@@ -1958,6 +1970,59 @@ spec:
                       description: The update strategy used for the DaemonSet
                       type: string
                   type: object
+                dnsConfig:
+                  description: Specifies the DNS parameters of a pod. Parameters specified
+                    here will be merged to the generated DNS configuration based on
+                    DNSPolicy.
+                  properties:
+                    nameservers:
+                      description: A list of DNS name server IP addresses. This will
+                        be appended to the base nameservers generated from DNSPolicy.
+                        Duplicated nameservers will be removed.
+                      items:
+                        type: string
+                      type: array
+                    options:
+                      description: A list of DNS resolver options. This will be merged
+                        with the base options generated from DNSPolicy. Duplicated
+                        entries will be removed. Resolution options given in Options
+                        will override those that appear in the base DNSPolicy.
+                      items:
+                        description: PodDNSConfigOption defines DNS resolver options
+                          of a pod.
+                        properties:
+                          name:
+                            description: Required.
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    searches:
+                      description: A list of DNS search domains for host-name lookup.
+                        This will be appended to the base search paths generated from
+                        DNSPolicy. Duplicated search paths will be removed.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                dnsPolicy:
+                  description: Set DNS policy for the pod. Defaults to "ClusterFirst".
+                    Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default'
+                    or 'None'. DNS parameters given in DNSConfig will be merged with
+                    the policy selected with DNSPolicy. To have DNS options set along
+                    with hostNetwork, you have to specify DNS policy explicitly to
+                    'ClusterFirstWithHostNet'.
+                  type: string
+                hostNetwork:
+                  description: Host networking requested for this pod. Use the host's
+                    network namespace. If this option is set, the ports that will
+                    be used must be specified. Default to false.
+                  type: boolean
+                hostPID:
+                  description: 'Use the host''s pid namespace. Optional: Default to
+                    false.'
+                  type: boolean
                 image:
                   description: The container image of the Datadog Agent
                   properties:
@@ -2016,6 +2081,14 @@ spec:
                         tailing the log files from the right offset Default to `/var/lib/datadog-agent/logs`
                       type: string
                   type: object
+                priorityClassName:
+                  description: If specified, indicates the pod's priority. "system-node-critical"
+                    and "system-cluster-critical" are two special keywords which indicate
+                    the highest priorities with the former being the highest priority.
+                    Any other name must be defined by creating a PriorityClass object
+                    with that name. If not specified, the pod priority will be default
+                    or zero if there is no default.
+                  type: string
                 process:
                   description: Process Agent configuration
                   properties:
@@ -2322,6 +2395,137 @@ spec:
                       description: SecCompRootPath specify the seccomp profile root
                         directory
                       type: string
+                    securityContext:
+                      description: You can modify the security context used to run
+                        the containers by modifying the label type
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                          type: object
+                        privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options from the PodSecurityContext
+                            will be used. If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field. This field is
+                                alpha-level and is only honored by servers that enable
+                                the WindowsGMSA feature flag.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use. This field is alpha-level
+                                and is only honored by servers that enable the WindowsGMSA
+                                feature flag.
+                              type: string
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. This field is alpha-level and it
+                                is only honored by servers that enable the WindowsRunAsUserName
+                                feature flag.
+                              type: string
+                          type: object
+                      type: object
                   type: object
                 useExtendedDaemonset:
                   description: UseExtendedDaemonset use ExtendedDaemonset for Agent
@@ -2333,6 +2537,18 @@ spec:
             clusterAgent:
               description: The desired state of the Cluster Agent as a deployment
               properties:
+                additionalAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: AdditionalAnnotations provide annotations that will
+                    be added to the cluster-agent Pods.
+                  type: object
+                additionalLabels:
+                  additionalProperties:
+                    type: string
+                  description: AdditionalLabels provide labels that will be added
+                    to the cluster checks runner Pods.
+                  type: object
                 affinity:
                   description: If specified, the pod's scheduling constraints
                   properties:
@@ -4320,6 +4536,14 @@ spec:
                     the pod to fit on a node. Selector which must match a node''s
                     labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                   type: object
+                priorityClassName:
+                  description: If specified, indicates the pod's priority. "system-node-critical"
+                    and "system-cluster-critical" are two special keywords which indicate
+                    the highest priorities with the former being the highest priority.
+                    Any other name must be defined by creating a PriorityClass object
+                    with that name. If not specified, the pod priority will be default
+                    or zero if there is no default.
+                  type: string
                 rbac:
                   description: RBAC configuration of the Datadog Cluster Agent
                   properties:
@@ -4381,6 +4605,18 @@ spec:
             clusterChecksRunner:
               description: The desired state of the Cluster Checks Runner as a deployment
               properties:
+                additionalAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: AdditionalAnnotations provide annotations that will
+                    be added to the cluster checks runner Pods.
+                  type: object
+                additionalLabels:
+                  additionalProperties:
+                    type: string
+                  description: AdditionalLabels provide labels that will be added
+                    to the cluster checks runner Pods.
+                  type: object
                 affinity:
                   description: If specified, the pod's scheduling constraints
                   properties:
@@ -5049,6 +5285,14 @@ spec:
                     the pod to fit on a node. Selector which must match a node''s
                     labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                   type: object
+                priorityClassName:
+                  description: If specified, indicates the pod's priority. "system-node-critical"
+                    and "system-cluster-critical" are two special keywords which indicate
+                    the highest priorities with the former being the highest priority.
+                    Any other name must be defined by creating a PriorityClass object
+                    with that name. If not specified, the pod priority will be default
+                    or zero if there is no default.
+                  type: string
                 rbac:
                   description: RBAC configuration of the Datadog Cluster Checks Runner
                   properties:

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -100,6 +100,44 @@ type DatadogAgentSpecAgentSpec struct {
 	// Update strategy configuration for the DaemonSet
 	DeploymentStrategy *DaemonSetDeploymentStrategy `json:"deploymentStrategy,omitempty"`
 
+	// AdditionalAnnotations provide annotations that will be added to the Agent Pods.
+	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
+
+	// AdditionalLabels provide labels that will be added to the cluster checks runner Pods.
+	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
+
+	// If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"
+	// are two special keywords which indicate the highest priorities with the former being the highest priority.
+	// Any other name must be defined by creating a PriorityClass object with that name. If not specified,
+	// the pod priority will be default or zero if there is no default.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// Set DNS policy for the pod.
+	// Defaults to "ClusterFirst".
+	// Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+	// DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+	// To have DNS options set along with hostNetwork, you have to specify DNS policy
+	// explicitly to 'ClusterFirstWithHostNet'.
+	// +optional
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty" protobuf:"bytes,6,opt,name=dnsPolicy,casttype=DNSPolicy"`
+	// Specifies the DNS parameters of a pod.
+	// Parameters specified here will be merged to the generated DNS
+	// configuration based on DNSPolicy.
+	// +optional
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+
+	// Host networking requested for this pod. Use the host's network namespace.
+	// If this option is set, the ports that will be used must be specified.
+	// Default to false.
+	// +k8s:conversion-gen=false
+	// +optional
+	HostNetwork bool `json:"hostNetwork,omitempty"`
+	// Use the host's pid namespace.
+	// Optional: Default to false.
+	// +k8s:conversion-gen=false
+	// +optional
+	HostPID bool `json:"hostPID,omitempty"`
+
 	// Trace Agent configuration
 	// +optional
 	Apm APMSpec `json:"apm,omitempty"`
@@ -308,6 +346,11 @@ type SystemProbeSpec struct {
 	// Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
 	// Ref: http://kubernetes.io/docs/user-guide/compute-resources/
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// You can modify the security context used to run the containers by
+	// modifying the label type
+	// +optional
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 }
 
 // ConfigDirSpec contains config file directory configuration
@@ -439,6 +482,18 @@ type DatadogAgentSpecClusterAgentSpec struct {
 	// Number of the Cluster Agent replicas
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// AdditionalAnnotations provide annotations that will be added to the cluster-agent Pods.
+	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
+
+	// AdditionalLabels provide labels that will be added to the cluster checks runner Pods.
+	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
+
+	// If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"
+	// are two special keywords which indicate the highest priorities with the former being the highest priority.
+	// Any other name must be defined by creating a PriorityClass object with that name. If not specified,
+	// the pod priority will be default or zero if there is no default.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// If specified, the pod's scheduling constraints
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
@@ -516,6 +571,18 @@ type DatadogAgentSpecClusterChecksRunnerSpec struct {
 
 	// Number of the Cluster Agent replicas
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// AdditionalAnnotations provide annotations that will be added to the cluster checks runner Pods.
+	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
+
+	// AdditionalLabels provide labels that will be added to the cluster checks runner Pods.
+	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
+
+	// If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"
+	// are two special keywords which indicate the highest priorities with the former being the highest priority.
+	// Any other name must be defined by creating a PriorityClass object with that name. If not specified,
+	// the pod priority will be default or zero if there is no default.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 
 	// If specified, the pod's scheduling constraints
 	// +optional

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -420,6 +420,25 @@ func (in *DatadogAgentSpecAgentSpec) DeepCopyInto(out *DatadogAgentSpecAgentSpec
 		*out = new(DaemonSetDeploymentStrategy)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AdditionalAnnotations != nil {
+		in, out := &in.AdditionalAnnotations, &out.AdditionalAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AdditionalLabels != nil {
+		in, out := &in.AdditionalLabels, &out.AdditionalLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.DNSConfig != nil {
+		in, out := &in.DNSConfig, &out.DNSConfig
+		*out = new(v1.PodDNSConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Apm.DeepCopyInto(&out.Apm)
 	in.Log.DeepCopyInto(&out.Log)
 	in.Process.DeepCopyInto(&out.Process)
@@ -457,6 +476,20 @@ func (in *DatadogAgentSpecClusterAgentSpec) DeepCopyInto(out *DatadogAgentSpecCl
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)
 		**out = **in
+	}
+	if in.AdditionalAnnotations != nil {
+		in, out := &in.AdditionalAnnotations, &out.AdditionalAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AdditionalLabels != nil {
+		in, out := &in.AdditionalLabels, &out.AdditionalLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
@@ -500,6 +533,20 @@ func (in *DatadogAgentSpecClusterChecksRunnerSpec) DeepCopyInto(out *DatadogAgen
 		in, out := &in.Replicas, &out.Replicas
 		*out = new(int32)
 		**out = **in
+	}
+	if in.AdditionalAnnotations != nil {
+		in, out := &in.AdditionalAnnotations, &out.AdditionalAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.AdditionalLabels != nil {
+		in, out := &in.AdditionalLabels, &out.AdditionalLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
@@ -878,6 +925,11 @@ func (in *SystemProbeSpec) DeepCopyInto(out *SystemProbeSpec) {
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -727,6 +727,70 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentSpecAgentSpec(ref common.Ref
 							Ref:         ref("./pkg/apis/datadoghq/v1alpha1.DaemonSetDeploymentStrategy"),
 						},
 					},
+					"additionalAnnotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalAnnotations provide annotations that will be added to the Agent Pods.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"additionalLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalLabels provide labels that will be added to the cluster checks runner Pods.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"priorityClassName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"dnsPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"dnsConfig": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
+							Ref:         ref("k8s.io/api/core/v1.PodDNSConfig"),
+						},
+					},
+					"hostNetwork": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"hostPID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Use the host's pid namespace. Optional: Default to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"apm": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Trace Agent configuration",
@@ -775,7 +839,7 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentSpecAgentSpec(ref common.Ref
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/datadoghq/v1alpha1.APMSpec", "./pkg/apis/datadoghq/v1alpha1.ConfigDirSpec", "./pkg/apis/datadoghq/v1alpha1.DaemonSetDeploymentStrategy", "./pkg/apis/datadoghq/v1alpha1.ImageConfig", "./pkg/apis/datadoghq/v1alpha1.LogSpec", "./pkg/apis/datadoghq/v1alpha1.NodeAgentConfig", "./pkg/apis/datadoghq/v1alpha1.ProcessSpec", "./pkg/apis/datadoghq/v1alpha1.RbacConfig", "./pkg/apis/datadoghq/v1alpha1.SystemProbeSpec"},
+			"./pkg/apis/datadoghq/v1alpha1.APMSpec", "./pkg/apis/datadoghq/v1alpha1.ConfigDirSpec", "./pkg/apis/datadoghq/v1alpha1.DaemonSetDeploymentStrategy", "./pkg/apis/datadoghq/v1alpha1.ImageConfig", "./pkg/apis/datadoghq/v1alpha1.LogSpec", "./pkg/apis/datadoghq/v1alpha1.NodeAgentConfig", "./pkg/apis/datadoghq/v1alpha1.ProcessSpec", "./pkg/apis/datadoghq/v1alpha1.RbacConfig", "./pkg/apis/datadoghq/v1alpha1.SystemProbeSpec", "k8s.io/api/core/v1.PodDNSConfig"},
 	}
 }
 
@@ -816,6 +880,43 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref com
 							Description: "Number of the Cluster Agent replicas",
 							Type:        []string{"integer"},
 							Format:      "int32",
+						},
+					},
+					"additionalAnnotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalAnnotations provide annotations that will be added to the cluster-agent Pods.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"additionalLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalLabels provide labels that will be added to the cluster checks runner Pods.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"priorityClassName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"affinity": {
@@ -903,6 +1004,43 @@ func schema_pkg_apis_datadoghq_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(
 							Description: "Number of the Cluster Agent replicas",
 							Type:        []string{"integer"},
 							Format:      "int32",
+						},
+					},
+					"additionalAnnotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalAnnotations provide annotations that will be added to the cluster checks runner Pods.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"additionalLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AdditionalLabels provide labels that will be added to the cluster checks runner Pods.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"priorityClassName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"affinity": {
@@ -1545,10 +1683,16 @@ func schema_pkg_apis_datadoghq_v1alpha1_SystemProbeSpec(ref common.ReferenceCall
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
+					"securityContext": {
+						SchemaProps: spec.SchemaProps{
+							Description: "You can modify the security context used to run the containers by modifying the label type",
+							Ref:         ref("k8s.io/api/core/v1.SecurityContext"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext"},
 	}
 }

--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -288,9 +288,10 @@ func newClusterAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent,
 					VolumeMounts: agentdeployment.Spec.ClusterAgent.Config.VolumeMounts,
 				},
 			},
-			Affinity:    getPodAffinity(clusterAgentSpec.Affinity, getClusterAgentName(agentdeployment)),
-			Tolerations: clusterAgentSpec.Tolerations,
-			Volumes:     agentdeployment.Spec.ClusterAgent.Config.Volumes,
+			Affinity:          getPodAffinity(clusterAgentSpec.Affinity, getClusterAgentName(agentdeployment)),
+			Tolerations:       clusterAgentSpec.Tolerations,
+			PriorityClassName: agentdeployment.Spec.ClusterAgent.PriorityClassName,
+			Volumes:           agentdeployment.Spec.ClusterAgent.Config.Volumes,
 		},
 	}
 
@@ -299,6 +300,14 @@ func newClusterAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent,
 	}
 
 	for key, val := range annotations {
+		newPodTemplate.Annotations[key] = val
+	}
+
+	for key, val := range agentdeployment.Spec.ClusterAgent.AdditionalLabels {
+		newPodTemplate.Labels[key] = val
+	}
+
+	for key, val := range agentdeployment.Spec.ClusterAgent.AdditionalAnnotations {
 		newPodTemplate.Annotations[key] = val
 	}
 

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -42,6 +42,10 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = agentdeployment.Name
 	labels[datadoghqv1alpha1.AgentDeploymentComponentLabelKey] = "agent"
 
+	for key, val := range agentdeployment.Spec.Agent.AdditionalLabels {
+		labels[key] = val
+	}
+
 	if selector != nil {
 		for key, val := range selector.MatchLabels {
 			labels[key] = val
@@ -52,6 +56,10 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 	if isSystemProbeEnabled(agentdeployment) {
 		annotations["container.apparmor.security.beta.kubernetes.io/system-probe"] = getAppArmorProfileName(&agentdeployment.Spec.Agent.SystemProbe)
 		annotations["container.seccomp.security.alpha.kubernetes.io/system-probe"] = "localhost/system-probe"
+	}
+
+	for key, val := range agentdeployment.Spec.Agent.AdditionalAnnotations {
+		annotations[key] = val
 	}
 
 	containers := []corev1.Container{}
@@ -108,6 +116,11 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 			Containers:         containers,
 			Volumes:            getVolumesForAgent(agentdeployment),
 			Tolerations:        agentdeployment.Spec.Agent.Config.Tolerations,
+			PriorityClassName:  agentdeployment.Spec.Agent.PriorityClassName,
+			HostNetwork:        agentdeployment.Spec.Agent.HostNetwork,
+			HostPID:            agentdeployment.Spec.Agent.HostPID,
+			DNSPolicy:          agentdeployment.Spec.Agent.DNSPolicy,
+			DNSConfig:          agentdeployment.Spec.Agent.DNSConfig,
 		},
 	}, nil
 }
@@ -253,6 +266,9 @@ func getSystemProbeContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Con
 		},
 		Env:          systemProbeEnvVars,
 		VolumeMounts: getVolumeMountsForSystemProbe(),
+	}
+	if agentSpec.SystemProbe.SecurityContext != nil {
+		systemProbe.SecurityContext = agentSpec.SystemProbe.SecurityContext.DeepCopy()
 	}
 	if agentSpec.SystemProbe.Resources != nil {
 		systemProbe.Resources = *agentSpec.SystemProbe.Resources


### PR DESCRIPTION
### What does this PR do?

Add missing fields in `DatadogAgent` CRD,  for `agent`, `cluster-agent`,  `clustercheckrunner` pods

* `AdditionnalAnnotations`
* `AdditionnalLabels`
* `PriorityClassName`

for the Agent configuration:
* `hostNetwork`
* `hostPID`
* `dnsConfig`
* `dnsPolicy`

for `system-probe`: add the possibility to overwrite the default `securityContext`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

