### PR TITLE
Fix process-agent and trace-agent custom-config configuration

### DIFF
--- a/api/v1alpha1/test/new.go
+++ b/api/v1alpha1/test/new.go
@@ -79,6 +79,8 @@ type NewDatadogAgentOptions struct {
 	RuntimePoliciesDir               *datadoghqv1alpha1.ConfigDirSpec
 	SecurityContext                  *corev1.PodSecurityContext
 	CreateNetworkPolicy              bool
+	AgentSpecAdditionalLabels        map[string]string
+	AgentSpecAdditionalAnnotations   map[string]string
 }
 
 // NewDefaultedDatadogAgent returns an initialized and defaulted DatadogAgent for testing purpose
@@ -129,6 +131,14 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		ad.Spec.Site = options.Site
 		ad.Spec.Agent.NetworkPolicy = datadoghqv1alpha1.NetworkPolicySpec{
 			Create: &options.CreateNetworkPolicy,
+		}
+
+		if len(options.AgentSpecAdditionalLabels) > 0 {
+			ad.Spec.Agent.AdditionalLabels = options.AgentSpecAdditionalLabels
+		}
+
+		if len(options.AgentSpecAdditionalAnnotations) > 0 {
+			ad.Spec.Agent.AdditionalAnnotations = options.AgentSpecAdditionalAnnotations
 		}
 
 		if options.HostPort != 0 {

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -363,7 +363,7 @@ func buildAgentNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, name string) *
 		},
 	}
 
