### PR TITLE
Add DatadogMetrics example in OLM

### DIFF
--- a/hack/release/cluster-service-version-patch.yaml
+++ b/hack/release/cluster-service-version-patch.yaml
@@ -50,6 +50,17 @@ metadata:
             }
           }
         }
+      },
+      {
+        "apiVersion": "datadoghq.com/v1alpha1",
+        "kind": "DatadogMetric",
+        "metadata": {
+          "name": "cpu-example"
+        },
+        "spec": {
+          "externalMetricName": "cpu-example",
+          "query": "avg:kubernetes.cpu.usage.total{app:foo}.rollup(avg,30)/(avg:kubernetes.cpu.limits{app:foo}.rollup(avg,30)*10000000)"
+        }
       }]
 spec:
   description: Datadog provides a modern monitoring and analytics platform. Gather
@@ -71,5 +82,4 @@ spec:
   maintainers:
   - email: support@datadoghq.com
     name: Datadog Inc.
-  provider:
-    name: Datadog
+  provider: {name: Datadog}


### PR DESCRIPTION
### What does this PR do?

Add a `DatadogMetrics` in the OLM ClusterServiceVersion patch.

### Motivation

Since we package the `DatadogMetrics` CRD in the OLM configuration. we also need to have an example to be validated by the Operatorhub.io CI process.

### Additional Notes

Anything else we should know when reviewing?

### Test plan

Generate a new Release locally with `make pre-release` command, then go to https://operatorhub.io/preview and copy/paste the content of the generated `csv` file. The DatadogMetrics example should be present in the description of the Operator. 
