### PR TITLE
fix zip file version in getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,7 +154,7 @@ helm delete $DD_NAMEOP -n $DD_NAMESPACE
 [2]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [3]: https://www.openshift.com/learn/topics/operators
 [4]: https://github.com/operator-framework/operator-sdk
-[5]: https://github.com/DataDog/datadog-operator/archive/master.zip
+[5]: https://github.com/DataDog/datadog-operator/archive/0.1.3.zip
 [6]: https://github.com/DataDog/datadog-operator
 [7]: https://github.com/DataDog/datadog-operator/blob/master/examples/datadog-agent.yaml
 [8]: https://app.datadoghq.com/account/settings#api


### PR DESCRIPTION
### What does this PR do?

Fix the .zip version to fit with the last datadog-operator docker image release.

### Motivation

sync the chart version and the docker image in the `getting_started.md` documentation

### Additional Notes

Anything else we should know when reviewing?

