### PR TITLE
Fix compliance CheckInterval set in DCA/SecAgent

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -508,7 +508,7 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 		if dda.Spec.Agent.Security.Compliance.CheckInterval != nil {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  datadoghqv1alpha1.DDComplianceConfigCheckInterval,
-				Value: dda.Spec.Agent.Security.Compliance.CheckInterval.String(),
+				Value: strconv.FormatInt(dda.Spec.Agent.Security.Compliance.CheckInterval.Nanoseconds(), 10),
 			})
 		}
 

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -679,7 +679,7 @@ func getEnvVarsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.E
 		if dda.Spec.Agent.Security.Compliance.CheckInterval != nil {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  datadoghqv1alpha1.DDComplianceConfigCheckInterval,
-				Value: dda.Spec.Agent.Security.Compliance.CheckInterval.String(),
+				Value: strconv.FormatInt(dda.Spec.Agent.Security.Compliance.CheckInterval.Nanoseconds(), 10),
 			})
 		}
 


### PR DESCRIPTION
### What does this PR do?

Since move from string to `metav1.Duration`, CheckInterval is not working anymore. It's because `String()` of a `metav1.Duration` is not what the Agent/ClusterAgent expects.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Activate compliance, set CheckInterval, checks the outputted check interval in the logs, should be the same value.