### PR TITLE
Fix Daemonset hash annotation generation

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -12,8 +12,6 @@ const (
 	AgentDeploymentComponentLabelKey = "agent.datadoghq.com/component"
 	// MD5AgentDeploymentAnnotationKey annotation key used on a Resource in order to identify which AgentDeployment have been used to generate it.
 	MD5AgentDeploymentAnnotationKey = "agent.datadoghq.com/agentspechash"
-	// MD5ResourceAnnotationKey  annotation key used on Resource in order to identify a change compared to the previous Resource version.
-	MD5ResourceAnnotationKey = "agent.datadoghq.com/resourcespechash"
 
 	// DefaultAgentResourceSuffix use as suffix for agent resource naming
 	DefaultAgentResourceSuffix = "agent"

--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -10,8 +10,10 @@ const (
 	AgentDeploymentNameLabelKey = "agent.datadoghq.com/name"
 	// AgentDeploymentComponentLabelKey label key use to know with component is it
 	AgentDeploymentComponentLabelKey = "agent.datadoghq.com/component"
-	// MD5AgentDeploymentAnnotationKey annotation key used on ExtendedDaemonSet in order to identify which AgentDeployment have been used to generate it.
+	// MD5AgentDeploymentAnnotationKey annotation key used on a Resource in order to identify which AgentDeployment have been used to generate it.
 	MD5AgentDeploymentAnnotationKey = "agent.datadoghq.com/agentspechash"
+	// MD5ResourceAnnotationKey  annotation key used on Resource in order to identify a change compared to the previous Resource version.
+	MD5ResourceAnnotationKey = "agent.datadoghq.com/resourcespechash"
 
 	// DefaultAgentResourceSuffix use as suffix for agent resource naming
 	DefaultAgentResourceSuffix = "agent"

--- a/api/v1alpha1/test/new.go
+++ b/api/v1alpha1/test/new.go
@@ -412,7 +412,7 @@ func NewClusterAgentDeployment(ns, name string, options *NewDeploymentOptions) *
 		},
 	}
 
-	_, _ = comparison.SetMD5GenerationAnnotation(&dca.ObjectMeta, dca.Spec)
+	_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dca.ObjectMeta, dca.Spec)
 	if options != nil {
 		if options.CreationTime != nil {
 			dca.CreationTimestamp = metav1.NewTime(*options.CreationTime)

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -431,7 +431,7 @@ func newExtendedDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selec
 			},
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&eds.ObjectMeta, dda.Spec)
+	hash, err := comparison.SetMD5GenerationAnnotation(&eds.ObjectMeta, eds.Spec)
 	if err != nil {
 		return nil, "", err
 	}
