### PR TITLE
Honor DD_SITE by not adding DD_DD_URL env var by default

### DIFF
--- a/cmd/kubectl-datadog/flare/flare.go
+++ b/cmd/kubectl-datadog/flare/flare.go
@@ -132,7 +132,7 @@ func (o *options) complete(cmd *cobra.Command, args []string) error {
 	}
 
 	if ddSite == "" {
-		ddSite, err = common.AskForInput("Please enter your Datatod site [us/eu] (default us): ")
+		ddSite, err = common.AskForInput("Please enter your Datatog site [us/eu] (default us): ")
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -19,7 +19,6 @@ import (
 // default values
 const (
 	DefaultLogLevel                               string = "INFO"
-	defaultDatadogURL                             string = "https://app.datadoghq.com"
 	defaultAgentImage                             string = "datadog/agent:latest"
 	defaultCollectEvents                          bool   = false
 	defaultLeaderElection                         bool   = false
@@ -152,10 +151,6 @@ func IsDefaultedImageConfig(imageConfig *ImageConfig) bool {
 // returns true if yes, else false
 func IsDefaultedDatadogAgentSpecAgentConfig(config *NodeAgentConfig) bool {
 	if config == nil {
-		return false
-	}
-
-	if config.DDUrl == nil {
 		return false
 	}
 
@@ -400,10 +395,6 @@ func DefaultDatadogAgentSpecAgentImage(image *ImageConfig) *ImageConfig {
 func DefaultDatadogAgentSpecAgentConfig(config *NodeAgentConfig) *NodeAgentConfig {
 	if config == nil {
 		config = &NodeAgentConfig{}
-	}
-
-	if config.DDUrl == nil {
-		config.DDUrl = NewStringPointer(defaultDatadogURL)
 	}
 
 	if config.LogLevel == nil {

--- a/pkg/controller/datadogagent/agent_rbac.go
+++ b/pkg/controller/datadogagent/agent_rbac.go
@@ -52,7 +52,7 @@ func (r *ReconcileDatadogAgent) manageAgentRBACs(logger logr.Logger, dda *datado
 		return reconcile.Result{}, err
 	}
 
-	// Create ClusterRoleBindig
+	// Create ClusterRoleBinding
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesName}, clusterRoleBinding); err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -169,10 +169,6 @@ func defaultEnvVars() []corev1.EnvVar {
 			Value: "",
 		},
 		{
-			Name:  "DD_DD_URL",
-			Value: "https://app.datadoghq.com",
-		},
-		{
 			Name:  "DD_HEALTH_PORT",
 			Value: "5555",
 		},

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -165,10 +165,6 @@ func defaultEnvVars() []corev1.EnvVar {
 			Value: "",
 		},
 		{
-			Name:  "DD_SITE",
-			Value: "",
-		},
-		{
 			Name:  "DD_HEALTH_PORT",
 			Value: "5555",
 		},
@@ -207,6 +203,10 @@ func defaultEnvVars() []corev1.EnvVar {
 		{
 			Name:  "DD_LOG_LEVEL",
 			Value: "INFO",
+		},
+		{
+			Name:  "DD_SITE",
+			Value: "",
 		},
 		{
 			Name: "DD_KUBERNETES_KUBELET_HOST",

--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -436,7 +436,7 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 		},
 	}
 
-	if spec.Agent != nil {
+	if spec.Agent != nil && spec.Agent.Config.DDUrl != nil {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDddURL,
 			Value: *spec.Agent.Config.DDUrl,

--- a/pkg/controller/datadogagent/clusteragent_test.go
+++ b/pkg/controller/datadogagent/clusteragent_test.go
@@ -89,10 +89,6 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 			Value: "true",
 		},
 		{
-			Name:  "DD_DD_URL",
-			Value: "https://app.datadoghq.com",
-		},
-		{
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
 		},

--- a/pkg/controller/datadogagent/clusterchecksrunner.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner.go
@@ -310,10 +310,6 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 			Value: spec.Site,
 		},
 		{
-			Name:  datadoghqv1alpha1.DDddURL,
-			Value: *spec.Agent.Config.DDUrl,
-		},
-		{
 			Name:  datadoghqv1alpha1.DDClusterChecksEnabled,
 			Value: "true",
 		},
@@ -371,6 +367,13 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDLogLevel,
 			Value: *spec.ClusterChecksRunner.Config.LogLevel,
+		})
+	}
+
+	if spec.Agent.Config.DDUrl != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDddURL,
+			Value: *spec.Agent.Config.DDUrl,
 		})
 	}
 

--- a/pkg/controller/datadogagent/clusterchecksrunner_test.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner_test.go
@@ -83,10 +83,6 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 			Value: "",
 		},
 		{
-			Name:  "DD_DD_URL",
-			Value: "https://app.datadoghq.com",
-		},
-		{
 			Name:  "DD_CLUSTER_CHECKS_ENABLED",
 			Value: "true",
 		},

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -404,6 +404,10 @@ func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]c
 			Value: getLogLevel(dda),
 		},
 		{
+			Name:  datadoghqv1alpha1.DDSite,
+			Value: dda.Spec.Site,
+		},
+		{
 			Name: datadoghqv1alpha1.DDKubeletHost,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -471,10 +475,6 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 		{
 			Name:  datadoghqv1alpha1.DDClusterName,
 			Value: spec.ClusterName,
-		},
-		{
-			Name:  datadoghqv1alpha1.DDSite,
-			Value: spec.Site,
 		},
 		{
 			Name:  datadoghqv1alpha1.DDHealthPort,

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -444,6 +444,13 @@ func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]c
 		})
 	}
 
+	if dda.Spec.Agent.Config.DDUrl != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDddURL,
+			Value: *dda.Spec.Agent.Config.DDUrl,
+		})
+	}
+
 	return envVars, nil
 }
 
@@ -468,10 +475,6 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 		{
 			Name:  datadoghqv1alpha1.DDSite,
 			Value: spec.Site,
-		},
-		{
-			Name:  datadoghqv1alpha1.DDddURL,
-			Value: *spec.Agent.Config.DDUrl,
 		},
 		{
 			Name:  datadoghqv1alpha1.DDHealthPort,


### PR DESCRIPTION
### What does this PR do?

While trying Datadog Operator for my use case, I started noticing that no matter if I had set `Site` to `EU`, my agents would try to send data to `https://app.datadoghq.com`. 

After inspecting the generated manifests for both the datadog agent and the datadog cluster agent, I noticed that even though `DD_SITE` was set to `EU`, a `DD_DD_URL` env var was populated and set to `https://app.datadoghq.com`, overriding `DD_SITE`.

In the documentation, it is said that `DD_DD_URL` is optional, and should only be set when one wants to override the endpoint that `DD_SITE` would make Datadog Agent use (for example if you use a proxy, or need a mock endpoint, etc...)

After looking through the codebase, I noticed that `DD_DD_URL` was indeed set by default. This PR is addressing this issue

### Motivation

Solving my issues with Datadog Operator

### Additional Notes

For Datadog people, a support case was opened (#342506)