### PR TITLE
Fix deep equal of CRB if it already exist and is incorrect

### DIFF
--- a/controllers/datadogagent/agent_rbac.go
+++ b/controllers/datadogagent/agent_rbac.go
@@ -65,6 +65,10 @@ func (r *Reconciler) manageAgentRBACs(logger logr.Logger, dda *datadoghqv1alpha1
 		return reconcile.Result{}, err
 	}
 
+	if result, err := r.udpateIfNeededAgentClusterRoleBinding(logger, dda, rbacResourcesName, serviceAccountName, agentVersion, clusterRoleBinding); err != nil {
+		return result, err
+	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -818,6 +818,24 @@ func (r *Reconciler) updateIfNeededAgentClusterRole(logger logr.Logger, dda *dat
 	return reconcile.Result{}, nil
 }
 
+func (r *Reconciler) udpateIfNeededAgentClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, serviceAccountName, agentVersion string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (reconcile.Result, error) {
+	info := roleBindingInfo{
+		name:               name,
+		roleName:           name,
+		serviceAccountName: serviceAccountName,
+	}
+	newClusterRoleBinding := buildClusterRoleBinding(dda, info, agentVersion)
+	if !apiequality.Semantic.DeepEqual(newClusterRoleBinding.Subjects, clusterRoleBinding.Subjects) || !apiequality.Semantic.DeepEqual(newClusterRoleBinding.RoleRef, clusterRoleBinding.RoleRef) {
+		logger.V(1).Info("updateAgentClusterRoleBinding", "clusterRoleBinding.name", clusterRoleBinding.Name)
+		if err := r.client.Update(context.TODO(), newClusterRoleBinding); err != nil {
+			return reconcile.Result{}, err
+		}
+		event := buildEventInfo(newClusterRoleBinding.Name, newClusterRoleBinding.Namespace, clusterRoleKind, datadog.UpdateEvent)
+		r.recordEvent(dda, event)
+	}
+	return reconcile.Result{}, nil
+}
+
 // cleanupClusterAgentRbacResources deletes ClusterRole, ClusterRoleBindings, and ServiceAccount of the Cluster Agent
 func (r *Reconciler) cleanupClusterAgentRbacResources(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
 	rbacResourcesName := getClusterAgentRbacResourcesName(dda)


### PR DESCRIPTION
### What does this PR do?

If the Agent's CRB already exists but is targeting a different service account, the operator does not update it.
This leads to the SA of the agent created from the operator to not be tied to the CR created by the operator.

### Motivation

Hit the bug while QA'ing another feature.
This is also to be consistent with the logic of the cluster role.

### Additional Notes

There were no tests on the package, let's add a card in the backlog to increase the coverage.
Secondly, the new CRB (or CR with the current logic) will be deleted when the operator terminates the DA resource. This means that if a customer has a CR (or a CRB with this logic) that is used with the agent independently, we mutate it, change the ownership and delete it. 
This could come as a surprise.

### Describe your test plan

Create a CRB:

```
➜  datadog-operator git:(charlyf/ksm_core) ✗ k get clusterrolebinding datadog-agent -oyaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: datadog-agent
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: datadog-agent
subjects:
- kind: ServiceAccount
  name: datadog-agent
  namespace: default
```
note that the ns of the SA is not the same as the default one for the operator (datadog-operator-system IIRC).
Start a DatadogAgent resource and:
```
➜  datadog-operator git:(charlyf/ksm_core) ✗ k describe clusterrolebinding datadog-agent
Name:         datadog-agent
Labels:       app.kubernetes.io/instance=datadog-agent
              app.kubernetes.io/managed-by=datadog-operator
              app.kubernetes.io/name=datadog-agent-deployment
              app.kubernetes.io/part-of=datadog
              app.kubernetes.io/version=
Annotations:  <none>
Role:
  Kind:  ClusterRole
  Name:  datadog-agent
Subjects:
  Kind            Name           Namespace
  ----            ----           ---------
  ServiceAccount  datadog-agent  datadog-operator-system
```

Note that the ns is the one of the agents spun up by the operator now.