### PR TITLE
fix DatadogAgent.Status when EDS activated

### DIFF
--- a/chart/datadog-operator/templates/role.yaml
+++ b/chart/datadog-operator/templates/role.yaml
@@ -45,7 +45,8 @@ rules:
   resources:
   - 'datadogagents'
   - 'datadogagents/status'
-  - 'extendeddaemonset'
+  - 'datadogagents/finalizers'
+  - 'extendeddaemonsets'
   verbs:
   - '*'
 {{- end -}}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -32,3 +32,17 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "datadog-operator"
+          ports:
+            - name: metrics
+              containerPort: 8383
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8080
+            periodSeconds: 10

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -51,6 +51,6 @@ rules:
   - 'datadogagents'
   - 'datadogagents/status'
   - 'datadogagents/finalizers'
-  - 'extendeddaemonset'
+  - 'extendeddaemonsets'
   verbs:
   - '*'

--- a/pkg/controller/datadogagent/agent.go
+++ b/pkg/controller/datadogagent/agent.go
@@ -195,7 +195,7 @@ func (r *ReconcileDatadogAgent) updateExtendedDaemonSet(logger logr.Logger, agen
 
 	if comparison.IsSameSpecMD5Hash(newHash, eds.GetAnnotations()) {
 		// no update needed so return, update the status and return
-		newStatus.Agent = updateExtendedDaemonSetStatus(newEDS, newStatus.Agent, &now)
+		newStatus.Agent = updateExtendedDaemonSetStatus(eds, newStatus.Agent, &now)
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

* Fix `ClusterRole` for extendeddaemonset support
* Add Probes in `/deploy/operator.yaml`  operator deployment
* Fix status update when ExtendedDaemonset is used

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

