### PR TITLE
Use 8443 as default port for the external metrics provider

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -396,6 +396,13 @@ spec:
                       x-kubernetes-list-map-keys:
                       - name
                       x-kubernetes-list-type: map
+                    hostPort:
+                      description: Number of port to expose on the host. If specified,
+                        this must be a valid port number, 0 < x < 65536. If HostNetwork
+                        is specified, this must match ContainerPort. Most containers
+                        do not need this.
+                      format: int32
+                      type: integer
                     leaderElection:
                       description: Enables leader election mechanism for event collection.
                       type: boolean

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -31,6 +31,8 @@ const (
 	DefaultClusterAgentServicePort = 5005
 	// DefaultMetricsServerServicePort default metrics-server port
 	DefaultMetricsServerServicePort = 443
+	// DefaultMetricsServerTargetPort default metrics-server pod port
+	DefaultMetricsServerTargetPort = int(defaultMetricsProviderPort)
 	// DefaultDogstatsdPort default dogstatsd port
 	DefaultDogstatsdPort = 8125
 )

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -35,7 +35,7 @@ const (
 	defaultLogsTempStoragePath                    string = "/var/lib/datadog-agent/logs"
 	defaultProcessEnabled                         bool   = false
 	defaultMetricsProviderEnabled                 bool   = false
-	defaultMetricsProviderPort                    int32  = 443
+	defaultMetricsProviderPort                    int32  = 8443
 	defaultClusterChecksEnabled                   bool   = false
 	defaultClusterAgentReplicas                   int32  = 1
 	defaultAgentCanaryReplicas                    int32  = 1

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -1055,6 +1055,11 @@ func (in *NodeAgentConfig) DeepCopyInto(out *NodeAgentConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HostPort != nil {
+		in, out := &in.HostPort, &out.HostPort
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -1856,6 +1856,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_NodeAgentConfig(ref common.ReferenceCall
 							},
 						},
 					},
+					"hostPort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/datadogagent/clusteragent.go
+++ b/pkg/controller/datadogagent/clusteragent.go
@@ -503,7 +503,7 @@ func getClusterAgentMetricsProviderPort(config datadoghqv1alpha1.ClusterAgentCon
 	if config.MetricsProviderPort != nil {
 		return *config.MetricsProviderPort
 	}
-	return datadoghqv1alpha1.DefaultMetricsServerServicePort
+	return int32(datadoghqv1alpha1.DefaultMetricsServerTargetPort)
 }
 
 // manageClusterAgentRBACs creates deletes and updates the RBACs for the Cluster Agent

--- a/pkg/controller/datadogagent/datadogagent_controller_test.go
+++ b/pkg/controller/datadogagent/datadogagent_controller_test.go
@@ -1166,7 +1166,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						Ports: []corev1.ServicePort{
 							{
 								Protocol:   corev1.ProtocolTCP,
-								TargetPort: intstr.FromInt(datadoghqv1alpha1.DefaultMetricsServerServicePort),
+								TargetPort: intstr.FromInt(datadoghqv1alpha1.DefaultMetricsServerTargetPort),
 								Port:       datadoghqv1alpha1.DefaultMetricsServerServicePort,
 							},
 						},
@@ -1239,7 +1239,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						Ports: []corev1.ServicePort{
 							{
 								Protocol:   corev1.ProtocolTCP,
-								TargetPort: intstr.FromInt(datadoghqv1alpha1.DefaultMetricsServerServicePort),
+								TargetPort: intstr.FromInt(datadoghqv1alpha1.DefaultMetricsServerTargetPort),
 								Port:       datadoghqv1alpha1.DefaultMetricsServerServicePort,
 							},
 						},

--- a/pkg/controller/datadogagent/service.go
+++ b/pkg/controller/datadogagent/service.go
@@ -183,7 +183,6 @@ func newMetricsServerService(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Servi
 	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
 	annotations := getDefaultAnnotations(dda)
 
-	port := getClusterAgentMetricsProviderPort(dda.Spec.ClusterAgent.Config)
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        getMetricsServerServiceName(dda),
@@ -200,8 +199,8 @@ func newMetricsServerService(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Servi
 			Ports: []corev1.ServicePort{
 				{
 					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(int(port)),
-					Port:       port,
+					TargetPort: intstr.FromInt(int(getClusterAgentMetricsProviderPort(dda.Spec.ClusterAgent.Config))),
+					Port:       datadoghqv1alpha1.DefaultMetricsServerServicePort,
 				},
 			},
 			SessionAffinity: corev1.ServiceAffinityNone,


### PR DESCRIPTION
### What does this PR do?

- Use 8443 as default port for the external metrics provider

### Motivation

443 doesn't work OOTB on openshift


