### PR TITLE
Ensure the API and APP key are read from the secret

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -56,6 +56,7 @@ type NewDatadogAgentOptions struct {
 	ClusterChecksRunnerVolumes      []corev1.Volume
 	ClusterChecksRunnerVolumeMounts []corev1.VolumeMount
 	ClusterChecksRunnerEnvVars      []corev1.EnvVar
+	APIKeyExistingSecret            string
 }
 
 // NewDefaultedDatadogAgent returns an initialized and defaulted DatadogAgent for testing purpose
@@ -204,6 +205,10 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			ad.Spec.Agent.CustomConfig = &datadoghqv1alpha1.CustomConfigSpec{
 				ConfigData: &options.CustomConfig,
 			}
+		}
+
+		if options.APIKeyExistingSecret != "" {
+			ad.Spec.Credentials.APIKeyExistingSecret = options.APIKeyExistingSecret
 		}
 	}
 	return datadoghqv1alpha1.DefaultDatadogAgent(ad)

--- a/pkg/controller/datadogagent/agent.go
+++ b/pkg/controller/datadogagent/agent.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (r *ReconcileDatadogAgent) reconcileAgent(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageAgentDependencies(logger, dda)
+	result, err := r.manageAgentDependencies(logger, dda, newStatus)
 	if shouldReturn(result, err) {
 		return result, err
 	}
@@ -269,8 +269,13 @@ func (r *ReconcileDatadogAgent) updateDaemonSet(logger logr.Logger, dda *datadog
 	return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
-func (r *ReconcileDatadogAgent) manageAgentDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
-	result, err := r.manageAgentRBACs(logger, dda)
+func (r *ReconcileDatadogAgent) manageAgentDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+	result, err := r.manageAgentSecret(logger, dda, newStatus)
+	if shouldReturn(result, err) {
+		return result, err
+	}
+
+	result, err = r.manageAgentRBACs(logger, dda)
 	if shouldReturn(result, err) {
 		return result, err
 	}

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -26,11 +26,33 @@ import (
 
 const testDdaName = "foo"
 
+func apiKeyValue() *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: testDdaName,
+			},
+			Key: "api_key",
+		},
+	}
+}
+
+func appKeyValue() *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: testDdaName,
+			},
+			Key: "app_key",
+		},
+	}
+}
+
 func authTokenValue() *corev1.EnvVarSource {
 	return &corev1.EnvVarSource{
 		SecretKeyRef: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{
-				Name: fmt.Sprintf("%s-%s", testDdaName, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix),
+				Name: testDdaName,
 			},
 			Key: "token",
 		},
@@ -207,8 +229,8 @@ func defaultEnvVars() []corev1.EnvVar {
 			Value: "yes",
 		},
 		{
-			Name:  "DD_API_KEY",
-			Value: "",
+			Name:      "DD_API_KEY",
+			ValueFrom: apiKeyValue(),
 		},
 		{
 			Name:  "DD_CRI_SOCKET_PATH",

--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -451,17 +451,10 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 	}
 
 	if needClusterAgentSecret(dda) {
-		if spec.Credentials.APIKeyExistingSecret != "" {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:      datadoghqv1alpha1.DDAPIKey,
-				ValueFrom: getAPIKeyFromSecret(dda),
-			})
-		} else {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:  datadoghqv1alpha1.DDAPIKey,
-				Value: spec.Credentials.APIKey,
-			})
-		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:      datadoghqv1alpha1.DDAPIKey,
+			ValueFrom: getAPIKeyFromSecret(dda),
+		})
 		if isMetricsProviderEnabled(spec.ClusterAgent) {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  datadoghqv1alpha1.DDMetricsProviderEnabled,
@@ -472,17 +465,10 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 				Name:  datadoghqv1alpha1.DDMetricsProviderPort,
 				Value: strconv.Itoa(int(getClusterAgentMetricsProviderPort(spec.ClusterAgent.Config))),
 			})
-			if spec.Credentials.APIKeyExistingSecret != "" {
-				envVars = append(envVars, corev1.EnvVar{
-					Name:      datadoghqv1alpha1.DDAppKey,
-					ValueFrom: getAppKeyFromSecret(dda),
-				})
-			} else {
-				envVars = append(envVars, corev1.EnvVar{
-					Name:  datadoghqv1alpha1.DDAppKey,
-					Value: spec.Credentials.AppKey,
-				})
-			}
+			envVars = append(envVars, corev1.EnvVar{
+				Name:      datadoghqv1alpha1.DDAppKey,
+				ValueFrom: getAppKeyFromSecret(dda),
+			})
 		}
 	}
 

