### PR TITLE
[Doc] secret backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The **Datadog Operator** aims to provide a new way of deploying the [Datadog Age
 - Optionally, use of an advanced `DaemonSet` deployment by leveraging the [ExtendedDaemonSet][2].
 - Many other features to come :).
 
-The **Datadog Operator** is [RedHat certified][9] and available on [operatorhub.io][10].
+The **Datadog Operator** is [RedHat certified][10] and available on [operatorhub.io][11].
 
 ## Datadog Operator vs. Helm chart
 
@@ -36,10 +36,11 @@ The Datadog operator also allows you to:
 
 - [Configure and provide custom checks to the Agents][6].
 - [Deploy the Datadog Cluster Agent with your node Agents][7].
+- [Secrets Management with the Datadog Operator][8].
 
 ## How to contribute
 
-See the [How to Contribute page][8].
+See the [How to Contribute page][9].
 
 [1]: https://github.com/DataDog/datadog-agent/
 [2]: https://github.com/DataDog/extendeddaemonset
@@ -48,9 +49,10 @@ See the [How to Contribute page][8].
 [5]: https://github.com/DataDog/datadog-operator/blob/master/docs/getting_started.md
 [6]: https://github.com/DataDog/datadog-operator/blob/master/docs/custom_check.md
 [7]: https://github.com/DataDog/datadog-operator/blob/master/docs/cluster_agent_setup.md
-[8]: https://github.com/DataDog/datadog-operator/tree/master/docs/how-to-contribute.md
-[9]: https://catalog.redhat.com/software/operators/detail/5e845a42ecb5246c09fe90b6
-[10]: https://operatorhub.io/operator/datadog-operator
+[8]: https://github.com/DataDog/datadog-operator/blob/master/docs/secret_management.md
+[9]: https://github.com/DataDog/datadog-operator/tree/master/docs/how-to-contribute.md
+[10]: https://catalog.redhat.com/software/operators/detail/5e845a42ecb5246c09fe90b6
+[11]: https://operatorhub.io/operator/datadog-operator
 
 ## Release
 

--- a/chart/datadog-operator/templates/deployment.yaml
+++ b/chart/datadog-operator/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             - "--supportExtendedDaemonset={{ .Values.supportExtendedDaemonset}}"
             - "--probesPort={{ .Values.probesPort }}"
             - "--metricsPort={{ .Values.metricsPort }}"
+          {{- if .Values.secretBackend.command }}
+            - "--secretBackendCommand={{ .Values.secretBackend.command }}"
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metricsPort }}

--- a/chart/datadog-operator/values.yaml
+++ b/chart/datadog-operator/values.yaml
@@ -13,6 +13,11 @@ logLevel: "info"
 supportExtendedDaemonset: "false"
 probesPort: 9090
 metricsPort: 8383
+
+secretBackend:
+  # Specifies the path to the command that implements the secret backend api
+  command: ""
+
 rbac:
   # Specifies whether the RBAC resources should be created
   create: true

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -37,7 +37,7 @@ spec:
   # ...
 ```
 
-In this case, the secret(s) should exist before trying to create the `DatadogAgent`, else the deployment will failed.
+In this case, the secret(s) should exist before trying to create the `DatadogAgent`, else the deployment will fail.
 
 ```yaml
 apiVersion: v1
@@ -56,9 +56,9 @@ data:
   app_key: <app-key>
 ```
 
-The keys used in the secret(s) are important. for the "API key" the key inside the secret should be `api_key`, and for the "APP key" it is `app_key`.
+The data keys used in the secret(s) are important. for the "API key" the key inside the secret should be `api_key`, and for the "APP key" it is `app_key`.
 
-**Remarks:**
+**Note:**
 
 * It is possible to use the same secret to store both credentials
 
@@ -95,14 +95,14 @@ success
 ```
 
 Then, during the installation or the update of the "Datadog Operator" deployment the value parameter: `.Values.secretBackend.command` should be set with the secret backend command path (inside the container).
-Also don't for get use the "custom" Datadog Operator container image.
+Also don't forget to use the "custom" Datadog Operator container image.
 
 ```console
 $ helm [install|upgrade] dd-operator --set "secretBackend.command=/my-secret-backend.sh" --set "image.repository=datadog-operator-with-secret-be" ./chart/datadog-operator
 success
 ```
 
