### PR TITLE
Fix scheduling of system-probe related checks in the core agent and missing permissions for network policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= datadog/datadog-operator:latest
+IMG ?= datadog/operator:latest
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: datadog/datadog-operator
+  newName: datadog/operator
   newTag: latest
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -211,6 +211,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -938,7 +938,7 @@ func buildAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, version st
 // getDefaultClusterAgentPolicyRules returns the default policy rules for the Cluster Agent
 // Can be used by the Agent if the Cluster Agent is disabled
 func getDefaultClusterAgentPolicyRules() []rbacv1.PolicyRule {
-	return []rbacv1.PolicyRule{
+	return append([]rbacv1.PolicyRule{
 		{
 			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
 			Resources: []string{
@@ -964,7 +964,7 @@ func getDefaultClusterAgentPolicyRules() []rbacv1.PolicyRule {
 			NonResourceURLs: []string{datadoghqv1alpha1.VersionURL, datadoghqv1alpha1.HealthzURL},
 			Verbs:           []string{datadoghqv1alpha1.GetVerb},
 		},
-	}
+	}, getLeaderElectionPolicyRule()...)
 }
 
 // buildClusterRoleBinding creates a ClusterRoleBinding object
@@ -1016,14 +1016,8 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 		Verbs: []string{datadoghqv1alpha1.GetVerb},
 	})
 
-	if dda.Spec.Agent != nil {
-		if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Config.CollectEvents) {
-			rbacRules = append(rbacRules, getEventCollectionPolicyRule())
-		}
-
-		if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Config.LeaderElection) {
-			rbacRules = append(rbacRules, getLeaderElectionPolicyRule()...)
-		}
+	if datadoghqv1alpha1.BoolValue(dda.Spec.ClusterAgent.Config.CollectEvents) {
+		rbacRules = append(rbacRules, getEventCollectionPolicyRule())
 	}
 
 	if dda.Spec.ClusterAgent.Config.ExternalMetrics != nil && dda.Spec.ClusterAgent.Config.ExternalMetrics.Enabled {

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1153,6 +1153,23 @@ func getVolumeMountsForAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []corev1.
 			},
 		}...)
 	}
+
+	// SystemProbe volumes
+	if datadoghqv1alpha1.BoolValue(spec.Agent.SystemProbe.Enabled) {
+		volumeMounts = append(volumeMounts, []corev1.VolumeMount{
+			{
+				Name:      datadoghqv1alpha1.SystemProbeSocketVolumeName,
+				MountPath: datadoghqv1alpha1.SystemProbeSocketVolumePath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      datadoghqv1alpha1.SystemProbeConfigVolumeName,
+				MountPath: datadoghqv1alpha1.SystemProbeConfigVolumePath,
+				SubPath:   datadoghqv1alpha1.SystemProbeConfigVolumeSubPath,
+			},
+		}...)
+	}
+
 	return append(volumeMounts, spec.Agent.Config.VolumeMounts...)
 }
 

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -93,6 +93,7 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=*
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=*
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=*
 
 // Reconcile loop for DatadogAgent
 func (r *DatadogAgentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
### What does this PR do?

To auto-activate OOM and TCP checks, the core agent needs to have access to `system-probe` socket and configuration file.
RBAC declaration for NetworkPolicies was missing (Kustomize)
Fixed DCA RBAC to collect events following introduction of `Spec.ClusterAgent.Config.CollectEvents`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Activate system-probe OOM or TCP checks and verify they run in core agent.
