### PR TITLE
Fix panic in case of missing `ClusterChecksEnabled` property in the CR

### DIFF
--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -424,7 +424,7 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 		},
 		{
 			Name:  datadoghqv1alpha1.DDClusterChecksEnabled,
-			Value: strconv.FormatBool(*spec.ClusterAgent.Config.ClusterChecksEnabled),
+			Value: datadoghqv1alpha1.BoolToString(spec.ClusterAgent.Config.ClusterChecksEnabled),
 		},
 		{
 			Name:  datadoghqv1alpha1.DDClusterAgentKubeServiceName,
@@ -484,7 +484,7 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 	}
 
 	// Cluster Checks config
-	if *spec.ClusterAgent.Config.ClusterChecksEnabled {
+	if datadoghqv1alpha1.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled) {
 		envVars = append(envVars, []corev1.EnvVar{
 			{
 				Name:  datadoghqv1alpha1.DDExtraConfigProviders,

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -544,7 +544,7 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 				ValueFrom: getClusterAgentAuthToken(dda),
 			},
 		}
-		if *spec.ClusterAgent.Config.ClusterChecksEnabled {
+		if datadoghqv1alpha1.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled) {
 			if spec.ClusterChecksRunner == nil {
 				clusterEnv = append(clusterEnv, corev1.EnvVar{
 					Name:  datadoghqv1alpha1.DDExtraConfigProviders,


### PR DESCRIPTION
### What does this PR do?

Fix panic in case of missing `ClusterChecksEnabled` property in the CR.

### Motivation

Panics are uncool.

### Additional Notes
