### PR TITLE
Update getting started guide links to helm charts

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@ Using the Datadog Operator requires the following prerequisites:
 - [`Helm`][1] for deploying the `Datadog-operator`.
 - [`Kubectl` cli][2] for installing the `Datadog-agent`.
 
-## Deploy an agent with the operator
+## Deploy the Agent with the operator
 
 To deploy the Datadog Agent with the operator in the minimum number of steps, see the [`datadog-operator`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog-operator) helm chart.
 Here are the steps:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,7 +13,7 @@ Using the Datadog Operator requires the following prerequisites:
 
 ## Deploy an agent with the operator
 
-In order to deploy a Datadog agent with the operator in the minimum number of steps, the [`datadog-operator`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog-operator) helm chart can be used.
+To deploy the Datadog Agent with the operator in the minimum number of steps, see the [`datadog-operator`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog-operator) helm chart.
 Here are the steps:
 
 1. Install the [Datadog Operator][3]:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,7 +13,7 @@ Using the Datadog Operator requires the following prerequisites:
 
 ## Deploy an agent with the operator
 
-In order to deploy a Datadog agent with the operator in the minimum number of steps, the [`datadog-agent-with-operator`](https://github.com/DataDog/datadog-operator/tree/master/chart/datadog-agent-with-operator) helm chart can be used.
+In order to deploy a Datadog agent with the operator in the minimum number of steps, the [`datadog-operator`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog-operator) helm chart can be used.
 Here are the steps:
 
 1. Install the [Datadog Operator][3]:


### PR DESCRIPTION
### What does this PR do?

Fixes links to Helm chart in the Getting started documentation.

### Motivation

The links to Helm charts were broken.
