### PR TITLE
Add SecCompProfileName for system-probe

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -2408,6 +2408,9 @@ spec:
                             https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
+                    secCompProfileName:
+                      description: SecCompProfileName specify a seccomp profile
+                      type: string
                     secCompRootPath:
                       description: SecCompRootPath specify the seccomp profile root
                         directory

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -123,7 +123,8 @@ const (
 	DefaultSystemProbeSecCompRootPath = "/var/lib/kubelet/seccomp"
 	DefaultAppArmorProfileName        = "unconfined"
 	DefaultSeccompProfileName         = "localhost/system-probe"
-
+	SysteProbeAppArmorAnnotationKey   = "container.apparmor.security.beta.kubernetes.io/system-probe"
+	SysteProbeSeccompAnnotationKey    = "container.seccomp.security.alpha.kubernetes.io/system-probe"
 	// Extra config provider names
 
 	KubeServicesConfigProvider    = "kube_services"

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -122,6 +122,7 @@ const (
 
 	DefaultSystemProbeSecCompRootPath = "/var/lib/kubelet/seccomp"
 	DefaultAppArmorProfileName        = "unconfined"
+	DefaultSeccompProfileName         = "localhost/system-probe"
 
 	// Extra config provider names
 

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -311,6 +311,10 @@ type SystemProbeSpec struct {
 	// +optional
 	SecCompRootPath string `json:"secCompRootPath,omitempty"`
 
+	// SecCompProfileName specify a seccomp profile
+	// +optional
+	SecCompProfileName string `json:"secCompProfileName,omitempty"`
+
 	// AppArmorProfileName specify a apparmor profile
 	// +optional
 	AppArmorProfileName string `json:"appArmorProfileName,omitempty"`

--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -38,6 +38,8 @@ type NewDatadogAgentOptions struct {
 	APMEnabled                      bool
 	ProcessEnabled                  bool
 	SystemProbeEnabled              bool
+	SystemProbeSeccompProfileName   string
+	SystemProbeAppArmorProfileName  string
 	Creds                           *datadoghqv1alpha1.AgentCredentials
 	ClusterName                     *string
 	Confd                           *datadoghqv1alpha1.ConfigDirSpec
@@ -173,6 +175,12 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 
 		if options.SystemProbeEnabled {
 			ad.Spec.Agent.SystemProbe.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+			if options.SystemProbeAppArmorProfileName != "" {
+				ad.Spec.Agent.SystemProbe.AppArmorProfileName = options.SystemProbeAppArmorProfileName
+			}
+			if options.SystemProbeSeccompProfileName != "" {
+				ad.Spec.Agent.SystemProbe.SecCompProfileName = options.SystemProbeSeccompProfileName
+			}
 		}
 
 		if options.Creds != nil {

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -1777,6 +1777,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_SystemProbeSpec(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"secCompProfileName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecCompProfileName specify a seccomp profile",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"appArmorProfileName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AppArmorProfileName specify a apparmor profile",

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -57,7 +57,7 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 	annotations := getDefaultAnnotations(agentdeployment)
 	if isSystemProbeEnabled(agentdeployment) {
 		annotations["container.apparmor.security.beta.kubernetes.io/system-probe"] = getAppArmorProfileName(&agentdeployment.Spec.Agent.SystemProbe)
-		annotations["container.seccomp.security.alpha.kubernetes.io/system-probe"] = "localhost/system-probe"
+		annotations["container.seccomp.security.alpha.kubernetes.io/system-probe"] = getSeccompProfileName(&agentdeployment.Spec.Agent.SystemProbe)
 	}
 
 	for key, val := range agentdeployment.Spec.Agent.AdditionalAnnotations {
@@ -740,6 +740,13 @@ func getAppArmorProfileName(spec *datadoghqv1alpha1.SystemProbeSpec) string {
 		return spec.AppArmorProfileName
 	}
 	return datadoghqv1alpha1.DefaultAppArmorProfileName
+}
+
+func getSeccompProfileName(spec *datadoghqv1alpha1.SystemProbeSpec) string {
+	if spec.SecCompProfileName != "" {
+		return spec.SecCompProfileName
+	}
+	return datadoghqv1alpha1.DefaultSeccompProfileName
 }
 
 func getVolumeFromCustomConfigSpec(cfcm *datadoghqv1alpha1.CustomConfigSpec, defaultConfigMapName, volumeName string) corev1.Volume {

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -56,8 +56,8 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 
 	annotations := getDefaultAnnotations(agentdeployment)
 	if isSystemProbeEnabled(agentdeployment) {
-		annotations["container.apparmor.security.beta.kubernetes.io/system-probe"] = getAppArmorProfileName(&agentdeployment.Spec.Agent.SystemProbe)
-		annotations["container.seccomp.security.alpha.kubernetes.io/system-probe"] = getSeccompProfileName(&agentdeployment.Spec.Agent.SystemProbe)
+		annotations[datadoghqv1alpha1.SysteProbeAppArmorAnnotationKey] = getAppArmorProfileName(&agentdeployment.Spec.Agent.SystemProbe)
+		annotations[datadoghqv1alpha1.SysteProbeSeccompAnnotationKey] = getSeccompProfileName(&agentdeployment.Spec.Agent.SystemProbe)
 	}
 
 	for key, val := range agentdeployment.Spec.Agent.AdditionalAnnotations {


### PR DESCRIPTION
### What does this PR do?

Add `secCompProfileName` parameter in system-probe spec.

### Motivation

In order to ease the debuging of `system-probe` container, add the possibility to provides another seccomp profile.

### Additional Notes

Anything else we should know when reviewing?

