### PR TITLE
Add .Spec.Agent.Log.OpenFilesLimit

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -2267,6 +2267,13 @@ spec:
                       description: 'Enable this to allow log collection for all containers.
                         ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup'
                       type: boolean
+                    openFilesLimit:
+                      description: 'Set the maximum number of logs files that the
+                        Datadog Agent will tail up to. Increasing this limit can increase
+                        resource consumption of the Agent. ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                        Default to 100'
+                      format: int32
+                      type: integer
                     podLogsPath:
                       description: This to allow log collection from pod log path.
                         Default to `/var/log/pods`

--- a/pkg/apis/datadoghq/v1alpha1/const.go
+++ b/pkg/apis/datadoghq/v1alpha1/const.go
@@ -58,6 +58,7 @@ const (
 	DDLogsEnabled                         = "DD_LOGS_ENABLED"
 	DDLogsConfigContainerCollectAll       = "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL"
 	DDLogsContainerCollectUsingFiles      = "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE"
+	DDLogsConfigOpenFilesLimit            = "DD_LOGS_CONFIG_OPEN_FILES_LIMIT"
 	DDDogstatsdOriginDetection            = "DD_DOGSTATSD_ORIGIN_DETECTION"
 	DDDogstatsdPort                       = "DD_DOGSTATSD_PORT"
 	DDClusterAgentEnabled                 = "DD_CLUSTER_AGENT_ENABLED"

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -32,6 +32,7 @@ const (
 	defaultContainerLogsPath                      string = "/var/lib/docker/containers"
 	defaultPodLogsPath                            string = "/var/log/pods"
 	defaultLogsTempStoragePath                    string = "/var/lib/datadog-agent/logs"
+	defaultLogsOpenFilesLimit                     int32  = 100
 	defaultProcessEnabled                         bool   = false
 	defaultMetricsProviderPort                    int32  = 8443
 	defaultClusterChecksEnabled                   bool   = false
@@ -292,6 +293,10 @@ func IsDefaultedDatadogAgentSpecLog(log *LogSpec) bool {
 	}
 
 	if log.TempStoragePath == nil {
+		return false
+	}
+
+	if log.OpenFilesLimit == nil {
 		return false
 	}
 
@@ -566,6 +571,10 @@ func DefaultDatadogAgentSpecAgentLog(log *LogSpec) *LogSpec {
 
 	if log.TempStoragePath == nil {
 		log.TempStoragePath = NewStringPointer(defaultLogsTempStoragePath)
+	}
+
+	if log.OpenFilesLimit == nil {
+		log.OpenFilesLimit = NewInt32Pointer(defaultLogsOpenFilesLimit)
 	}
 
 	return log

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -316,6 +316,15 @@ type LogSpec struct {
 	//
 	// +optional
 	TempStoragePath *string `json:"tempStoragePath,omitempty"`
+
+	// Set the maximum number of logs files that the Datadog Agent will
+	// tail up to. Increasing this limit can increase resource consumption
+	// of the Agent.
+	// ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+	// Default to 100
+	//
+	// +optional
+	OpenFilesLimit *int32 `json:"openFilesLimit,omitempty"`
 }
 
 // ProcessSpec contains the Process Agent configuration

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -989,6 +989,11 @@ func (in *LogSpec) DeepCopyInto(out *LogSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.OpenFilesLimit != nil {
+		in, out := &in.OpenFilesLimit, &out.OpenFilesLimit
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -1715,6 +1715,13 @@ func schema_pkg_apis_datadoghq_v1alpha1_LogSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"openFilesLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Set the maximum number of logs files that the Datadog Agent will tail up to. Increasing this limit can increase resource consumption of the Agent. ref: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default to 100",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/datadogagent/agent_test.go
+++ b/pkg/controller/datadogagent/agent_test.go
@@ -197,6 +197,10 @@ func defaultEnvVars() []corev1.EnvVar {
 			Value: "true",
 		},
 		{
+			Name:  "DD_LOGS_CONFIG_OPEN_FILES_LIMIT",
+			Value: "100",
+		},
+		{
 			Name:  "DD_DOGSTATSD_ORIGIN_DETECTION",
 			Value: "false",
 		},

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -542,6 +542,10 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 			Value: strconv.FormatBool(*spec.Agent.Log.ContainerCollectUsingFiles),
 		},
 		{
+			Name:  datadoghqv1alpha1.DDLogsConfigOpenFilesLimit,
+			Value: strconv.FormatInt(int64(*spec.Agent.Log.OpenFilesLimit), 10),
+		},
+		{
 			Name:  datadoghqv1alpha1.DDDogstatsdOriginDetection,
 			Value: strconv.FormatBool(*spec.Agent.Config.Dogstatsd.DogstatsdOriginDetection),
 		},


### PR DESCRIPTION
This is to match a change to the datadog helm chart [1] adding the same
option. This option sets the maximum number of logs files that the
Datadog Agent will tail up to.

[1] https://github.com/helm/charts/pull/22347