@@ -463,7 +463,7 @@ func newDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *met
 			},
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&ds.ObjectMeta, dda.Spec)
+	hash, err := comparison.SetMD5GenerationAnnotation(&ds.ObjectMeta, ds.Spec)
 	if err != nil {
 		return nil, "", err
 	}

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -140,8 +140,8 @@ func (r *Reconciler) createNewExtendedDaemonSet(logger logr.Logger, dda *datadog
 	var err error
 	// ExtendedDaemonSet up to date didn't exist yet, create a new one
 	var newEDS *edsdatadoghqv1alpha1.ExtendedDaemonSet
-	var hash string
-	if newEDS, hash, err = newExtendedDaemonSetFromInstance(dda, nil); err != nil {
+	var hashDDA, hashEDS string
+	if newEDS, hashDDA, hashEDS, err = newExtendedDaemonSetFromInstance(dda, nil); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -150,7 +150,7 @@ func (r *Reconciler) createNewExtendedDaemonSet(logger logr.Logger, dda *datadog
 		return reconcile.Result{}, err
 	}
 
-	logger.Info("Creating a new ExtendedDaemonSet", "extendedDaemonSet.Namespace", newEDS.Namespace, "extendedDaemonSet.Name", newEDS.Name, "agentdeployment.Status.Agent.CurrentHash", hash)
+	logger.Info("Creating a new ExtendedDaemonSet", "extendedDaemonSet.Namespace", newEDS.Namespace, "extendedDaemonSet.Name", newEDS.Name, "agentdeployment.Status.Agent.CurrentHash", hashDDA, "extendeddemonset.CurrentHash", hashEDS)
 
 	err = r.client.Create(context.TODO(), newEDS)
 	if err != nil {
@@ -168,8 +168,8 @@ func (r *Reconciler) createNewDaemonSet(logger logr.Logger, dda *datadoghqv1alph
 	var err error
 	// DaemonSet up to date didn't exist yet, create a new one
 	var newDS *appsv1.DaemonSet
-	var hash string
-	if newDS, hash, err = newDaemonSetFromInstance(dda, nil); err != nil {
+	var hashDDA, hashDS string
+	if newDS, hashDDA, hashDS, err = newDaemonSetFromInstance(dda, nil); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -177,7 +177,7 @@ func (r *Reconciler) createNewDaemonSet(logger logr.Logger, dda *datadoghqv1alph
 	if err = controllerutil.SetControllerReference(dda, newDS, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
-	logger.Info("Creating a new DaemonSet", "daemonSet.Namespace", newDS.Namespace, "daemonSet.Name", newDS.Name, "agentdeployment.Status.Agent.CurrentHash", hash)
+	logger.Info("Creating a new DaemonSet", "daemonSet.Namespace", newDS.Namespace, "daemonSet.Name", newDS.Name, "agentdeployment.Status.Agent.CurrentHash", hashDDA, "demonset.CurrentHash", hashDS)
 	err = r.client.Create(context.TODO(), newDS)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -192,12 +192,12 @@ func (r *Reconciler) createNewDaemonSet(logger logr.Logger, dda *datadoghqv1alph
 
 func (r *Reconciler) updateExtendedDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, eds *edsdatadoghqv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
 	now := metav1.NewTime(time.Now())
-	newEDS, newHash, err := newExtendedDaemonSetFromInstance(dda, eds.Spec.Selector)
+	newEDS, newHashDDA, newHashEDS, err := newExtendedDaemonSetFromInstance(dda, eds.Spec.Selector)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if comparison.IsSameSpecMD5Hash(newHash, eds.GetAnnotations()) {
+	if comparison.IsSameSpecMD5Hash(newHashDDA, eds.GetAnnotations()) && comparison.IsSameResourceMD5Hash(newHashEDS, eds.GetAnnotations()) {
 		// no update needed so return, update the status and return
 		newStatus.Agent = updateExtendedDaemonSetStatus(eds, newStatus.Agent, &now)
 		return reconcile.Result{}, nil
@@ -237,12 +237,12 @@ func (r *Reconciler) updateDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.
 	// Update values from current DS in any case
 	newStatus.Agent = updateDaemonSetStatus(ds, newStatus.Agent, nil)
 
-	newDS, newHash, err := newDaemonSetFromInstance(dda, ds.Spec.Selector)
+	newDS, newHashDDA, newHashDS, err := newDaemonSetFromInstance(dda, ds.Spec.Selector)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 	now := metav1.NewTime(time.Now())
-	if comparison.IsSameSpecMD5Hash(newHash, ds.GetAnnotations()) {
+	if comparison.IsSameSpecMD5Hash(newHashDDA, ds.GetAnnotations()) && comparison.IsSameResourceMD5Hash(newHashDS, ds.GetAnnotations()) {
 		// no update needed so update the status and return
 		newStatus.Agent = updateDaemonSetStatus(ds, newStatus.Agent, &now)
 		return reconcile.Result{}, nil
@@ -408,10 +408,10 @@ func buildAgentNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, name string) *
 }
 
 // newExtendedDaemonSetFromInstance creates an ExtendedDaemonSet from a given DatadogAgent
-func newExtendedDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*edsdatadoghqv1alpha1.ExtendedDaemonSet, string, error) {
+func newExtendedDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*edsdatadoghqv1alpha1.ExtendedDaemonSet, string, string, error) {
 	template, err := newAgentPodTemplate(dda, selector)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	eds := &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 		ObjectMeta: newDaemonsetObjectMetaData(dda),
@@ -431,18 +431,22 @@ func newExtendedDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selec
 			},
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&eds.ObjectMeta, eds.Spec)
+	hashDDA, err := comparison.SetMD5DatadogAgentGenerationAnnotation(&eds.ObjectMeta, dda.Spec)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
-	return eds, hash, nil
+	hashEDS, err := comparison.SetMD5GenerationAnnotation(&eds.ObjectMeta, eds.Spec, datadoghqv1alpha1.MD5ResourceAnnotationKey)
+	if err != nil {
+		return nil, "", "", err
+	}
+	return eds, hashDDA, hashEDS, nil
 }
 
 // newDaemonSetFromInstance creates a DaemonSet from a given DatadogAgent
-func newDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*appsv1.DaemonSet, string, error) {
+func newDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*appsv1.DaemonSet, string, string, error) {
 	template, err := newAgentPodTemplate(dda, selector)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 
 	if selector == nil {
@@ -463,11 +467,15 @@ func newDaemonSetFromInstance(dda *datadoghqv1alpha1.DatadogAgent, selector *met
 			},
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&ds.ObjectMeta, ds.Spec)
+	hashDDA, err := comparison.SetMD5DatadogAgentGenerationAnnotation(&ds.ObjectMeta, dda.Spec)
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
-	return ds, hash, nil
+	hashDS, err := comparison.SetMD5GenerationAnnotation(&ds.ObjectMeta, ds.Spec, datadoghqv1alpha1.MD5ResourceAnnotationKey)
+	if err != nil {
+		return nil, "", "", err
+	}
+	return ds, hashDDA, hashDS, nil
 }
 
 func daemonsetName(dda *datadoghqv1alpha1.DatadogAgent) string {

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1419,12 +1419,16 @@ type extendedDaemonSetFromInstanceTest struct {
 func (test extendedDaemonSetFromInstanceTest) Run(t *testing.T) {
 	t.Helper()
 	logf.SetLogger(logf.ZapLogger(true))
-	got, _, err := newExtendedDaemonSetFromInstance(test.agentdeployment, test.selector)
+	got, _, _, err := newExtendedDaemonSetFromInstance(test.agentdeployment, test.selector)
 	if test.wantErr {
 		assert.Error(t, err, "newExtendedDaemonSetFromInstance() expected an error")
 	} else {
 		assert.NoError(t, err, "newExtendedDaemonSetFromInstance() unexpected error: %v", err)
 	}
+
+	// Remove the generated Resource hash before comparison because it is not easy generate it in the test definition.
+	delete(got.Annotations, datadoghqv1alpha1.MD5ResourceAnnotationKey)
+
 	assert.True(t, apiequality.Semantic.DeepEqual(got, test.want), "newExtendedDaemonSetFromInstance() = %#v\n\nwant %#v\ndiff: %s",
 		got, test.want, cmp.Diff(got, test.want))
 }

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -919,7 +919,10 @@ func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 		Ports:           []corev1.ContainerPort{{Name: "traceport", ContainerPort: 8126, Protocol: "TCP"}},
 		Env:             defaultAPMContainerEnvVars(),
 		VolumeMounts: []corev1.VolumeMount{
-			{Name: "config", MountPath: "/etc/datadog-agent"},
+			{
+				Name:      "config",
+				MountPath: "/etc/datadog-agent",
+			},
 			{
 				Name:      "custom-datadog-yaml",
 				ReadOnly:  true,

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -210,7 +210,7 @@ func newClusterAgentDeploymentFromInstance(agentdeployment *datadoghqv1alpha1.Da
 			Selector: selector,
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&dca.ObjectMeta, dca.Spec)
+	hash, err := comparison.SetMD5DatadogAgentGenerationAnnotation(&dca.ObjectMeta, dca.Spec)
 	return dca, hash, err
 }
 

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -198,7 +198,7 @@ func newClusterChecksRunnerDeploymentFromInstance(
 			Selector: selector,
 		},
 	}
-	hash, err := comparison.SetMD5GenerationAnnotation(&dca.ObjectMeta, dda.Spec.ClusterChecksRunner)
+	hash, err := comparison.SetMD5DatadogAgentGenerationAnnotation(&dca.ObjectMeta, dda.Spec.ClusterChecksRunner)
 	return dca, hash, err
 }
 

--- a/controllers/datadogagent/common_configmap.go
+++ b/controllers/datadogagent/common_configmap.go
@@ -87,7 +87,7 @@ func (r *Reconciler) updateIfNeededConfigMap(dda *datadoghqv1alpha1.DatadogAgent
 
 func (r *Reconciler) createConfigMap(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, configMap *corev1.ConfigMap) (reconcile.Result, error) {
 	result := reconcile.Result{}
-	_, err := comparison.SetMD5GenerationAnnotation(&configMap.ObjectMeta, configMap.Data)
+	_, err := comparison.SetMD5DatadogAgentGenerationAnnotation(&configMap.ObjectMeta, configMap.Data)
 	if err != nil {
 		return result, err
 	}

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -46,15 +46,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
-var defaultAgentHash string
-
 func init() {
 	const resourcesName = "foo"
 	const resourcesNamespace = "bar"
-
-	// init default hashes global variables for a bar/foo datadog agent deployment default config
-	ad := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{UseEDS: true, ClusterAgentEnabled: true, Labels: map[string]string{"label-foo-key": "label-bar-value"}})
-	defaultAgentHash, _ = comparison.GenerateMD5ForSpec(ad.Spec)
 }
 
 func TestReconcileDatadogAgent_createNewExtendedDaemonSet(t *testing.T) {

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -974,7 +974,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 					dcaService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaService)
 				},
@@ -1022,7 +1022,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 					dcaService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaService)
 				},
@@ -1103,7 +1103,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 					dcaService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaService)
 				},
@@ -1155,7 +1155,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 					dcaService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaService)
 					_ = c.Create(context.TODO(), buildClusterAgentPDB(dda))
@@ -1213,7 +1213,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaExternalMetricsService.ObjectMeta, dcaExternalMetricsService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaExternalMetricsService.ObjectMeta, dcaExternalMetricsService.Spec)
 					dcaExternalMetricsService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaExternalMetricsService)
 					_ = c.Create(context.TODO(), buildClusterAgentPDB(dda))
