### PR TITLE
Generate Helm chart as a release artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,9 @@ jobs:
       -
         name: Generate Plugin manifest
         run: ./hack/release/generate-plugin-manifest.sh ${{steps.tag.outputs.tag}}
+      -
+        name: Generate Chart tarball
+        run: ./hack/release/generate-chart-tarball.sh ${{steps.tag.outputs.tag}}
       - 
         name: OLM RedHat bundle
         run: ./hack/generate-olm-bundle.sh ${{steps.tag.outputs.tag}}
@@ -43,6 +46,7 @@ jobs:
           files: |
             dist/datadog-plugin.yaml
             dist/*.zip
+            dist/*.tar.gz
         env:
           COMMIT_TAG: ${{steps.tag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/chart/datadog-agent-with-operator/Chart.yaml
+++ b/chart/datadog-agent-with-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: datadog-agent-with-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.1
-appVersion: 0.1.3
+version: PLACEHOLDER_VERSION
+appVersion: PLACEHOLDER_VERSION

--- a/chart/datadog-operator/Chart.yaml
+++ b/chart/datadog-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.1.3"
+appVersion: "PLACEHOLDER_VERSION"
 description: Datadog Operator
 name: datadog-operator
-version: 0.2.1
+version: "PLACEHOLDER_VERSION"

--- a/chart/datadog-operator/values.yaml
+++ b/chart/datadog-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   repository: datadog/operator
-  tag: 0.2.1
+  tag: "PLACEHOLDER_VERSION"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,11 +16,10 @@ Using the Datadog Operator requires the following prerequisites:
 In order to deploy a Datadog agent with the operator in the minimum number of steps, the [`datadog-agent-with-operator`](https://github.com/DataDog/datadog-operator/tree/master/chart/datadog-agent-with-operator) helm chart can be used.
 Here are the steps:
 
-1. Download the [Datadog Operator project zip ball][3] and unzip it. Source code can be found at [`DataDog/datadog-operator`][4]. Go into the `datadog-operator-<tag>` folder.
+1. [Download the chart][3]:
 
    ```shell
-   curl -L https://github.com/DataDog/datadog-operator/archive/master.tar.gz | tar xvz
-   cd datadog-operator-master
+   curl -Lo datadog-agent-with-operator.tar.gz https://github.com/DataDog/datadog-operator/releases/latest/download/datadog-agent-with-operator.tar.gz
    ```
 
 2. Create a file with the spec of your agent. The simplest configuration is:
@@ -34,11 +33,11 @@ Here are the steps:
        name: "datadog/agent:latest"
    ```
 
-   Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][5]
+   Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][4]
 
 3. Deploy the Datadog agent with the above configuration file:
    ```shell
-   helm install --set-file agent_spec=/path/to/your/datadog-agent.yaml datadog chart/datadog-agent-with-operator
+   helm install --set-file agent_spec=/path/to/your/datadog-agent.yaml datadog datadog-agent-with-operator.tar.gz
    ```
 
 ## Cleanup
@@ -52,6 +51,5 @@ helm delete datadog
 
 [1]: https://helm.sh
 [2]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[3]: https://github.com/DataDog/datadog-operator/archive/master.tar.gz
-[4]: https://github.com/DataDog/datadog-operator
-[5]: https://app.datadoghq.com/account/settings#api
+[3]: https://github.com/DataDog/datadog-operator/releases/latest/download/datadog-agent-with-operator.tar.gz
+[4]: https://app.datadoghq.com/account/settings#api

--- a/hack/release/generate-chart-tarball.sh
+++ b/hack/release/generate-chart-tarball.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+source "$(dirname $0)/../os-env.sh"
+
+TAG=""
+if [ $# -gt 0 ]; then
+    TAG=$1
+    echo "TAG=$TAG"
+else
+    echo "First parameter should be the new TAG"
+    exit 1
+fi
+VERSION=${TAG:1}
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+PLUGIN_NAME=kubectl-datadog
+OUTPUT_FOLDER=$GIT_ROOT/dist
+TARBALL_NAME="$PLUGIN_NAME_$VERSION.tar.gz"
+
+cp -Lr $GIT_ROOT/chart/* $OUTPUT_FOLDER/
+
+for CHART in datadog-operator datadog-agent-with-operator
+do
+    $SED "s/PLACEHOLDER_VERSION/$VERSION/g" $OUTPUT_FOLDER/$CHART/Chart.yaml
+    $SED "s/PLACEHOLDER_VERSION/$VERSION/g" $OUTPUT_FOLDER/$CHART/values.yaml
+    tar -zcvf $OUTPUT_FOLDER/$CHART.tar.gz -C $OUTPUT_FOLDER $CHART
+done


### PR DESCRIPTION
This helps with several things: it's no longer necessary to download an
archive of the entire repo, and it's impossible to have a mismatch
between the version of the chart being used, the release version, and
the links the documentation.

### Additional Notes

The documented `curl` oneliner in this PR doesn't work right now, as the tarball is not in the latest release. It can be added manually, so I'll upload both charts there once the PR is approved.