### PR TITLE
Removing usage disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![codecov](https://codecov.io/gh/datadog/datadog-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/datadog/datadog-operator)
 
 > **!!! Alpha version !!!**
->
-> Please don't use it yet in production.
 
 ## Overview
 


### PR DESCRIPTION
### What does this PR do?

Removes the disclaimer, only leaving the Alpha version as a warning on the state of this project.