### PR TITLE
Fix logs configuration defaulting

### DIFF
--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -286,6 +286,10 @@ func IsDefaultedDatadogAgentSpecLog(log *LogSpec) bool {
 		return false
 	}
 
+	if log.ContainerCollectUsingFiles == nil {
+		return false
+	}
+
 	if log.ContainerLogsPath == nil {
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: cedric lamoriniere <cedric.lamoriniere@datadoghq.com>

### What does this PR do?

fix the defaulting of the `ContainerCollectUsingFiles` logs parameter. 

### Motivation

If the `ContainerCollectUsingFiles` parameter is the only one not default, this parameter will not be default in the `LogSpec` struct. Which end up with a controller crash when it try to access this value.

### Additional Notes

Anything else we should know when reviewing?

