### PR TITLE
Actually use `securityContext` attribute as PodSecurityContext

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -440,59 +440,35 @@ spec:
                           type: object
                       type: object
                     securityContext:
-                      description: You can modify the security context used to run
-                        the containers by modifying the label type
+                      description: Pod-level SecurityContext
                       properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by
-                            the container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes
-                            in privileged containers are essentially equivalent to
-                            root on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to
-                            use for the containers. The default is DefaultProcMount
-                            which uses the container runtime defaults for readonly
-                            paths and masked paths. This requires the ProcMountType
-                            feature flag to be enabled.
+                        fsGroup:
+                          description: "A special supplemental group that applies
+                            to all containers in a pod. Some volume types allow the
+                            Kubelet to change the ownership of that volume to be owned
+                            by the pod: \n 1. The owning GID will be the FSGroup 2.
+                            The setgid bit is set (new files created in the volume
+                            will be owned by FSGroup) 3. The permission bits are OR'd
+                            with rw-rw---- \n If unset, the Kubelet will not modify
+                            the ownership and permissions of any volume."
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified defaults
+                            to "Always".'
                           type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root
-                            filesystem. Default is false.
-                          type: boolean
                         runAsGroup:
                           description: The GID to run the entrypoint of the container
                             process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
@@ -501,25 +477,26 @@ spec:
                             image at runtime to ensure that it does not run as UID
                             0 (root) and fail to start the container if it does. If
                             unset or false, no such validation will be performed.
-                            May also be set in PodSecurityContext.  If set in both
-                            SecurityContext and PodSecurityContext, the value specified
-                            in SecurityContext takes precedence.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           type: boolean
                         runAsUser:
                           description: The UID to run the entrypoint of the container
                             process. Defaults to user specified in image metadata
-                            if unspecified. May also be set in PodSecurityContext.  If
+                            if unspecified. May also be set in SecurityContext.  If
                             set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
+                            value specified in SecurityContext takes precedence for
+                            that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
+                          description: The SELinux context to be applied to all containers.
                             If unspecified, the container runtime will allocate a
                             random SELinux context for each container.  May also be
-                            set in PodSecurityContext.  If set in both SecurityContext
+                            set in SecurityContext.  If set in both SecurityContext
                             and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
+                            takes precedence for that container.
                           properties:
                             level:
                               description: Level is SELinux level label that applies
@@ -538,11 +515,39 @@ spec:
                                 to the container.
                               type: string
                           type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
                         windowsOptions:
                           description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
                               description: GMSACredentialSpec is where the GMSA admission

--- a/deploy/crds/v1/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/v1/datadoghq.com_datadogagents_crd.yaml
@@ -455,59 +455,36 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: You can modify the security context used to run
-                          the containers by modifying the label type
+                        description: Pod-level SecurityContext
                         properties:
-                          allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                              a process can gain more privileges than its parent process.
-                              This bool directly controls if the no_new_privs flag
-                              will be set on the container process. AllowPrivilegeEscalation
-                              is true always when the container is: 1) run as Privileged
-                              2) has CAP_SYS_ADMIN'
-                            type: boolean
-                          capabilities:
-                            description: The capabilities to add/drop when running
-                              containers. Defaults to the default set of capabilities
-                              granted by the container runtime.
-                            properties:
-                              add:
-                                description: Added capabilities
-                                items:
-                                  description: Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                              drop:
-                                description: Removed capabilities
-                                items:
-                                  description: Capability represent POSIX capabilities
-                                    type
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent
-                              to root on the host. Defaults to false.
-                            type: boolean
-                          procMount:
-                            description: procMount denotes the type of proc mount
-                              to use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled.
+                          fsGroup:
+                            description: "A special supplemental group that applies
+                              to all containers in a pod. Some volume types allow
+                              the Kubelet to change the ownership of that volume to
+                              be owned by the pod: \n 1. The owning GID will be the
+                              FSGroup 2. The setgid bit is set (new files created
+                              in the volume will be owned by FSGroup) 3. The permission
+                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
+                              will not modify the ownership and permissions of any
+                              volume."
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified
+                              defaults to "Always".'
                             type: string
-                          readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false.
-                            type: boolean
                           runAsGroup:
                             description: The GID to run the entrypoint of the container
                               process. Uses runtime default if unset. May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
+                              set in SecurityContext.  If set in both SecurityContext
                               and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
+                              takes precedence for that container.
                             format: int64
                             type: integer
                           runAsNonRoot:
@@ -516,25 +493,26 @@ spec:
                               the image at runtime to ensure that it does not run
                               as UID 0 (root) and fail to start the container if it
                               does. If unset or false, no such validation will be
-                              performed. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
                             description: The UID to run the entrypoint of the container
                               process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
+                              if unspecified. May also be set in SecurityContext.  If
                               set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
+                              the value specified in SecurityContext takes precedence
+                              for that container.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the
-                              container. If unspecified, the container runtime will
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
                               allocate a random SELinux context for each container.  May
-                              also be set in PodSecurityContext.  If set in both SecurityContext
+                              also be set in SecurityContext.  If set in both SecurityContext
                               and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
+                              takes precedence for that container.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -553,12 +531,40 @@ spec:
                                   to the container.
                                 type: string
                             type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
                           windowsOptions:
                             description: The Windows specific settings applied to
-                              all containers. If unspecified, the options from the
-                              PodSecurityContext will be used. If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence.
                             properties:
                               gmsaCredentialSpec:
                                 description: GMSACredentialSpec is where the GMSA

