### PR TITLE
Fix minor typo and add Helm chart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ However, the Datadog Operator is still in beta, so it is not yet a recommended w
 
 See the [Getting Started][5] dedicated documentation to learn how to deploy the Datadog operator and your first Agent.
 
-## Functionnalities
+## Functionalities
 
 The Datadog operator also allows you to:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,7 +13,7 @@ Using the Datadog Operator requires the following prerequisites:
 
 ## Deploy an agent with the operator
 
-In order to deploy a Datadog agent with the operator in the minimum number of steps, the `datadog-agent-with-operator` helm chart can be used.
+In order to deploy a Datadog agent with the operator in the minimum number of steps, the [`datadog-agent-with-operator`](https://github.com/DataDog/datadog-operator/tree/master/chart/datadog-agent-with-operator) helm chart can be used.
 Here are the steps:
 
 1. Download the [Datadog Operator project zip ball][3] and unzip it. Source code can be found at [`DataDog/datadog-operator`][4]. Go into the `datadog-operator-<tag>` folder.


### PR DESCRIPTION
### What does this PR do?

Fixes a minor typo and adds a link to the Helm chart for deploying the Datadog agent with the k8s operator

### Motivation

The motivation is to contribute to the documentation

### Additional Notes
N/A

