### PR TITLE
Update the datadog krew plugin installation instructions

### DIFF
--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -6,10 +6,8 @@ The Datadog Operator comes with a kubectl plugin providing a set of helper utili
 
 To install, use the [krew plugin manager](https://krew.sigs.k8s.io/).
 
-The krew plugin manifest url can be found on the project [release page](https://github.com/DataDog/datadog-operator/releases). Each release has its own `datadog-plugin.yaml` manifest file.
-
 ```console
-$ kubectl krew install --manifest-url https://github.com/DataDog/datadog-operator/releases/download/<release-version>/datadog-plugin.yaml
+$ kubectl krew install datadog
 Installing plugin: datadog
 Installed plugin: datadog
 \

--- a/hack/release/README.md
+++ b/hack/release/README.md
@@ -18,5 +18,5 @@
 
 ## Other PRs to create
 
-- Create krew PR for the plugin on https://github.com/kubernetes-sigs/krew-index to update the `datadog-plugin.yaml` artifact.
+- Create krew PR for the plugin on https://github.com/kubernetes-sigs/krew-index to update the `datadog.yaml` artifact. (See [kubernetes-sigs/krew-index#727](https://github.com/kubernetes-sigs/krew-index/pull/727) as an example)
 - Create PRs on https://github.com/operator-framework/community-operators for `community` and `upstream` operator.


### PR DESCRIPTION
### What does this PR do?

Update the datadog krew plugin installation instructions.

### Motivation

We’ve opened a PR to add the `datadog` plugin into the `krew` index: kubernetes-sigs/krew-index#727

### Additional Notes

Anything else we should know when reviewing?

