### PR TITLE
Add SecCompCustomProfileConfigMap for system-probe

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -2408,6 +2408,10 @@ spec:
                             https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
+                    secCompCustomProfileConfigMap:
+                      description: SecCompCustomProfileConfigMap specify a pre-existing
+                        ConfigMap containing a custom SecComp profile
+                      type: string
                     secCompProfileName:
                       description: SecCompProfileName specify a seccomp profile
                       type: string

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -313,7 +313,7 @@ type SystemProbeSpec struct {
 
 	// SecCompCustomProfileConfigMap specify a pre-existing ConfigMap containing a custom SecComp profile
 	// +optional
-	SecCompCustomProfileConfigMap string `json:"secCompCustomProfileConfigMap"`
+	SecCompCustomProfileConfigMap string `json:"secCompCustomProfileConfigMap,omitempty"`
 
 	// SecCompProfileName specify a seccomp profile
 	// +optional

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -311,6 +311,10 @@ type SystemProbeSpec struct {
 	// +optional
 	SecCompRootPath string `json:"secCompRootPath,omitempty"`
 
+	// SecCompCustomProfileConfigMap specify a pre-existing ConfigMap containing a custom SecComp profile
+	// +optional
+	SecCompCustomProfileConfigMap string `json:"secCompCustomProfileConfigMap"`
+
 	// SecCompProfileName specify a seccomp profile
 	// +optional
 	SecCompProfileName string `json:"secCompProfileName,omitempty"`

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -1777,6 +1777,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_SystemProbeSpec(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"secCompCustomProfileConfigMap": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecCompCustomProfileConfigMap specify a pre-existing ConfigMap containing a custom SecComp profile",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"secCompProfileName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SecCompProfileName specify a seccomp profile",

--- a/pkg/controller/datadogagent/systemprobe.go
+++ b/pkg/controller/datadogagent/systemprobe.go
@@ -29,9 +29,11 @@ func (r *ReconcileDatadogAgent) manageSystemProbeDependencies(logger logr.Logger
 		return result, err
 	}
 
-	result, err = r.manageConfigMap(logger, dda, getSecCompConfigMapName(dda.Name), buildSystemProbeSecCompConfigMap)
-	if shouldReturn(result, err) {
-		return result, err
+	if getSeccompProfileName(&dda.Spec.Agent.SystemProbe) == datadoghqv1alpha1.DefaultSeccompProfileName && dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap == "" {
+		result, err = r.manageConfigMap(logger, dda, getSecCompConfigMapName(dda.Name), buildSystemProbeSecCompConfigMap)
+		if shouldReturn(result, err) {
+			return result, err
+		}
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
### What does this PR do?

Add `SecCompCustomProfileConfigMap` for `system-probe`.

### Motivation

Implement the following behaviours regarding the `seccomp` profile for `system-probe`:

(“ConfigMap” is a shortcut for “the ConfigMap containing the seccomp profile for `system-probe`.
“init container” is a shortcut for “the init container that copies the seccomp profile from the ConfigMap to the host.)

* Let the operator use its own `seccomp` profile:
  * create a ConfigMap
  * use an init container to copy its content to the hosts.
  * ```
    systemProbe:
      enabled: true
* Make `system-probe` use the default `seccomp` profile:
  * do **not** create the ConfigMap
  * do **not** create the init container
  * ```
    systemProbe:
      enabled: true
      secCompProfileName: runtime/default
* Make `system-probe` use a `seccomp` profile that is already available on the hosts (in `/var/lib/kubelet/seccomp/my_custom_profile`)
  * do **not** create the ConfigMap
  * do **not** create the init container
  * ```
    systemProbe:
      enabled: true
      secCompProfileName: localhost/my_custom_profile
* Make `system-probe` use a `seccomp` profile provided in a user-supplied ConfigMap.
  * do **not** create the ConfigMap. The user has to create one beforehand.
  * use an init container to copy the content of the user provided ConfigMap to the hosts.
  * ```
    systemProbe:
      enabled: true
      secCompCustomProfileConfigMap: lenaic-system-probe-seccomp

### Additional Notes

Anything else we should know when reviewing?

