### PR TITLE
Propagate custom check definitions to CLC Runners

### DIFF
--- a/docs/custom_check.md
+++ b/docs/custom_check.md
@@ -96,10 +96,11 @@ spec:
   agent:
     image:
       name: "datadog/agent:latest"
-    confd:
-      configMapName: "confd-config"
-    checksd:
-      configMapName: "checksd-config"
+    config:
+      confd:
+        configMapName: "confd-config"
+      checksd:
+        configMapName: "checksd-config"
 ```
 
 **Note**: Any ConfigMaps you create need to be in the same `DD_NAMESPACE` as the `DatadogAgent` resource.

--- a/pkg/controller/datadogagent/clusterchecksrunner.go
+++ b/pkg/controller/datadogagent/clusterchecksrunner.go
@@ -249,6 +249,11 @@ func newClusterChecksRunnerPodTemplate(dda *datadoghqv1alpha1.DatadogAgent, labe
 	// copy Spec to configure the Cluster Checks Runner Pod Template
 	clusterChecksRunnerSpec := dda.Spec.ClusterChecksRunner.DeepCopy()
 
+	spec := &dda.Spec
+	volumeMounts := getVolumeMountsForClusterChecksRunner(dda)
+	envVars := getEnvVarsForClusterChecksRunner(dda)
+	initContainers := getConfigInitContainers(spec, volumeMounts, envVars)
+
 	newPodTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,
@@ -256,13 +261,14 @@ func newClusterChecksRunnerPodTemplate(dda *datadoghqv1alpha1.DatadogAgent, labe
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: getClusterChecksRunnerServiceAccount(dda),
+			InitContainers:     initContainers,
 			Containers: []corev1.Container{
 				{
 					Name:            "cluster-checks-runner",
 					Image:           clusterChecksRunnerSpec.Image.Name,
 					ImagePullPolicy: *clusterChecksRunnerSpec.Image.PullPolicy,
-					Env:             getEnvVarsForClusterChecksRunner(dda),
-					VolumeMounts:    getVolumeMountsForClusterChecksRunner(dda),
+					Env:             envVars,
+					VolumeMounts:    volumeMounts,
 					LivenessProbe:   getDefaultLivenessProbe(),
 				},
 			},
@@ -397,6 +403,8 @@ func getClusterChecksRunnerName(dda *datadoghqv1alpha1.DatadogAgent) string {
 // getVolumesForClusterChecksRunner defines volumes for the Cluster Checks Runner
 func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 	volumes := []corev1.Volume{
+		getVolumeForChecksd(dda),
+		getVolumeForConfig(),
 		{
 			Name: "s6-run",
 			VolumeSource: corev1.VolumeSource{
@@ -421,6 +429,8 @@ func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 // getVolumeMountsForClusterChecksRunner defines volume mounts for the Cluster Checks Runner
 func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
+		getVolumeMountForChecksd(),
+		getVolumeMountForConfig(),
 		{
 			Name:      "s6-run",
 			MountPath: "/var/run/s6",
@@ -430,6 +440,7 @@ func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) 
 			MountPath: fmt.Sprintf("%s/%s", datadoghqv1alpha1.ConfigVolumePath, "conf.d"),
 		},
 	}
+
 	if dda.Spec.ClusterChecksRunner.CustomConfig != nil {
 		volumeMount := getVolumeMountFromCustomConfigSpec(dda.Spec.ClusterChecksRunner.CustomConfig, datadoghqv1alpha1.AgentCustomConfigVolumeName, datadoghqv1alpha1.AgentCustomConfigVolumePath, datadoghqv1alpha1.AgentCustomConfigVolumeSubPath)
 		volumeMounts = append(volumeMounts, volumeMount)

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -308,32 +308,9 @@ func getInitContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Container,
 	if err != nil {
 		return nil, err
 	}
-	containers := []corev1.Container{
-		{
-			Name:            "init-volume",
-			Image:           spec.Agent.Image.Name,
-			ImagePullPolicy: *spec.Agent.Image.PullPolicy,
-			Resources:       *spec.Agent.Config.Resources,
-			Command:         []string{"bash", "-c"},
-			Args:            []string{"cp -r /etc/datadog-agent /opt"},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      datadoghqv1alpha1.ConfigVolumeName,
-					MountPath: "/opt/datadog-agent",
-				},
-			},
-		},
-		{
-			Name:            "init-config",
-			Image:           spec.Agent.Image.Name,
-			ImagePullPolicy: *spec.Agent.Image.PullPolicy,
-			Resources:       *spec.Agent.Config.Resources,
-			Command:         []string{"bash", "-c"},
-			Args:            []string{"for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done"},
-			Env:             envVars,
-			VolumeMounts:    volumeMounts,
-		},
-	}
+
+	containers := getConfigInitContainers(spec, volumeMounts, envVars)
+
 	if isSystemProbeEnabled(dda) {
 		if getSeccompProfileName(&dda.Spec.Agent.SystemProbe) == datadoghqv1alpha1.DefaultSeccompProfileName || dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap != "" {
 			systemProbeInit := corev1.Container{
@@ -362,6 +339,37 @@ func getInitContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Container,
 	}
 
 	return containers, nil
+}
+
+// getConfigInitContainers returns the init containers necessary to set up the
+// agent's configuration volume.
+func getConfigInitContainers(spec *datadoghqv1alpha1.DatadogAgentSpec, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar) []corev1.Container {
+	return []corev1.Container{
+		{
+			Name:            "init-volume",
+			Image:           spec.Agent.Image.Name,
+			ImagePullPolicy: *spec.Agent.Image.PullPolicy,
+			Resources:       *spec.Agent.Config.Resources,
+			Command:         []string{"bash", "-c"},
+			Args:            []string{"cp -r /etc/datadog-agent /opt"},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      datadoghqv1alpha1.ConfigVolumeName,
+					MountPath: "/opt/datadog-agent",
+				},
+			},
+		},
+		{
+			Name:            "init-config",
+			Image:           spec.Agent.Image.Name,
+			ImagePullPolicy: *spec.Agent.Image.PullPolicy,
+			Resources:       *spec.Agent.Config.Resources,
+			Command:         []string{"bash", "-c"},
+			Args:            []string{"for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done"},
+			Env:             envVars,
+			VolumeMounts:    volumeMounts,
+		},
+	}
 }
 
 // getEnvVarsForAPMAgent converts APM Agent Config into container env vars
@@ -592,46 +600,10 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 
 // getVolumesForAgent defines volumes for the Agent
 func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
-	confdVolumeSource := corev1.VolumeSource{
-		EmptyDir: &corev1.EmptyDirVolumeSource{},
-	}
-	if dda.Spec.Agent.Config.Confd != nil {
-		confdVolumeSource = corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: dda.Spec.Agent.Config.Confd.ConfigMapName,
-				},
-			},
-		}
-	}
-	checksdVolumeSource := corev1.VolumeSource{
-		EmptyDir: &corev1.EmptyDirVolumeSource{},
-	}
-	if dda.Spec.Agent.Config.Checksd != nil {
-		checksdVolumeSource = corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: dda.Spec.Agent.Config.Checksd.ConfigMapName,
-				},
-			},
-		}
-	}
-
 	volumes := []corev1.Volume{
-		{
-			Name:         datadoghqv1alpha1.ConfdVolumeName,
-			VolumeSource: confdVolumeSource,
-		},
-		{
-			Name:         datadoghqv1alpha1.ChecksdVolumeName,
-			VolumeSource: checksdVolumeSource,
-		},
-		{
-			Name: datadoghqv1alpha1.ConfigVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
+		getVolumeForConfd(dda),
+		getVolumeForChecksd(dda),
+		getVolumeForConfig(),
 		{
 			Name: datadoghqv1alpha1.ProcVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -771,6 +743,55 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 	return volumes
 }
 
+func getVolumeForConfd(dda *datadoghqv1alpha1.DatadogAgent) corev1.Volume {
+	source := corev1.VolumeSource{
+		EmptyDir: &corev1.EmptyDirVolumeSource{},
+	}
+	if dda.Spec.Agent.Config.Confd != nil {
+		source = corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: dda.Spec.Agent.Config.Confd.ConfigMapName,
+				},
+			},
+		}
+	}
+
+	return corev1.Volume{
+		Name:         datadoghqv1alpha1.ConfdVolumeName,
+		VolumeSource: source,
+	}
+}
+
+func getVolumeForChecksd(dda *datadoghqv1alpha1.DatadogAgent) corev1.Volume {
+	source := corev1.VolumeSource{
+		EmptyDir: &corev1.EmptyDirVolumeSource{},
+	}
+	if dda.Spec.Agent.Config.Checksd != nil {
+		source = corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: dda.Spec.Agent.Config.Checksd.ConfigMapName,
+				},
+			},
+		}
+	}
+
+	return corev1.Volume{
+		Name:         datadoghqv1alpha1.ChecksdVolumeName,
+		VolumeSource: source,
+	}
+}
+
+func getVolumeForConfig() corev1.Volume {
+	return corev1.Volume{
+		Name: datadoghqv1alpha1.ConfigVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
 func getSecCompRootPath(spec *datadoghqv1alpha1.SystemProbeSpec) string {
 	if spec.SecCompRootPath != "" {
 		return spec.SecCompRootPath
@@ -828,20 +849,9 @@ func getVolumeMountFromCustomConfigSpec(cfcm *datadoghqv1alpha1.CustomConfigSpec
 func getVolumeMountsForAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []corev1.VolumeMount {
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      datadoghqv1alpha1.ConfdVolumeName,
-			MountPath: datadoghqv1alpha1.ConfdVolumePath,
-			ReadOnly:  true,
-		},
-		{
-			Name:      datadoghqv1alpha1.ChecksdVolumeName,
-			MountPath: datadoghqv1alpha1.ChecksdVolumePath,
-			ReadOnly:  true,
-		},
-		{
-			Name:      datadoghqv1alpha1.ConfigVolumeName,
-			MountPath: datadoghqv1alpha1.ConfigVolumePath,
-		},
+		getVolumeMountForConfd(),
+		getVolumeMountForChecksd(),
+		getVolumeMountForConfig(),
 		{
 			Name:      datadoghqv1alpha1.ProcVolumeName,
 			MountPath: datadoghqv1alpha1.ProcVolumePath,
@@ -905,6 +915,28 @@ func getVolumeMountsForAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []corev1.
 		}...)
 	}
 	return append(volumeMounts, spec.Agent.Config.VolumeMounts...)
+}
+
+func getVolumeMountForConfig() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      datadoghqv1alpha1.ConfigVolumeName,
+		MountPath: datadoghqv1alpha1.ConfigVolumePath,
+	}
+}
+
+func getVolumeMountForConfd() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      datadoghqv1alpha1.ConfdVolumeName,
+		MountPath: datadoghqv1alpha1.ConfdVolumePath,
+		ReadOnly:  true,
+	}
+}
+func getVolumeMountForChecksd() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      datadoghqv1alpha1.ChecksdVolumeName,
+		MountPath: datadoghqv1alpha1.ChecksdVolumePath,
+		ReadOnly:  true,
+	}
 }
 
 // getVolumeMountsForAgent defines mounted volumes for the Process Agent


### PR DESCRIPTION
It's already possible to define`.Spec.Agent.Config.Checksd`, but this option is not propagated to
the Clusterchecks Runner. As a runner is basically an agent, we're just
reusing the same configuration.

This applies the same changes as this proposed change to
stable/datadog's Helm chart: https://github.com/helm/charts/pull/23139