### PR TITLE
Fix missing mount of system-probe config in process agent and remove s6 from CLC (aligned on Helm chart)

### DIFF
--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -288,6 +288,10 @@ func newClusterChecksRunnerPodTemplate(dda *datadoghqv1alpha1.DatadogAgent, labe
 					VolumeMounts:    volumeMounts,
 					LivenessProbe:   getDefaultLivenessProbe(),
 					ReadinessProbe:  getDefaultReadinessProbe(),
+					Command: []string{
+						"agent",
+						"run",
+					},
 				},
 			},
 			Volumes:           getVolumesForClusterChecksRunner(dda),
@@ -442,12 +446,6 @@ func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 			},
 		},
 		{
-			Name: "s6-run",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
-		{
 			Name: "remove-corechecks",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
@@ -472,10 +470,6 @@ func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) 
 			SubPath:   datadoghqv1alpha1.InstallInfoVolumeSubPath,
 			MountPath: datadoghqv1alpha1.InstallInfoVolumePath,
 			ReadOnly:  datadoghqv1alpha1.InstallInfoVolumeReadOnly,
-		},
-		{
-			Name:      "s6-run",
-			MountPath: "/var/run/s6",
 		},
 		{
 			Name:      "remove-corechecks",

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -60,6 +60,7 @@ func clusterChecksRunnerDefaultPodSpec() corev1.PodSpec {
 				VolumeMounts:    clusterChecksRunnerDefaultVolumeMounts(),
 				LivenessProbe:   getDefaultLivenessProbe(),
 				ReadinessProbe:  getDefaultReadinessProbe(),
+				Command:         []string{"agent", "run"},
 			},
 		},
 		Volumes: clusterChecksRunnerDefaultVolumes(),
@@ -82,10 +83,6 @@ func clusterChecksRunnerDefaultVolumeMounts() []corev1.VolumeMount {
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
 			ReadOnly:  true,
-		},
-		{
-			Name:      "s6-run",
-			MountPath: "/var/run/s6",
 		},
 		{
 			Name:      "remove-corechecks",
@@ -116,12 +113,6 @@ func clusterChecksRunnerDefaultVolumes() []corev1.Volume {
 						Name: "foo-install-info",
 					},
 				},
-			},
-		},
-		{
-			Name: "s6-run",
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 		{

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1238,11 +1238,18 @@ func getVolumeMountsForProcessAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []
 	}
 
 	if datadoghqv1alpha1.BoolValue(spec.Agent.SystemProbe.Enabled) {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      datadoghqv1alpha1.SystemProbeSocketVolumeName,
-			MountPath: datadoghqv1alpha1.SystemProbeSocketVolumePath,
-			ReadOnly:  true,
-		})
+		volumeMounts = append(volumeMounts, []corev1.VolumeMount{
+			{
+				Name:      datadoghqv1alpha1.SystemProbeSocketVolumeName,
+				MountPath: datadoghqv1alpha1.SystemProbeSocketVolumePath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      datadoghqv1alpha1.SystemProbeConfigVolumeName,
+				MountPath: datadoghqv1alpha1.SystemProbeConfigVolumePath,
+				SubPath:   datadoghqv1alpha1.SystemProbeConfigVolumeSubPath,
+			},
+		}...)
 	}
 
 	return volumeMounts


### PR DESCRIPTION
### What does this PR do?

- Missing mount of system-probe config file causes process-agent inability to find sysprobe.sock
- CLC is currently using S6 while init containers already runs files in `cont-init.d`, removing s6 to align with Helm chart.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy operator with system-probe and process-agent activated, process-agent should be able to find sysprobe.sock.
CLC must sill work properly.
