### PR TITLE
Add syscalls needed for 7.22.0 version of system-probe

### DIFF
--- a/pkg/controller/datadogagent/systemprobe.go
+++ b/pkg/controller/datadogagent/systemprobe.go
@@ -122,6 +122,8 @@ const systemProbeSecCompData = `{
 			"epoll_wait",
 			"epoll_wait",
 			"epoll_wait_old",
+			"eventfd",
+			"eventfd2",
 			"execve",
 			"execveat",
 			"exit",


### PR DESCRIPTION
### What does this PR do?

The new ebpf library we are using needs these additional syscalls. See https://github.com/DataDog/helm-charts/pull/18 for corresponding update to the Helm chart.

### Motivation

Without these syscalls, system-probe will `CrashLoopBackoff`.

