### PR TITLE
remove mounting of clusterID CM from process-agent

### DIFF
--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1227,7 +1227,6 @@ func defaultOrchestratorEnvVars() []corev1.EnvVar {
 	}
 	orchestratorEnvs, _ := orchestrator.EnvVars(&explorerConfig)
 	newVars = append(newVars, orchestratorEnvs...)
-	newVars = append(newVars, orchestrator.ClusterID())
 
 	return append(newVars, vars...)
 }

--- a/controllers/datadogagent/orchestrator/envs.go
+++ b/controllers/datadogagent/orchestrator/envs.go
@@ -16,7 +16,6 @@ const (
 	DDOrchestratorExplorerDDUrl                     = "DD_ORCHESTRATOR_EXPLORER_DD_URL"
 	DDOrchestratorExplorerAdditionalEndpoints       = "DD_ORCHESTRATOR_ADDITIONAL_ENDPOINTS"
 	DDOrchestratorExplorerContainerScrubbingEnabled = "DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED"
-	DDOrchestratorClusterID                         = "DD_ORCHESTRATOR_CLUSTER_ID"
 	DefaultID                                       = "id"
 )
 
@@ -58,19 +57,4 @@ func EnvVars(orc *datadoghqv1alpha1.OrchestratorExplorerConfig) ([]corev1.EnvVar
 	}
 
 	return envVars, nil
-}
-
-// ClusterID returns the ClusterID for the orchestrator. The ClusterAgent creates the ID as a configmap while the agent retrieves it from there.
-func ClusterID() corev1.EnvVar {
-	authTokenValue := &corev1.EnvVarSource{
-		ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{Name: datadoghqv1alpha1.DatadogClusterIDResourceName},
-			Key:                  DefaultID,
-		},
-	}
-
-	return corev1.EnvVar{
-		Name:      DDOrchestratorClusterID,
-		ValueFrom: authTokenValue,
-	}
 }

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -489,7 +489,6 @@ func getEnvVarsForProcessAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.En
 			return nil, err
 		}
 		envVars = append(envVars, envs...)
-		envVars = append(envVars, orchestrator.ClusterID())
 	}
 
 	commonEnvVars, err := getEnvVarsCommon(dda, true)


### PR DESCRIPTION
### What does this PR do?

remove mounting of clusterID CM from process-agent

### Motivation

https://github.com/DataDog/datadog-agent/pull/6925 removes the need for this step, the Process Agent will get the cluster-id from a Cluster Agent API endpoint instead, which has a nicer failure mode.

### Additional Notes

This change requires Agent >= 7.25 and Cluster Agent >= 1.11. I'm not sure how to handle this nicely for older versions. Maybe we should keep the configmap for now? I'm open to suggestions.

### Describe your test plan

Write there any instructions and details you may have to test your PR.
