### PR TITLE
Fix issues with Secret management

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -534,12 +534,10 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Env
 		})
 	}
 
-	if needAgentSecret(dda) {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:      datadoghqv1alpha1.DDAPIKey,
-			ValueFrom: getAPIKeyFromSecret(dda),
-		})
-	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name:      datadoghqv1alpha1.DDAPIKey,
+		ValueFrom: getAPIKeyFromSecret(dda),
+	})
 
 	if isMetricsProviderEnabled(spec.ClusterAgent) {
 		envVars = append(envVars, corev1.EnvVar{


### PR DESCRIPTION
### What does this PR do?

Fix the following issues with Secret management:
* When a secret was provided for the API key but the APP key was provided in clear, the operator wrongly tried to create a secret for the APP key with the same name as the user-provided one for the API key.
* When a secret was provided for the API key and for the APP key, but the DCA token was not provided, the DCA pod manifest were referencing a secret for the token that was not created by the operator. The DCA pod were staying in `CreateContainerConfigError` state forever with a event saying `Error: secret "datadog" not found`.

### Motivation

Make things work!

### Additional Notes

Fixes #96
Fixes #191

### Describe your test plan

Try to create a `datadogagent` CR with the following `credentials` part:
```
spec:
  credentials:
    appKey: PUTYOUROWNHERE
    apiSecret:
      keyName: api_key
      secretName: my-datadog-secrets
```
The operator must spawn the agents properly instead of doing nothing and logging the following error:
```
{"level":"ERROR","ts":"2020-12-08T14:09:47Z","logger":"controller","msg":"Reconciler error","reconcilerGroup":"datadoghq.com","reconcilerKind":"DatadogAgent","controller":"datadogagent","name":"datadog","namespace":"datadog-operator-system","error":"secrets \"my-datadog-secrets\" already exists"}
```

Try to create a `datadogagent` CR with the following `credentials` part:
```
spec:
  credentials:
    appSecret:
      keyName: app_key
      secretName: my-datadog-secrets
    apiSecret:
      keyName: api_key
      secretName: my-datadog-secrets
```
The operator must spawn the agents properly instead of having DCA pods stuck in `CreateContainerConfigError` state with the following error: 
```
Events:
  Type     Reason          Age                  From               Message
  ----     ------          ----                 ----               -------
  Warning  Failed          109s (x9 over 2m8s)  kubelet            Error: secret "datadog" not found
```