-### How deploy agents using the secret backend feature with DatadogDeployment
+### How deploy agents using the secret backend feature with DatadogAgent
 
 To activate the secret backend feature in the `DatadogAgent` configuration, the `spec.credentials.useSecretBackend` parameter should be set to `true`.
 

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -1,0 +1,172 @@
+# Secrets Management for the API and APP keys
+
+The Datadog-Operator is able to retrieves the datadog credentials securely thanks to 3 different methods.
+
+## 1. Plain credentials in DatadogAgent resource
+
+this is the simplest way to provide the credentials that will be used by the agents.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: "<api-key>"
+    appKey: "<app-key>"
+  # ...
+```
+
+The credentials provided here will be stored in a Secret created by the Operator. By setting properly the `RBAC` on the `DatadogAgent` CRD. It is possible to limit who is able to see those credentials.
+But still, it is not the best solution in terms of security. This solution is good for testing purposes.
+
+## 2. Use secret(s) references
+
+Another solution is to provide the name of the secret(s) that store the credentials. like this the `DatadogAgent` resource doesn't contain any credentials as plain text.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKeyExistingSecret: "my-api-key-secret"
+    appKeyExistingSecret: "my-app-key-secret"
+  # ...
+```
+
+In this case, the secret(s) should exist before trying to create the `DatadogAgent`, else the deployment will failed.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-api-key-secret
+data:
+  api_key: <api-key>
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-app-key-secret
+data:
+  app_key: <app-key>
+```
+
+The keys used in the secret(s) are important. for the "API key" the key inside the secret should be `api_key`, and for the "APP key" it is `app_key`.
+
+**Remarks:**
+
+* It is possible to use the same secret to store both credentials
+
+    ```yaml
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: my-credentials
+    data:
+      api_key: <api-key>
+      app_key: <app-key>
+    ```
+
+## 3. Use the Secret backend feature
+
+The Datatog Operator is compatible with the ["Secret backend" feature][1] implemented initialy in the datadog agent.
+
+### How Deploy the Datadog-Operator with the secret backend activated
+
+The first step is to create a container image from the `datadog/operator` that contains the secret backend command.
+
+The following Dockerfile example takes the `datadog/operator:latest` image as the base image and copies the `my-secret-backend.sh` script file.
+
+```Dockerfile
+FROM datadog/operator:latest
+COPY ./my-secret-backend.sh /my-secret-backend.sh
+RUN chmod 755 /my-secret-backend.sh
+```
+
+```console
+$ docker build -t datadog-operator-with-secret-be:latest .
+success
+```
+
+Then, during the installation or the update of the "Datadog Operator" deployment the value parameter: `.Values.secretBackend.command` should be set with the secret backend command path (inside the container).
+Also don't for get use the "custom" Datadog Operator container image.
+
+```console
+$ helm [install|upgrade] dd-operator --set "secretBackend.command=/my-secret-backend.sh" --set "image.repository=datadog-operator-with-secret-be" ./chart/datadog-operator
+success
+```
+
+### How deploy agents using the secret backend feature with DatadogDeployment
+
+To activate the secret backend feature in the `DatadogAgent` configuration, the `spec.credentials.useSecretBackend` parameter should be set to `true`.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: ENC[<api-key-secret-id>]
+    appKey: ENC[<app-key-secret-id>]
+    useSecretBackend: true
+  # ...
+```
+
+Then inside the `spec.agent` configuration part, the secret backend command can be specified by adding a new environment variable: "DD_SECRET_BACKEND_COMMAND".
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  # ..
+  agent:
+    image:
+      name: "datadog/agent:latest"
+    config:
+      env:
+      - name: DD_SECRET_BACKEND_COMMAND
+        value: "/my-secret-backend.sh"
+```
+
+If the "Cluster Agent" and the "Cluster Check Runner" are also deployed, the environment variable needs to be added also in the other environment variables configuration.
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  # ...
+  clusterAgent:
+    # ...
+    config:
+      env:
+      - name: DD_SECRET_BACKEND_COMMAND
+        value: "/my-secret-backend.sh"
+  clusterChecksRunner:
+    # ...
+    config:
+      env:
+      - name: DD_SECRET_BACKEND_COMMAND
+        value: "/my-secret-backend.sh"
+```
+
+**Remarks:**
+
+* Like for the "Datadog Operator", the "Agent" and "Cluster Agent" container images need to contain the "secret backend" command.
+* For the "Agent" and "Cluster Agent", others options exist to configure secret backend command:
+
+  * **DD_SECRET_BACKEND_ARGUMENTS**: those arguments will be specified to the command when the agent executes the secret backend command.
+  * **DD_SECRET_BACKEND_OUTPUT_MAX_SIZE**: maximum output size of the secret backend command. The default value is 1048576 (1Mb).
+  * **DD_SECRET_BACKEND_TIMEOUT**: secret backend execution timeout in second. The default value is 5 seconds.
+
+[1]: https://docs.datadoghq.com/agent/guide/secrets-management

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -1,8 +1,10 @@
 # Secrets Management for the API and APP keys
 