@@ -1288,11 +1288,11 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 					dcaService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaService)
 
-					_, _ = comparison.SetMD5GenerationAnnotation(&admissionService.ObjectMeta, admissionService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&admissionService.ObjectMeta, admissionService.Spec)
 					admissionService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), admissionService)
 
@@ -1351,7 +1351,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 					dcaService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaService)
 					_ = c.Create(context.TODO(), buildServiceAccount(dda, "foo-cluster-agent", getClusterAgentVersion(dda)))
@@ -1408,7 +1408,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaExternalMetricsService.ObjectMeta, dcaExternalMetricsService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaExternalMetricsService.ObjectMeta, dcaExternalMetricsService.Spec)
 					dcaExternalMetricsService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaExternalMetricsService)
 
@@ -1427,7 +1427,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 							VersionPriority:       100,
 						},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaExternalMetricsAPIService.ObjectMeta, dcaExternalMetricsAPIService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaExternalMetricsAPIService.ObjectMeta, dcaExternalMetricsAPIService.Spec)
 					dcaExternalMetricsAPIService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaExternalMetricsAPIService)
 
@@ -1481,7 +1481,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 					dcaService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaService)
 					dcaExternalMetricsService := test.NewService(resourcesNamespace, "foo-cluster-agent-metrics-server", &test.NewServiceOptions{Spec: &corev1.ServiceSpec{
@@ -1500,7 +1500,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						SessionAffinity: corev1.ServiceAffinityNone,
 					},
 					})
