### PR TITLE
[Plugin] Add DD_LOG_LEVEL=off to get agent status

### DIFF
--- a/cmd/kubectl-datadog/agent/check/check.go
+++ b/cmd/kubectl-datadog/agent/check/check.go
@@ -164,7 +164,7 @@ func (o *options) run(cmd *cobra.Command) error {
 	statusCmd := []string{
 		"bash",
 		"-c",
-		"agent status --json",
+		"DD_LOG_LEVEL=off agent status --json",
 	}
 	podErrors := make(map[string][]string)
 	mutex := &sync.Mutex{}


### PR DESCRIPTION
### What does this PR do?

- Make sure `agent status --json` returns a valid json

### Motivation

`agent status --json` prints the logs if `DD_LOG_LEVEL` is set in the agent container => invalid json


