### PR TITLE
Align resource names

### DIFF
--- a/docs/cluster_agent_setup.md
+++ b/docs/cluster_agent_setup.md
@@ -6,7 +6,7 @@ To deploy the Cluster Agent along with the Agent, update the current `DatadogAge
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   # Credentials to communicate between:
   #  * Agents and Datadog (API/APP key)
@@ -40,19 +40,19 @@ Then apply it with:
 
 ```shell
 $ kubectl apply -n $DD_NAMESPACE -f datadog-agent-with-clusteragent.yaml
-datadogagent.datadoghq.com/datadog-agent configured
+datadogagent.datadoghq.com/datadog configured
 ```
 
 Verify that the Agent and Cluster Agent are correctly running:
 
 ```shell
-$ kubectl get -n $DD_NAMESPACE dd datadog-agent
+$ kubectl get -n $DD_NAMESPACE dd datadog
 NAME            ACTIVE   AGENT             CLUSTER-AGENT     CLUSTER-CHECKS-RUNNER   AGE
 datadog-agent   True     Running (2/2/2)   Running (2/2/2)                           6m
 
-$ kubectl get -n $DD_NAMESPACE deployment datadog-agent-cluster-agent
+$ kubectl get -n $DD_NAMESPACE deployment datadog-cluster-agent
 NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
-datadog-agent-cluster-agent   2/2     2            2           21s
+datadog-cluster-agent   2/2     2            2           21s
 ```
 
 The "datadog-agent" `DaemonSet` has also been updated to get the new configuration for using the `Cluster-Agent` deployment pods.
@@ -63,8 +63,8 @@ NAME                                         READY   STATUS    RESTARTS   AGE
 datadog-operator-6f49889b99-vlscz            1/1     Running   0          15h
 datadog-agent-22x44                          1/1     Running   0          40s
 datadog-agent-665dr                          1/1     Running   0          50s
-datadog-agent-cluster-agent-9f9c5c4c-2v9f7   1/1     Running   0          58s
-datadog-agent-cluster-agent-9f9c5c4c-pmhqb   1/1     Running   0          58s
+datadog-cluster-agent-9f9c5c4c-2v9f7         1/1     Running   0          58s
+datadog-cluster-agent-9f9c5c4c-pmhqb         1/1     Running   0          58s
 datadog-agent-hjlbg                          1/1     Running   0          33s
 ```
 

--- a/docs/custom_check.md
+++ b/docs/custom_check.md
@@ -88,7 +88,7 @@ Once the `ConfigMaps` are configured, a `DatadogAgent` resource can be created t
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: "<DATADOG_API_KEY>"
@@ -132,7 +132,7 @@ Additional user-configured volumes can be mounted in either the node or Cluster 
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: "<DATADOG_API_KEY>"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -53,7 +53,7 @@ The following [`datadog-agent.yaml` file][7] is the simplest configuration for t
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: "<DATADOG_API_KEY>"
@@ -67,13 +67,13 @@ Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and a
 
 ```shell
 $ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
-datadogagent.datadoghq.com/datadog-agent created
+datadogagent.datadoghq.com/datadog created
 ```
 
 You can check the state of the `DatadogAgent` ressource with:
 
 ```shell
-kubectl get -n $DD_NAMESPACE dd datadog-agent
+kubectl get -n $DD_NAMESPACE dd datadog
 NAME            ACTIVE   AGENT             CLUSTER-AGENT   CLUSTER-CHECKS-RUNNER   AGE
 datadog-agent   True     Running (2/2/2)                                           110m
 ```
@@ -100,7 +100,7 @@ Update your [`datadog-agent.yaml` file][9] with the following configuration to a
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: "<DATADOG_API_KEY>"
@@ -117,7 +117,7 @@ Apply this new configuration:
 
 ```shell
 $ kubectl apply -f datadog-agent.yaml
-datadogagent.datadoghq.com/datadog-agent updated
+datadogagent.datadoghq.com/datadog updated
 ```
 
 The DaemonSet update can be validated by looking at the new desired pod value:
