### PR TITLE
Pass existing DS to updateDaemonSetStatus in updateDaemonSet when no change is required

### DIFF
--- a/pkg/controller/datadogagent/agent.go
+++ b/pkg/controller/datadogagent/agent.go
@@ -240,7 +240,7 @@ func (r *ReconcileDatadogAgent) updateDaemonSet(logger logr.Logger, dda *datadog
 	now := metav1.NewTime(time.Now())
 	if comparison.IsSameSpecMD5Hash(newHash, ds.GetAnnotations()) {
 		// no update needed so update the status and return
-		newStatus.Agent = updateDaemonSetStatus(newDS, newStatus.Agent, &now)
+		newStatus.Agent = updateDaemonSetStatus(ds, newStatus.Agent, &now)
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes https://github.com/DataDog/datadog-operator/issues/93

In `updateDaemonSet`, we create a new daemonset before checking if we need to make an update to the daemonset. Unfortunately, instead of passing the existing DS to the `updateDaemonSetStatus` method, we were passing the new one, which obviously had no containers running, resulting in the Agent having its status stuck in `Progressing (0/0/0)`.

Once we pass the existing DS, the status updates as expected.

### Motivation

Fixing my own issue

### Additional Notes