### PR TITLE
change probes port, make it configurable

### DIFF
--- a/chart/datadog-operator/templates/deployment.yaml
+++ b/chart/datadog-operator/templates/deployment.yaml
@@ -48,19 +48,21 @@ spec:
           args:
             - --zap-level={{ .Values.logLevel }}
             - "--supportExtendedDaemonset={{ .Values.supportExtendedDaemonset}}"
+            - "--probesPort={{ .Values.probesPort }}"
+            - "--metricsPort={{ .Values.metricsPort }}"
           ports:
             - name: metrics
-              containerPort: 8383
+              containerPort: {{ .Values.metricsPort }}
               protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready
-              port: 8080
+              port: {{ .Values.probesPort }}
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /live
-              port: 8080
+              port: {{ .Values.probesPort }}
             periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/chart/datadog-operator/values.yaml
+++ b/chart/datadog-operator/values.yaml
@@ -13,6 +13,8 @@ nameOverride: ""
 fullnameOverride: ""
 logLevel: "info"
 supportExtendedDaemonset: "false"
+probesPort: 9090
+metricsPort: 8383
 
 rbac:
   # Specifies whether the RBAC resources should be created

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -31,6 +31,7 @@ import (
 var (
 	metricsHost              = "0.0.0.0"
 	metricsPort        int32 = 8383
+	probesPort         int32 = 9090
 	printVersionArg    bool
 	printVersionFormat string
 	log                = logf.Log.WithName("cmd")
@@ -46,7 +47,8 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.BoolVarP(&printVersionArg, "version", "v", printVersionArg, "print version")
 	pflag.StringVarP(&printVersionFormat, "version-format", "f", "text", "version output format ('text', 'json')")
-
+	pflag.Int32VarP(&probesPort, "probesPort", "", probesPort, "port used for the probes endpoint")
+	pflag.Int32VarP(&metricsPort, "metricsPort", "", metricsPort, "port used for the metrics endpoint")
 	pflag.Parse()
 
 	// Use a zap logr.Logger implementation. If none of the zap
@@ -88,7 +90,7 @@ func main() {
 	health.AddLivenessCheck("goroutine-threshold", healthcheck.GoroutineCountCheck(200))
 
 	go func() {
-		log.Error(http.ListenAndServe(":8080", health),
+		log.Error(http.ListenAndServe(fmt.Sprintf(":%d", probesPort), health),
 			"Failed to listen on the probe endpoint. We’ll be killed by k8s.")
 	}()
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -39,10 +39,10 @@ spec:
           readinessProbe:
             httpGet:
               path: /ready
-              port: 8080
+              port: 9090
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /live
-              port: 8080
+              port: 9090
             periodSeconds: 10


### PR DESCRIPTION
### What does this PR do?

Change the probes port from `8080` to `9090`, also make it parametrisable.

### Motivation

the Operatorhub.io validation process inject a container that use also the port `8080`. in order to make the validation test working.

### Additional Notes

Anything else we should know when reviewing?