--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -208,7 +208,7 @@ func newClusterAgentDeploymentFromInstance(agentdeployment *datadoghqv1alpha1.Da
 }
 
 func (r *ReconcileDatadogAgent) manageClusterAgentDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageClusterAgentSecret(logger, dda, newStatus)
+	result, err := r.manageAgentSecret(logger, dda, newStatus)
 	if shouldReturn(result, err) {
 		return result, err
 	}
@@ -450,7 +450,7 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 		})
 	}
 
-	if needClusterAgentSecret(dda) {
+	if needAgentSecret(dda) {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:      datadoghqv1alpha1.DDAPIKey,
 			ValueFrom: getAPIKeyFromSecret(dda),

--- a/pkg/controller/datadogagent/clusteragent_test.go
+++ b/pkg/controller/datadogagent/clusteragent_test.go
@@ -93,8 +93,8 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 			Value: "https://app.datadoghq.com",
 		},
 		{
-			Name:  "DD_API_KEY",
-			Value: "",
+			Name:      "DD_API_KEY",
+			ValueFrom: apiKeyValue(),
 		},
 	}
 }
@@ -470,8 +470,8 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 				Value: strconv.Itoa(int(metricsServerPort)),
 			},
 			{
-				Name:  "DD_APP_KEY",
-				Value: "",
+				Name:      "DD_APP_KEY",
+				ValueFrom: appKeyValue(),
 			},
 		}...,
 	)

--- a/pkg/controller/datadogagent/clusteragent_test.go
+++ b/pkg/controller/datadogagent/clusteragent_test.go
@@ -554,6 +554,70 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 	test.Run(t)
 }
 
+func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T) {
+	podSpec := clusterAgentDefaultPodSpec()
+	for _, e := range podSpec.Containers[0].Env {
+		if e.Name == "DD_API_KEY" {
+			e.ValueFrom.SecretKeyRef.LocalObjectReference.Name = "my_secret"
+		}
+	}
+
+	tests := clusterAgentDeploymentFromInstanceTestSuite{
+		{
+			name: "user provided secret for API key",
+			agentdeployment: test.NewDefaultedDatadogAgent(
+				"bar",
+				"foo",
+				&test.NewDatadogAgentOptions{
+					ClusterAgentEnabled:  true,
+					APIKeyExistingSecret: "my_secret",
+				},
+			),
+			newStatus: &datadoghqv1alpha1.DatadogAgentStatus{},
+			wantErr:   false,
+			want: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "bar",
+					Name:      "foo-cluster-agent",
+					Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+						"agent.datadoghq.com/component": "cluster-agent",
+						"app.kubernetes.io/instance":    "cluster-agent",
+						"app.kubernetes.io/managed-by":  "datadog-operator",
+						"app.kubernetes.io/name":        "datadog-agent-deployment",
+						"app.kubernetes.io/part-of":     "foo",
+						"app.kubernetes.io/version":     "",
+					},
+					Annotations: map[string]string{"agent.datadoghq.com/agentspechash": defaultClusterAgentHash},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"agent.datadoghq.com/name":      "foo",
+								"agent.datadoghq.com/component": "cluster-agent",
+								"app.kubernetes.io/instance":    "cluster-agent",
+								"app.kubernetes.io/managed-by":  "datadog-operator",
+								"app.kubernetes.io/name":        "datadog-agent-deployment",
+								"app.kubernetes.io/part-of":     "foo",
+								"app.kubernetes.io/version":     "",
+							},
+						},
+						Spec: podSpec,
+					},
+					Replicas: &testClusterAgentReplicas,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"agent.datadoghq.com/name":      "foo",
+							"agent.datadoghq.com/component": "cluster-agent",
+						},
+					},
+				},
+			},
+		},
+	}
+	tests.Run(t)
+}
+
 func TestReconcileDatadogAgent_createNewClusterAgentDeployment(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileDatadogAgent_createNewClusterAgentDeployment"})

--- a/pkg/controller/datadogagent/clusterchecksrunner.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner.go
@@ -298,6 +298,10 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 			Value: spec.ClusterName,
 		},
 		{
+			Name:      datadoghqv1alpha1.DDAPIKey,
+			ValueFrom: getAPIKeyFromSecret(dda),
+		},
+		{
 			Name:  datadoghqv1alpha1.DDSite,
 			Value: spec.Site,
 		},
@@ -363,18 +367,6 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDLogLevel,
 			Value: *spec.ClusterChecksRunner.Config.LogLevel,
