### PR TITLE
Fix DD_SITE env variable integration

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -485,10 +485,6 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.En
 			Value: spec.ClusterName,
 		},
 		{
-			Name:  datadoghqv1alpha1.DDSite,
-			Value: spec.Site,
-		},
-		{
 			Name:  datadoghqv1alpha1.DDClusterChecksEnabled,
 			Value: datadoghqv1alpha1.BoolToString(spec.ClusterAgent.Config.ClusterChecksEnabled),
 		},
@@ -548,6 +544,13 @@ func getEnvVarsForClusterAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.En
 		envVars = append(envVars, corev1.EnvVar{
 			Name:      datadoghqv1alpha1.DDAPIKey,
 			ValueFrom: getAPIKeyFromSecret(dda),
+		})
+	}
+
+	if spec.Site != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDSite,
+			Value: spec.Site,
 		})
 	}
 

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -78,10 +78,6 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 			Value: "",
 		},
 		{
-			Name:  "DD_SITE",
-			Value: "",
-		},
-		{
 			Name:  "DD_CLUSTER_CHECKS_ENABLED",
 			Value: "false",
 		},
@@ -581,6 +577,9 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 		Name:          "metricsapi",
 		Protocol:      "TCP",
 	})
+
+	updateContainersEnv(&metricsServerWithSitePodSpec.Containers[0], "DD_SITE", "datadoghq.eu")
+
 	metricsServerWithSitePodSpec.Containers[0].Env = append(metricsServerWithSitePodSpec.Containers[0].Env,
 		[]corev1.EnvVar{
 			{
@@ -611,12 +610,6 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 	)
 	metricsServerWithSitePodSpec.Containers[0].LivenessProbe = probe
 	metricsServerWithSitePodSpec.Containers[0].ReadinessProbe = probe
-
-	for index := range metricsServerWithSitePodSpec.Containers[0].Env {
-		if metricsServerWithSitePodSpec.Containers[0].Env[index].Name == "DD_SITE" {
-			metricsServerWithSitePodSpec.Containers[0].Env[index].Value = "datadoghq.eu"
-		}
-	}
 
 	metricsServerAgentWithSiteDeployment := test.NewDefaultedDatadogAgent("bar", "foo",
 		&test.NewDatadogAgentOptions{
@@ -716,6 +709,7 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 								"app.kubernetes.io/version":     "",
 								"app":                           "datadog-monitoring",
 							},
+							Annotations: map[string]string{},
 						},
 						Spec: metricsServerWithSitePodSpec,
 					},

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -336,10 +336,6 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 			ValueFrom: getAPIKeyFromSecret(dda),
 		},
 		{
-			Name:  datadoghqv1alpha1.DDSite,
-			Value: spec.Site,
-		},
-		{
 			Name:  datadoghqv1alpha1.DDClusterChecksEnabled,
 			Value: "true",
 		},
@@ -399,6 +395,13 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 				},
 			},
 		},
+	}
+
+	if spec.Site != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDSite,
+			Value: spec.Site,
+		})
 	}
 
 	if spec.ClusterChecksRunner.Config.LogLevel != nil {

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -135,10 +135,6 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 			ValueFrom: apiKeyValue(),
 		},
 		{
-			Name:  "DD_SITE",
-			Value: "",
-		},
-		{
 			Name:  "DD_CLUSTER_CHECKS_ENABLED",
 			Value: "true",
 		},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -520,10 +520,6 @@ func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]c
 			Value: getLogLevel(dda),
 		},
 		{
-			Name:  datadoghqv1alpha1.DDSite,
-			Value: dda.Spec.Site,
-		},
-		{
 			Name: datadoghqv1alpha1.DDKubeletHost,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -578,6 +574,13 @@ func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]c
 	}
 
 	envVars = append(envVars, dda.Spec.Agent.Env...)
+
+	if dda.Spec.Site != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDSite,
+			Value: dda.Spec.Site,
+		})
+	}
 
 	return envVars, nil
 }


### PR DESCRIPTION
### What does this PR do?

add `DD_SITE` envvar only if the value is provide in the `DatadogAgent.spec`
configuration.

### Motivation

Previously the `DD_SITE` env variables was always added even if the
value wasn't provided.

### Additional Notes

N/A

### Describe your test plan

* Create a DatadogAgent without configuring the `spec.Site` setting, and verify
that the `DD_SITE` envvar is not added to the containers.
* Update the `DatadogAgent` to configure the `spec.Site`, then verify the presence
of the envvar in the updated pods.


Write there any instructions and details you may have to test your PR.
