### PR TITLE
Increase to 250Mi the operator default resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,10 +43,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 100Mi
+            memory: 250Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 250Mi
         ports:
           - name: metrics
             containerPort: 8080


### PR DESCRIPTION
### What does this PR do?

Increase to 250Mi the operator default resources

### Motivation

with only 100Mi the operator can be in crashloopbackoff when it is deployed in a large cluster.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Generate operator bundle and check that the `ClusterServiceVersion` resources contains the new settings
 