### PR TITLE
Fix DatadogMetric CRD: references should be optional (will be filled by DCA 1.9+)

### DIFF
--- a/deploy/crds/datadoghq.com_datadogmetrics_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogmetrics_crd.yaml
@@ -101,7 +101,6 @@ spec:
               description: Value is the latest value of the metric
               type: string
           required:
-          - autoscalerReferences
           - currentValue
           type: object
       type: object

--- a/pkg/apis/datadoghq/v1alpha1/datadogmetric_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogmetric_types.go
@@ -27,7 +27,7 @@ type DatadogMetricStatus struct {
 	// Value is the latest value of the metric
 	Value string `json:"currentValue"`
 	// List of autoscalers currently using this DatadogMetric
-	AutoscalerReferences string `json:"autoscalerReferences"`
+	AutoscalerReferences string `json:"autoscalerReferences,omitempty"`
 }
 
 // DatadogMetricCondition describes the state of a DatadogMetric at a certain point.


### PR DESCRIPTION
### What does this PR do?

Make `autoscalerReferences` optional as it's not filled by DCA ATM (will require DCA 1.9+)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

