### PR TITLE
Use DdSite or DdUrl for MetricsForwarder API client

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -57,6 +57,7 @@ type NewDatadogAgentOptions struct {
 	ClusterChecksRunnerVolumeMounts []corev1.VolumeMount
 	ClusterChecksRunnerEnvVars      []corev1.EnvVar
 	APIKeyExistingSecret            string
+	Site                            string
 }
 
 // NewDefaultedDatadogAgent returns an initialized and defaulted DatadogAgent for testing purpose
@@ -104,6 +105,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		}
 
 		ad.Spec.Agent.DaemonsetName = options.AgentDaemonsetName
+		ad.Spec.Site = options.Site
 
 		if options.Status != nil {
 			ad.Status = *options.Status
@@ -123,6 +125,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 				},
 				DeploymentName: options.ClusterAgentDeploymentName,
 			}
+
 			if options.MetricsServerEnabled {
 				ad.Spec.ClusterAgent.Config.MetricsProviderEnabled = datadoghqv1alpha1.NewBoolPointer(true)
 

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -1029,3 +1029,59 @@ func Test_metricsForwarder_getSecretsFromCache(t *testing.T) {
 		})
 	}
 }
+
+func Test_getbaseURL(t *testing.T) {
+	type args struct {
+		dda *datadoghqv1alpha1.DatadogAgent
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Get default baseURL",
+			args: args{
+				dda: test.NewDefaultedDatadogAgent("foo", "bar", &test.NewDatadogAgentOptions{}),
+			},
+			want: "https://api.datadoghq.com",
+		},
+		{
+			name: "Compute baseURL from site when passing Site",
+			args: args{
+				dda: test.NewDefaultedDatadogAgent("foo", "bar", &test.NewDatadogAgentOptions{
+					Site: "datadoghq.eu",
+				}),
+			},
+			want: "https://api.datadoghq.eu",
+		},
+		{
+			name: "Compute baseURL from ddUrl when Site is not defined",
+			args: args{
+				dda: test.NewDefaultedDatadogAgent("foo", "bar", &test.NewDatadogAgentOptions{
+					NodeAgentConfig: &datadoghqv1alpha1.NodeAgentConfig{
+						DDUrl: datadoghqv1alpha1.NewStringPointer("https://test.url.com"),
+					}}),
+			},
+			want: "https://test.url.com",
+		},
+		{
+			name: "Test that DDUrl takes precedence over Site",
+			args: args{
+				dda: test.NewDefaultedDatadogAgent("foo", "bar", &test.NewDatadogAgentOptions{
+					Site: "datadoghq.eu",
+					NodeAgentConfig: &datadoghqv1alpha1.NodeAgentConfig{
+						DDUrl: datadoghqv1alpha1.NewStringPointer("https://test.url.com"),
+					}}),
+			},
+			want: "https://test.url.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getbaseURL(tt.args.dda); got != tt.want {
+				t.Errorf("getbaseURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
 
This PR:
*  Adds a field to the `metricsForwarder` struct: `baseURL`
* Adds a `getBaseURL` method that returns the appropriate base URL based on the `ddUrl` or `site` fields in the definition of the agent
* Sets the base URL after the client has been initialized
* Adds the base URL used when error-ing out on invalid credentials.

### Motivation

After submitting #90 and testing it out, I realized that the operator was also trying to push metrics, grabbing the credentials from the agent. Unfortunately the metrics forwarder wasn't using the DD_SITE / DD_DD_URL setting and would use the default of the client SDK, which is `https://api.datadoghq.com`

### Additional Notes

I've tested this successfully in a 1.16 EKS cluster, using `site: datadoghq.eu`

PS: The validation build failure doesn't seem to be related to my changes. 