### PR TITLE
Use DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -97,6 +97,7 @@ const (
 	DDRuntimeSecurityConfigPoliciesDir           = "DD_RUNTIME_SECURITY_CONFIG_POLICIES_DIR"
 	DDRuntimeSecurityConfigSocket                = "DD_RUNTIME_SECURITY_CONFIG_SOCKET"
 	DDRuntimeSecurityConfigSyscallMonitorEnabled = "DD_RUNTIME_SECURITY_CONFIG_SYSCALL_MONITOR_ENABLED"
+	DDExternalMetricsProviderEndpoint            = "DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT"
 
 	// KubernetesEnvvarName Env var used by the Datadog Agent container entrypoint
 	// to add kubelet config provider and listener


### PR DESCRIPTION
### What does this PR do?

We used to use DATADOG_HOST for setting the external metrics endpoint,
since the Cluster Agent did not have specific support for setting the
external metrics endpoint directly. This has since been added:
https://github.com/DataDog/datadog-agent/pull/6952 -- so we use that and
remove all the decision making and fallbacks to the DCA itself.

### Describe your test plan

Edit a `DatadogAgent` to add the key below, and check the DCA deployment to see the `DD_EXTERNAL_METRICS_PROVIDER_ENDPOINT` applied for the container with the appropriate value.

````
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  clusterAgent:
    config:
      externalMetrics:
        enabled: true
        endpoint: "https://example.com"
```