### PR TITLE
Update datadog-agent-apm.yaml

### DIFF
--- a/examples/datadog-agent-apm.yaml
+++ b/examples/datadog-agent-apm.yaml
@@ -11,3 +11,4 @@ spec:
       name: "datadog/agent:latest"
     apm:
       enabled: true
+      hostPort: 8126


### PR DESCRIPTION
### What does this PR do?

This is to align the APM sample manifest with our [public docs](https://docs.datadoghq.com/agent/kubernetes/apm/?tab=operator#setup) which requires the apm containerPort to be mapped to a hostPort.

PR to modify the public documentation: https://github.com/DataDog/documentation/pull/9071

### Motivation

To prevent customers from encountering issues by following the documentation for Datadog Operator.

