### PR TITLE
Fix generate-olm-bundle.sh to only package one version

### DIFF
--- a/hack/generate-olm-bundle.sh
+++ b/hack/generate-olm-bundle.sh
@@ -33,7 +33,7 @@ trap cleanup EXIT
 # move all zip file if exit
 mv $ZIP_FILE_NAME $ZIP_FILE_NAME.old
 
-for i in $OLM_FOLDER/*/*.yaml $OLM_FOLDER/*.yaml
+for i in $OLM_FOLDER/$VERSION/*.yaml $OLM_FOLDER/*.yaml
 do  
     cp $i $WORK_DIR/${i##*/}
     $SED -e "s|${IMAGE_NAME}|${REDHAT_IMAGE_NAME}|g" $WORK_DIR/${i##*/}


### PR DESCRIPTION
### What does this PR do?

the Redhat validation script in the Redhat partner portable, only support bundle with one OLM version.

### Motivation

Redhat [docs](https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory) related to the creation of the bundle

### Additional Notes

N/A

