### PR TITLE
[Plugin] fix component status

### DIFF
--- a/cmd/kubectl-datadog/get/get.go
+++ b/cmd/kubectl-datadog/get/get.go
@@ -110,17 +110,17 @@ func (o *options) run() error {
 	for _, item := range ddList.Items {
 		data := []string{item.Namespace, item.Name}
 		if item.Status.Agent != nil {
-			data = append(data, item.Status.Agent.State)
+			data = append(data, item.Status.Agent.Status)
 		} else {
 			data = append(data, "")
 		}
 		if item.Status.ClusterAgent != nil {
-			data = append(data, item.Status.ClusterAgent.State)
+			data = append(data, item.Status.ClusterAgent.Status)
 		} else {
 			data = append(data, "")
 		}
 		if item.Status.ClusterChecksRunner != nil {
-			data = append(data, item.Status.ClusterChecksRunner.State)
+			data = append(data, item.Status.ClusterChecksRunner.Status)
 		} else {
 			data = append(data, "")
 		}


### PR DESCRIPTION
### What does this PR do?

Small bug fix in the kubectl plugin:
the components status  in `kubectl datadog get` was using
`State` instead of `Status`
so the displayed status was: `Running` instead of `Running (3/3/3)`
for example.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

