### PR TITLE
Extend DCA and CLC Runners config

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -3157,6 +3157,114 @@ spec:
                         Autodiscovery via Kube Service annotations is automatically
                         enabled'
                       type: boolean
+                    env:
+                      description: 'The Datadog Agent supports many environment variables
+                        Ref: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, metadata.labels,
+                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                  status.hostIP, status.podIP.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    type: string
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
                     logLevel:
                       description: 'Set logging verbosity, valid log levels are: trace,
                         debug, info, warn, error, critical, and off'
@@ -5219,6 +5327,114 @@ spec:
                 config:
                   description: Agent configuration
                   properties:
+                    env:
+                      description: 'The Datadog Agent supports many environment variables
+                        Ref: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, metadata.labels,
+                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                  status.hostIP, status.podIP.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    type: string
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
                     logLevel:
                       description: 'Set logging verbosity, valid log levels are: trace,
                         debug, info, warn, error, critical, and off'
@@ -5243,6 +5459,1311 @@ spec:
                             https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
+                    volumeMounts:
+                      description: Specify additional volume mounts in the Datadog
+                        Cluster Agent container
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive. This field is beta in 1.15.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                    volumes:
+                      description: Specify additional volumes in the Datadog Cluster
+                        Agent container
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'AWSElasticBlockStore represents an AWS Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
+                                type: string
+                              partition:
+                                description: 'The partition in the volume that you
+                                  want to mount. If omitted, the default is to mount
+                                  by volume name. Examples: For volume /dev/sda1,
+                                  you specify the partition as "1". Similarly, the
+                                  volume partition for /dev/sda is "0" (or you can
+                                  leave the property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'Specify "true" to force and set the
+                                  ReadOnly property in VolumeMounts to "true". If
+                                  omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'Unique ID of the persistent disk resource
+                                  in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: AzureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'Host Caching mode: None, Read Only,
+                                  Read Write.'
+                                type: string
+                              diskName:
+                                description: The Name of the data disk in the blob
+                                  storage
+                                type: string
+                              diskURI:
+                                description: The URI the data disk in the blob storage
+                                type: string
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'Expected values Shared: multiple blob
+                                  disks per storage account  Dedicated: single blob
+                                  disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: AzureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: the name of secret that contains Azure
+                                  Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: Share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: CephFS represents a Ceph FS mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'Required: Monitors is a collection of
+                                  Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'Optional: Used as the mounted root,
+                                  rather than the full Ceph tree, default is /'
+                                type: string
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'Optional: SecretFile is the path to
+                                  key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'Optional: SecretRef is reference to
+                                  the authentication secret for User, default is empty.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'Optional: User is the rados user name,
+                                  default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: 'Cinder represents a cinder volume attached
+                              and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'Filesystem type to mount. Must be a
+                                  filesystem type supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'Optional: points to a secret object
+                                  containing parameters used to connect to OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              volumeID:
+                                description: 'volume id used to identify the volume
+                                  in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: ConfigMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a value between 0 and
+                                  0777. Defaults to 0644. Directories within the path
+                                  are not affected by this setting. This might be
+                                  in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will
+                                  be projected into the volume as a file whose name
+                                  is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits to use on
+                                        this file, must be a value between 0 and 0777.
+                                        If not specified, the volume defaultMode will
+                                        be used. This might be in conflict with other
+                                        options that affect the file mode, like fsGroup,
+                                        and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  keys must be defined
+                                type: boolean
+                            type: object
+                          csi:
+                            description: CSI (Container Storage Interface) represents
+                              storage that is handled by an external CSI driver (Alpha
+                              feature).
+                            properties:
+                              driver:
+                                description: Driver is the name of the CSI driver
+                                  that handles this volume. Consult with your admin
+                                  for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: Filesystem type to mount. Ex. "ext4",
+                                  "xfs", "ntfs". If not provided, the empty value
+                                  is passed to the associated CSI driver which will
+                                  determine the default filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: NodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all
+                                  secret references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              readOnly:
+                                description: Specifies a read-only configuration for
+                                  the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: VolumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: DownwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a value between 0 and
+                                  0777. Defaults to 0644. Directories within the path
+                                  are not affected by this setting. This might be
+                                  in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits to use on
+                                        this file, must be a value between 0 and 0777.
+                                        If not specified, the volume defaultMode will
+                                        be used. This might be in conflict with other
+                                        options that affect the file mode, like fsGroup,
+                                        and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          type: string
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'EmptyDir represents a temporary directory
+                              that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'What type of storage medium should back
+                                  this directory. The default is "" which means to
+                                  use the node''s default medium. Must be an empty
+                                  string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                description: 'Total amount of local storage required
+                                  for this EmptyDir volume. The size limit is also
+                                  applicable for memory medium. The maximum usage
+                                  on memory medium EmptyDir would be the minimum value
+                                  between the SizeLimit specified here and the sum
+                                  of memory limits of all containers in a pod. The
+                                  default is nil which means that the limit is undefined.
+                                  More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                type: string
+                            type: object
+                          fc:
+                            description: FC represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: 'Filesystem type to mount. Must be a
+                                  filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified. TODO: how do we prevent
+                                  errors in the filesystem from compromising the machine'
+                                type: string
+                              lun:
+                                description: 'Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'Optional: FC target worldwide names
+                                  (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'Optional: FC volume world wide identifiers
+                                  (wwids) Either wwids or combination of targetWWNs
+                                  and lun must be set, but not both simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: FlexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: Driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". The default filesystem depends
+                                  on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'Optional: Extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'Optional: Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'Optional: SecretRef is reference to
+                                  the secret object containing sensitive information
+                                  to pass to the plugin scripts. This may be empty
+                                  if no secret object is specified. If the secret
+                                  object contains more than one secret, all secrets
+                                  are passed to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: Flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
+                            properties:
+                              datasetName:
+                                description: Name of the dataset stored as metadata
+                                  -> name on the dataset for Flocker should be considered
+                                  as deprecated
+                                type: string
+                              datasetUUID:
+                                description: UUID of the dataset. This is unique identifier
+                                  of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'GCEPersistentDisk represents a GCE Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
+                                type: string
+                              partition:
+                                description: 'The partition in the volume that you
+                                  want to mount. If omitted, the default is to mount
+                                  by volume name. Examples: For volume /dev/sda1,
+                                  you specify the partition as "1". Similarly, the
+                                  volume partition for /dev/sda is "0" (or you can
+                                  leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'Unique name of the PD resource in GCE.
+                                  Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: 'GitRepo represents a git repository at a
+                              particular revision. DEPRECATED: GitRepo is deprecated.
+                              To provision a container with a git repo, mount an EmptyDir
+                              into an InitContainer that clones the repo using git,
+                              then mount the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: Target directory name. Must not contain
+                                  or start with '..'.  If '.' is supplied, the volume
+                                  directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: Repository URL
+                                type: string
+                              revision:
+                                description: Commit hash for the specified revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: 'Glusterfs represents a Glusterfs mount on
+                              the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'EndpointsName is the endpoint name that
+                                  details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'Path is the Glusterfs volume path. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the Glusterfs
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: 'HostPath represents a pre-existing file
+                              or directory on the host machine that is directly exposed
+                              to the container. This is generally used for system
+                              agents or other privileged things that are allowed to
+                              see the host machine. Most containers will NOT need
+                              this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              --- TODO(jonesdl) We need to restrict who can use host
+                              directory mounts and who can/can not mount host directories
+                              as read/write.'
+                            properties:
+                              path:
+                                description: 'Path of the directory on the host. If
+                                  the path is a symlink, it will follow the link to
+                                  the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'Type for HostPath Volume Defaults to
+                                  "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            description: 'ISCSI represents an ISCSI Disk resource
+                              that is attached to a kubelet''s host machine and then
+                              exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: whether support iSCSI Discovery CHAP
+                                  authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: whether support iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
+                                type: string
+                              initiatorName:
+                                description: Custom iSCSI Initiator Name. If initiatorName
+                                  is specified with iscsiInterface simultaneously,
+                                  new iSCSI interface <target portal>:<volume name>
+                                  will be created for the connection.
+                                type: string
+                              iqn:
+                                description: Target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iSCSI Interface Name that uses an iSCSI
+                                  transport. Defaults to 'default' (tcp).
+                                type: string
+                              lun:
+                                description: iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: iSCSI Target Portal List. The portal
+                                  is either an IP or ip_addr:port if the port is other
+                                  than default (typically TCP ports 860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: CHAP Secret for iSCSI target and initiator
+                                  authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              targetPortal:
+                                description: iSCSI Target Portal. The Portal is either
+                                  an IP or ip_addr:port if the port is other than
+                                  default (typically TCP ports 860 and 3260).
+                                type: string
+                            required:
+                            - iqn
+                            - lun
+                            - targetPortal
+                            type: object
+                          name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and
+                              unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'NFS represents an NFS mount on the host
+                              that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'Path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the NFS export
+                                  to be mounted with read-only permissions. Defaults
+                                  to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'Server is the hostname or IP address
+                                  of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                            - path
+                            - server
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'PersistentVolumeClaimVolumeSource represents
+                              a reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: PhotonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: ID that identifies Photon Controller
+                                  persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: PortworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: FSType represents the filesystem type
+                                  to mount Must be a filesystem type supported by
+                                  the host operating system. Ex. "ext4", "xfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: VolumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: Items for all in one resources secrets, configmaps,
+                              and downward API
+                            properties:
+                              defaultMode:
+                                description: Mode bits to use on created files by
+                                  default. Must be a value between 0 and 0777. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: list of volume projections
+                                items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: information about the configMap
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: If unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed
+                                            keys will be projected into the specified
+                                            paths, and unlisted keys will not be present.
+                                            If a key is specified which is not present
+                                            in the ConfigMap, the volume setup will
+                                            error unless it is marked optional. Paths
+                                            must be relative and may not contain the
+                                            '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  to use on this file, must be a value
+                                                  between 0 and 0777. If not specified,
+                                                  the volume defaultMode will be used.
+                                                  This might be in conflict with other
+                                                  options that affect the file mode,
+                                                  like fsGroup, and the result can
+                                                  be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of
+                                                  the file to map the key to. May
+                                                  not be an absolute path. May not
+                                                  contain the path element '..'. May
+                                                  not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      description: information about the downwardAPI
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  to use on this file, must be a value
+                                                  between 0 and 0777. If not specified,
+                                                  the volume defaultMode will be used.
+                                                  This might be in conflict with other
+                                                  options that affect the file mode,
+                                                  like fsGroup, and the result can
+                                                  be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    type: string
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: information about the secret data
+                                        to project
+                                      properties:
+                                        items:
+                                          description: If unspecified, each key-value
+                                            pair in the Data field of the referenced
+                                            Secret will be projected into the volume
+                                            as a file whose name is the key and content
+                                            is the value. If specified, the listed
+                                            keys will be projected into the specified
+                                            paths, and unlisted keys will not be present.
+                                            If a key is specified which is not present
+                                            in the Secret, the volume setup will error
+                                            unless it is marked optional. Paths must
+                                            be relative and may not contain the '..'
+                                            path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: The key to project.
+                                                type: string
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  to use on this file, must be a value
+                                                  between 0 and 0777. If not specified,
+                                                  the volume defaultMode will be used.
+                                                  This might be in conflict with other
+                                                  options that affect the file mode,
+                                                  like fsGroup, and the result can
+                                                  be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: The relative path of
+                                                  the file to map the key to. May
+                                                  not be an absolute path. May not
+                                                  contain the path element '..'. May
+                                                  not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      description: information about the serviceAccountToken
+                                        data to project
+                                      properties:
+                                        audience:
+                                          description: Audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience
+                                            defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: ExpirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The
+                                            kubelet will start trying to rotate the
+                                            token if the token is older than 80 percent
+                                            of its time to live or if the token is
+                                            older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: Path is the path relative to
+                                            the mount point of the file to project
+                                            the token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            required:
+                            - sources
+                            type: object
+                          quobyte:
+                            description: Quobyte represents a Quobyte mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: Group to map volume access to Default
+                                  is no group
+                                type: string
+                              readOnly:
+                                description: ReadOnly here will force the Quobyte
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: Registry represents a single or multiple
+                                  Quobyte Registry services specified as a string
+                                  as host:port pair (multiple entries are separated
+                                  with commas) which acts as the central registry
+                                  for volumes
+                                type: string
+                              tenant:
+                                description: Tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned
+                                  Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: User to map volume access to Defaults
+                                  to serivceaccount user
+                                type: string
+                              volume:
+                                description: Volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: 'RBD represents a Rados Block Device mount
+                              on the host that shares a pod''s lifetime. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'Filesystem type of the volume that you
+                                  want to mount. Tip: Ensure that the filesystem type
+                                  is supported by the host operating system. Examples:
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  TODO: how do we prevent errors in the filesystem
+                                  from compromising the machine'
+                                type: string
+                              image:
+                                description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'Keyring is the path to key ring for
+                                  RBDUser. Default is /etc/ceph/keyring. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'A collection of Ceph monitors. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'The rados pool name. Default is rbd.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'SecretRef is name of the authentication
+                                  secret for RBDUser. If provided overrides keyring.
+                                  Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'The rados user name. Default is admin.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - image
+                            - monitors
+                            type: object
+                          scaleIO:
+                            description: ScaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Default is "xfs".
+                                type: string
+                              gateway:
+                                description: The host address of the ScaleIO API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: The name of the ScaleIO Protection Domain
+                                  for the configured storage.
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: SecretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If
+                                  this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                description: Flag to enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: Indicates whether the storage for a volume
+                                  should be ThickProvisioned or ThinProvisioned. Default
+                                  is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: The ScaleIO Storage Pool associated with
+                                  the protection domain.
+                                type: string
+                              system:
+                                description: The name of the storage system as configured
+                                  in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: The name of a volume already created
+                                  in the ScaleIO system that is associated with this
+                                  volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - secretRef
+                            - system
+                            type: object
+                          secret:
+                            description: 'Secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a value between 0 and
+                                  0777. Defaults to 0644. Directories within the path
+                                  are not affected by this setting. This might be
+                                  in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: The key to project.
+                                      type: string
+                                    mode:
+                                      description: 'Optional: mode bits to use on
+                                        this file, must be a value between 0 and 0777.
+                                        If not specified, the volume defaultMode will
+                                        be used. This might be in conflict with other
+                                        options that affect the file mode, like fsGroup,
+                                        and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May
+                                        not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: Specify whether the Secret or its keys
+                                  must be defined
+                                type: boolean
+                              secretName:
+                                description: 'Name of the secret in the pod''s namespace
+                                  to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: StorageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: Defaults to false (read/write). ReadOnly
+                                  here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: SecretRef specifies the secret to use
+                                  for obtaining the StorageOS API credentials.  If
+                                  not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              volumeName:
+                                description: VolumeName is the human-readable name
+                                  of the StorageOS volume.  Volume names are only
+                                  unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: VolumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is
+                                  specified then the Pod's namespace will be used.  This
+                                  allows the Kubernetes name scoping to be mirrored
+                                  within StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: VsphereVolume represents a vSphere volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: Filesystem type to mount. Must be a filesystem
+                                  type supported by the host operating system. Ex.
+                                  "ext4", "xfs", "ntfs". Implicitly inferred to be
+                                  "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: Storage Policy Based Management (SPBM)
+                                  profile ID associated with the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: Storage Policy Based Management (SPBM)
+                                  profile name.
+                                type: string
+                              volumePath:
+                                description: Path that identifies vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
                   type: object
                 deploymentName:
                   description: Name of the cluster checks deployment to create or

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -56,6 +56,8 @@ const (
 	DDMetricsProviderPort           = "DD_EXTERNAL_METRICS_PROVIDER_PORT"
 	DDAppKey                        = "DD_APP_KEY"
 	DDClusterChecksRunnerEnabled    = "DD_CLUSTER_CHECKS_ENABLED"
+	DDClcRunnerEnabled              = "DD_CLC_RUNNER_ENABLED"
+	DDClcRunnerHost                 = "DD_CLC_RUNNER_HOST"
 	DDExtraConfigProviders          = "DD_EXTRA_CONFIG_PROVIDERS"
 	DDExtraListeners                = "DD_EXTRA_LISTENERS"
 	DDHostname                      = "DD_HOSTNAME"

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -532,6 +532,13 @@ type ClusterAgentConfig struct {
 	// Datadog cluster-agent resource requests and limits
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// The Datadog Agent supports many environment variables
+	// Ref: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables
+	//
+	// +optional
+	// +listType=set
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
 	// Specify additional volume mounts in the Datadog Cluster Agent container
 	// +optional
 	// +listType=set
@@ -548,9 +555,27 @@ type ClusterAgentConfig struct {
 type ClusterChecksRunnerConfig struct {
 	// Datadog Cluster Checks Runner resource requests and limits
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
 	// Set logging verbosity, valid log levels are:
 	// trace, debug, info, warn, error, critical, and off
 	LogLevel *string `json:"logLevel,omitempty"`
+
+	// The Datadog Agent supports many environment variables
+	// Ref: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables
+	//
+	// +optional
+	// +listType=set
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// Specify additional volume mounts in the Datadog Cluster Agent container
+	// +optional
+	// +listType=set
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+
+	// Specify additional volumes in the Datadog Cluster Agent container
+	// +optional
+	// +listType=set
+	Volumes []corev1.Volume `json:"volumes,omitempty"`
 }
 
 // DatadogAgentSpecClusterChecksRunnerSpec defines the desired state of the Cluster Checks Runner

--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -26,29 +26,33 @@ var (
 
 // NewDatadogAgentOptions set of option for the DatadogAgent creation
 type NewDatadogAgentOptions struct {
-	Labels                     map[string]string
-	Annotations                map[string]string
-	Status                     *datadoghqv1alpha1.DatadogAgentStatus
-	UseEDS                     bool
-	ClusterAgentEnabled        bool
-	MetricsServerEnabled       bool
-	MetricsServerPort          int32
-	ClusterChecksRunnerEnabled bool
-	NodeAgentConfig            *datadoghqv1alpha1.NodeAgentConfig
-	APMEnabled                 bool
-	ProcessEnabled             bool
-	SystemProbeEnabled         bool
-	Creds                      *datadoghqv1alpha1.AgentCredentials
-	ClusterName                *string
-	Confd                      *datadoghqv1alpha1.ConfigDirSpec
-	Checksd                    *datadoghqv1alpha1.ConfigDirSpec
-	Volumes                    []corev1.Volume
-	VolumeMounts               []corev1.VolumeMount
-	ClusterAgentVolumes        []corev1.Volume
-	ClusterAgentVolumeMounts   []corev1.VolumeMount
-	CustomConfig               string
-	AgentDaemonsetName         string
-	ClusterAgentDeploymentName string
+	Labels                          map[string]string
+	Annotations                     map[string]string
+	Status                          *datadoghqv1alpha1.DatadogAgentStatus
+	UseEDS                          bool
+	ClusterAgentEnabled             bool
+	MetricsServerEnabled            bool
+	MetricsServerPort               int32
+	ClusterChecksRunnerEnabled      bool
+	NodeAgentConfig                 *datadoghqv1alpha1.NodeAgentConfig
+	APMEnabled                      bool
+	ProcessEnabled                  bool
+	SystemProbeEnabled              bool
+	Creds                           *datadoghqv1alpha1.AgentCredentials
+	ClusterName                     *string
+	Confd                           *datadoghqv1alpha1.ConfigDirSpec
+	Checksd                         *datadoghqv1alpha1.ConfigDirSpec
+	Volumes                         []corev1.Volume
+	VolumeMounts                    []corev1.VolumeMount
+	ClusterAgentVolumes             []corev1.Volume
+	ClusterAgentVolumeMounts        []corev1.VolumeMount
+	ClusterAgentEnvVars             []corev1.EnvVar
+	CustomConfig                    string
+	AgentDaemonsetName              string
+	ClusterAgentDeploymentName      string
+	ClusterChecksRunnerVolumes      []corev1.Volume
+	ClusterChecksRunnerVolumeMounts []corev1.VolumeMount
+	ClusterChecksRunnerEnvVars      []corev1.EnvVar
 }
 
 // NewDefaultedDatadogAgent returns an initialized and defaulted DatadogAgent for testing purpose
@@ -131,6 +135,27 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			}
 			if len(options.ClusterAgentVolumeMounts) != 0 {
 				ad.Spec.ClusterAgent.Config.VolumeMounts = options.ClusterAgentVolumeMounts
+			}
+			if len(options.ClusterAgentEnvVars) != 0 {
+				ad.Spec.ClusterAgent.Config.Env = options.ClusterAgentEnvVars
+			}
+		}
+
+		if options.ClusterChecksRunnerEnabled {
+			ad.Spec.ClusterChecksRunner = &datadoghqv1alpha1.DatadogAgentSpecClusterChecksRunnerSpec{
+				Config: datadoghqv1alpha1.ClusterChecksRunnerConfig{},
+				Rbac: datadoghqv1alpha1.RbacConfig{
+					Create: datadoghqv1alpha1.NewBoolPointer(true),
+				},
+			}
+			if len(options.ClusterChecksRunnerEnvVars) != 0 {
+				ad.Spec.ClusterChecksRunner.Config.Env = options.ClusterChecksRunnerEnvVars
+			}
+			if len(options.ClusterChecksRunnerVolumes) != 0 {
+				ad.Spec.ClusterChecksRunner.Config.VolumeMounts = options.ClusterChecksRunnerVolumeMounts
+			}
+			if len(options.ClusterChecksRunnerVolumes) != 0 {
+				ad.Spec.ClusterChecksRunner.Config.Volumes = options.ClusterChecksRunnerVolumes
 			}
 		}
 

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -131,6 +131,13 @@ func (in *ClusterAgentConfig) DeepCopyInto(out *ClusterAgentConfig) {
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
 		*out = make([]v1.VolumeMount, len(*in))
@@ -170,6 +177,27 @@ func (in *ClusterChecksRunnerConfig) DeepCopyInto(out *ClusterChecksRunnerConfig
 		in, out := &in.LogLevel, &out.LogLevel
 		*out = new(string)
 		**out = **in
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -222,6 +222,24 @@ func schema_pkg_apis_datadoghq_v1alpha1_ClusterAgentConfig(ref common.ReferenceC
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
+					"env": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "The Datadog Agent supports many environment variables Ref: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+									},
+								},
+							},
+						},
+					},
 					"volumeMounts": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -262,7 +280,7 @@ func schema_pkg_apis_datadoghq_v1alpha1_ClusterAgentConfig(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -286,11 +304,65 @@ func schema_pkg_apis_datadoghq_v1alpha1_ClusterChecksRunnerConfig(ref common.Ref
 							Format:      "",
 						},
 					},
+					"env": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "The Datadog Agent supports many environment variables Ref: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+									},
+								},
+							},
+						},
+					},
+					"volumeMounts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify additional volume mounts in the Datadog Cluster Agent container",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
+									},
+								},
+							},
+						},
+					},
+					"volumes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify additional volumes in the Datadog Cluster Agent container",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.Volume"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ResourceRequirements"},
+			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 