--- a/deploy/crds/v1beta1/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/v1beta1/datadoghq.com_datadogagents_crd.yaml
@@ -440,59 +440,35 @@ spec:
                           type: object
                       type: object
                     securityContext:
-                      description: You can modify the security context used to run
-                        the containers by modifying the label type
+                      description: Pod-level SecurityContext
                       properties:
-                        allowPrivilegeEscalation:
-                          description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN'
-                          type: boolean
-                        capabilities:
-                          description: The capabilities to add/drop when running containers.
-                            Defaults to the default set of capabilities granted by
-                            the container runtime.
-                          properties:
-                            add:
-                              description: Added capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                            drop:
-                              description: Removed capabilities
-                              items:
-                                description: Capability represent POSIX capabilities
-                                  type
-                                type: string
-                              type: array
-                          type: object
-                        privileged:
-                          description: Run container in privileged mode. Processes
-                            in privileged containers are essentially equivalent to
-                            root on the host. Defaults to false.
-                          type: boolean
-                        procMount:
-                          description: procMount denotes the type of proc mount to
-                            use for the containers. The default is DefaultProcMount
-                            which uses the container runtime defaults for readonly
-                            paths and masked paths. This requires the ProcMountType
-                            feature flag to be enabled.
+                        fsGroup:
+                          description: "A special supplemental group that applies
+                            to all containers in a pod. Some volume types allow the
+                            Kubelet to change the ownership of that volume to be owned
+                            by the pod: \n 1. The owning GID will be the FSGroup 2.
+                            The setgid bit is set (new files created in the volume
+                            will be owned by FSGroup) 3. The permission bits are OR'd
+                            with rw-rw---- \n If unset, the Kubelet will not modify
+                            the ownership and permissions of any volume."
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified defaults
+                            to "Always".'
                           type: string
-                        readOnlyRootFilesystem:
-                          description: Whether this container has a read-only root
-                            filesystem. Default is false.
-                          type: boolean
                         runAsGroup:
                           description: The GID to run the entrypoint of the container
                             process. Uses runtime default if unset. May also be set
-                            in PodSecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
@@ -501,25 +477,26 @@ spec:
                             image at runtime to ensure that it does not run as UID
                             0 (root) and fail to start the container if it does. If
                             unset or false, no such validation will be performed.
-                            May also be set in PodSecurityContext.  If set in both
-                            SecurityContext and PodSecurityContext, the value specified
-                            in SecurityContext takes precedence.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           type: boolean
                         runAsUser:
                           description: The UID to run the entrypoint of the container
                             process. Defaults to user specified in image metadata
-                            if unspecified. May also be set in PodSecurityContext.  If
+                            if unspecified. May also be set in SecurityContext.  If
                             set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
+                            value specified in SecurityContext takes precedence for
+                            that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to the container.
+                          description: The SELinux context to be applied to all containers.
                             If unspecified, the container runtime will allocate a
                             random SELinux context for each container.  May also be
-                            set in PodSecurityContext.  If set in both SecurityContext
+                            set in SecurityContext.  If set in both SecurityContext
                             and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
+                            takes precedence for that container.
                           properties:
                             level:
                               description: Level is SELinux level label that applies
@@ -538,11 +515,39 @@ spec:
                                 to the container.
                               type: string
                           type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
                         windowsOptions:
                           description: The Windows specific settings applied to all
-                            containers. If unspecified, the options from the PodSecurityContext
-                            will be used. If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
                               description: GMSACredentialSpec is where the GMSA admission

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -514,10 +514,9 @@ type CustomConfigSpec struct {
 // NodeAgentConfig contains the configuration of the Node Agent
 // +k8s:openapi-gen=true
 type NodeAgentConfig struct {
-	// You can modify the security context used to run the containers by
-	// modifying the label type
+	// Pod-level SecurityContext
 	// +optional
-	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 
 	// The host of the Datadog intake server to send Agent data to, only set this option
 	// if you need the Agent to send data to a custom URL.

--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -76,6 +76,7 @@ type NewDatadogAgentOptions struct {
 	RuntimeSecurityEnabled           bool
 	RuntimeSyscallMonitorEnabled     bool
 	RuntimePoliciesDir               *datadoghqv1alpha1.ConfigDirSpec
+	SecurityContext                  *corev1.PodSecurityContext
 }
 
 // NewDefaultedDatadogAgent returns an initialized and defaulted DatadogAgent for testing purpose

--- a/pkg/apis/datadoghq/v1alpha1/utils.go
+++ b/pkg/apis/datadoghq/v1alpha1/utils.go
@@ -10,6 +10,11 @@ func NewInt32Pointer(i int32) *int32 {
 	return &i
 }
 
+// NewInt64Pointer returns pointer on a new int32 value instance
+func NewInt64Pointer(i int64) *int64 {
+	return &i
+}
+
 // NewStringPointer returns pointer on a new string value instance
 func NewStringPointer(s string) *string {
 	return &s

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -1046,7 +1046,7 @@ func (in *NodeAgentConfig) DeepCopyInto(out *NodeAgentConfig) {
 	*out = *in
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.SecurityContext)
+		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.DDUrl != nil {

--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -129,6 +129,7 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 			Annotations:  annotations,
 		},
 		Spec: corev1.PodSpec{
+			SecurityContext:    agentdeployment.Spec.Agent.Config.SecurityContext,
 			ServiceAccountName: getAgentServiceAccount(agentdeployment),
 			InitContainers:     initContainers,
 			Containers:         containers,


### PR DESCRIPTION
### What does this PR do?

Actually use `securityContext` attribute as PodSecurityContext

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Use the `SecurityContext` attribute and verify that it's effectively used as PodSecurityContext in DaemonSet
