### PR TITLE
Add hostPort for Agent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         go-version: 1.13
       id: go
-    - name: install requiere packages
+    - name: install required packages
       uses: mstksg/get-package@v1
       with:
         apt-get: mercurial jq build-essential

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -52,7 +52,7 @@ const (
 	DDLogsConfigContainerCollectAll  = "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL"
 	DDLogsContainerCollectUsingFiles = "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE"
 	DDDogstatsdOriginDetection       = "DD_DOGSTATSD_ORIGIN_DETECTION"
-	DDDogstatsdPort                  = "DD_DOGSTATD_PORT"
+	DDDogstatsdPort                  = "DD_DOGSTATSD_PORT"
 	DDClusterAgentEnabled            = "DD_CLUSTER_AGENT_ENABLED"
 	DDClusterAgentKubeServiceName    = "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME"
 	DDClusterAgentAuthToken          = "DD_CLUSTER_AGENT_AUTH_TOKEN"

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -52,6 +52,7 @@ const (
 	DDLogsConfigContainerCollectAll  = "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL"
 	DDLogsContainerCollectUsingFiles = "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE"
 	DDDogstatsdOriginDetection       = "DD_DOGSTATSD_ORIGIN_DETECTION"
+	DDDogstatsdPort                  = "DD_DOGSTATD_PORT"
 	DDClusterAgentEnabled            = "DD_CLUSTER_AGENT_ENABLED"
 	DDClusterAgentKubeServiceName    = "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME"
 	DDClusterAgentAuthToken          = "DD_CLUSTER_AGENT_AUTH_TOKEN"

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -31,6 +31,8 @@ const (
 	DefaultClusterAgentServicePort = 5005
 	// DefaultMetricsServerServicePort default metrics-server port
 	DefaultMetricsServerServicePort = 443
+	// DefaultDogstatsdPort default dogstatsd port
+	DefaultDogstatsdPort = 8125
 )
 
 // Datadog env var names

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -471,6 +471,14 @@ type NodeAgentConfig struct {
 	// +optional
 	// +listType=set
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// Number of port to expose on the host.
+	// If specified, this must be a valid port number, 0 < x < 65536.
+	// If HostNetwork is specified, this must match ContainerPort.
+	// Most containers do not need this.
+	//
+	// +optional
+	HostPort *int32 `json:"hostPort,omitempty"`
 }
 
 // CRISocketConfig contains the CRI socket configuration parameters

--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -59,6 +59,7 @@ type NewDatadogAgentOptions struct {
 	APIKeyExistingSecret            string
 	Site                            string
 	HostPort                        int32
+	HostNetwork                     bool
 }
 
 // NewDefaultedDatadogAgent returns an initialized and defaulted DatadogAgent for testing purpose
@@ -181,6 +182,10 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 
 		if options.ProcessEnabled {
 			ad.Spec.Agent.Process.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+		}
+
+		if options.HostNetwork {
+			ad.Spec.Agent.HostNetwork = true
 		}
 
 		if options.SystemProbeEnabled {

--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -58,6 +58,7 @@ type NewDatadogAgentOptions struct {
 	ClusterChecksRunnerEnvVars      []corev1.EnvVar
 	APIKeyExistingSecret            string
 	Site                            string
+	HostPort                        int32
 }
 
 // NewDefaultedDatadogAgent returns an initialized and defaulted DatadogAgent for testing purpose
@@ -106,6 +107,10 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 
 		ad.Spec.Agent.DaemonsetName = options.AgentDaemonsetName
 		ad.Spec.Site = options.Site
+
+		if options.HostPort != 0 {
+			ad.Spec.Agent.Config.HostPort = &options.HostPort
+		}
 
 		if options.Status != nil {
 			ad.Status = *options.Status

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -7,6 +7,7 @@ package datadogagent
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -362,6 +363,10 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 
 	hostPortPodSpec := defaultPodSpec()
 	hostPortPodSpec.Containers[0].Ports[0].HostPort = datadoghqv1alpha1.DefaultDogstatsdPort
+	hostPortPodSpec.Containers[0].Env = append(hostPortPodSpec.Containers[0].Env, corev1.EnvVar{
+		Name:  datadoghqv1alpha1.DDDogstatsdPort,
+		Value: strconv.Itoa(int(datadoghqv1alpha1.DefaultDogstatsdPort)),
+	})
 
 	tests := extendedDaemonSetFromInstanceTestSuite{
 		{

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -16,7 +16,6 @@ import (
 	edsdatadoghqv1alpha1 "github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	assert "github.com/stretchr/testify/require"
-
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -352,6 +351,18 @@ func (tests extendedDaemonSetFromInstanceTestSuite) Run(t *testing.T) {
 }
 
 func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
+
+	hostPortAgent := test.NewDefaultedDatadogAgent("bar", "foo",
+		&test.NewDatadogAgentOptions{
+			UseEDS:              true,
+			ClusterAgentEnabled: true,
+			HostPort:            datadoghqv1alpha1.DefaultDogstatsdPort,
+		})
+	hostPortAgentSpecHash, _ := comparison.GenerateMD5ForSpec(hostPortAgent.Spec)
+
+	hostPortPodSpec := defaultPodSpec()
+	hostPortPodSpec.Containers[0].Ports[0].HostPort = datadoghqv1alpha1.DefaultDogstatsdPort
+
 	tests := extendedDaemonSetFromInstanceTestSuite{
 		{
 			name:            "defaulted case",
@@ -430,6 +441,47 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 							},
 						},
 						Spec: defaultPodSpec(),
+					},
+					Strategy: getDefaultEDSStrategy(),
+				},
+			},
+		},
+		{
+			name:            "with host port",
+			agentdeployment: hostPortAgent,
+			wantErr:         false,
+			want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "bar",
+					Name:      "foo-agent",
+					Labels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
+						"agent.datadoghq.com/component": "agent",
+						"app.kubernetes.io/instance":    "agent",
+						"app.kubernetes.io/managed-by":  "datadog-operator",
+						"app.kubernetes.io/name":        "datadog-agent-deployment",
+						"app.kubernetes.io/part-of":     "foo",
+						"app.kubernetes.io/version":     "",
+					},
+					Annotations: map[string]string{"agent.datadoghq.com/agentspechash": hostPortAgentSpecHash},
+				},
+				Spec: edsdatadoghqv1alpha1.ExtendedDaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "foo",
+							Namespace:    "bar",
+							Labels: map[string]string{
+								"agent.datadoghq.com/name":      "foo",
+								"agent.datadoghq.com/component": "agent",
+								"app.kubernetes.io/instance":    "agent",
+								"app.kubernetes.io/managed-by":  "datadog-operator",
+								"app.kubernetes.io/name":        "datadog-agent-deployment",
+								"app.kubernetes.io/part-of":     "foo",
+								"app.kubernetes.io/version":     "",
+							},
+							Annotations: make(map[string]string),
+						},
+						Spec: hostPortPodSpec,
 					},
 					Strategy: getDefaultEDSStrategy(),
 				},

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -167,7 +167,11 @@ func getAgentContainer(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Container, 
 	}
 
 	if agentSpec.Config.HostPort != nil {
+		// Create the host port configuration
 		udpPort.HostPort = *agentSpec.Config.HostPort
+		// If HostNetwork is enabled, set the container port
+		// and the DD_DOGSTATSD_PORT environment variable to match the host port
+		// so that Dogstatsd can be reached on the port configured in HostPort
 		if agentSpec.HostNetwork {
 			udpPort.ContainerPort = *agentSpec.Config.HostPort
 			envVars = append(envVars, corev1.EnvVar{

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -159,6 +159,17 @@ func getAgentContainer(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Container, 
 	if err != nil {
 		return nil, err
 	}
+
+	udpPort := corev1.ContainerPort{
+		ContainerPort: datadoghqv1alpha1.DefaultDogstatsdPort,
+		Name:          "dogstatsdport",
+		Protocol:      corev1.ProtocolUDP,
+	}
+
+	if agentSpec.Config.HostPort != nil {
+		udpPort.HostPort = *agentSpec.Config.HostPort
+	}
+
 	agentContainer := &corev1.Container{
 		Name:            "agent",
 		Image:           agentSpec.Image.Name,
@@ -169,11 +180,7 @@ func getAgentContainer(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Container, 
 		},
 		Resources: *agentSpec.Config.Resources,
 		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 8125,
-				Name:          "dogstatsdport",
-				Protocol:      "UDP",
-			},
+			udpPort,
 		},
 		Env:           envVars,
 		VolumeMounts:  getVolumeMountsForAgent(&dda.Spec),

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -168,10 +168,13 @@ func getAgentContainer(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Container, 
 
 	if agentSpec.Config.HostPort != nil {
 		udpPort.HostPort = *agentSpec.Config.HostPort
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  datadoghqv1alpha1.DDDogstatsdPort,
-			Value: strconv.Itoa(int(*agentSpec.Config.HostPort)),
-		})
+		if agentSpec.HostNetwork {
+			udpPort.ContainerPort = *agentSpec.Config.HostPort
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  datadoghqv1alpha1.DDDogstatsdPort,
+				Value: strconv.Itoa(int(*agentSpec.Config.HostPort)),
+			})
+		}
 	}
 
 	agentContainer := &corev1.Container{

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -168,6 +168,10 @@ func getAgentContainer(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Container, 
 
 	if agentSpec.Config.HostPort != nil {
 		udpPort.HostPort = *agentSpec.Config.HostPort
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDDogstatsdPort,
+			Value: strconv.Itoa(int(*agentSpec.Config.HostPort)),
+		})
 	}
 
 	agentContainer := &corev1.Container{


### PR DESCRIPTION
### What does this PR do?

This PR adds the `hostPort` parameter to the Agent config, which allows exposing the Dogstatsd port to the cluster, and therefore receiving custom metrics from our applications.

### Motivation

I couldn't expose port 8125 to my applications without modifying manually the DaemonSet definition.

### Additional Notes

1. I saw that the `newDaemonSetfromInstance` method is not tested in `agent_test.go`. Therefore I added the test case to the `newExtendedDaemonSetfromInstance` method tests. I' m not sure whether this is an oversight or a design decision in an effort to reduce the amount of duplicated code, but I'm happy to write tests for `newDaemonSetFromInstance` if needed.
2. I'm also not sure if the lack of `hostPort` for Agent was by design. I saw that the APM Agent already had that setting. Please let me know if this isn't supposed to be how we should expose port 8125 to our applications.

Thanks!

Matthieu