--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -432,7 +432,7 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 			},
 		}...)
 	}
-	return append(envVars, spec.Agent.Config.Env...)
+	return append(envVars, spec.ClusterAgent.Config.Env...)
 }
 
 func getClusterAgentName(dda *datadoghqv1alpha1.DatadogAgent) string {

--- a/pkg/controller/datadogagent/clusteragent_test.go
+++ b/pkg/controller/datadogagent/clusteragent_test.go
@@ -298,6 +298,81 @@ func Test_newClusterAgentDeploymentFromInstance_UserVolumes(t *testing.T) {
 	test.Run(t)
 }
 
+func Test_newClusterAgentDeploymentFromInstance_EnvVars(t *testing.T) {
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "ExtraEnvVar",
+			Value: "ExtraEnvVarValue",
+		},
+		{
+			Name: "ExtraEnvVarFromSpec",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.podIP",
+				},
+			},
+		},
+	}
+	podSpec := clusterAgentDefaultPodSpec()
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, envVars...)
+
+	envVarsAgentDeployment := test.NewDefaultedDatadogAgent(
+		"bar",
+		"foo",
+		&test.NewDatadogAgentOptions{
+			ClusterAgentEnabled: true,
+			ClusterAgentEnvVars: envVars,
+		},
+	)
+	envVarsClusterAgentHash, _ := comparison.GenerateMD5ForSpec(envVarsAgentDeployment.Spec.ClusterAgent)
+
+	test := clusterAgentDeploymentFromInstanceTest{
+		name:            "with extra env vars",
+		agentdeployment: envVarsAgentDeployment,
+		newStatus:       &datadoghqv1alpha1.DatadogAgentStatus{},
+		wantErr:         false,
+		want: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "bar",
+				Name:      "foo-cluster-agent",
+				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					"agent.datadoghq.com/component": "cluster-agent",
+					"app.kubernetes.io/instance":    "cluster-agent",
+					"app.kubernetes.io/managed-by":  "datadog-operator",
+					"app.kubernetes.io/name":        "datadog-agent-deployment",
+					"app.kubernetes.io/part-of":     "foo",
+					"app.kubernetes.io/version":     "",
+				},
+				Annotations: map[string]string{"agent.datadoghq.com/agentspechash": envVarsClusterAgentHash},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"agent.datadoghq.com/name":      "foo",
+							"agent.datadoghq.com/component": "cluster-agent",
+							"app.kubernetes.io/instance":    "cluster-agent",
+							"app.kubernetes.io/managed-by":  "datadog-operator",
+							"app.kubernetes.io/name":        "datadog-agent-deployment",
+							"app.kubernetes.io/part-of":     "foo",
+							"app.kubernetes.io/version":     "",
+						},
+					},
+					Spec: podSpec,
+				},
+				Replicas: &testClusterAgentReplicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
+						"agent.datadoghq.com/component": "cluster-agent",
+					},
+				},
+			},
+		},
+	}
+	test.Run(t)
+}
+
 func Test_newClusterAgentDeploymentFromInstance_CustomDeploymentName(t *testing.T) {
 	customDeploymentName := "custom-cluster-agent-deployment"
 	deploymentNamePodSpec := clusterAgentDefaultPodSpec()

--- a/pkg/controller/datadogagent/clusterchecksrunner.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner.go
@@ -74,17 +74,17 @@ func needClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	return false
 }
 
