### PR TITLE
Always mount `config` volume when security agent is enabled

### DIFF
--- a/pkg/controller/datadogagent/utils.go
+++ b/pkg/controller/datadogagent/utils.go
@@ -1283,7 +1283,12 @@ func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1
 
 // getVolumeMountsForSecurityAgent defines mounted volumes for the Security Agent
 func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
-	var volumeMounts []corev1.VolumeMount
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      datadoghqv1alpha1.ConfigVolumeName,
+			MountPath: datadoghqv1alpha1.ConfigVolumePath,
+		},
+	}
 
 	complianceEnabled := isComplianceEnabled(dda)
 	runtimeEnabled := isRuntimeSecurityEnabled(dda)
@@ -1294,10 +1299,6 @@ func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []core
 				Name:      datadoghqv1alpha1.CgroupsVolumeName,
 				MountPath: datadoghqv1alpha1.CgroupsVolumePath,
 				ReadOnly:  true,
-			},
-			{
-				Name:      datadoghqv1alpha1.ConfigVolumeName,
-				MountPath: datadoghqv1alpha1.ConfigVolumePath,
 			},
 			{
 				Name:      datadoghqv1alpha1.PasswdVolumeName,


### PR DESCRIPTION
If only the runtime security agent is enabled, the process won't be able
to start because it can't find the `datadog.yaml` that's available in
the `config` volume, as it was only mounted when the compliance agent
was enabled. Now, it's mounted if either of them is enabled.

### Describe your test plan

This can be tested by enabling the security agent in three different permutations (only runtime, only compliance, and both), and checking that the process starts successfully.