@@ -137,11 +137,11 @@ datadog-agent-zvdbw                          1/1     Running    0          8m1s
 
 ## Cleanup
 
-The following command deletes all the Kubernetes resources created by the Datadog Operator and the linked `DatadogAgent` `datadog-agent`.
+The following command deletes all the Kubernetes resources created by the Datadog Operator and the linked `DatadogAgent` `datadog`.
 
 ```shell
-$ kubectl delete -n $DD_NAMESPACE datadogagent datadog-agent
-datadogagent.datadoghq.com/datadog-agent deleted
+$ kubectl delete -n $DD_NAMESPACE datadogagent datadog
+datadogagent.datadoghq.com/datadog deleted
 ```
 
 You can then remove the Datadog-Operator with the `helm delete` command:

--- a/examples/datadog-agent-all.yaml
+++ b/examples/datadog-agent-all.yaml
@@ -1,7 +1,7 @@
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: <DATADOG_API_KEY>

--- a/examples/datadog-agent-with-clusteragent.yaml
+++ b/examples/datadog-agent-with-clusteragent.yaml
@@ -1,7 +1,7 @@
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: <DATADOG_API_KEY>

--- a/examples/datadog-agent-with-dca-clusterchecksrunner.yaml
+++ b/examples/datadog-agent-with-dca-clusterchecksrunner.yaml
@@ -1,7 +1,7 @@
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: <DATADOG_API_KEY>

--- a/examples/datadog-agent-with-tolerations.yaml
+++ b/examples/datadog-agent-with-tolerations.yaml
@@ -1,7 +1,7 @@
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: <DATADOG_API_KEY>

--- a/examples/datadog-agent.yaml
+++ b/examples/datadog-agent.yaml
@@ -1,7 +1,7 @@
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgent
 metadata:
-  name: datadog-agent
+  name: datadog
 spec:
   credentials:
     apiKey: <DATADOG_API_KEY>

--- a/pkg/controller/datadogagent/agent.go
+++ b/pkg/controller/datadogagent/agent.go
@@ -110,39 +110,39 @@ func (r *ReconcileDatadogAgent) reconcileAgent(logger logr.Logger, dda *datadogh
 
 }
 
