### PR TITLE
Fix missing OpenShift RBAC to use SCC

### DIFF
--- a/bundle/manifests/datadog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/datadog-operator.clusterserviceversion.yaml
@@ -44,6 +44,23 @@ metadata:
           "spec": {
             "foo": "bar"
           }
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogMonitor",
+          "metadata": {
+            "name": "datadogmonitor-sample"
+          },
+          "spec": {
+            "message": "Something is wrong and we need to fix it.",
+            "query": "avg(last_15m):avg:foo{env:staging,service:bar} \u003e 1",
+            "tags": [
+              "env:staging",
+              "service:bar"
+            ],
+            "title": "Latency is increasing on staging",
+            "type": "metric alert"
+          }
         }
       ]
     capabilities: Basic Install
@@ -64,6 +81,11 @@ spec:
       displayName: Datadog Metric
       kind: DatadogMetric
       name: datadogmetrics.datadoghq.com
+      version: v1alpha1
+    - description: DatadogMonitor is the Schema for the datadogmonitor API
+      displayName: Datadog Monitor
+      kind: DatadogMonitor
+      name: datadogmonitors.datadoghq.com
       version: v1alpha1
   description: Datadog provides a modern monitoring and analytics platform. Gather metrics, logs and traces for full observability of your Kubernetes cluster with Datadog Operator.
   displayName: Datadog Operator
@@ -345,6 +367,14 @@ spec:
           - roles
           verbs:
           - '*'
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - restricted
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
         serviceAccountName: default
       deployments:
       - name: datadog-operator-controller-manager
@@ -450,5 +480,4 @@ spec:
   maturity: alpha
   provider:
     name: Datadog
-  replaces: datadog-operator.v0.3.2
   version: 0.4.0

--- a/bundle/manifests/datadoghq.com_datadogmetrics.yaml
+++ b/bundle/manifests/datadoghq.com_datadogmetrics.yaml
@@ -49,6 +49,9 @@ spec:
             externalMetricName:
               description: ExternalMetricName is reversed for internal use
               type: string
+            maxAge:
+              description: MaxAge provides the max age for the metric query (overrides the default setting `external_metrics_provider.max_age`)
+              type: string
             query:
               description: Query is the raw datadog query
               type: string

--- a/config/manifests/bases/datadog-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/datadog-operator.clusterserviceversion.yaml
@@ -22,6 +22,11 @@ spec:
       kind: DatadogMetric
       name: datadogmetrics.datadoghq.com
       version: v1alpha1
+    - description: DatadogMonitor is the Schema for the datadogmonitor API
+      displayName: Datadog Monitor
+      kind: DatadogMonitor
+      name: datadogmonitors.datadoghq.com
+      version: v1alpha1
   description: Datadog provides a modern monitoring and analytics platform. Gather metrics, logs and traces for full observability of your Kubernetes cluster with Datadog Operator.
   displayName: Datadog Operator
   icon:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -277,3 +277,11 @@ rules:
   - roles
   verbs:
   - '*'
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - restricted
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -75,6 +75,7 @@ type DatadogAgentReconciler struct {
 
 // OpenShift
 // +kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=get;list
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=restricted,verbs=use
 
 // +kubebuilder:rbac:urls=/metrics,verbs=get
 // +kubebuilder:rbac:groups="",resources=componentstatuses,verbs=get;list;watch


### PR DESCRIPTION
### What does this PR do?

Add OpenShift use restricted SCC RBAC in controller annotations

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Restricted SCC is usually default and having permissions to use is not always necessary, so can only be tested in specific environments (e.g. OpenShift dedicated)
