### PR TITLE
Fix compliance checkInterval duration type

### DIFF
--- a/deploy/crds/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/datadoghq.com_datadogagents_crd.yaml
@@ -2426,8 +2426,7 @@ spec:
                       properties:
                         checkInterval:
                           description: Check interval
-                          format: int64
-                          type: integer
+                          type: string
                         configDir:
                           description: Config dir containing compliance benchmarks
                           properties:
@@ -3560,7 +3559,7 @@ spec:
                         enabled'
                       type: boolean
                     collectEvents:
-                      description: 'Enable this to start event collection from the
+                      description: 'Enables this to start event collection from the
                         kubernetes API ref: https://docs.datadoghq.com/agent/cluster_agent/event_collection/'
                       type: boolean
                     confd:

--- a/deploy/crds/v1/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/v1/datadoghq.com_datadogagents_crd.yaml
@@ -2506,8 +2506,7 @@ spec:
                         properties:
                           checkInterval:
                             description: Check interval
-                            format: int64
-                            type: integer
+                            type: string
                           configDir:
                             description: Config dir containing compliance benchmarks
                             properties:
@@ -3674,8 +3673,8 @@ spec:
                           enabled'
                         type: boolean
                       collectEvents:
-                        description: 'Enable this to start event collection from the
-                          kubernetes API ref: https://docs.datadoghq.com/agent/cluster_agent/event_collection/'
+                        description: 'Enables this to start event collection from
+                          the kubernetes API ref: https://docs.datadoghq.com/agent/cluster_agent/event_collection/'
                         type: boolean
                       confd:
                         description: Confd Provide additional cluster check configurations.

--- a/deploy/crds/v1beta1/datadoghq.com_datadogagents_crd.yaml
+++ b/deploy/crds/v1beta1/datadoghq.com_datadogagents_crd.yaml
@@ -2426,8 +2426,7 @@ spec:
                       properties:
                         checkInterval:
                           description: Check interval
-                          format: int64
-                          type: integer
+                          type: string
                         configDir:
                           description: Config dir containing compliance benchmarks
                           properties:
@@ -3558,6 +3557,10 @@ spec:
                         https://docs.datadoghq.com/agent/cluster_agent/endpointschecks/
                         Autodiscovery via Kube Service annotations is automatically
                         enabled'
+                      type: boolean
+                    collectEvents:
+                      description: 'Enables this to start event collection from the
+                        kubernetes API ref: https://docs.datadoghq.com/agent/cluster_agent/event_collection/'
                       type: boolean
                     confd:
                       description: Confd Provide additional cluster check configurations.

--- a/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -6,8 +6,6 @@
 package v1alpha1
 
 import (
-	"time"
-
 	edsdatadoghqv1alpha1 "github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -453,7 +451,7 @@ type ComplianceSpec struct {
 
 	// Check interval
 	// +optional
-	CheckInterval *time.Duration `json:"checkInterval,omitempty"`
+	CheckInterval *metav1.Duration `json:"checkInterval,omitempty"`
 
 	// Config dir containing compliance benchmarks
 	// +optional

--- a/pkg/apis/datadoghq/v1alpha1/test/new.go
+++ b/pkg/apis/datadoghq/v1alpha1/test/new.go
@@ -71,7 +71,7 @@ type NewDatadogAgentOptions struct {
 	AdmissionMutateUnlabelled        bool
 	AdmissionServiceName             string
 	ComplianceEnabled                bool
-	ComplianceCheckInterval          time.Duration
+	ComplianceCheckInterval          metav1.Duration
 	ComplianceConfigDir              *datadoghqv1alpha1.ConfigDirSpec
 	RuntimeSecurityEnabled           bool
 	RuntimeSyscallMonitorEnabled     bool
@@ -273,7 +273,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		if options.ComplianceEnabled {
 			ad.Spec.Agent.Security.Compliance.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
 
-			if options.ComplianceCheckInterval != 0 {
+			if options.ComplianceCheckInterval.Duration != 0 {
 				ad.Spec.Agent.Security.Compliance.CheckInterval = &options.ComplianceCheckInterval
 			}
 			if options.ComplianceConfigDir != nil {

--- a/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -10,8 +10,6 @@
 package v1alpha1
 
 import (
-	time "time"
-
 	datadoghqv1alpha1 "github.com/datadog/extendeddaemonset/pkg/apis/datadoghq/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -159,6 +157,11 @@ func (in *ClusterAgentConfig) DeepCopyInto(out *ClusterAgentConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CollectEvents != nil {
+		in, out := &in.CollectEvents, &out.CollectEvents
+		*out = new(bool)
+		**out = **in
+	}
 	if in.LogLevel != nil {
 		in, out := &in.LogLevel, &out.LogLevel
 		*out = new(string)
@@ -265,7 +268,7 @@ func (in *ComplianceSpec) DeepCopyInto(out *ComplianceSpec) {
 	}
 	if in.CheckInterval != nil {
 		in, out := &in.CheckInterval, &out.CheckInterval
-		*out = new(time.Duration)
+		*out = new(metav1.Duration)
 		**out = **in
 	}
 	if in.ConfigDir != nil {


### PR DESCRIPTION
### What does this PR do?

Replace `security.compliance.checkInterval` CRD field type from `time.Duration`
to `metav1.Duration`. 

### Motivation

Previously the checkInterval type in the `AgentDeployment.spec`
was `time.Duration`. So it wasn't possible to use a value like `20min`.

Now, with `metav1.Duration` type, it is possible and more align with the other
Duration fields in the CRD.

### Additional Notes

N/A

### Describe your test plan

Deploy a DatadogAgent with the compliance feature activated and the `checkInterval` 
value set to `20s` for example. The Operator should be able to create the Daemonset without
`checkInterval` decoding error. 