-The Datadog Operator is able to retrieve the Datadog credentials securely using these three methods:
+Datadog Operator can be configured to retrieve the Datadog credentials using secrets for enhanced security. There are three methods you can choose from to set it up
 
-## 1. Plain credentials in DatadogAgent resource
+## 1. Plain credentials in `DatadogAgent` resource
+
+This is the simplest way to provide the credentials to the agents. This method is recommended for testing purposes only.
 
 Add credentials to the Agent:
 
@@ -19,7 +21,6 @@ spec:
 ```
 
 The credentials provided here will be stored in a Secret created by the Operator. By setting properly the `RBAC` on the `DatadogAgent` CRD, it is possible to limit who is able to see those credentials.
-But still, it is not the best solution in terms of security. This solution is good for testing purposes.
 
 ## 2. Use secret(s) references
 

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -1,10 +1,10 @@
 # Secrets Management for the API and APP keys
 
-The Datadog-Operator is able to retrieves the datadog credentials securely thanks to 3 different methods.
+The Datadog Operator is able to retrieve the Datadog credentials securely using these three methods:
 
 ## 1. Plain credentials in DatadogAgent resource
 
-this is the simplest way to provide the credentials that will be used by the agents.
+Add credentials to the Agent:
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -18,12 +18,12 @@ spec:
   # ...
 ```
 
-The credentials provided here will be stored in a Secret created by the Operator. By setting properly the `RBAC` on the `DatadogAgent` CRD. It is possible to limit who is able to see those credentials.
+The credentials provided here will be stored in a Secret created by the Operator. By setting properly the `RBAC` on the `DatadogAgent` CRD, it is possible to limit who is able to see those credentials.
 But still, it is not the best solution in terms of security. This solution is good for testing purposes.
 
 ## 2. Use secret(s) references
 
-Another solution is to provide the name of the secret(s) that store the credentials. like this the `DatadogAgent` resource doesn't contain any credentials as plain text.
+Another solution is to provide the name of the secret(s) that store the credentials:
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1
@@ -37,7 +37,7 @@ spec:
   # ...
 ```
 
-In this case, the secret(s) should exist before trying to create the `DatadogAgent`, else the deployment will fail.
+Create the secret before deploying the Datadog Agent, or the deployment fails.
 
 ```yaml
 apiVersion: v1
@@ -60,7 +60,7 @@ The data keys used in the secret(s) are important. for the "API key" the key ins
 
 **Note:**
 
-* It is possible to use the same secret to store both credentials
+It is possible to use the same secret to store both credentials:
 
     ```yaml
     ---
@@ -75,7 +75,7 @@ The data keys used in the secret(s) are important. for the "API key" the key ins
 
 ## 3. Use the Secret backend feature
 
-The Datatog Operator is compatible with the ["Secret backend" feature][1] implemented initialy in the datadog agent.
+The Datatog Operator is compatible with the ["Secret backend" feature][1] implemented.
 
 ### How Deploy the Datadog-Operator with the secret backend activated
 


### PR DESCRIPTION
### What does this PR do?

* Add documentation regarding "secret management" with the Operator 
* Add new parameter in the "Datadog-Operator" chart to allow the specification of the "secret backend command".

### Motivation

Helps user to deploy the agent with the "secret backend" activated on the operator and on the Agents deployed with the operator.