-	if isAPMEnabled(dda) {
+	if isAPMEnabled(&dda.Spec) {
 		port := datadoghqv1alpha1.DefaultAPMAgentTCPPort
 		if dda.Spec.Agent.Apm.HostPort != nil {
 			port = *dda.Spec.Agent.Apm.HostPort
@@ -485,6 +485,9 @@ func newDaemonsetObjectMetaData(dda *datadoghqv1alpha1.DatadogAgent) metav1.Obje
 		labels[key] = val
 	}
 	annotations := map[string]string{}
+	for key, val := range dda.Annotations {
+		annotations[key] = val
+	}
 
 	return metav1.ObjectMeta{
 		Name:        daemonsetName(dda),

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 const testDdaName = "foo"
+const agentConfigFile = "/etc/datadog-agent/datadog.yaml"
 
 func apiKeyValue() *corev1.EnvVarSource {
 	return &corev1.EnvVarSource{
@@ -877,7 +878,7 @@ func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 		Name:            "trace-agent",
 		Image:           "datadog/agent:latest",
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"trace-agent", "--config=/etc/datadog-agent/datadog.yaml"},
+		Command:         []string{"trace-agent", "--config=" + agentConfigFile},
 		Resources:       corev1.ResourceRequirements{},
 		Ports:           []corev1.ContainerPort{{Name: "traceport", ContainerPort: 8126, Protocol: "TCP"}},
 		Env:             defaultAPMContainerEnvVars(),
@@ -886,7 +887,7 @@ func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 			{
 				Name:      "custom-datadog-yaml",
 				ReadOnly:  true,
-				MountPath: "/etc/datadog-agent/datadog.yaml",
+				MountPath: agentConfigFile,
 				SubPath:   "datadog.yaml",
 			},
 		},
@@ -1092,7 +1093,7 @@ func runtimeSecurityAgentPodSpec() corev1.PodSpec {
 				Command: []string{
 					"security-agent",
 					"start",
-					"-c=/etc/datadog-agent/datadog.yaml",
+					"-c=" + agentConfigFile,
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
@@ -1167,7 +1168,7 @@ func complianceSecurityAgentPodSpec() corev1.PodSpec {
 				Command: []string{
 					"security-agent",
 					"start",
-					"-c=/etc/datadog-agent/datadog.yaml",
+					"-c=" + agentConfigFile,
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
@@ -1642,7 +1643,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 		},
 		{
 			Name:      "custom-datadog-yaml",
-			MountPath: "/etc/datadog-agent/datadog.yaml",
+			MountPath: agentConfigFile,
 			SubPath:   "datadog.yaml",
 			ReadOnly:  true,
 		},

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -356,7 +356,7 @@ func newClusterAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent,
 		volumeMounts = append(volumeMounts, volumeMount)
 	}
 
-	if isComplianceEnabled(agentdeployment) {
+	if isComplianceEnabled(&agentdeployment.Spec) {
 		if agentdeployment.Spec.Agent.Security.Compliance.ConfigDir != nil {
 			volumes = append(volumes, corev1.Volume{
 				Name: datadoghqv1alpha1.SecurityAgentComplianceConfigDirVolumeName,
@@ -467,7 +467,7 @@ func getClusterAgentCustomConfigConfigMapName(dda *datadoghqv1alpha1.DatadogAgen
 func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.EnvVar {
 	spec := &dda.Spec
 
-	complianceEnabled := isComplianceEnabled(dda)
+	complianceEnabled := isComplianceEnabled(&dda.Spec)
 
 	envVars := []corev1.EnvVar{
 		{
@@ -1141,7 +1141,7 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 		})
 	}
 
-	if isComplianceEnabled(dda) {
+	if isComplianceEnabled(&dda.Spec) {
 		// ServiceAccounts and Namespaces
 		rbacRules = append(rbacRules, rbacv1.PolicyRule{
 			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -464,7 +464,6 @@ func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		getVolumeMountForChecksd(),
-		getVolumeMountForConfig(),
 		{
 			Name:      datadoghqv1alpha1.InstallInfoVolumeName,
 			SubPath:   datadoghqv1alpha1.InstallInfoVolumeSubPath,
@@ -477,10 +476,9 @@ func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) 
 		},
 	}
 
-	if dda.Spec.ClusterChecksRunner.CustomConfig != nil {
-		volumeMount := getVolumeMountFromCustomConfigSpec(dda.Spec.ClusterChecksRunner.CustomConfig, datadoghqv1alpha1.AgentCustomConfigVolumeName, datadoghqv1alpha1.AgentCustomConfigVolumePath, datadoghqv1alpha1.AgentCustomConfigVolumeSubPath)
-		volumeMounts = append(volumeMounts, volumeMount)
-	}
+	// Add configuration volumesMount default and custom config (datadog.yaml) volume
+	volumeMounts = append(volumeMounts, getVolumeMountForConfig(dda.Spec.ClusterChecksRunner.CustomConfig)...)
+
 	return append(volumeMounts, dda.Spec.ClusterChecksRunner.Config.VolumeMounts...)
 }
 

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -75,10 +75,6 @@ func clusterChecksRunnerDefaultVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 		{
-			Name:      datadoghqv1alpha1.ConfigVolumeName,
-			MountPath: datadoghqv1alpha1.ConfigVolumePath,
-		},
-		{
 			Name:      "installinfo",
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
@@ -87,6 +83,10 @@ func clusterChecksRunnerDefaultVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      "remove-corechecks",
 			MountPath: fmt.Sprintf("%s/%s", datadoghqv1alpha1.ConfigVolumePath, "conf.d"),
+		},
+		{
+			Name:      datadoghqv1alpha1.ConfigVolumeName,
+			MountPath: datadoghqv1alpha1.ConfigVolumePath,
 		},
 	}
 }

--- a/controllers/datadogagent/systemprobe.go
+++ b/controllers/datadogagent/systemprobe.go
@@ -41,7 +41,7 @@ func (r *Reconciler) manageSystemProbeDependencies(logger logr.Logger, dda *data
 }
 
 func buildSystemProbeConfigConfiMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.ConfigMap, error) {
-	if !isSystemProbeEnabled(dda) {
+	if !isSystemProbeEnabled(&dda.Spec) {
 		return nil, nil
 	}
 
@@ -62,10 +62,10 @@ func buildSystemProbeConfigConfiMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev
 				datadoghqv1alpha1.BoolToString(spec.EnableTCPQueueLength),
 				datadoghqv1alpha1.BoolToString(spec.EnableOOMKill),
 				datadoghqv1alpha1.BoolToString(spec.CollectDNSStats),
-				isRuntimeSecurityEnabled(dda),
+				isRuntimeSecurityEnabled(&dda.Spec),
 				filepath.Join(datadoghqv1alpha1.SystemProbeSocketVolumePath, "runtime-security.sock"),
 				datadoghqv1alpha1.SecurityAgentRuntimePoliciesDirVolumePath,
-				isSyscallMonitorEnabled(dda),
+				isSyscallMonitorEnabled(&dda.Spec),
 			),
 		},
 	}
@@ -93,7 +93,7 @@ runtime_security_config:
 `
 
 func buildSystemProbeSecCompConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.ConfigMap, error) {
-	if !isSystemProbeEnabled(dda) {
+	if !isSystemProbeEnabled(&dda.Spec) {
 		return nil, nil
 	}
 

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -62,7 +62,7 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 	}
 
 	annotations := getDefaultAnnotations(agentdeployment)
-	if isSystemProbeEnabled(agentdeployment) {
+	if isSystemProbeEnabled(&agentdeployment.Spec) {
 		annotations[datadoghqv1alpha1.SysteProbeAppArmorAnnotationKey] = getAppArmorProfileName(&agentdeployment.Spec.Agent.SystemProbe)
 		annotations[datadoghqv1alpha1.SysteProbeSeccompAnnotationKey] = getSeccompProfileName(&agentdeployment.Spec.Agent.SystemProbe)
 	}
@@ -78,7 +78,7 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 	}
 	containers = append(containers, *agentContainer)
 
-	if isAPMEnabled(agentdeployment) {
+	if isAPMEnabled(&agentdeployment.Spec) {
 		var apmContainers []corev1.Container
 
 		apmContainers, err = getAPMAgentContainers(agentdeployment)
@@ -87,7 +87,7 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 		}
 		containers = append(containers, apmContainers...)
 	}
-	if isProcessEnabled(agentdeployment) {
+	if isProcessEnabled(&agentdeployment.Spec) {
 		var processContainers []corev1.Container
 
 		processContainers, err = getProcessContainers(agentdeployment)
@@ -96,7 +96,7 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 		}
 		containers = append(containers, processContainers...)
 	}
-	if isSystemProbeEnabled(agentdeployment) {
+	if isSystemProbeEnabled(&agentdeployment.Spec) {
 		var systemProbeContainers []corev1.Container
 
 		systemProbeContainers, err = getSystemProbeContainers(agentdeployment)
@@ -105,7 +105,7 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 		}
 		containers = append(containers, systemProbeContainers...)
 	}
-	if isSecurityAgentEnabled(agentdeployment) {
+	if isSecurityAgentEnabled(&agentdeployment.Spec) {
 		var securityAgentContainer *corev1.Container
 
 		securityAgentContainer, err = getSecurityAgentContainer(agentdeployment)
@@ -137,61 +137,43 @@ func newAgentPodTemplate(agentdeployment *datadoghqv1alpha1.DatadogAgent, select
 			Tolerations:        agentdeployment.Spec.Agent.Config.Tolerations,
 			PriorityClassName:  agentdeployment.Spec.Agent.PriorityClassName,
 			HostNetwork:        agentdeployment.Spec.Agent.HostNetwork,
-			HostPID:            agentdeployment.Spec.Agent.HostPID || isComplianceEnabled(agentdeployment),
+			HostPID:            agentdeployment.Spec.Agent.HostPID || isComplianceEnabled(&agentdeployment.Spec),
 			DNSPolicy:          agentdeployment.Spec.Agent.DNSPolicy,
 			DNSConfig:          agentdeployment.Spec.Agent.DNSConfig,
 		},
 	}, nil
 }
 
-func isAPMEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	if dda.Spec.Agent == nil {
-		return false
-	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Apm.Enabled)
+func isAPMEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
+	return datadoghqv1alpha1.BoolValue(spec.Agent.Apm.Enabled)
 }
 
-func isProcessEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	if dda.Spec.Agent == nil {
-		return false
-	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Process.Enabled)
+func isProcessEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
+	return datadoghqv1alpha1.BoolValue(spec.Agent.Process.Enabled)
 }
 
-func isSystemProbeEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	if dda.Spec.Agent == nil {
-		return false
-	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.SystemProbe.Enabled) || datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Security.Runtime.Enabled)
+func isSystemProbeEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
+	return datadoghqv1alpha1.BoolValue(spec.Agent.SystemProbe.Enabled) || datadoghqv1alpha1.BoolValue(spec.Agent.Security.Runtime.Enabled)
 }
 
-func isComplianceEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	if dda.Spec.Agent == nil {
-		return false
-	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Security.Compliance.Enabled)
+func isComplianceEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
+	return datadoghqv1alpha1.BoolValue(spec.Agent.Security.Compliance.Enabled)
 }
 
-func isRuntimeSecurityEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	if dda.Spec.Agent == nil {
-		return false
-	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Security.Runtime.Enabled)
+func isRuntimeSecurityEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
+	return datadoghqv1alpha1.BoolValue(spec.Agent.Security.Runtime.Enabled)
 }
 
-func isSecurityAgentEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	if dda.Spec.Agent == nil {
-		return false
-	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Security.Compliance.Enabled) || datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Security.Runtime.Enabled)
+func isSecurityAgentEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
+	return datadoghqv1alpha1.BoolValue(spec.Agent.Security.Compliance.Enabled) || datadoghqv1alpha1.BoolValue(spec.Agent.Security.Runtime.Enabled)
 }
 
-func isSyscallMonitorEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	if !isRuntimeSecurityEnabled(dda) {
+func isSyscallMonitorEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
+	if !isRuntimeSecurityEnabled(spec) {
 		return false
 	}
 
-	return dda.Spec.Agent.Security.Runtime.SyscallMonitor != nil && datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Security.Runtime.SyscallMonitor.Enabled)
+	return spec.Agent.Security.Runtime.SyscallMonitor != nil && datadoghqv1alpha1.BoolValue(spec.Agent.Security.Runtime.SyscallMonitor.Enabled)
 }
 
 func getAgentContainer(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Container, error) {
@@ -378,7 +360,7 @@ func getInitContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Container,
 
 	containers := getConfigInitContainers(spec, volumeMounts, envVars)
 
-	if isSystemProbeEnabled(dda) {
+	if isSystemProbeEnabled(&dda.Spec) {
 		if getSeccompProfileName(&dda.Spec.Agent.SystemProbe) == datadoghqv1alpha1.DefaultSeccompProfileName || dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap != "" {
 			systemProbeInit := corev1.Container{
 				Name:            "seccomp-setup",
@@ -444,7 +426,7 @@ func getEnvVarsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar
 	envVars := []corev1.EnvVar{
 		{
 			Name:  datadoghqv1alpha1.DDAPMEnabled,
-			Value: strconv.FormatBool(isAPMEnabled(dda)),
+			Value: strconv.FormatBool(isAPMEnabled(&dda.Spec)),
 		},
 	}
 	commonEnvVars, err := getEnvVarsCommon(dda, true)
@@ -461,11 +443,11 @@ func getEnvVarsForProcessAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.En
 	envVars := []corev1.EnvVar{
 		{
 			Name:  datadoghqv1alpha1.DDProcessAgentEnabled,
-			Value: strconv.FormatBool(isProcessEnabled(dda)),
+			Value: strconv.FormatBool(isProcessEnabled(&dda.Spec)),
 		},
 		{
 			Name:  datadoghqv1alpha1.DDSystemProbeAgentEnabled,
-			Value: strconv.FormatBool(isSystemProbeEnabled(dda)),
+			Value: strconv.FormatBool(isSystemProbeEnabled(&dda.Spec)),
 		},
 	}
 	commonEnvVars, err := getEnvVarsCommon(dda, true)
@@ -661,8 +643,8 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 func getEnvVarsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, error) {
 	spec := dda.Spec
 
-	complianceEnabled := isComplianceEnabled(dda)
-	runtimeEnabled := isRuntimeSecurityEnabled(dda)
+	complianceEnabled := isComplianceEnabled(&dda.Spec)
+	runtimeEnabled := isRuntimeSecurityEnabled(&dda.Spec)
 
 	envVars := []corev1.EnvVar{
 		{
@@ -711,7 +693,7 @@ func getEnvVarsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.E
 			},
 			{
 				Name:  datadoghqv1alpha1.DDRuntimeSecurityConfigSyscallMonitorEnabled,
-				Value: strconv.FormatBool(isSyscallMonitorEnabled(dda)),
+				Value: strconv.FormatBool(isSyscallMonitorEnabled(&dda.Spec)),
 			},
 		}...)
 	}
@@ -801,7 +783,7 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 			volumes = append(volumes, criVolume)
 		}
 	}
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Process.Enabled) || isComplianceEnabled(dda) {
+	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Process.Enabled) || isComplianceEnabled(&dda.Spec) {
 		passwdVolume := corev1.Volume{
 			Name: datadoghqv1alpha1.PasswdVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -813,7 +795,7 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 		volumes = append(volumes, passwdVolume)
 	}
 
-	if isSystemProbeEnabled(dda) {
+	if isSystemProbeEnabled(&dda.Spec) {
 		seccompConfigMapName := getSecCompConfigMapName(dda.Name)
 		if dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap != "" {
 			seccompConfigMapName = dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap
@@ -917,7 +899,7 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 		}...)
 	}
 
-	if isComplianceEnabled(dda) {
+	if isComplianceEnabled(&dda.Spec) {
 		groupVolume := corev1.Volume{
 			Name: datadoghqv1alpha1.GroupVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -952,7 +934,7 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 		}
 	}
 
-	if isRuntimeSecurityEnabled(dda) {
+	if isRuntimeSecurityEnabled(&dda.Spec) {
 		if dda.Spec.Agent.Security.Runtime.PoliciesDir != nil {
 			volumes = append(volumes, corev1.Volume{
 				Name: datadoghqv1alpha1.SecurityAgentRuntimePoliciesDirVolumeName,
@@ -1306,7 +1288,7 @@ func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1
 		}...)
 	}
 
-	if isRuntimeSecurityEnabled(dda) && dda.Spec.Agent.Security.Runtime.PoliciesDir != nil {
+	if isRuntimeSecurityEnabled(&dda.Spec) && dda.Spec.Agent.Security.Runtime.PoliciesDir != nil {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      datadoghqv1alpha1.SecurityAgentRuntimePoliciesDirVolumeName,
 			MountPath: datadoghqv1alpha1.SecurityAgentRuntimePoliciesDirVolumePath,
@@ -1326,8 +1308,8 @@ func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []core
 		},
 	}
 
-	complianceEnabled := isComplianceEnabled(dda)
-	runtimeEnabled := isRuntimeSecurityEnabled(dda)
+	complianceEnabled := isComplianceEnabled(&dda.Spec)
+	runtimeEnabled := isRuntimeSecurityEnabled(&dda.Spec)
 
 	if complianceEnabled {
 		volumeMounts = append(volumeMounts, []corev1.VolumeMount{


### PR DESCRIPTION
### What does this PR do?

Add missing `custom-config` volumeMount in `process-agent` and `trace-agent`. 
 
### Motivation

Fix `process-agent` and `trace-agent` configuration when the user provide a `customConfig`.


### Additional Notes

N/A

### Describe your test plan

Create a new DatadogAgent deployment. In the agent.spec add a `customConfig` configMap. Check
If this configMap is properly mounted in the `process-agent` and the `trace-agent`.

