### PR TITLE
Explicitly set DOCKER_HOST

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -67,6 +67,7 @@ const (
 	DDEnableMetadataCollection      = "DD_ENABLE_METADATA_COLLECTION"
 	DDKubeletHost                   = "DD_KUBERNETES_KUBELET_HOST"
 	DDCriSocketPath                 = "DD_CRI_SOCKET_PATH"
+	DockerHost                      = "DOCKER_HOST"
 
 	// KubernetesEnvvarName Env var used by the Datadog Agent container entrypoint
 	// to add kubelet config provider and listener

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -226,6 +226,10 @@ func defaultEnvVars() []corev1.EnvVar {
 			Name:  "DD_CRI_SOCKET_PATH",
 			Value: "/host/var/run/docker.sock",
 		},
+		{
+			Name:  "DOCKER_HOST",
+			Value: "unix:///host/var/run/docker.sock",
+		},
 	}
 }
 

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
@@ -542,6 +543,13 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 			Name:  datadoghqv1alpha1.DDCriSocketPath,
 			Value: filepath.Join(datadoghqv1alpha1.HostCriSocketPathPrefix, *dda.Spec.Agent.Config.CriSocket.CriSocketPath),
 		})
+
+		if strings.HasSuffix(*dda.Spec.Agent.Config.CriSocket.CriSocketPath, "docker.sock") {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  datadoghqv1alpha1.DockerHost,
+				Value: "unix://" + filepath.Join(datadoghqv1alpha1.HostCriSocketPathPrefix, *dda.Spec.Agent.Config.CriSocket.CriSocketPath),
+			})
+		}
 	}
 
 	return append(envVars, spec.Agent.Config.Env...), nil


### PR DESCRIPTION
### What does this PR do?

Explicitly set DOCKER_HOST

### Motivation

Following f3e7d709, the docker socket is at a non-standard location inside the agent container.

### Additional Notes

This change implements the same behavior as the one introduced in helm/charts#21300

