### PR TITLE
Grant access to the Lease objects

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1038,6 +1038,12 @@ func buildAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, version st
 			Resources: []string{datadoghqv1alpha1.EndpointsResource},
 			Verbs:     []string{datadoghqv1alpha1.GetVerb},
 		},
+		{
+			// Leader election check
+			APIGroups: []string{datadoghqv1alpha1.CoordinationAPIGroup},
+			Resources: []string{datadoghqv1alpha1.LeasesResource},
+			Verbs:     []string{datadoghqv1alpha1.GetVerb},
+		},
 	}
 
 	if dda.Spec.ClusterAgent == nil {


### PR DESCRIPTION
### What does this PR do?

Grant access to the `Lease` objects.

### Motivation

In recent versions of Kubernetes, the leader election mechanism has transitioned from dedicated annotations on `Endpoints` objects to dedicated `Lease` objects.

### Additional Notes

This extra permission is needed by DataDog/integrations-core#8535.

### Describe your test plan

Spawn a version of the agent that contains DataDog/integrations-core#8535 on a recent Kubernetes cluster that uses `Lease` objects and make the `kube_scheduler` and `kube_controller_manager` checks use the `Lease` object:
```yaml
  confd:
    kube_scheduler.yaml: |-
      ad_identifiers:
        - kube-scheduler
      init_config:
      instances:
        - prometheus_url: http://%%host%%:10251/metrics
          leader_election_kind: lease
    kube_controller_manager.yaml: |-
      ad_identifiers:
        - kube-controller-manager
      init_config:
      instances:
        - prometheus_url: "http://%%host%%:10252/metrics"
          bearer_token_auth: true
          leader_election_kind: lease
```
And validate that those two checks are working as expected, in particular the metrics linked to leader.