### PR TITLE
Fix Dogstatsd config defaulting

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -490,12 +490,7 @@ func DefaultDatadogAgentSpecAgentConfig(config *NodeAgentConfig) *NodeAgentConfi
 		config.CriSocket.DockerSocketPath = NewStringPointer(defaultDockerSocketPath)
 	}
 
-	if config.Dogstatsd == nil {
-		config.Dogstatsd = &DogstatsdConfig{
-			DogstatsdOriginDetection: NewBoolPointer(defaultDogstatsdOriginDetection),
-			UseDogStatsDSocketVolume: NewBoolPointer(defaultUseDogStatsDSocketVolume),
-		}
-	}
+	DefaultConfigDogstatsd(config)
 
 	if config.PodLabelsAsTags == nil {
 		config.PodLabelsAsTags = map[string]string{}
@@ -510,6 +505,21 @@ func DefaultDatadogAgentSpecAgentConfig(config *NodeAgentConfig) *NodeAgentConfi
 	}
 
 	return config
+}
+
+// DefaultConfigDogstatsd used to default Dogstatsd config in NodeAgentConfig
+func DefaultConfigDogstatsd(config *NodeAgentConfig) {
+	if config.Dogstatsd == nil {
+		config.Dogstatsd = &DogstatsdConfig{}
+	}
+
+	if config.Dogstatsd.DogstatsdOriginDetection == nil {
+		config.Dogstatsd.DogstatsdOriginDetection = NewBoolPointer(defaultDogstatsdOriginDetection)
+	}
+
+	if config.Dogstatsd.UseDogStatsDSocketVolume == nil {
+		config.Dogstatsd.UseDogStatsDSocketVolume = NewBoolPointer(defaultUseDogStatsDSocketVolume)
+	}
 }
 
 // DefaultDatadogAgentSpecRbacConfig used to default a RbacConfig

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDefaultConfigDogstatsd(t *testing.T) {
+
+	defaultAgentConfig := NodeAgentConfig{
+		Dogstatsd: &DogstatsdConfig{
+			DogstatsdOriginDetection: NewBoolPointer(false),
+			UseDogStatsDSocketVolume: NewBoolPointer(false),
+		},
+	}
+
+	type args struct {
+		config *NodeAgentConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want *NodeAgentConfig
+	}{
+		{
+			name: "dogtatsd not set",
+			args: args{
+				config: &NodeAgentConfig{},
+			},
+			want: &defaultAgentConfig,
+		},
+		{
+			name: "dogtatsd missing defaulting: DogstatsdOriginDetection",
+			args: args{
+				config: &NodeAgentConfig{
+					Dogstatsd: &DogstatsdConfig{
+						UseDogStatsDSocketVolume: NewBoolPointer(false),
+					},
+				},
+			},
+			want: &defaultAgentConfig,
+		},
+		{
+			name: "dogtatsd missing defaulting: UseDogStatsDSocketVolume",
+			args: args{
+				config: &NodeAgentConfig{
+					Dogstatsd: &DogstatsdConfig{
+						DogstatsdOriginDetection: NewBoolPointer(false),
+					},
+				},
+			},
+			want: &defaultAgentConfig,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DefaultConfigDogstatsd(tt.args.config)
+			if diff := cmp.Diff(tt.args.config, tt.want); diff != "" {
+				t.Errorf("DefaultConfigDogstatsd err, diff:\n %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fix `spec.agent.config.dogstatsd` defaulting.

Previously if the `spec.agent.config.dogstatsd` is nil, the defaulting
was working properly, but if it was half defaulted, like:

```yaml
spec:
  agent:
    config:
      dogstatsd:
        dogstatsdOriginDetection: true
```

the function `IsDefaulted` was properly detecting that `useDogStatsDSocketVolume` was missing,
but the `Default()` wasn't updating properly the configuration.

### Motivation

Fix an issue where the Operator was in an infinit reconcile loop retry, because `IsDefault()` and `Default()`
functions weren't aligned.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Create a `DatadogAgent` with a `dogstatsd` confi not fully defaulted, like:

```
```yaml
spec:
  agent:
    config:
      dogstatsd:
        dogstatsdOriginDetection: true
```

after a defaulting tentative the configuration should be:

```yaml
spec:
  agent:
    config:
      dogstatsd:
        dogstatsdOriginDetection: true
        useDogStatsDSocketVolume: false
```
