### PR TITLE
Activate push to latest when tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,8 +94,7 @@ push_tag_to_docker_hub:
     - docker build --build-arg TAG=${CI_COMMIT_TAG:1} -t $IMAGE_NAME -f Dockerfile .
     - docker push $IMAGE_NAME
 
-# remove the leading dot from the name to let the job appear in gitlab
-.push_latest_to_docker_hub:
+push_latest_to_docker_hub:
   only:
     - tags
   stage: release


### PR DESCRIPTION
### What does this PR do?

Allow in gitlab-ci to push the docker image latest tag, when it is a job triggered by a "tag"

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

