### PR TITLE
Fix duplicate paths for UDS Sockets

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -108,7 +108,7 @@ const (
 	// Datadog volume names and mount paths
 
 	APMSocketVolumeName                = "apmsocket"
-	APMSocketVolumePath                = "/var/run/datadog"
+	APMSocketVolumePath                = "/var/run/datadog/apm"
 	InstallInfoVolumeName              = "installinfo"
 	InstallInfoVolumeSubPath           = "install_info"
 	InstallInfoVolumePath              = "/etc/datadog-agent/install_info"
@@ -136,7 +136,7 @@ const (
 	CriSocketVolumeName                = "runtimesocketdir"
 	CriSocketVolumeReadOnly            = true
 	DogstatsdSocketVolumeName          = "dsdsocket"
-	DogstatsdSocketVolumePath          = "/var/run/datadog"
+	DogstatsdSocketVolumePath          = "/var/run/datadog/statsd"
 	KubeStateMetricCoreVolumeName      = "ksm-core-config"
 	PointerVolumeName                  = "pointerdir"
 	PointerVolumePath                  = "/opt/datadog-agent/run"

--- a/api/v1alpha1/datadogagent_types.go
+++ b/api/v1alpha1/datadogagent_types.go
@@ -310,7 +310,7 @@ type APMUnixDomainSocketSpec struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Define the host APM socket filepath used when APM over Unix Domain Socket is enabled
-	// (default value: /var/run/datadog/apm.sock)
+	// (default value: /var/run/datadog/apm/apm.sock)
 	// ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
 	// +optional
 	HostFilepath *string `json:"hostFilepath,omitempty"`
@@ -736,7 +736,7 @@ type DSDUnixDomainSocketSpec struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Define the host APM socket filepath used when APM over Unix Domain Socket is enabled
-	// (default value: /var/run/datadog/statsd.sock)
+	// (default value: /var/run/datadog/statsd/statsd.sock)
 	// ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/
 	// +optional
 	HostFilepath *string `json:"hostFilepath,omitempty"`

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -142,7 +142,7 @@ func schema__api_v1alpha1_APMUnixDomainSocketSpec(ref common.ReferenceCallback) 
 					},
 					"hostFilepath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
+							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/apm/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -623,7 +623,7 @@ func schema__api_v1alpha1_DSDUnixDomainSocketSpec(ref common.ReferenceCallback) 
 					},
 					"hostFilepath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
+							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/statsd/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -239,7 +239,7 @@ spec:
                           hostFilepath:
                             description: 'Define the host APM socket filepath used
                               when APM over Unix Domain Socket is enabled (default
-                              value: /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
+                              value: /var/run/datadog/apm/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
                             type: string
                         type: object
                     type: object
@@ -307,8 +307,8 @@ spec:
                               hostFilepath:
                                 description: 'Define the host APM socket filepath
                                   used when APM over Unix Domain Socket is enabled
-                                  (default value: /var/run/datadog/statsd.sock) ref:
-                                  https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
+                                  (default value: /var/run/datadog/statsd/statsd.sock)
+                                  ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
                                 type: string
                             type: object
                         type: object

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -229,7 +229,7 @@ spec:
                         hostFilepath:
                           description: 'Define the host APM socket filepath used when
                             APM over Unix Domain Socket is enabled (default value:
-                            /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
+                            /var/run/datadog/apm/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
                           type: string
                       type: object
                   type: object
@@ -296,7 +296,7 @@ spec:
                             hostFilepath:
                               description: 'Define the host APM socket filepath used
                                 when APM over Unix Domain Socket is enabled (default
-                                value: /var/run/datadog/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
+                                value: /var/run/datadog/statsd/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
                               type: string
                           type: object
                       type: object

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -861,6 +861,23 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 		volumes = append(volumes, dsdsocketVolume)
 	}
 
+	// APM volume
+	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Apm.UnixDomainSocket.Enabled) {
+		volumeType := corev1.HostPathDirectoryOrCreate
+		hostPath := getDirFromFilepath(*dda.Spec.Agent.Apm.UnixDomainSocket.HostFilepath)
+
+		dsdsocketVolume := corev1.Volume{
+			Name: datadoghqv1alpha1.APMSocketVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: hostPath,
+					Type: &volumeType,
+				},
+			},
+		}
+		volumes = append(volumes, dsdsocketVolume)
+	}
+
 	if dda.Spec.Agent.Config.CriSocket != nil {
 		path := ""
 		if dda.Spec.Agent.Config.CriSocket.DockerSocketPath != nil {
@@ -1207,14 +1224,6 @@ func getVolumeMountsForAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []corev1.
 
 	// Dogstatsd volume
 	if datadoghqv1alpha1.BoolValue(spec.Agent.Config.Dogstatsd.UnixDomainSocket.Enabled) {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      datadoghqv1alpha1.DogstatsdSocketVolumeName,
-			MountPath: datadoghqv1alpha1.DogstatsdSocketVolumePath,
-		})
-	}
-
-	// APM volume
-	if datadoghqv1alpha1.BoolValue(spec.Agent.Apm.UnixDomainSocket.Enabled) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      datadoghqv1alpha1.DogstatsdSocketVolumeName,
 			MountPath: datadoghqv1alpha1.DogstatsdSocketVolumePath,


### PR DESCRIPTION
### What does this PR do?

Fix some issues with UDS paths that do not allow using both UDS at the same time

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Activate `agent.apm.unixDomainSocket.enabled` and `agent.config.dogstatsd.unixDomainSocket.enabled`