-		})
-	}
-
-	if spec.Credentials.APIKeyExistingSecret != "" {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:      datadoghqv1alpha1.DDAPIKey,
-			ValueFrom: getAPIKeyFromSecret(dda),
-		})
-	} else {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  datadoghqv1alpha1.DDAPIKey,
-			Value: spec.Credentials.APIKey,
 		})
 	}
 

--- a/pkg/controller/datadogagent/clusterchecksrunner.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (r *ReconcileDatadogAgent) reconcileClusterChecksRunner(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageClusterChecksRunnerDependencies(logger, dda)
+	result, err := r.manageClusterChecksRunnerDependencies(logger, dda, newStatus)
 	if shouldReturn(result, err) {
 		return result, err
 	}
@@ -199,8 +199,12 @@ func newClusterChecksRunnerDeploymentFromInstance(
 	return dca, hash, err
 }
 
-func (r *ReconcileDatadogAgent) manageClusterChecksRunnerDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
-	result, err := r.manageClusterChecksRunnerPDB(logger, dda)
+func (r *ReconcileDatadogAgent) manageClusterChecksRunnerDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+	result, err := r.manageAgentSecret(logger, dda, newStatus)
+	if shouldReturn(result, err) {
+		return result, err
+	}
+	result, err = r.manageClusterChecksRunnerPDB(logger, dda)
 	if shouldReturn(result, err) {
 		return result, err
 	}

--- a/pkg/controller/datadogagent/clusterchecksrunner_test.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner_test.go
@@ -75,6 +75,10 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 			Value: "",
 		},
 		{
+			Name:      "DD_API_KEY",
+			ValueFrom: apiKeyValue(),
+		},
+		{
 			Name:  "DD_SITE",
 			Value: "",
 		},
@@ -133,10 +137,6 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 					FieldPath: "status.podIP",
 				},
 			},
-		},
-		{
-			Name:  "DD_API_KEY",
-			Value: "",
 		},
 	}
 }

--- a/pkg/controller/datadogagent/datadogagent_controller_test.go
+++ b/pkg/controller/datadogagent/datadogagent_controller_test.go
@@ -255,7 +255,14 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			args: args{
 				request: newRequest(resourcesNamespace, resourcesName),
 				loadFunc: func(c client.Client) {
-					_ = c.Create(context.TODO(), test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{UseEDS: true, Labels: map[string]string{"label-foo-key": "label-bar-value"}}))
+					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{UseEDS: true, Labels: map[string]string{"label-foo-key": "label-bar-value"}})
+					_ = c.Create(context.TODO(), dda)
+					labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(dda))
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: labels, Data: map[string][]byte{
+						"api-key": []byte(base64.StdEncoding.EncodeToString([]byte("api-foo"))),
+						"app-key": []byte(base64.StdEncoding.EncodeToString([]byte("app-foo"))),
+						"token":   []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
+					}}))
 				},
 			},
 			want:    reconcile.Result{Requeue: true},
@@ -292,6 +299,12 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					_ = c.Create(context.TODO(), dda)
 					_ = c.Create(context.TODO(), buildAgentClusterRole(dda, getAgentRbacResourcesName(dda), getAgentVersion(dda)))
 					_ = c.Create(context.TODO(), buildServiceAccount(dda, getAgentRbacResourcesName(dda), getAgentVersion(dda)))
+					labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(dda))
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: labels, Data: map[string][]byte{
+						"api-key": []byte(base64.StdEncoding.EncodeToString([]byte("api-foo"))),
+						"app-key": []byte(base64.StdEncoding.EncodeToString([]byte("app-foo"))),
+						"token":   []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
+					}}))
 				},
 			},
 			want:    reconcile.Result{Requeue: true},
@@ -328,6 +341,12 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						roleName:           resourceName,
 						serviceAccountName: resourceName,
 					}, version))
+					labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(dda))
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: labels, Data: map[string][]byte{
+						"api-key": []byte(base64.StdEncoding.EncodeToString([]byte("api-foo"))),
+						"app-key": []byte(base64.StdEncoding.EncodeToString([]byte("app-foo"))),
+						"token":   []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
+					}}))
 				},
 			},
 			want:    reconcile.Result{Requeue: true},
@@ -1958,6 +1977,14 @@ func createAgentDependencies(c client.Client, dda *datadoghqv1alpha1.DatadogAgen
 		serviceAccountName: getAgentServiceAccount(dda),
 	}, version))
 	_ = c.Create(context.TODO(), buildServiceAccount(dda, getAgentServiceAccount(dda), version))