-					_, _ = comparison.SetMD5GenerationAnnotation(&dcaExternalMetricsService.ObjectMeta, dcaExternalMetricsService.Spec)
+					_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaExternalMetricsService.ObjectMeta, dcaExternalMetricsService.Spec)
 					dcaExternalMetricsService.Labels = commonDCAlabels
 					_ = c.Create(context.TODO(), dcaExternalMetricsService)
 					version := getClusterAgentVersion(dda)
@@ -2474,7 +2474,7 @@ func createClusterAgentDependencies(c client.Client, dda *datadoghqv1alpha1.Data
 		SessionAffinity: corev1.ServiceAffinityNone,
 	},
 	})
-	_, _ = comparison.SetMD5GenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
+	_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&dcaService.ObjectMeta, dcaService.Spec)
 	dcaService.Labels = getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
 	_ = c.Create(context.TODO(), dcaService)
 

--- a/controllers/datadogagent/service.go
+++ b/controllers/datadogagent/service.go
@@ -86,7 +86,7 @@ func newClusterAgentService(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Servic
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 	}
-	hash, _ := comparison.SetMD5GenerationAnnotation(&service.ObjectMeta, &service.Spec)
+	hash, _ := comparison.SetMD5DatadogAgentGenerationAnnotation(&service.ObjectMeta, &service.Spec)
 
 	return service, hash
 }
@@ -324,7 +324,7 @@ func newMetricsServerService(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Servi
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 	}
-	hash, _ := comparison.SetMD5GenerationAnnotation(&service.ObjectMeta, &service.Spec)
+	hash, _ := comparison.SetMD5DatadogAgentGenerationAnnotation(&service.ObjectMeta, &service.Spec)
 
 	return service, hash
 }
@@ -353,7 +353,7 @@ func newMetricsServerAPIService(dda *datadoghqv1alpha1.DatadogAgent) (*apiregist
 			VersionPriority:       100,
 		},
 	}
-	hash, _ := comparison.SetMD5GenerationAnnotation(&apiService.ObjectMeta, &apiService.Spec)
+	hash, _ := comparison.SetMD5DatadogAgentGenerationAnnotation(&apiService.ObjectMeta, &apiService.Spec)
 	return apiService, hash
 }
 