-func (r *ReconcileDatadogAgent) createNewClusterChecksRunnerDeployment(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	newDCAW, hash, err := newClusterChecksRunnerDeploymentFromInstance(agentdeployment, nil)
+func (r *ReconcileDatadogAgent) createNewClusterChecksRunnerDeployment(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+	newDCAW, hash, err := newClusterChecksRunnerDeploymentFromInstance(dda, nil)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Set ClusterChecksRunner Deployment instance as the owner and controller
-	if err = controllerutil.SetControllerReference(agentdeployment, newDCAW, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(dda, newDCAW, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
-	logger.Info("Creating a new Cluster Checks Runner Deployment", "deployment.Namespace", newDCAW.Namespace, "deployment.Name", newDCAW.Name, "agentdeployment.Status.ClusterAgent.CurrentHash", hash)
+	logger.Info("Creating a new Cluster Checks Runner Deployment", "deployment.Namespace", newDCAW.Namespace, "deployment.Name", newDCAW.Name, "agentdeployment.Status.ClusterChecksRunner.CurrentHash", hash)
 	newStatus.ClusterChecksRunner = &datadoghqv1alpha1.DeploymentStatus{}
 	err = r.client.Create(context.TODO(), newDCAW)
 	now := metav1.NewTime(time.Now())
@@ -95,7 +95,7 @@ func (r *ReconcileDatadogAgent) createNewClusterChecksRunnerDeployment(logger lo
 
 	updateStatusWithClusterChecksRunner(newDCAW, newStatus, &now)
 	event := buildEventInfo(newDCAW.Name, newDCAW.Namespace, deploymentKind, datadog.CreationEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	return reconcile.Result{}, nil
 }
 
@@ -103,8 +103,8 @@ func updateStatusWithClusterChecksRunner(dcaw *appsv1.Deployment, newStatus *dat
 	newStatus.ClusterChecksRunner = updateDeploymentStatus(dcaw, newStatus.ClusterChecksRunner, updateTime)
 }
 
-func (r *ReconcileDatadogAgent) updateClusterChecksRunnerDeployment(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, dep *appsv1.Deployment, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	newDCAW, hash, err := newClusterChecksRunnerDeploymentFromInstance(agentdeployment, dep.Spec.Selector)
+func (r *ReconcileDatadogAgent) updateClusterChecksRunnerDeployment(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, dep *appsv1.Deployment, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+	newDCAW, hash, err := newClusterChecksRunnerDeploymentFromInstance(dda, dep.Spec.Selector)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -123,7 +123,7 @@ func (r *ReconcileDatadogAgent) updateClusterChecksRunnerDeployment(logger logr.
 	logger.Info("update Cluster Checks Runner deployment", "name", dep.Name, "namespace", dep.Namespace)
 
 	// Set DatadogAgent instance  instance as the owner and controller
-	if err = controllerutil.SetControllerReference(agentdeployment, dep, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(dda, dep, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 	logger.Info("Updating an existing Cluster Checks Runner Deployment", "deployment.Namespace", newDCAW.Namespace, "deployment.Name", newDCAW.Name, "currentHash", hash)
@@ -144,23 +144,23 @@ func (r *ReconcileDatadogAgent) updateClusterChecksRunnerDeployment(logger logr.
 		return reconcile.Result{}, err
 	}
 	event := buildEventInfo(updateDca.Name, updateDca.Namespace, deploymentKind, datadog.UpdateEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	updateStatusWithClusterChecksRunner(updateDca, newStatus, &now)
 	return reconcile.Result{}, nil
 }
 
-// newClusterAgentDeploymentFromInstance creates a Cluster Agent Deployment from a given DatadogAgent
+// newClusterChecksRunnerDeploymentFromInstance creates a Cluster Agent Deployment from a given DatadogAgent
 func newClusterChecksRunnerDeploymentFromInstance(
-	agentdeployment *datadoghqv1alpha1.DatadogAgent,
+	dda *datadoghqv1alpha1.DatadogAgent,
 	selector *metav1.LabelSelector) (*appsv1.Deployment, string, error) {
 	labels := map[string]string{
-		datadoghqv1alpha1.AgentDeploymentNameLabelKey:      agentdeployment.Name,
+		datadoghqv1alpha1.AgentDeploymentNameLabelKey:      dda.Name,
 		datadoghqv1alpha1.AgentDeploymentComponentLabelKey: datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix,
 	}
-	for key, val := range agentdeployment.Labels {
+	for key, val := range dda.Labels {
 		labels[key] = val
 	}
-	for key, val := range getDefaultLabels(agentdeployment, datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix, getClusterChecksRunnerVersion(agentdeployment)) {
+	for key, val := range getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix, getClusterChecksRunnerVersion(dda)) {
 		labels[key] = val
 	}
 
@@ -171,31 +171,31 @@ func newClusterChecksRunnerDeploymentFromInstance(
 	} else {
 		selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				datadoghqv1alpha1.AgentDeploymentNameLabelKey:      agentdeployment.Name,
+				datadoghqv1alpha1.AgentDeploymentNameLabelKey:      dda.Name,
 				datadoghqv1alpha1.AgentDeploymentComponentLabelKey: datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix,
 			},
 		}
 	}
 
 	annotations := map[string]string{}
-	for key, val := range agentdeployment.Annotations {
+	for key, val := range dda.Annotations {
 		annotations[key] = val
 	}
 
 	dca := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        getClusterChecksRunnerName(agentdeployment),
-			Namespace:   agentdeployment.Namespace,
+			Name:        getClusterChecksRunnerName(dda),
+			Namespace:   dda.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Template: newClusterChecksRunnerPodTemplate(agentdeployment, labels, annotations),
-			Replicas: agentdeployment.Spec.ClusterChecksRunner.Replicas,
+			Template: newClusterChecksRunnerPodTemplate(dda, labels, annotations),
+			Replicas: dda.Spec.ClusterChecksRunner.Replicas,
 			Selector: selector,
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&dca.ObjectMeta, agentdeployment.Spec.ClusterAgent)
+	hash, err := comparison.SetMD5GenerationAnnotation(&dca.ObjectMeta, dda.Spec.ClusterChecksRunner)
 	return dca, hash, err
 }
 
@@ -235,9 +235,9 @@ func (r *ReconcileDatadogAgent) cleanupClusterChecksRunner(logger logr.Logger, d
 }
 
 // newClusterChecksRunnerPodTemplate generates a PodTemplate from a DatadogClusterChecksRunnerDeployment spec
-func newClusterChecksRunnerPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, labels, annotations map[string]string) corev1.PodTemplateSpec {
+func newClusterChecksRunnerPodTemplate(dda *datadoghqv1alpha1.DatadogAgent, labels, annotations map[string]string) corev1.PodTemplateSpec {
 	// copy Spec to configure the Cluster Checks Runner Pod Template
-	clusterChecksRunnerSpec := agentdeployment.Spec.ClusterChecksRunner.DeepCopy()
+	clusterChecksRunnerSpec := dda.Spec.ClusterChecksRunner.DeepCopy()
 
 	newPodTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -245,41 +245,19 @@ func newClusterChecksRunnerPodTemplate(agentdeployment *datadoghqv1alpha1.Datado
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: getClusterChecksRunnerServiceAccount(agentdeployment),
+			ServiceAccountName: getClusterChecksRunnerServiceAccount(dda),
 			Containers: []corev1.Container{
 				{
 					Name:            "cluster-checks-runner",
 					Image:           clusterChecksRunnerSpec.Image.Name,
 					ImagePullPolicy: *clusterChecksRunnerSpec.Image.PullPolicy,
-					Env:             getEnvVarsForClusterChecksRunner(agentdeployment),
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "s6-run",
-							MountPath: "/var/run/s6",
-						},
-						{
-							Name:      "remove-corechecks",
-							MountPath: fmt.Sprintf("%s/%s", datadoghqv1alpha1.ConfigVolumePath, "conf.d"),
-						},
-					},
-					LivenessProbe: getDefaultLivenessProbe(),
+					Env:             getEnvVarsForClusterChecksRunner(dda),
+					VolumeMounts:    getVolumeMountsForClusterChecksRunner(dda),
+					LivenessProbe:   getDefaultLivenessProbe(),
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "s6-run",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-				{
-					Name: "remove-corechecks",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-			},
-			Affinity:          getPodAffinity(clusterChecksRunnerSpec.Affinity, getClusterChecksRunnerName(agentdeployment)),
+			Volumes:           getVolumesForClusterChecksRunner(dda),
+			Affinity:          getPodAffinity(clusterChecksRunnerSpec.Affinity, getClusterChecksRunnerName(dda)),
 			Tolerations:       clusterChecksRunnerSpec.Tolerations,
 			PriorityClassName: clusterChecksRunnerSpec.PriorityClassName,
 		},
@@ -352,6 +330,18 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 			Name:  datadoghqv1alpha1.DDEnableMetadataCollection,
 			Value: "false",
 		},
+		{
+			Name:  datadoghqv1alpha1.DDClcRunnerEnabled,
+			Value: "true",
+		},
+		{
+			Name: datadoghqv1alpha1.DDClcRunnerHost,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: FieldPathStatusPodIP,
+				},
+			},
+		},
 	}
 
 	if spec.ClusterChecksRunner.Config.LogLevel != nil {
@@ -373,7 +363,7 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 		})
 	}
 
-	return append(envVars, spec.Agent.Config.Env...)
+	return append(envVars, spec.ClusterChecksRunner.Config.Env...)
 }
 
 func getClusterChecksRunnerVersion(dda *datadoghqv1alpha1.DatadogAgent) string {
@@ -386,4 +376,38 @@ func getClusterChecksRunnerName(dda *datadoghqv1alpha1.DatadogAgent) string {
 		return dda.Spec.ClusterChecksRunner.DeploymentName
 	}
 	return fmt.Sprintf("%s-%s", dda.Name, "cluster-checks-runner")
+}
+
+// getVolumesForClusterChecksRunner defines volumes for the Cluster Checks Runner
+func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
+	volumes := []corev1.Volume{
+		{
+			Name: "s6-run",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: "remove-corechecks",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	return append(volumes, dda.Spec.ClusterChecksRunner.Config.Volumes...)
+}
+
+// getVolumeMountsForClusterChecksRunner defines volume mounts for the Cluster Checks Runner
+func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "s6-run",
+			MountPath: "/var/run/s6",
+		},
+		{
+			Name:      "remove-corechecks",
+			MountPath: fmt.Sprintf("%s/%s", datadoghqv1alpha1.ConfigVolumePath, "conf.d"),
+		},
+	}
+	return append(volumeMounts, dda.Spec.ClusterChecksRunner.Config.VolumeMounts...)
 }

--- a/pkg/controller/datadogagent/clusterchecksrunner_test.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner_test.go
@@ -1,0 +1,328 @@
+package datadogagent
+
+import (
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
+	test "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1/test"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/google/go-cmp/cmp"
+	assert "github.com/stretchr/testify/require"
+)
+
+var testClusterChecksRunnerReplicas int32 = 2
+
+func clusterChecksRunnerDefaultPodSpec() corev1.PodSpec {
+	return corev1.PodSpec{
+		Affinity:           getPodAffinity(nil, "foo-cluster-checks-runner"),
+		ServiceAccountName: "foo-cluster-checks-runner",
+		Containers: []corev1.Container{
+			{
+				Name:            "cluster-checks-runner",
+				Image:           "datadog/agent:latest",
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Resources:       corev1.ResourceRequirements{},
+				Env:             clusterChecksRunnerDefaultEnvVars(),
+				VolumeMounts:    clusterChecksRunnerDefaultVolumeMounts(),
+				LivenessProbe:   getDefaultLivenessProbe(),
+			},
+		},
+		Volumes: clusterChecksRunnerDefaultVolumes(),
+	}
+}
+
+func clusterChecksRunnerDefaultVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "s6-run",
+			MountPath: "/var/run/s6",
+		},
+		{
+			Name:      "remove-corechecks",
+			MountPath: fmt.Sprintf("%s/%s", datadoghqv1alpha1.ConfigVolumePath, "conf.d"),
+		},
+	}
+}
+
+func clusterChecksRunnerDefaultVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: "s6-run",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: "remove-corechecks",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+}
+
+func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "DD_CLUSTER_NAME",
+			Value: "",
+		},
+		{
+			Name:  "DD_SITE",
+			Value: "",
+		},
+		{
+			Name:  "DD_DD_URL",
+			Value: "https://app.datadoghq.com",
+		},
+		{
+			Name:  "DD_CLUSTER_CHECKS_ENABLED",
+			Value: "true",
+		},
+		{
+			Name:  "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME",
+			Value: fmt.Sprintf("%s-%s", testDadName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
+		},
+		{
+			Name:      "DD_CLUSTER_AGENT_AUTH_TOKEN",
+			ValueFrom: authTokenValue(),
+		},
+		{
+			Name:  "DD_EXTRA_CONFIG_PROVIDERS",
+			Value: "clusterchecks",
+		},
+		{
+			Name:  "DD_HEALTH_PORT",
+			Value: "5555",
+		},
+		{
+			Name:  "DD_APM_ENABLED",
+			Value: "false",
+		},
+		{
+			Name:  "DD_PROCESS_AGENT_ENABLED",
+			Value: "false",
+		},
+		{
+			Name:  "DD_LOGS_ENABLED",
+			Value: "false",
+		},
+		{
+			Name:  "DD_ENABLE_METADATA_COLLECTION",
+			Value: "false",
+		},
+		{
+			Name:  "DD_CLC_RUNNER_ENABLED",
+			Value: "true",
+		},
+		{
+			Name: "DD_CLC_RUNNER_HOST",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.podIP",
+				},
+			},
+		},
+		{
+			Name:  "DD_API_KEY",
+			Value: "",
+		},
+	}
+}
+
+type clusterChecksRunnerDeploymentFromInstanceTest struct {
+	name            string
+	agentdeployment *datadoghqv1alpha1.DatadogAgent
+	selector        *metav1.LabelSelector
+	newStatus       *datadoghqv1alpha1.DatadogAgentStatus
+	want            *appsv1.Deployment
+	wantErr         bool
+}
+
+func (test clusterChecksRunnerDeploymentFromInstanceTest) Run(t *testing.T) {
+	t.Helper()
+	logf.SetLogger(logf.ZapLogger(true))
+	got, _, err := newClusterChecksRunnerDeploymentFromInstance(test.agentdeployment, test.selector)
+	if test.wantErr {
+		assert.Error(t, err, "newClusterChecksRunnerDeploymentFromInstance() expected an error")
+	} else {
+		assert.NoError(t, err, "newClusterChecksRunnerDeploymentFromInstance() unexpected error: %v", err)
+	}
+	assert.True(t, apiequality.Semantic.DeepEqual(got, test.want), "newClusterChecksRunnerDeploymentFromInstance() = %#v, want %#v\ndiff = %s", got, test.want,
+		cmp.Diff(got, test.want))
+}
+
+type clusterChecksRunnerDeploymentFromInstanceTestSuite []clusterChecksRunnerDeploymentFromInstanceTest
+
+func (tests clusterChecksRunnerDeploymentFromInstanceTestSuite) Run(t *testing.T) {
+	t.Helper()
+	for _, tt := range tests {
+		t.Run(tt.name, tt.Run)
+	}
+}
+
+func Test_newClusterChecksRunnerDeploymentFromInstance_UserVolumes(t *testing.T) {
+	userVolumes := []corev1.Volume{
+		{
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/tmp",
+				},
+			},
+		},
+	}
+	userVolumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "tmp",
+			MountPath: "/some/path",
+			ReadOnly:  true,
+		},
+	}
+	userMountsPodSpec := clusterChecksRunnerDefaultPodSpec()
+	userMountsPodSpec.Volumes = append(userMountsPodSpec.Volumes, userVolumes...)
+	userMountsPodSpec.Containers[0].VolumeMounts = append(userMountsPodSpec.Containers[0].VolumeMounts, userVolumeMounts...)
+
+	envVarsAgentDeployment := test.NewDefaultedDatadogAgent(
+		"bar",
+		"foo",
+		&test.NewDatadogAgentOptions{
+			ClusterAgentEnabled:             true,
+			ClusterChecksRunnerEnabled:      true,
+			ClusterChecksRunnerVolumes:      userVolumes,
+			ClusterChecksRunnerVolumeMounts: userVolumeMounts,
+		},
+	)
+	envVarsClusterChecksRunnerAgentHash, _ := comparison.GenerateMD5ForSpec(envVarsAgentDeployment.Spec.ClusterChecksRunner)
+
+	test := clusterChecksRunnerDeploymentFromInstanceTest{
+		name:            "with user volumes",
+		agentdeployment: envVarsAgentDeployment,
+		newStatus:       &datadoghqv1alpha1.DatadogAgentStatus{},
+		wantErr:         false,
+		want: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "bar",
+				Name:      "foo-cluster-checks-runner",
+				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					"agent.datadoghq.com/component": "cluster-checks-runner",
+					"app.kubernetes.io/instance":    "cluster-checks-runner",
+					"app.kubernetes.io/managed-by":  "datadog-operator",
+					"app.kubernetes.io/name":        "datadog-agent-deployment",
+					"app.kubernetes.io/part-of":     "foo",
+					"app.kubernetes.io/version":     "",
+				},
+				Annotations: map[string]string{"agent.datadoghq.com/agentspechash": envVarsClusterChecksRunnerAgentHash},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"agent.datadoghq.com/name":      "foo",
+							"agent.datadoghq.com/component": "cluster-checks-runner",
+							"app.kubernetes.io/instance":    "cluster-checks-runner",
+							"app.kubernetes.io/managed-by":  "datadog-operator",
+							"app.kubernetes.io/name":        "datadog-agent-deployment",
+							"app.kubernetes.io/part-of":     "foo",
+							"app.kubernetes.io/version":     "",
+						},
+						Annotations: map[string]string{"agent.datadoghq.com/agentspechash": envVarsClusterChecksRunnerAgentHash},
+					},
+					Spec: userMountsPodSpec,
+				},
+				Replicas: &testClusterChecksRunnerReplicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
+						"agent.datadoghq.com/component": "cluster-checks-runner",
+					},
+				},
+			},
+		},
+	}
+	test.Run(t)
+}
+
+func Test_newClusterChecksRunnerDeploymentFromInstance_EnvVars(t *testing.T) {
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "ExtraEnvVar",
+			Value: "ExtraEnvVarValue",
+		},
+		{
+			Name: "ExtraEnvVarFromSpec",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.podIP",
+				},
+			},
+		},
+	}
+	podSpec := clusterChecksRunnerDefaultPodSpec()
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, envVars...)
+
+	envVarsAgentDeployment := test.NewDefaultedDatadogAgent(
+		"bar",
+		"foo",
+		&test.NewDatadogAgentOptions{
+			ClusterAgentEnabled:        true,
+			ClusterChecksRunnerEnabled: true,
+			ClusterChecksRunnerEnvVars: envVars,
+		},
+	)
+	envVarsClusterChecksRunnerAgentHash, _ := comparison.GenerateMD5ForSpec(envVarsAgentDeployment.Spec.ClusterChecksRunner)
+
+	test := clusterChecksRunnerDeploymentFromInstanceTest{
+		name:            "with extra env vars",
+		agentdeployment: envVarsAgentDeployment,
+		newStatus:       &datadoghqv1alpha1.DatadogAgentStatus{},
+		wantErr:         false,
+		want: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "bar",
+				Name:      "foo-cluster-checks-runner",
+				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					"agent.datadoghq.com/component": "cluster-checks-runner",
+					"app.kubernetes.io/instance":    "cluster-checks-runner",
+					"app.kubernetes.io/managed-by":  "datadog-operator",
+					"app.kubernetes.io/name":        "datadog-agent-deployment",
+					"app.kubernetes.io/part-of":     "foo",
+					"app.kubernetes.io/version":     "",
+				},
+				Annotations: map[string]string{"agent.datadoghq.com/agentspechash": envVarsClusterChecksRunnerAgentHash},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"agent.datadoghq.com/name":      "foo",
+							"agent.datadoghq.com/component": "cluster-checks-runner",
+							"app.kubernetes.io/instance":    "cluster-checks-runner",
+							"app.kubernetes.io/managed-by":  "datadog-operator",
+							"app.kubernetes.io/name":        "datadog-agent-deployment",
+							"app.kubernetes.io/part-of":     "foo",
+							"app.kubernetes.io/version":     "",
+						},
+						Annotations: map[string]string{"agent.datadoghq.com/agentspechash": envVarsClusterChecksRunnerAgentHash},
+					},
+					Spec: podSpec,
+				},
+				Replicas: &testClusterChecksRunnerReplicas,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
+						"agent.datadoghq.com/component": "cluster-checks-runner",
+					},
+				},
+			},
+		},
+	}
+	test.Run(t)
+}

--- a/pkg/controller/datadogagent/const.go
+++ b/pkg/controller/datadogagent/const.go
@@ -12,6 +12,9 @@ const (
 	// FieldPathStatusHostIP used as FieldPath to retrieve the host ip
 	FieldPathStatusHostIP = "status.hostIP"
 
+	// FieldPathStatusPodIP used as FieldPath to retrieve the pod ip
+	FieldPathStatusPodIP = "status.podIP"
+
 	// kind names definition
 	extendedDaemonSetKind   = "ExtendedDaemonSet"
 	daemonSetKind           = "DaemonSet"


### PR DESCRIPTION
### What does this PR do?

- configure env vars for the cluster agents
- configure env vars for the cluster checks runner
- configure volumes for the cluster checks runner
- configure the volume mounts for the cluster checks runner
- configure `DD_CLC_RUNNER_ENABLED` and `DD_CLC_RUNNER_HOST` by default

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

