### PR TITLE
[SB] Add secrets helper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,21 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
+COPY cmd/helpers/ cmd/helpers/
 
 # Build
 ARG LDFLAGS
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o helpers cmd/helpers/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
+
+COPY --from=builder /workspace/helpers .
+COPY scripts/readsecret.sh .
+RUN chmod 550 readsecret.sh && chmod 550 helpers
+
 USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/cmd/helpers/main.go
+++ b/cmd/helpers/main.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package main
+
+import (
+	"os"
+
+	"github.com/DataDog/datadog-operator/cmd/helpers/secrets"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	root := &cobra.Command{
+		Use:   "helpers [subcommand] [flags]",
+		Short: "Helpers that can be called inside the operator container",
+	}
+
+	root.AddCommand(secrets.NewCmd())
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/helpers/secrets/secrets.go
+++ b/cmd/helpers/secrets/secrets.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+package secrets
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	s "github.com/DataDog/datadog-operator/pkg/secrets"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	maxSecretFileSize = 8192
+)
+
+// NewCmd implements reading secrets from a directory/volume mount
+func NewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "read-secret",
+		Short: "Read secret from a directory",
+		Long:  ``,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return readSecrets(os.Stdin, os.Stdout, args[0])
+		},
+	}
+}
+
+type secretsRequest struct {
+	Version string   `json:"version"`
+	Secrets []string `json:"secrets"`
+}
+
+// ReadSecrets implements a secrets reader from a directory/mount
+func readSecrets(r io.Reader, w io.Writer, dir string) error {
+	in, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	var request secretsRequest
+	err = json.Unmarshal(in, &request)
+	if err != nil {
+		return errors.New("failed to unmarshal json input")
+	}
+
+	version := splitVersion(request.Version)
+	compatVersion := splitVersion(s.PayloadVersion)
+	if version[0] != compatVersion[0] {
+		return fmt.Errorf("incompatible protocol version %q", request.Version)
+	}
+
+	if len(request.Secrets) == 0 {
+		return errors.New("no secrets listed in input")
+	}
+
+	response := map[string]s.Secret{}
+	for _, name := range request.Secrets {
+		response[name] = readSecret(filepath.Join(dir, name))
+	}
+
+	out, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(out)
+	return err
+}
+
+func splitVersion(ver string) []string {
+	return strings.SplitN(ver, ".", 2)
+}
+
+func readSecret(path string) s.Secret {
+	value, err := readSecretFile(path)
+	var errMsg string
+	if err != nil {
+		errMsg = err.Error()
+	}
+	return s.Secret{Value: value, ErrorMsg: errMsg}
+}
+
+func readSecretFile(path string) (string, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.New("secret does not exist")
+		}
+		return "", err
+	}
+
+	if fi.Mode()&os.ModeSymlink != 0 {
+		// Ensure that the symlink is in the same dir
+		var target string
+		target, err = os.Readlink(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to read symlink target: %v", err)
+		}
+
+		dir := filepath.Dir(path)
+		if !filepath.IsAbs(target) {
+			target, err = filepath.Abs(filepath.Join(dir, target))
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve symlink absolute path: %v", err)
+			}
+		}
+
+		var dirAbs string
+		dirAbs, err = filepath.Abs(dir)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve absolute path of directory: %v", err)
+		}
+
+		if !strings.HasPrefix(target, dirAbs) {
+			return "", fmt.Errorf("not following symlink %q outside of %q", target, dir)
+		}
+	}
+	fi, err = os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+
+	if fi.Size() > maxSecretFileSize {
+		return "", errors.New("secret exceeds max allowed size")
+	}
+
+	var file *os.File
+	file, err = os.Open(path)
+	if err != nil {
+		return "", err
+	}
+
+	var bytes []byte
+	bytes, err = ioutil.ReadAll(file)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -80,6 +80,8 @@ The Datatog Operator is compatible with the ["Secret backend" feature][1] implem
 
 ### How Deploy the Datadog-Operator with the secret backend activated
 
+#### Custom secret backend
+
 The first step is to create a container image from the `datadog/operator` that contains the secret backend command.
 
 The following Dockerfile example takes the `datadog/operator:latest` image as the base image and copies the `my-secret-backend.sh` script file.
@@ -102,6 +104,14 @@ Also don't forget to use the "custom" Datadog Operator container image.
 $ helm [install|upgrade] dd-operator --set "secretBackend.command=/my-secret-backend.sh" --set "image.repository=datadog-operator-with-secret-be" ./chart/datadog-operator
 success
 ```
+
+#### Using the secret helper
+
+Kubernetes supports exposing secrets as files inside a pod, we provide a helper script in the Datadog Operator image to read the secrets from files.
+
+Install or the update of the Datadog Operator deployment, the value parameters `.Values.secretBackend.command` should be set to `/readsecret.sh` and `.Values.secretBackend.arguments` set to `/etc/secret-volume` if your secrets are mounted in `/etc/secret-volume`.
+
+**Note:** This secret helper requires Datadog Operator v0.5.0+
 
 ### How deploy agents using the secret backend feature with DatadogAgent
 

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -17,12 +17,13 @@ type Decryptor interface {
 // SecretBackend implements the Decryptor interface
 type SecretBackend struct {
 	cmd              string
+	cmdArgs          []string
 	cmdOutputMaxSize int
 	cmdTimeout       time.Duration
 }
 
-// secret defines the structure for secrets in JSON output
-type secret struct {
+// Secret defines the structure for secrets in JSON output
+type Secret struct {
 	Value    string `json:"value,omitempty"`
 	ErrorMsg string `json:"error,omitempty"`
 }

--- a/scripts/readsecret.sh
+++ b/scripts/readsecret.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-2020 Datadog, Inc.
+
+/helpers read-secret $@


### PR DESCRIPTION
### What does this PR do?

- Provide a secret helper to read k8s secrets via secret backend

### Motivation

- fixes https://github.com/DataDog/datadog-operator/issues/148

### Additional notes

The operator helm chart will be updated to allow configuring `secretBackendArgs`

### Describe your test plan

Mount the secret + Install the Datadog Operator with `secretBackendCommand=/readsecret.sh` and `secretBackendArgs=/etc/secret-volume` if your secrets are mounted in `/etc/secret-volume`. The datadog operator should be able to decrypt the secrets