+
+	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(dda))
+	_ = c.Create(context.TODO(), test.NewSecret(dda.ObjectMeta.Namespace, "foo", &test.NewSecretOptions{Labels: labels, Data: map[string][]byte{
+		"api-key": []byte(base64.StdEncoding.EncodeToString([]byte("api-foo"))),
+		"app-key": []byte(base64.StdEncoding.EncodeToString([]byte("app-foo"))),
+		"token":   []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
+	}}))
+
 }
 
 func createClusterAgentDependencies(c client.Client, dda *datadoghqv1alpha1.DatadogAgent) {

--- a/pkg/controller/datadogagent/datadogagent_controller_test.go
+++ b/pkg/controller/datadogagent/datadogagent_controller_test.go
@@ -538,7 +538,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
 				secret := &corev1.Secret{}
-				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, "foo-cluster-agent").NamespacedName, secret); err != nil {
+				if err := c.Get(context.TODO(), newRequest(resourcesNamespace, "foo").NamespacedName, secret); err != nil {
 					return err
 				}
 				if secret.OwnerReferences == nil || len(secret.OwnerReferences) != 1 {
@@ -863,7 +863,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 				},
@@ -892,7 +892,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true, MetricsServerEnabled: true})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 					dcaService := test.NewService(resourcesNamespace, "foo-cluster-agent", &test.NewServiceOptions{Spec: &corev1.ServiceSpec{
@@ -940,7 +940,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -973,7 +973,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 					dcaService := test.NewService(resourcesNamespace, "foo-cluster-agent", &test.NewServiceOptions{Spec: &corev1.ServiceSpec{
@@ -1024,7 +1024,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 					dcaService := test.NewService(resourcesNamespace, "foo-cluster-agent", &test.NewServiceOptions{Spec: &corev1.ServiceSpec{
@@ -1079,7 +1079,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 					dcaService := test.NewService(resourcesNamespace, "foo-cluster-agent", &test.NewServiceOptions{Spec: &corev1.ServiceSpec{
@@ -1132,7 +1132,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true, MetricsServerEnabled: true})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1189,7 +1189,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{Labels: map[string]string{"label-foo-key": "label-bar-value"}, ClusterAgentEnabled: true, MetricsServerEnabled: false})
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 					dcaService := test.NewService(resourcesNamespace, "foo-cluster-agent", &test.NewServiceOptions{Spec: &corev1.ServiceSpec{
@@ -1276,7 +1276,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, dadOptions)
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1339,7 +1339,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, dadOptions)
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1396,7 +1396,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						}
 						_ = c.Create(context.TODO(), dda)
 						// commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-						// _ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+						// _ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						// 	"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 						// }}))
 					},
@@ -1434,7 +1434,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, dadOptions)
 					_ = c.Create(context.TODO(), dda)
 					commonDCAlabels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1510,7 +1510,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					_ = c.Create(context.TODO(), dda)
 					_ = c.Create(context.TODO(), dca)
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1566,7 +1566,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					_ = c.Create(context.TODO(), dda)
 					_ = c.Create(context.TODO(), dca)
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1629,7 +1629,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					_ = c.Create(context.TODO(), dda)
 					_ = c.Create(context.TODO(), dca)
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1686,7 +1686,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					_ = c.Create(context.TODO(), dda)
 					_ = c.Create(context.TODO(), dca)
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1751,7 +1751,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					_ = c.Create(context.TODO(), dda)
 					_ = c.Create(context.TODO(), dca)
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 
@@ -1823,7 +1823,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					_ = c.Create(context.TODO(), dda)
 					_ = c.Create(context.TODO(), dca)
-					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo-cluster-agent", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
+					_ = c.Create(context.TODO(), test.NewSecret(resourcesNamespace, "foo", &test.NewSecretOptions{Labels: commonDCAlabels, Data: map[string][]byte{
 						"token": []byte(base64.StdEncoding.EncodeToString([]byte("token-foo"))),
 					}}))
 

--- a/pkg/controller/utils/shared_utils.go
+++ b/pkg/controller/utils/shared_utils.go
@@ -6,12 +6,10 @@
 package utils
 
 import (
-	"fmt"
-
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/pkg/apis/datadoghq/v1alpha1"
 )
 
-// GetAPIKeySecretName return API key secret name
+// GetAPIKeySecretName return the API key secret name
 func GetAPIKeySecretName(dda *datadoghqv1alpha1.DatadogAgent) string {
 	if dda.Spec.Credentials.APIKeyExistingSecret != "" {
 		return dda.Spec.Credentials.APIKeyExistingSecret
@@ -19,10 +17,10 @@ func GetAPIKeySecretName(dda *datadoghqv1alpha1.DatadogAgent) string {
 	return dda.Name
 }
 
-// GetAppKeySecretName return APP key secret name
+// GetAppKeySecretName return the APP key secret name
 func GetAppKeySecretName(dda *datadoghqv1alpha1.DatadogAgent) string {
 	if dda.Spec.Credentials.AppKeyExistingSecret != "" {
 		return dda.Spec.Credentials.AppKeyExistingSecret
 	}
-	return fmt.Sprintf("%s-%s", dda.Name, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix)
+	return dda.Name
 }


### PR DESCRIPTION
### What does this PR do?

Ensure the API and APP key are read from the secret

### Motivation

#### Before

```
$ kubectl --context gke_datadog-sandbox_europe-west4-c_lenaic --namespace datadog-agent-operator describe pod/datadog-agent-cluster-agent-7bcd56d9c9-lztvp pod/datadog-agent-cluster-checks-runner-649ff5b589-q6v47 pod/datadog-agent-agent-8xdbx | grep -E "^Name:|Environment:|DD_CLUSTER_AGENT_AUTH_TOKEN:|DD_API_KEY:|DD_APP_KEY:" | sed "s|$DD_API_KEY|DD_API_KEY_IN_CLEAR_CONCEALED_HERE|; s|$DD_APP_KEY|DD_APP_KEY_IN_CLEAR_CONCEALED_HERE|"
Name:         datadog-agent-cluster-agent-7bcd56d9c9-lztvp
    Environment:
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent-cluster-agent'>  Optional: false
      DD_API_KEY:                                DD_API_KEY_IN_CLEAR_CONCEALED_HERE
      DD_APP_KEY:                                DD_APP_KEY_IN_CLEAR_CONCEALED_HERE
Name:         datadog-agent-cluster-checks-runner-649ff5b589-q6v47
    Environment:
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent-cluster-agent'>  Optional: false
      DD_API_KEY:                                DD_API_KEY_IN_CLEAR_CONCEALED_HERE
Name:         datadog-agent-agent-8xdbx
    Environment:    <none>
    Environment:
      DD_API_KEY:                                DD_API_KEY_IN_CLEAR_CONCEALED_HERE
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent-cluster-agent'>  Optional: false
    Environment:    <none>
    Environment:
      DD_API_KEY:                                DD_API_KEY_IN_CLEAR_CONCEALED_HERE
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent-cluster-agent'>  Optional: false
    Environment:
      DD_API_KEY:                  DD_API_KEY_IN_CLEAR_CONCEALED_HERE
    Environment:
      DD_API_KEY:                  DD_API_KEY_IN_CLEAR_CONCEALED_HERE
    Environment:
```

#### After

```
$ kubectl --context gke_datadog-sandbox_europe-west4-c_lenaic --namespace datadog-agent-operator describe pod/datadog-agent-cluster-agent-d9cfb75fc-mfpjh pod/datadog-agent-cluster-checks-runner-69b4bf645c-tb68f pod/datadog-agent-agent-7k9sp | grep -E "^Name:|Environment:|DD_CLUSTER_AGENT_AUTH_TOKEN:|DD_API_KEY:|DD_APP_KEY:"
Name:         datadog-agent-cluster-agent-d9cfb75fc-mfpjh
    Environment:
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent'>  Optional: false
      DD_API_KEY:                                <set to the key 'api_key' in secret 'datadog-agent'>  Optional: false
      DD_APP_KEY:                                <set to the key 'app_key' in secret 'datadog-agent'>  Optional: false
Name:         datadog-agent-cluster-checks-runner-69b4bf645c-tb68f
    Environment:
      DD_API_KEY:                                <set to the key 'api_key' in secret 'datadog-agent'>  Optional: false
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent'>  Optional: false
Name:         datadog-agent-agent-7k9sp
    Environment:    <none>
    Environment:
      DD_API_KEY:                                <set to the key 'api_key' in secret 'datadog-agent'>  Optional: false
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent'>  Optional: false
    Environment:    <none>
    Environment:
      DD_API_KEY:                                <set to the key 'api_key' in secret 'datadog-agent'>  Optional: false
      DD_CLUSTER_AGENT_AUTH_TOKEN:               <set to the key 'token' in secret 'datadog-agent'>  Optional: false
    Environment:
      DD_API_KEY:                  <set to the key 'api_key' in secret 'datadog-agent'>  Optional: false
    Environment:
      DD_API_KEY:                  <set to the key 'api_key' in secret 'datadog-agent'>  Optional: false
    Environment:
```

### Additional Notes