@@ -381,7 +381,7 @@ func newAdmissionControllerService(dda *datadoghqv1alpha1.DatadogAgent) (*corev1
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 	}
-	hash, _ := comparison.SetMD5GenerationAnnotation(&service.ObjectMeta, &service.Spec)
+	hash, _ := comparison.SetMD5DatadogAgentGenerationAnnotation(&service.ObjectMeta, &service.Spec)
 
 	return service, hash
 }

--- a/pkg/controller/utils/comparison/comparison.go
+++ b/pkg/controller/utils/comparison/comparison.go
@@ -18,9 +18,19 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 )
 
-// IsSameSpecMD5Hash used to compare a md5 hash with the one set in annotations
+// IsSameSpecMD5Hash used to compare the DatadogAgent.spec md5 hash with the one set in annotations
 func IsSameSpecMD5Hash(hash string, annotations map[string]string) bool {
-	if val, ok := annotations[datadoghqv1alpha1.MD5AgentDeploymentAnnotationKey]; ok && val == hash {
+	return IsSameMD5Hash(hash, annotations, datadoghqv1alpha1.MD5AgentDeploymentAnnotationKey)
+}
+
+// IsSameResourceMD5Hash used to compare the Resource.spec md5 hash with the one set in annotations
+func IsSameResourceMD5Hash(hash string, annotations map[string]string) bool {
+	return IsSameMD5Hash(hash, annotations, datadoghqv1alpha1.MD5ResourceAnnotationKey)
+}
+
+// IsSameMD5Hash used to compare a md5 hash with the one set in annotations
+func IsSameMD5Hash(hash string, annotations map[string]string, annotationKey string) bool {
+	if val, ok := annotations[annotationKey]; ok && val == hash {
 		return true
 	}
 	return false
@@ -41,8 +51,13 @@ func GenerateMD5ForSpec(spec interface{}) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
+// SetMD5DatadogAgentGenerationAnnotation is used to set the md5 annotation key/value from spec
+func SetMD5DatadogAgentGenerationAnnotation(obj *metav1.ObjectMeta, spec interface{}) (string, error) {
+	return SetMD5GenerationAnnotation(obj, spec, datadoghqv1alpha1.MD5AgentDeploymentAnnotationKey)
+}
+
 // SetMD5GenerationAnnotation is used to set the md5 annotation key/value from spec
-func SetMD5GenerationAnnotation(obj *metav1.ObjectMeta, spec interface{}) (string, error) {
+func SetMD5GenerationAnnotation(obj *metav1.ObjectMeta, spec interface{}, annotationKey string) (string, error) {
 	hash, err := GenerateMD5ForSpec(spec)
 	if err != nil {
 		return "", fmt.Errorf("unable to generate the spec MD5, %v", err)
@@ -51,6 +66,6 @@ func SetMD5GenerationAnnotation(obj *metav1.ObjectMeta, spec interface{}) (strin
 	if obj.Annotations == nil {
 		obj.SetAnnotations(map[string]string{})
 	}
-	obj.Annotations[datadoghqv1alpha1.MD5AgentDeploymentAnnotationKey] = hash
+	obj.Annotations[annotationKey] = hash
 	return hash, nil
 }

--- a/pkg/controller/utils/comparison/comparison.go
+++ b/pkg/controller/utils/comparison/comparison.go
@@ -23,11 +23,6 @@ func IsSameSpecMD5Hash(hash string, annotations map[string]string) bool {
 	return IsSameMD5Hash(hash, annotations, datadoghqv1alpha1.MD5AgentDeploymentAnnotationKey)
 }
 
-// IsSameResourceMD5Hash used to compare the Resource.spec md5 hash with the one set in annotations
-func IsSameResourceMD5Hash(hash string, annotations map[string]string) bool {
-	return IsSameMD5Hash(hash, annotations, datadoghqv1alpha1.MD5ResourceAnnotationKey)
-}
-
 // IsSameMD5Hash used to compare a md5 hash with the one set in annotations
 func IsSameMD5Hash(hash string, annotations map[string]string, annotationKey string) bool {
 	if val, ok := annotations[annotationKey]; ok && val == hash {


### PR DESCRIPTION
### What does this PR do?

Fix annotation hash generation used to detect a change in the `Daemonset|ExtendedDaemonset` spec.

### Motivation

The operator doesn't detect properly new change in the `Daemonset|ExtendedDaemonset`

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Create and deploy the agent with the operator. Update a small option in the DatadogAgent manifest. the Daemonset should be updated.