-func (r *ReconcileDatadogAgent) deleteDaemonSet(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, ds *appsv1.DaemonSet) error {
+func (r *ReconcileDatadogAgent) deleteDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, ds *appsv1.DaemonSet) error {
 	err := r.client.Delete(context.TODO(), ds)
 	if err != nil {
 		return err
 	}
 	logger.Info("Delete DaemonSet", "daemonSet.Namespace", ds.Namespace, "daemonSet.Name", ds.Name)
 	event := buildEventInfo(ds.Name, ds.Namespace, daemonSetKind, datadog.DeletionEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	return err
 }
 
-func (r *ReconcileDatadogAgent) deleteExtendedDaemonSet(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, eds *edsdatadoghqv1alpha1.ExtendedDaemonSet) error {
+func (r *ReconcileDatadogAgent) deleteExtendedDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, eds *edsdatadoghqv1alpha1.ExtendedDaemonSet) error {
 	err := r.client.Delete(context.TODO(), eds)
 	if err != nil {
 		return err
 	}
 	logger.Info("Delete DaemonSet", "extendedDaemonSet.Namespace", eds.Namespace, "extendedDaemonSet.Name", eds.Name)
 	event := buildEventInfo(eds.Name, eds.Namespace, extendedDaemonSetKind, datadog.DeletionEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	return err
 }
 
-func (r *ReconcileDatadogAgent) createNewExtendedDaemonSet(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+func (r *ReconcileDatadogAgent) createNewExtendedDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
 	var err error
 	// ExtendedDaemonSet up to date didn't exist yet, create a new one
 	var newEDS *edsdatadoghqv1alpha1.ExtendedDaemonSet
 	var hash string
-	if newEDS, hash, err = newExtendedDaemonSetFromInstance(agentdeployment, nil); err != nil {
+	if newEDS, hash, err = newExtendedDaemonSetFromInstance(dda, nil); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Set ExtendedDaemonSet instance as the owner and controller
-	if err = controllerutil.SetControllerReference(agentdeployment, newEDS, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(dda, newEDS, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -153,24 +153,24 @@ func (r *ReconcileDatadogAgent) createNewExtendedDaemonSet(logger logr.Logger, a
 		return reconcile.Result{}, err
 	}
 	event := buildEventInfo(newEDS.Name, newEDS.Namespace, extendedDaemonSetKind, datadog.CreationEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	now := metav1.NewTime(time.Now())
 	newStatus.Agent = updateExtendedDaemonSetStatus(newEDS, newStatus.Agent, &now)
 
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileDatadogAgent) createNewDaemonSet(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+func (r *ReconcileDatadogAgent) createNewDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
 	var err error
 	// DaemonSet up to date didn't exist yet, create a new one
 	var newDS *appsv1.DaemonSet
 	var hash string
-	if newDS, hash, err = newDaemonSetFromInstance(agentdeployment, nil); err != nil {
+	if newDS, hash, err = newDaemonSetFromInstance(dda, nil); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Set DaemonSet instance as the owner and controller
-	if err = controllerutil.SetControllerReference(agentdeployment, newDS, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(dda, newDS, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 	logger.Info("Creating a new DaemonSet", "daemonSet.Namespace", newDS.Namespace, "daemonSet.Name", newDS.Name, "agentdeployment.Status.Agent.CurrentHash", hash)
@@ -179,16 +179,16 @@ func (r *ReconcileDatadogAgent) createNewDaemonSet(logger logr.Logger, agentdepl
 		return reconcile.Result{}, err
 	}
 	event := buildEventInfo(newDS.Name, newDS.Namespace, daemonSetKind, datadog.CreationEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	now := metav1.NewTime(time.Now())
 	newStatus.Agent = updateDaemonSetStatus(newDS, newStatus.Agent, &now)
 
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileDatadogAgent) updateExtendedDaemonSet(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, eds *edsdatadoghqv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+func (r *ReconcileDatadogAgent) updateExtendedDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, eds *edsdatadoghqv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
 	now := metav1.NewTime(time.Now())
-	newEDS, newHash, err := newExtendedDaemonSetFromInstance(agentdeployment, eds.Spec.Selector)
+	newEDS, newHash, err := newExtendedDaemonSetFromInstance(dda, eds.Spec.Selector)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -200,7 +200,7 @@ func (r *ReconcileDatadogAgent) updateExtendedDaemonSet(logger logr.Logger, agen
 	}
 
 	// Set ExtendedDaemonSet instance as the owner and controller
-	if err = controllerutil.SetControllerReference(agentdeployment, eds, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(dda, eds, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 	logger.Info("Updating an existing ExtendedDaemonSet", "extendedDaemonSet.Namespace", newEDS.Namespace, "extendedDaemonSet.Name", newEDS.Name)
@@ -220,7 +220,7 @@ func (r *ReconcileDatadogAgent) updateExtendedDaemonSet(logger logr.Logger, agen
 		return reconcile.Result{}, err
 	}
 	event := buildEventInfo(updatedEds.Name, updatedEds.Namespace, extendedDaemonSetKind, datadog.UpdateEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	newStatus.Agent = updateExtendedDaemonSetStatus(updatedEds, newStatus.Agent, &now)
 	return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 }
@@ -229,11 +229,11 @@ func getHashAnnotation(annotations map[string]string) string {
 	return annotations[datadoghqv1alpha1.MD5AgentDeploymentAnnotationKey]
 }
 
-func (r *ReconcileDatadogAgent) updateDaemonSet(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+func (r *ReconcileDatadogAgent) updateDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
 	// Update values from current DS in any case
 	newStatus.Agent = updateDaemonSetStatus(ds, newStatus.Agent, nil)
 
-	newDS, newHash, err := newDaemonSetFromInstance(agentdeployment, ds.Spec.Selector)
+	newDS, newHash, err := newDaemonSetFromInstance(dda, ds.Spec.Selector)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -245,7 +245,7 @@ func (r *ReconcileDatadogAgent) updateDaemonSet(logger logr.Logger, agentdeploym
 	}
 
 	// Set DaemonSet instance as the owner and controller
-	if err = controllerutil.SetControllerReference(agentdeployment, ds, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(dda, ds, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 	logger.Info("Updating an existing DaemonSet", "daemonSet.Namespace", newDS.Namespace, "daemonSet.Name", newDS.Name)
@@ -264,7 +264,7 @@ func (r *ReconcileDatadogAgent) updateDaemonSet(logger logr.Logger, agentdeploym
 		return reconcile.Result{}, err
 	}
 	event := buildEventInfo(updatedDS.Name, updatedDS.Namespace, daemonSetKind, datadog.UpdateEvent)
-	r.recordEvent(agentdeployment, event)
+	r.recordEvent(dda, event)
 	newStatus.Agent = updateDaemonSetStatus(updatedDS, newStatus.Agent, &now)
 	return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 }
@@ -289,30 +289,30 @@ func (r *ReconcileDatadogAgent) manageAgentDependencies(logger logr.Logger, dda 
 }
 
 // newExtendedDaemonSetFromInstance creates an ExtendedDaemonSet from a given DatadogAgent
-func newExtendedDaemonSetFromInstance(agentdeployment *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*edsdatadoghqv1alpha1.ExtendedDaemonSet, string, error) {
-	template, err := newAgentPodTemplate(agentdeployment, selector)
+func newExtendedDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*edsdatadoghqv1alpha1.ExtendedDaemonSet, string, error) {
+	template, err := newAgentPodTemplate(dda, selector)
 	if err != nil {
 		return nil, "", err
 	}
 	eds := &edsdatadoghqv1alpha1.ExtendedDaemonSet{
-		ObjectMeta: newDaemonsetObjectMetaData(agentdeployment),
+		ObjectMeta: newDaemonsetObjectMetaData(dda),
 		Spec: edsdatadoghqv1alpha1.ExtendedDaemonSetSpec{
 			Selector: selector,
 			Template: *template,
 			Strategy: edsdatadoghqv1alpha1.ExtendedDaemonSetSpecStrategy{
-				Canary:             agentdeployment.Spec.Agent.DeploymentStrategy.Canary.DeepCopy(),
-				ReconcileFrequency: agentdeployment.Spec.Agent.DeploymentStrategy.ReconcileFrequency.DeepCopy(),
+				Canary:             dda.Spec.Agent.DeploymentStrategy.Canary.DeepCopy(),
+				ReconcileFrequency: dda.Spec.Agent.DeploymentStrategy.ReconcileFrequency.DeepCopy(),
 				RollingUpdate: edsdatadoghqv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate{
-					MaxUnavailable:            agentdeployment.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxUnavailable,
-					MaxPodSchedulerFailure:    agentdeployment.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxPodSchedulerFailure,
-					MaxParallelPodCreation:    agentdeployment.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxParallelPodCreation,
-					SlowStartIntervalDuration: agentdeployment.Spec.Agent.DeploymentStrategy.RollingUpdate.SlowStartIntervalDuration,
-					SlowStartAdditiveIncrease: agentdeployment.Spec.Agent.DeploymentStrategy.RollingUpdate.SlowStartAdditiveIncrease,
+					MaxUnavailable:            dda.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxUnavailable,
+					MaxPodSchedulerFailure:    dda.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxPodSchedulerFailure,
+					MaxParallelPodCreation:    dda.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxParallelPodCreation,
+					SlowStartIntervalDuration: dda.Spec.Agent.DeploymentStrategy.RollingUpdate.SlowStartIntervalDuration,
+					SlowStartAdditiveIncrease: dda.Spec.Agent.DeploymentStrategy.RollingUpdate.SlowStartAdditiveIncrease,
 				},
 			},
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&eds.ObjectMeta, agentdeployment.Spec)
+	hash, err := comparison.SetMD5GenerationAnnotation(&eds.ObjectMeta, dda.Spec)
 	if err != nil {
 		return nil, "", err
 	}
@@ -320,8 +320,8 @@ func newExtendedDaemonSetFromInstance(agentdeployment *datadoghqv1alpha1.Datadog
 }
 
 // newDaemonSetFromInstance creates a DaemonSet from a given DatadogAgent
-func newDaemonSetFromInstance(agentdeployment *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*appsv1.DaemonSet, string, error) {
-	template, err := newAgentPodTemplate(agentdeployment, selector)
+func newDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*appsv1.DaemonSet, string, error) {
+	template, err := newAgentPodTemplate(dda, selector)
 	if err != nil {
 		return nil, "", err
 	}
@@ -332,44 +332,44 @@ func newDaemonSetFromInstance(agentdeployment *datadoghqv1alpha1.DatadogAgent, s
 		}
 	}
 	ds := &appsv1.DaemonSet{
-		ObjectMeta: newDaemonsetObjectMetaData(agentdeployment),
+		ObjectMeta: newDaemonsetObjectMetaData(dda),
 		Spec: appsv1.DaemonSetSpec{
 			Selector: selector,
 			Template: *template,
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
-				Type: *agentdeployment.Spec.Agent.DeploymentStrategy.UpdateStrategyType,
+				Type: *dda.Spec.Agent.DeploymentStrategy.UpdateStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
-					MaxUnavailable: agentdeployment.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxUnavailable,
+					MaxUnavailable: dda.Spec.Agent.DeploymentStrategy.RollingUpdate.MaxUnavailable,
 				},
 			},
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&ds.ObjectMeta, agentdeployment.Spec)
+	hash, err := comparison.SetMD5GenerationAnnotation(&ds.ObjectMeta, dda.Spec)
 	if err != nil {
 		return nil, "", err
 	}
 	return ds, hash, nil
 }
 
-func daemonsetName(agentdeployment *datadoghqv1alpha1.DatadogAgent) string {
-	if agentdeployment.Spec.Agent != nil && agentdeployment.Spec.Agent.DaemonsetName != "" {
-		return agentdeployment.Spec.Agent.DaemonsetName
+func daemonsetName(dda *datadoghqv1alpha1.DatadogAgent) string {
+	if dda.Spec.Agent != nil && dda.Spec.Agent.DaemonsetName != "" {
+		return dda.Spec.Agent.DaemonsetName
 	}
-	return agentdeployment.Name
+	return fmt.Sprintf("%s-%s", dda.Name, "agent")
 }
 
-func newDaemonsetObjectMetaData(agentdeployment *datadoghqv1alpha1.DatadogAgent) metav1.ObjectMeta {
-	labels := getDefaultLabels(agentdeployment, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(agentdeployment))
-	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = agentdeployment.Name
+func newDaemonsetObjectMetaData(dda *datadoghqv1alpha1.DatadogAgent) metav1.ObjectMeta {
+	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(dda))
+	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = dda.Name
 	labels[datadoghqv1alpha1.AgentDeploymentComponentLabelKey] = datadoghqv1alpha1.DefaultAgentResourceSuffix
-	for key, val := range agentdeployment.Labels {
+	for key, val := range dda.Labels {
 		labels[key] = val
 	}
 	annotations := map[string]string{}
 
 	return metav1.ObjectMeta{
-		Name:        daemonsetName(agentdeployment),
-		Namespace:   agentdeployment.Namespace,
+		Name:        daemonsetName(dda),
+		Namespace:   dda.Namespace,
 		Labels:      labels,
 		Annotations: annotations,
 	}

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -24,13 +24,13 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-const testDadName = "foo"
+const testDdaName = "foo"
 
 func authTokenValue() *corev1.EnvVarSource {
 	return &corev1.EnvVarSource{
 		SecretKeyRef: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: fmt.Sprintf("%s-%s", testDadName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
+				Name: fmt.Sprintf("%s-%s", testDdaName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
 			},
 			Key: "token",
 		},
@@ -224,7 +224,7 @@ func defaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME",
-			Value: fmt.Sprintf("%s-%s", testDadName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
+			Value: fmt.Sprintf("%s-%s", testDdaName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
 		},
 		{
 			Name:      "DD_CLUSTER_AGENT_AUTH_TOKEN",
@@ -338,7 +338,7 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 			want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
-					Name:      "foo",
+					Name:      "foo-agent",
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "agent",
@@ -379,7 +379,7 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 			want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
-					Name:      "foo",
+					Name:      "foo-agent",
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "agent",
@@ -495,7 +495,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomConfigMaps(t *testing.T) {
 		want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
-				Name:      "foo",
+				Name:      "foo-agent",
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "agent",
@@ -637,7 +637,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 		want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
-				Name:      "foo",
+				Name:      "foo-agent",
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "agent",
@@ -714,7 +714,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomVolumes(t *testing.T) {
 		want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
-				Name:      "foo",
+				Name:      "foo-agent",
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "agent",
@@ -882,7 +882,7 @@ func Test_newExtendedDaemonSetFromInstance_LogsEnabled(t *testing.T) {
 		want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
-				Name:      "foo",
+				Name:      "foo-agent",
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "agent",
@@ -942,7 +942,7 @@ func Test_newExtendedDaemonSetFromInstance_clusterChecksConfig(t *testing.T) {
 		want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
-				Name:      "foo",
+				Name:      "foo-agent",
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "agent",
@@ -1001,7 +1001,7 @@ func Test_newExtendedDaemonSetFromInstance_endpointsChecksConfig(t *testing.T) {
 		want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
-				Name:      "foo",
+				Name:      "foo-agent",
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "agent",

--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -78,7 +78,7 @@ func (r *ReconcileDatadogAgent) reconcileClusterAgent(logger logr.Logger, dda *d
 
 		// Make sure we have at least one Cluster Agent available replica
 		if clusterAgentDeployment.Status.AvailableReplicas == 0 {
-			return reconcile.Result{RequeueAfter: defaultRequeuPeriod}, fmt.Errorf("cluster agent deployment is not ready yet: 0 pods available out of %d", clusterAgentDeployment.Status.Replicas)
+			return reconcile.Result{RequeueAfter: defaultRequeuePeriod}, fmt.Errorf("cluster agent deployment is not ready yet: 0 pods available out of %d", clusterAgentDeployment.Status.Replicas)
 		}
 
 		return reconcile.Result{}, nil

--- a/pkg/controller/datadogagent/clusteragent_test.go
+++ b/pkg/controller/datadogagent/clusteragent_test.go
@@ -78,7 +78,7 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME",
-			Value: fmt.Sprintf("%s-%s", testDadName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
+			Value: fmt.Sprintf("%s-%s", testDdaName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
 		},
 		{
 			Name:      "DD_CLUSTER_AGENT_AUTH_TOKEN",

--- a/pkg/controller/datadogagent/clusterchecksrunner_test.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner_test.go
@@ -92,7 +92,7 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME",
-			Value: fmt.Sprintf("%s-%s", testDadName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
+			Value: fmt.Sprintf("%s-%s", testDdaName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
 		},
 		{
 			Name:      "DD_CLUSTER_AGENT_AUTH_TOKEN",

--- a/pkg/controller/datadogagent/datadogagent_controller.go
+++ b/pkg/controller/datadogagent/datadogagent_controller.go
@@ -42,7 +42,7 @@ var (
 )
 
 const (
-	defaultRequeuPeriod = 15 * time.Second
+	defaultRequeuePeriod = 15 * time.Second
 )
 
 func init() {
@@ -293,7 +293,7 @@ func (r *ReconcileDatadogAgent) internalReconcile(request reconcile.Request) (re
 
 	// Always requeue
 	if !result.Requeue && result.RequeueAfter == 0 {
-		result.RequeueAfter = defaultRequeuPeriod
+		result.RequeueAfter = defaultRequeuePeriod
 	}
 	return r.updateStatusIfNeeded(reqLogger, instance, newStatus, result, err)
 }

--- a/pkg/controller/datadogagent/datadogagent_controller_test.go
+++ b/pkg/controller/datadogagent/datadogagent_controller_test.go
@@ -114,6 +114,7 @@ func TestReconcileDatadogAgent_createNewExtendedDaemonSet(t *testing.T) {
 func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 	const resourcesName = "foo"
 	const resourcesNamespace = "bar"
+	const dsName = "foo-agent"
 	const rbacResourcesName = "foo-agent"
 	const rbacResourcesNameClusterAgent = "foo-cluster-agent"
 	const rbacResourcesNameClusterChecksRunner = "foo-cluster-checks-runner"
@@ -363,16 +364,15 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				eds := &edsdatadoghqv1alpha1.ExtendedDaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, eds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, eds); err != nil {
 					return err
 				}
-				if eds.Name != resourcesName {
+				if eds.Name != dsName {
 					return fmt.Errorf("eds bad name, should be: 'foo', current: %s", eds.Name)
 				}
 				if eds.OwnerReferences == nil || len(eds.OwnerReferences) != 1 {
 					return fmt.Errorf("eds bad owner references, should be: '[Kind DatadogAgent - Name foo]', current: %v", eds.OwnerReferences)
 				}
-				rbacResourcesName := fmt.Sprintf("%s-agent", eds.Name)
 				clusterRole := &rbacv1.ClusterRole{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesName}, clusterRole); err != nil {
 					return err
@@ -422,7 +422,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: true,
 			wantFunc: func(c client.Client) error {
 				eds := &edsdatadoghqv1alpha1.ExtendedDaemonSet{}
-				err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, eds)
+				err := c.Get(context.TODO(), newRequest(resourcesNamespace, dsName).NamespacedName, eds)
 				if apierrors.IsNotFound(err) {
 					// Daemonset must NOT be created
 					return nil
@@ -478,10 +478,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				eds := &edsdatadoghqv1alpha1.ExtendedDaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, eds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, eds); err != nil {
 					return err
 				}
-				if eds.Name != resourcesName {
+				if eds.Name != dsName {
 					return fmt.Errorf("eds bad name, should be: 'foo', current: %s", eds.Name)
 				}
 				if eds.OwnerReferences == nil || len(eds.OwnerReferences) != 1 {
@@ -568,10 +568,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				ds := &appsv1.DaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, ds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, ds); err != nil {
 					return err
 				}
-				if ds.Name != resourcesName {
+				if ds.Name != dsName {
 					return fmt.Errorf("ds bad name, should be: 'foo', current: %s", ds.Name)
 				}
 				if ds.OwnerReferences == nil || len(ds.OwnerReferences) != 1 {
@@ -600,7 +600,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				ds := &appsv1.DaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, ds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, ds); err != nil {
 					return err
 				}
 
@@ -632,7 +632,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				ds := &appsv1.DaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, ds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, ds); err != nil {
 					return err
 				}
 
@@ -728,7 +728,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				ds := &appsv1.DaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, ds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, ds); err != nil {
 					return err
 				}
 				var process, systemprobe bool
@@ -830,14 +830,14 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					_ = c.Create(context.TODO(), eds)
 				},
 			},
-			want:    reconcile.Result{RequeueAfter: 5 * time.Second},
+			want:    reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				eds := &edsdatadoghqv1alpha1.ExtendedDaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, eds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, eds); err != nil {
 					return err
 				}
-				if eds.Name != resourcesName {
+				if eds.Name != dsName {
 					return fmt.Errorf("eds bad name, should be: 'foo', current: %s", eds.Name)
 				}
 				if eds.OwnerReferences == nil || len(eds.OwnerReferences) != 1 {
@@ -1308,7 +1308,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				ds := &appsv1.DaemonSet{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, resourcesName).NamespacedName, ds); err != nil {
+				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, ds); err != nil {
 					return err
 				}
 
@@ -1462,7 +1462,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 				},
 			},
-			want:    reconcile.Result{RequeueAfter: defaultRequeuPeriod},
+			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: true,
 			wantFunc: func(c client.Client) error {
 				ds := &appsv1.DaemonSet{}

--- a/test/e2e/datadogagent_test.go
+++ b/test/e2e/datadogagent_test.go
@@ -106,7 +106,8 @@ func DeploymentDaemonset(t *testing.T) {
 		t.Logf("status false %#v", ds.Status)
 		return false, nil
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isDaemonsetOK, retryInterval, timeout)
+	dsName := fmt.Sprintf("%s-%s", name, "agent")
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isDaemonsetOK, retryInterval, timeout)
 	if err != nil {
 		exportPodsLogs(t, f, namespace, err)
 		t.Fatal(err)
@@ -141,11 +142,11 @@ func DeploymentDaemonset(t *testing.T) {
 		}
 		return false, nil
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isDaemonsetUpdated, retryInterval, timeout)
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isDaemonsetUpdated, retryInterval, timeout)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isDaemonsetOK, retryInterval, timeout)
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isDaemonsetOK, retryInterval, timeout)
 	if err != nil {
 		exportPodsLogs(t, f, namespace, err)
 		t.Fatal(err)
@@ -170,12 +171,12 @@ func DeploymentDaemonset(t *testing.T) {
 		}
 		return false, nil
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isApmActivatedAndRunning, retryInterval, timeout)
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isApmActivatedAndRunning, retryInterval, timeout)
 	if err != nil {
 		exportPodsLogs(t, f, namespace, err)
 		t.Fatal(err)
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isDaemonsetOK, retryInterval, timeout)
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isDaemonsetOK, retryInterval, timeout)
 	if err != nil {
 		printDaemonSet(t, f, namespace)
 		exportPodsLogs(t, f, namespace, err)
@@ -200,12 +201,12 @@ func DeploymentDaemonset(t *testing.T) {
 		}
 		return false, nil
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isProcessActivatedAndRunning, retryInterval, timeout)
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isProcessActivatedAndRunning, retryInterval, timeout)
 	if err != nil {
 		exportPodsLogs(t, f, namespace, err)
 		t.Fatal(err)
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isDaemonsetOK, retryInterval, timeout)
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isDaemonsetOK, retryInterval, timeout)
 	if err != nil {
 		exportPodsLogs(t, f, namespace, err)
 		t.Fatal(err)
@@ -230,7 +231,7 @@ func DeploymentDaemonset(t *testing.T) {
 		t.Logf("Daemonset pod not ready %#v", ds.Status)
 		return false, nil
 	}
-	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, name, isSystemProbeActivatedAndRunning, retryInterval, timeout)
+	err = utils.WaitForFuncOnDaemonSet(t, f.Client, namespace, dsName, isSystemProbeActivatedAndRunning, retryInterval, timeout)
 	if err != nil {
 		exportPodsLogs(t, f, namespace, err)
 		t.Fatal(err)


### PR DESCRIPTION
### What does this PR do?

- Recommend naming the CR `datadog`
- The DS or EDS created by the operator are named `<cr name>-agent` 

### Motivation

Avoid generating unnecessary long resource names
datadog-agent-cluster-agent -> datadog-cluster-agent
datadog-agent-cluster-checks-runner -> datadog-cluster-checks-runner
