### PR TITLE
move the clusterName to common for every agent instead, if set

### DIFF
--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -18,53 +18,53 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./api/v1alpha1.APMSpec":                                 schema__api_v1alpha1_APMSpec(ref),
-		"./api/v1alpha1.APMUnixDomainSocketSpec":                 schema__api_v1alpha1_APMUnixDomainSocketSpec(ref),
-		"./api/v1alpha1.AdmissionControllerConfig":               schema__api_v1alpha1_AdmissionControllerConfig(ref),
-		"./api/v1alpha1.AgentCredentials":                        schema__api_v1alpha1_AgentCredentials(ref),
-		"./api/v1alpha1.CRISocketConfig":                         schema__api_v1alpha1_CRISocketConfig(ref),
-		"./api/v1alpha1.ClusterAgentConfig":                      schema__api_v1alpha1_ClusterAgentConfig(ref),
-		"./api/v1alpha1.ClusterChecksRunnerConfig":               schema__api_v1alpha1_ClusterChecksRunnerConfig(ref),
-		"./api/v1alpha1.ComplianceSpec":                          schema__api_v1alpha1_ComplianceSpec(ref),
-		"./api/v1alpha1.ConfigDirSpec":                           schema__api_v1alpha1_ConfigDirSpec(ref),
-		"./api/v1alpha1.ConfigFileConfigMapSpec":                 schema__api_v1alpha1_ConfigFileConfigMapSpec(ref),
-		"./api/v1alpha1.CustomConfigSpec":                        schema__api_v1alpha1_CustomConfigSpec(ref),
-		"./api/v1alpha1.DSDUnixDomainSocketSpec":                 schema__api_v1alpha1_DSDUnixDomainSocketSpec(ref),
-		"./api/v1alpha1.DaemonSetDeploymentStrategy":             schema__api_v1alpha1_DaemonSetDeploymentStrategy(ref),
-		"./api/v1alpha1.DaemonSetRollingUpdateSpec":              schema__api_v1alpha1_DaemonSetRollingUpdateSpec(ref),
-		"./api/v1alpha1.DaemonSetStatus":                         schema__api_v1alpha1_DaemonSetStatus(ref),
-		"./api/v1alpha1.DatadogAgent":                            schema__api_v1alpha1_DatadogAgent(ref),
-		"./api/v1alpha1.DatadogAgentCondition":                   schema__api_v1alpha1_DatadogAgentCondition(ref),
-		"./api/v1alpha1.DatadogAgentSpec":                        schema__api_v1alpha1_DatadogAgentSpec(ref),
-		"./api/v1alpha1.DatadogAgentSpecAgentSpec":               schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref),
-		"./api/v1alpha1.DatadogAgentSpecClusterAgentSpec":        schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref),
-		"./api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec": schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref),
-		"./api/v1alpha1.DatadogAgentStatus":                      schema__api_v1alpha1_DatadogAgentStatus(ref),
-		"./api/v1alpha1.DatadogFeatures":                         schema__api_v1alpha1_DatadogFeatures(ref),
-		"./api/v1alpha1.DatadogMetric":                           schema__api_v1alpha1_DatadogMetric(ref),
-		"./api/v1alpha1.DatadogMetricCondition":                  schema__api_v1alpha1_DatadogMetricCondition(ref),
-		"./api/v1alpha1.DatadogMonitor":                          schema__api_v1alpha1_DatadogMonitor(ref),
-		"./api/v1alpha1.DatadogMonitorCondition":                 schema__api_v1alpha1_DatadogMonitorCondition(ref),
-		"./api/v1alpha1.DeploymentStatus":                        schema__api_v1alpha1_DeploymentStatus(ref),
-		"./api/v1alpha1.DogstatsdConfig":                         schema__api_v1alpha1_DogstatsdConfig(ref),
-		"./api/v1alpha1.ExternalMetricsConfig":                   schema__api_v1alpha1_ExternalMetricsConfig(ref),
-		"./api/v1alpha1.ImageConfig":                             schema__api_v1alpha1_ImageConfig(ref),
-		"./api/v1alpha1.KubeStateMetricsCore":                    schema__api_v1alpha1_KubeStateMetricsCore(ref),
-		"./api/v1alpha1.LogSpec":                                 schema__api_v1alpha1_LogSpec(ref),
-		"./api/v1alpha1.NetworkPolicySpec":                       schema__api_v1alpha1_NetworkPolicySpec(ref),
-		"./api/v1alpha1.NodeAgentConfig":                         schema__api_v1alpha1_NodeAgentConfig(ref),
-		"./api/v1alpha1.OrchestratorExplorerConfig":              schema__api_v1alpha1_OrchestratorExplorerConfig(ref),
-		"./api/v1alpha1.ProcessSpec":                             schema__api_v1alpha1_ProcessSpec(ref),
-		"./api/v1alpha1.RbacConfig":                              schema__api_v1alpha1_RbacConfig(ref),
-		"./api/v1alpha1.RuntimeSecuritySpec":                     schema__api_v1alpha1_RuntimeSecuritySpec(ref),
-		"./api/v1alpha1.Secret":                                  schema__api_v1alpha1_Secret(ref),
-		"./api/v1alpha1.SecuritySpec":                            schema__api_v1alpha1_SecuritySpec(ref),
-		"./api/v1alpha1.SyscallMonitorSpec":                      schema__api_v1alpha1_SyscallMonitorSpec(ref),
-		"./api/v1alpha1.SystemProbeSpec":                         schema__api_v1alpha1_SystemProbeSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.APMSpec":                                 schema_DataDog_datadog_operator_api_v1alpha1_APMSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.APMUnixDomainSocketSpec":                 schema_DataDog_datadog_operator_api_v1alpha1_APMUnixDomainSocketSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.AdmissionControllerConfig":               schema_DataDog_datadog_operator_api_v1alpha1_AdmissionControllerConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.AgentCredentials":                        schema_DataDog_datadog_operator_api_v1alpha1_AgentCredentials(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.CRISocketConfig":                         schema_DataDog_datadog_operator_api_v1alpha1_CRISocketConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterAgentConfig":                      schema_DataDog_datadog_operator_api_v1alpha1_ClusterAgentConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterChecksRunnerConfig":               schema_DataDog_datadog_operator_api_v1alpha1_ClusterChecksRunnerConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ComplianceSpec":                          schema_DataDog_datadog_operator_api_v1alpha1_ComplianceSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec":                           schema_DataDog_datadog_operator_api_v1alpha1_ConfigDirSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigFileConfigMapSpec":                 schema_DataDog_datadog_operator_api_v1alpha1_ConfigFileConfigMapSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec":                        schema_DataDog_datadog_operator_api_v1alpha1_CustomConfigSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DSDUnixDomainSocketSpec":                 schema_DataDog_datadog_operator_api_v1alpha1_DSDUnixDomainSocketSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetDeploymentStrategy":             schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetDeploymentStrategy(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetRollingUpdateSpec":              schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetRollingUpdateSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetStatus":                         schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetStatus(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgent":                            schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgent(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentCondition":                   schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentCondition(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpec":                        schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecAgentSpec":               schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterAgentSpec":        schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec": schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentStatus":                      schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentStatus(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogFeatures":                         schema_DataDog_datadog_operator_api_v1alpha1_DatadogFeatures(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetric":                           schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetric(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricCondition":                  schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetricCondition(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitor":                          schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitor(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorCondition":                 schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitorCondition(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus":                        schema_DataDog_datadog_operator_api_v1alpha1_DeploymentStatus(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.DogstatsdConfig":                         schema_DataDog_datadog_operator_api_v1alpha1_DogstatsdConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ExternalMetricsConfig":                   schema_DataDog_datadog_operator_api_v1alpha1_ExternalMetricsConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig":                             schema_DataDog_datadog_operator_api_v1alpha1_ImageConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.KubeStateMetricsCore":                    schema_DataDog_datadog_operator_api_v1alpha1_KubeStateMetricsCore(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.LogSpec":                                 schema_DataDog_datadog_operator_api_v1alpha1_LogSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec":                       schema_DataDog_datadog_operator_api_v1alpha1_NetworkPolicySpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.NodeAgentConfig":                         schema_DataDog_datadog_operator_api_v1alpha1_NodeAgentConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.OrchestratorExplorerConfig":              schema_DataDog_datadog_operator_api_v1alpha1_OrchestratorExplorerConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.ProcessSpec":                             schema_DataDog_datadog_operator_api_v1alpha1_ProcessSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig":                              schema_DataDog_datadog_operator_api_v1alpha1_RbacConfig(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.RuntimeSecuritySpec":                     schema_DataDog_datadog_operator_api_v1alpha1_RuntimeSecuritySpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.Secret":                                  schema_DataDog_datadog_operator_api_v1alpha1_Secret(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.SecuritySpec":                            schema_DataDog_datadog_operator_api_v1alpha1_SecuritySpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.SyscallMonitorSpec":                      schema_DataDog_datadog_operator_api_v1alpha1_SyscallMonitorSpec(ref),
+		"github.com/DataDog/datadog-operator/api/v1alpha1.SystemProbeSpec":                         schema_DataDog_datadog_operator_api_v1alpha1_SystemProbeSpec(ref),
 	}
 }
 
-func schema__api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -88,7 +88,7 @@ func schema__api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDe
 					"unixDomainSocket": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UnixDomainSocket socket configuration ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
-							Ref:         ref("./api/v1alpha1.APMUnixDomainSocketSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.APMUnixDomainSocketSpec"),
 						},
 					},
 					"env": {
@@ -122,11 +122,11 @@ func schema__api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDe
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.APMUnixDomainSocketSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.APMUnixDomainSocketSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
-func schema__api_v1alpha1_APMUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_APMUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -153,7 +153,7 @@ func schema__api_v1alpha1_APMUnixDomainSocketSpec(ref common.ReferenceCallback) 
 	}
 }
 
-func schema__api_v1alpha1_AdmissionControllerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_AdmissionControllerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -187,7 +187,7 @@ func schema__api_v1alpha1_AdmissionControllerConfig(ref common.ReferenceCallback
 	}
 }
 
-func schema__api_v1alpha1_AgentCredentials(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_AgentCredentials(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -211,7 +211,7 @@ func schema__api_v1alpha1_AgentCredentials(ref common.ReferenceCallback) common.
 					"apiSecret": {
 						SchemaProps: spec.SchemaProps{
 							Description: "APISecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"apiKeyExistingSecret\".",
-							Ref:         ref("./api/v1alpha1.Secret"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.Secret"),
 						},
 					},
 					"appKey": {
@@ -231,7 +231,7 @@ func schema__api_v1alpha1_AgentCredentials(ref common.ReferenceCallback) common.
 					"appSecret": {
 						SchemaProps: spec.SchemaProps{
 							Description: "APPSecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"appKeyExistingSecret\".",
-							Ref:         ref("./api/v1alpha1.Secret"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.Secret"),
 						},
 					},
 					"token": {
@@ -252,11 +252,11 @@ func schema__api_v1alpha1_AgentCredentials(ref common.ReferenceCallback) common.
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.Secret"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.Secret"},
 	}
 }
 
-func schema__api_v1alpha1_CRISocketConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_CRISocketConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -283,7 +283,7 @@ func schema__api_v1alpha1_CRISocketConfig(ref common.ReferenceCallback) common.O
 	}
 }
 
-func schema__api_v1alpha1_ClusterAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ClusterAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -292,13 +292,13 @@ func schema__api_v1alpha1_ClusterAgentConfig(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"externalMetrics": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./api/v1alpha1.ExternalMetricsConfig"),
+							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.ExternalMetricsConfig"),
 						},
 					},
 					"admissionController": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the Admission Controller",
-							Ref:         ref("./api/v1alpha1.AdmissionControllerConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.AdmissionControllerConfig"),
 						},
 					},
 					"clusterChecksEnabled": {
@@ -331,7 +331,7 @@ func schema__api_v1alpha1_ClusterAgentConfig(ref common.ReferenceCallback) commo
 					"confd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Confd Provide additional cluster check configurations. Each key will become a file in /conf.d see https://docs.datadoghq.com/agent/autodiscovery/ for more details.",
-							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"env": {
@@ -402,11 +402,11 @@ func schema__api_v1alpha1_ClusterAgentConfig(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.AdmissionControllerConfig", "./api/v1alpha1.ConfigDirSpec", "./api/v1alpha1.ExternalMetricsConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.AdmissionControllerConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.ExternalMetricsConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
-func schema__api_v1alpha1_ClusterChecksRunnerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ClusterChecksRunnerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -498,7 +498,7 @@ func schema__api_v1alpha1_ClusterChecksRunnerConfig(ref common.ReferenceCallback
 	}
 }
 
-func schema__api_v1alpha1_ComplianceSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ComplianceSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -521,18 +521,18 @@ func schema__api_v1alpha1_ComplianceSpec(ref common.ReferenceCallback) common.Op
 					"configDir": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Config dir containing compliance benchmarks",
-							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ConfigDirSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
-func schema__api_v1alpha1_ConfigDirSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ConfigDirSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -552,7 +552,7 @@ func schema__api_v1alpha1_ConfigDirSpec(ref common.ReferenceCallback) common.Ope
 	}
 }
 
-func schema__api_v1alpha1_ConfigFileConfigMapSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ConfigFileConfigMapSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -579,7 +579,7 @@ func schema__api_v1alpha1_ConfigFileConfigMapSpec(ref common.ReferenceCallback) 
 	}
 }
 
-func schema__api_v1alpha1_CustomConfigSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_CustomConfigSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -596,18 +596,18 @@ func schema__api_v1alpha1_CustomConfigSpec(ref common.ReferenceCallback) common.
 					"configMap": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConfigMap name of a ConfigMap used to mount the configuration file",
-							Ref:         ref("./api/v1alpha1.ConfigFileConfigMapSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigFileConfigMapSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ConfigFileConfigMapSpec"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigFileConfigMapSpec"},
 	}
 }
 
-func schema__api_v1alpha1_DSDUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DSDUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -634,7 +634,7 @@ func schema__api_v1alpha1_DSDUnixDomainSocketSpec(ref common.ReferenceCallback) 
 	}
 }
 
-func schema__api_v1alpha1_DaemonSetDeploymentStrategy(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetDeploymentStrategy(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -651,7 +651,7 @@ func schema__api_v1alpha1_DaemonSetDeploymentStrategy(ref common.ReferenceCallba
 					"rollingUpdate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the rolling updater strategy of the DaemonSet or the ExtendedDaemonSet",
-							Ref:         ref("./api/v1alpha1.DaemonSetRollingUpdateSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetRollingUpdateSpec"),
 						},
 					},
 					"canary": {
@@ -670,11 +670,11 @@ func schema__api_v1alpha1_DaemonSetDeploymentStrategy(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.DaemonSetRollingUpdateSpec", "github.com/DataDog/extendeddaemonset/api/v1alpha1.ExtendedDaemonSetSpecStrategyCanary", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetRollingUpdateSpec", "github.com/DataDog/extendeddaemonset/api/v1alpha1.ExtendedDaemonSetSpecStrategyCanary", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
-func schema__api_v1alpha1_DaemonSetRollingUpdateSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetRollingUpdateSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -720,7 +720,7 @@ func schema__api_v1alpha1_DaemonSetRollingUpdateSpec(ref common.ReferenceCallbac
 	}
 }
 
-func schema__api_v1alpha1_DaemonSetStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -796,7 +796,7 @@ func schema__api_v1alpha1_DaemonSetStatus(ref common.ReferenceCallback) common.O
 	}
 }
 
-func schema__api_v1alpha1_DatadogAgent(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgent(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -824,23 +824,23 @@ func schema__api_v1alpha1_DatadogAgent(ref common.ReferenceCallback) common.Open
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./api/v1alpha1.DatadogAgentSpec"),
+							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./api/v1alpha1.DatadogAgentStatus"),
+							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.DatadogAgentSpec", "./api/v1alpha1.DatadogAgentStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogAgentCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -896,7 +896,7 @@ func schema__api_v1alpha1_DatadogAgentCondition(ref common.ReferenceCallback) co
 	}
 }
 
-func schema__api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -906,31 +906,31 @@ func schema__api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.
 					"credentials": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the credentials needed to run Agents. If not set, then the credentials set in the DatadogOperator will be used",
-							Ref:         ref("./api/v1alpha1.AgentCredentials"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.AgentCredentials"),
 						},
 					},
 					"features": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Features running on the Agent and Cluster Agent",
-							Ref:         ref("./api/v1alpha1.DatadogFeatures"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogFeatures"),
 						},
 					},
 					"agent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The desired state of the Agent as an extended daemonset Contains the Node Agent configuration and deployment strategy",
-							Ref:         ref("./api/v1alpha1.DatadogAgentSpecAgentSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecAgentSpec"),
 						},
 					},
 					"clusterAgent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The desired state of the Cluster Agent as a deployment",
-							Ref:         ref("./api/v1alpha1.DatadogAgentSpecClusterAgentSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterAgentSpec"),
 						},
 					},
 					"clusterChecksRunner": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The desired state of the Cluster Checks Runner as a deployment",
-							Ref:         ref("./api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec"),
 						},
 					},
 					"clusterName": {
@@ -951,11 +951,11 @@ func schema__api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.AgentCredentials", "./api/v1alpha1.DatadogAgentSpecAgentSpec", "./api/v1alpha1.DatadogAgentSpecClusterAgentSpec", "./api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec", "./api/v1alpha1.DatadogFeatures"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.AgentCredentials", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecAgentSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterAgentSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogFeatures"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -972,7 +972,7 @@ func schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The container image of the Datadog Agent",
-							Ref:         ref("./api/v1alpha1.ImageConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig"),
 						},
 					},
 					"daemonsetName": {
@@ -985,19 +985,19 @@ func schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Agent configuration",
-							Ref:         ref("./api/v1alpha1.NodeAgentConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NodeAgentConfig"),
 						},
 					},
 					"rbac": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RBAC configuration of the Agent",
-							Ref:         ref("./api/v1alpha1.RbacConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig"),
 						},
 					},
 					"deploymentStrategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Update strategy configuration for the DaemonSet",
-							Ref:         ref("./api/v1alpha1.DaemonSetDeploymentStrategy"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetDeploymentStrategy"),
 						},
 					},
 					"additionalAnnotations": {
@@ -1088,43 +1088,43 @@ func schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback
 					"apm": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Trace Agent configuration",
-							Ref:         ref("./api/v1alpha1.APMSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.APMSpec"),
 						},
 					},
 					"log": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Log Agent configuration",
-							Ref:         ref("./api/v1alpha1.LogSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.LogSpec"),
 						},
 					},
 					"process": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Process Agent configuration",
-							Ref:         ref("./api/v1alpha1.ProcessSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ProcessSpec"),
 						},
 					},
 					"systemProbe": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SystemProbe configuration",
-							Ref:         ref("./api/v1alpha1.SystemProbeSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.SystemProbeSpec"),
 						},
 					},
 					"security": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Security Agent configuration",
-							Ref:         ref("./api/v1alpha1.SecuritySpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.SecuritySpec"),
 						},
 					},
 					"customConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow to put custom configuration for the agent, corresponding to the datadog.yaml config file See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 					"networkPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provide Agent Network Policy configuration",
-							Ref:         ref("./api/v1alpha1.NetworkPolicySpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec"),
 						},
 					},
 				},
@@ -1132,11 +1132,11 @@ func schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.APMSpec", "./api/v1alpha1.CustomConfigSpec", "./api/v1alpha1.DaemonSetDeploymentStrategy", "./api/v1alpha1.ImageConfig", "./api/v1alpha1.LogSpec", "./api/v1alpha1.NetworkPolicySpec", "./api/v1alpha1.NodeAgentConfig", "./api/v1alpha1.ProcessSpec", "./api/v1alpha1.RbacConfig", "./api/v1alpha1.SecuritySpec", "./api/v1alpha1.SystemProbeSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodDNSConfig"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.APMSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetDeploymentStrategy", "github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.LogSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.NodeAgentConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.ProcessSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.SecuritySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.SystemProbeSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodDNSConfig"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1146,7 +1146,7 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceC
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The container image of the Datadog Cluster Agent",
-							Ref:         ref("./api/v1alpha1.ImageConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig"),
 						},
 					},
 					"deploymentName": {
@@ -1159,19 +1159,19 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceC
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Cluster Agent configuration",
-							Ref:         ref("./api/v1alpha1.ClusterAgentConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ClusterAgentConfig"),
 						},
 					},
 					"customConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow to put custom configuration for the agent, corresponding to the datadog-cluster.yaml config file",
-							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 					"rbac": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RBAC configuration of the Datadog Cluster Agent",
-							Ref:         ref("./api/v1alpha1.RbacConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig"),
 						},
 					},
 					"replicas": {
@@ -1260,7 +1260,7 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceC
 					"networkPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provide Cluster Agent Network Policy configuration",
-							Ref:         ref("./api/v1alpha1.NetworkPolicySpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec"),
 						},
 					},
 				},
@@ -1268,11 +1268,11 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ClusterAgentConfig", "./api/v1alpha1.CustomConfigSpec", "./api/v1alpha1.ImageConfig", "./api/v1alpha1.NetworkPolicySpec", "./api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterAgentConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1282,7 +1282,7 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.Ref
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The container image of the Datadog Cluster Checks Runner",
-							Ref:         ref("./api/v1alpha1.ImageConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig"),
 						},
 					},
 					"deploymentName": {
@@ -1295,19 +1295,19 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.Ref
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Agent configuration",
-							Ref:         ref("./api/v1alpha1.ClusterChecksRunnerConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ClusterChecksRunnerConfig"),
 						},
 					},
 					"customConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow to put custom configuration for the agent, corresponding to the datadog.yaml config file See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 					"rbac": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RBAC configuration of the Datadog Cluster Checks Runner",
-							Ref:         ref("./api/v1alpha1.RbacConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig"),
 						},
 					},
 					"replicas": {
@@ -1396,7 +1396,7 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.Ref
 					"networkPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provide Cluster Checks Runner Network Policy configuration",
-							Ref:         ref("./api/v1alpha1.NetworkPolicySpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec"),
 						},
 					},
 				},
@@ -1404,11 +1404,11 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.Ref
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ClusterChecksRunnerConfig", "./api/v1alpha1.CustomConfigSpec", "./api/v1alpha1.ImageConfig", "./api/v1alpha1.NetworkPolicySpec", "./api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterChecksRunnerConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogAgentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1418,19 +1418,19 @@ func schema__api_v1alpha1_DatadogAgentStatus(ref common.ReferenceCallback) commo
 					"agent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Agent as an extended daemonset",
-							Ref:         ref("./api/v1alpha1.DaemonSetStatus"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetStatus"),
 						},
 					},
 					"clusterAgent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Cluster Agent as a deployment",
-							Ref:         ref("./api/v1alpha1.DeploymentStatus"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus"),
 						},
 					},
 					"clusterChecksRunner": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Cluster Checks Runner as a deployment",
-							Ref:         ref("./api/v1alpha1.DeploymentStatus"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus"),
 						},
 					},
 					"conditions": {
@@ -1448,7 +1448,7 @@ func schema__api_v1alpha1_DatadogAgentStatus(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("./api/v1alpha1.DatadogAgentCondition"),
+										Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentCondition"),
 									},
 								},
 							},
@@ -1458,11 +1458,11 @@ func schema__api_v1alpha1_DatadogAgentStatus(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.DaemonSetStatus", "./api/v1alpha1.DatadogAgentCondition", "./api/v1alpha1.DeploymentStatus"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetStatus", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentCondition", "github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogFeatures(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogFeatures(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1472,24 +1472,24 @@ func schema__api_v1alpha1_DatadogFeatures(ref common.ReferenceCallback) common.O
 					"orchestratorExplorer": {
 						SchemaProps: spec.SchemaProps{
 							Description: "OrchestratorExplorer configuration",
-							Ref:         ref("./api/v1alpha1.OrchestratorExplorerConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.OrchestratorExplorerConfig"),
 						},
 					},
 					"kubeStateMetricsCore": {
 						SchemaProps: spec.SchemaProps{
 							Description: "KubeStateMetricsCore configuration",
-							Ref:         ref("./api/v1alpha1.KubeStateMetricsCore"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.KubeStateMetricsCore"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.KubeStateMetricsCore", "./api/v1alpha1.OrchestratorExplorerConfig"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.KubeStateMetricsCore", "github.com/DataDog/datadog-operator/api/v1alpha1.OrchestratorExplorerConfig"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogMetric(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetric(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1517,23 +1517,23 @@ func schema__api_v1alpha1_DatadogMetric(ref common.ReferenceCallback) common.Ope
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./api/v1alpha1.DatadogMetricSpec"),
+							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./api/v1alpha1.DatadogMetricStatus"),
+							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.DatadogMetricSpec", "./api/v1alpha1.DatadogMetricStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogMetricCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetricCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1589,7 +1589,7 @@ func schema__api_v1alpha1_DatadogMetricCondition(ref common.ReferenceCallback) c
 	}
 }
 
-func schema__api_v1alpha1_DatadogMonitor(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitor(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1617,23 +1617,23 @@ func schema__api_v1alpha1_DatadogMonitor(ref common.ReferenceCallback) common.Op
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./api/v1alpha1.DatadogMonitorSpec"),
+							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./api/v1alpha1.DatadogMonitorStatus"),
+							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.DatadogMonitorSpec", "./api/v1alpha1.DatadogMonitorStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema__api_v1alpha1_DatadogMonitorCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitorCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1689,7 +1689,7 @@ func schema__api_v1alpha1_DatadogMonitorCondition(ref common.ReferenceCallback) 
 	}
 }
 
-func schema__api_v1alpha1_DeploymentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DeploymentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1778,7 +1778,7 @@ func schema__api_v1alpha1_DeploymentStatus(ref common.ReferenceCallback) common.
 	}
 }
 
-func schema__api_v1alpha1_DogstatsdConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_DogstatsdConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1795,18 +1795,18 @@ func schema__api_v1alpha1_DogstatsdConfig(ref common.ReferenceCallback) common.O
 					"unixDomainSocket": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the Dogstatsd Unix Domain Socket ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
-							Ref:         ref("./api/v1alpha1.DSDUnixDomainSocketSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DSDUnixDomainSocketSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.DSDUnixDomainSocketSpec"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.DSDUnixDomainSocketSpec"},
 	}
 }
 
-func schema__api_v1alpha1_ExternalMetricsConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ExternalMetricsConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1854,7 +1854,7 @@ func schema__api_v1alpha1_ExternalMetricsConfig(ref common.ReferenceCallback) co
 	}
 }
 
-func schema__api_v1alpha1_ImageConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ImageConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1897,7 +1897,7 @@ func schema__api_v1alpha1_ImageConfig(ref common.ReferenceCallback) common.OpenA
 	}
 }
 
-func schema__api_v1alpha1_KubeStateMetricsCore(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_KubeStateMetricsCore(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1914,18 +1914,18 @@ func schema__api_v1alpha1_KubeStateMetricsCore(ref common.ReferenceCallback) com
 					"conf": {
 						SchemaProps: spec.SchemaProps{
 							Description: "To override the configuration for the default Kubernetes State Metrics Core check. Must point to a ConfigMap containing a valid cluster check configuration.",
-							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.CustomConfigSpec"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"},
 	}
 }
 
-func schema__api_v1alpha1_LogSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_LogSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1987,7 +1987,7 @@ func schema__api_v1alpha1_LogSpec(ref common.ReferenceCallback) common.OpenAPIDe
 	}
 }
 
-func schema__api_v1alpha1_NetworkPolicySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_NetworkPolicySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2007,7 +2007,7 @@ func schema__api_v1alpha1_NetworkPolicySpec(ref common.ReferenceCallback) common
 	}
 }
 
-func schema__api_v1alpha1_NodeAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_NodeAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2037,13 +2037,13 @@ func schema__api_v1alpha1_NodeAgentConfig(ref common.ReferenceCallback) common.O
 					"confd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Confd configuration allowing to specify config files for custom checks placed under /etc/datadog-agent/conf.d/. See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"checksd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Checksd configuration allowing to specify custom checks placed under /etc/datadog-agent/checks.d/ See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"podLabelsAsTags": {
@@ -2182,13 +2182,13 @@ func schema__api_v1alpha1_NodeAgentConfig(ref common.ReferenceCallback) common.O
 					"criSocket": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the CRI Socket",
-							Ref:         ref("./api/v1alpha1.CRISocketConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CRISocketConfig"),
 						},
 					},
 					"dogstatsd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure Dogstatsd",
-							Ref:         ref("./api/v1alpha1.DogstatsdConfig"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DogstatsdConfig"),
 						},
 					},
 					"tolerations": {
@@ -2220,11 +2220,11 @@ func schema__api_v1alpha1_NodeAgentConfig(ref common.ReferenceCallback) common.O
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.CRISocketConfig", "./api/v1alpha1.ConfigDirSpec", "./api/v1alpha1.DogstatsdConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.CRISocketConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DogstatsdConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
-func schema__api_v1alpha1_OrchestratorExplorerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_OrchestratorExplorerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2241,7 +2241,7 @@ func schema__api_v1alpha1_OrchestratorExplorerConfig(ref common.ReferenceCallbac
 					"scrubbing": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Option to disable scrubbing of sensitive container data (passwords, tokens, etc. ).",
-							Ref:         ref("./api/v1alpha1.Scrubbing"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.Scrubbing"),
 						},
 					},
 					"additionalEndpoints": {
@@ -2281,11 +2281,11 @@ func schema__api_v1alpha1_OrchestratorExplorerConfig(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.Scrubbing"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.Scrubbing"},
 	}
 }
 
-func schema__api_v1alpha1_ProcessSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_ProcessSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2341,7 +2341,7 @@ func schema__api_v1alpha1_ProcessSpec(ref common.ReferenceCallback) common.OpenA
 	}
 }
 
-func schema__api_v1alpha1_RbacConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_RbacConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2368,7 +2368,7 @@ func schema__api_v1alpha1_RbacConfig(ref common.ReferenceCallback) common.OpenAP
 	}
 }
 
-func schema__api_v1alpha1_RuntimeSecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_RuntimeSecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2385,24 +2385,24 @@ func schema__api_v1alpha1_RuntimeSecuritySpec(ref common.ReferenceCallback) comm
 					"policiesDir": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConfigDir containing security policies",
-							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"syscallMonitor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Syscall monitor configuration",
-							Ref:         ref("./api/v1alpha1.SyscallMonitorSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.SyscallMonitorSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ConfigDirSpec", "./api/v1alpha1.SyscallMonitorSpec"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.SyscallMonitorSpec"},
 	}
 }
 
-func schema__api_v1alpha1_Secret(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_Secret(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2430,7 +2430,7 @@ func schema__api_v1alpha1_Secret(ref common.ReferenceCallback) common.OpenAPIDef
 	}
 }
 
-func schema__api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2440,13 +2440,13 @@ func schema__api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.Open
 					"compliance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Compliance configuration",
-							Ref:         ref("./api/v1alpha1.ComplianceSpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ComplianceSpec"),
 						},
 					},
 					"runtime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Runtime security configuration",
-							Ref:         ref("./api/v1alpha1.RuntimeSecuritySpec"),
+							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RuntimeSecuritySpec"),
 						},
 					},
 					"env": {
@@ -2480,11 +2480,11 @@ func schema__api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.Open
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ComplianceSpec", "./api/v1alpha1.RuntimeSecuritySpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"github.com/DataDog/datadog-operator/api/v1alpha1.ComplianceSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RuntimeSecuritySpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
-func schema__api_v1alpha1_SyscallMonitorSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_SyscallMonitorSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2504,7 +2504,7 @@ func schema__api_v1alpha1_SyscallMonitorSpec(ref common.ReferenceCallback) commo
 	}
 }
 
-func schema__api_v1alpha1_SystemProbeSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_datadog_operator_api_v1alpha1_SystemProbeSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -18,53 +18,53 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/DataDog/datadog-operator/api/v1alpha1.APMSpec":                                 schema_DataDog_datadog_operator_api_v1alpha1_APMSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.APMUnixDomainSocketSpec":                 schema_DataDog_datadog_operator_api_v1alpha1_APMUnixDomainSocketSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.AdmissionControllerConfig":               schema_DataDog_datadog_operator_api_v1alpha1_AdmissionControllerConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.AgentCredentials":                        schema_DataDog_datadog_operator_api_v1alpha1_AgentCredentials(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.CRISocketConfig":                         schema_DataDog_datadog_operator_api_v1alpha1_CRISocketConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterAgentConfig":                      schema_DataDog_datadog_operator_api_v1alpha1_ClusterAgentConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterChecksRunnerConfig":               schema_DataDog_datadog_operator_api_v1alpha1_ClusterChecksRunnerConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ComplianceSpec":                          schema_DataDog_datadog_operator_api_v1alpha1_ComplianceSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec":                           schema_DataDog_datadog_operator_api_v1alpha1_ConfigDirSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigFileConfigMapSpec":                 schema_DataDog_datadog_operator_api_v1alpha1_ConfigFileConfigMapSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec":                        schema_DataDog_datadog_operator_api_v1alpha1_CustomConfigSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DSDUnixDomainSocketSpec":                 schema_DataDog_datadog_operator_api_v1alpha1_DSDUnixDomainSocketSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetDeploymentStrategy":             schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetDeploymentStrategy(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetRollingUpdateSpec":              schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetRollingUpdateSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetStatus":                         schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetStatus(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgent":                            schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgent(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentCondition":                   schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentCondition(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpec":                        schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecAgentSpec":               schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterAgentSpec":        schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec": schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentStatus":                      schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentStatus(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogFeatures":                         schema_DataDog_datadog_operator_api_v1alpha1_DatadogFeatures(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetric":                           schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetric(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricCondition":                  schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetricCondition(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitor":                          schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitor(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorCondition":                 schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitorCondition(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus":                        schema_DataDog_datadog_operator_api_v1alpha1_DeploymentStatus(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.DogstatsdConfig":                         schema_DataDog_datadog_operator_api_v1alpha1_DogstatsdConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ExternalMetricsConfig":                   schema_DataDog_datadog_operator_api_v1alpha1_ExternalMetricsConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig":                             schema_DataDog_datadog_operator_api_v1alpha1_ImageConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.KubeStateMetricsCore":                    schema_DataDog_datadog_operator_api_v1alpha1_KubeStateMetricsCore(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.LogSpec":                                 schema_DataDog_datadog_operator_api_v1alpha1_LogSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec":                       schema_DataDog_datadog_operator_api_v1alpha1_NetworkPolicySpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.NodeAgentConfig":                         schema_DataDog_datadog_operator_api_v1alpha1_NodeAgentConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.OrchestratorExplorerConfig":              schema_DataDog_datadog_operator_api_v1alpha1_OrchestratorExplorerConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.ProcessSpec":                             schema_DataDog_datadog_operator_api_v1alpha1_ProcessSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig":                              schema_DataDog_datadog_operator_api_v1alpha1_RbacConfig(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.RuntimeSecuritySpec":                     schema_DataDog_datadog_operator_api_v1alpha1_RuntimeSecuritySpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.Secret":                                  schema_DataDog_datadog_operator_api_v1alpha1_Secret(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.SecuritySpec":                            schema_DataDog_datadog_operator_api_v1alpha1_SecuritySpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.SyscallMonitorSpec":                      schema_DataDog_datadog_operator_api_v1alpha1_SyscallMonitorSpec(ref),
-		"github.com/DataDog/datadog-operator/api/v1alpha1.SystemProbeSpec":                         schema_DataDog_datadog_operator_api_v1alpha1_SystemProbeSpec(ref),
+		"./api/v1alpha1.APMSpec":                                 schema__api_v1alpha1_APMSpec(ref),
+		"./api/v1alpha1.APMUnixDomainSocketSpec":                 schema__api_v1alpha1_APMUnixDomainSocketSpec(ref),
+		"./api/v1alpha1.AdmissionControllerConfig":               schema__api_v1alpha1_AdmissionControllerConfig(ref),
+		"./api/v1alpha1.AgentCredentials":                        schema__api_v1alpha1_AgentCredentials(ref),
+		"./api/v1alpha1.CRISocketConfig":                         schema__api_v1alpha1_CRISocketConfig(ref),
+		"./api/v1alpha1.ClusterAgentConfig":                      schema__api_v1alpha1_ClusterAgentConfig(ref),
+		"./api/v1alpha1.ClusterChecksRunnerConfig":               schema__api_v1alpha1_ClusterChecksRunnerConfig(ref),
+		"./api/v1alpha1.ComplianceSpec":                          schema__api_v1alpha1_ComplianceSpec(ref),
+		"./api/v1alpha1.ConfigDirSpec":                           schema__api_v1alpha1_ConfigDirSpec(ref),
+		"./api/v1alpha1.ConfigFileConfigMapSpec":                 schema__api_v1alpha1_ConfigFileConfigMapSpec(ref),
+		"./api/v1alpha1.CustomConfigSpec":                        schema__api_v1alpha1_CustomConfigSpec(ref),
+		"./api/v1alpha1.DSDUnixDomainSocketSpec":                 schema__api_v1alpha1_DSDUnixDomainSocketSpec(ref),
+		"./api/v1alpha1.DaemonSetDeploymentStrategy":             schema__api_v1alpha1_DaemonSetDeploymentStrategy(ref),
+		"./api/v1alpha1.DaemonSetRollingUpdateSpec":              schema__api_v1alpha1_DaemonSetRollingUpdateSpec(ref),
+		"./api/v1alpha1.DaemonSetStatus":                         schema__api_v1alpha1_DaemonSetStatus(ref),
+		"./api/v1alpha1.DatadogAgent":                            schema__api_v1alpha1_DatadogAgent(ref),
+		"./api/v1alpha1.DatadogAgentCondition":                   schema__api_v1alpha1_DatadogAgentCondition(ref),
+		"./api/v1alpha1.DatadogAgentSpec":                        schema__api_v1alpha1_DatadogAgentSpec(ref),
+		"./api/v1alpha1.DatadogAgentSpecAgentSpec":               schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref),
+		"./api/v1alpha1.DatadogAgentSpecClusterAgentSpec":        schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref),
+		"./api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec": schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref),
+		"./api/v1alpha1.DatadogAgentStatus":                      schema__api_v1alpha1_DatadogAgentStatus(ref),
+		"./api/v1alpha1.DatadogFeatures":                         schema__api_v1alpha1_DatadogFeatures(ref),
+		"./api/v1alpha1.DatadogMetric":                           schema__api_v1alpha1_DatadogMetric(ref),
+		"./api/v1alpha1.DatadogMetricCondition":                  schema__api_v1alpha1_DatadogMetricCondition(ref),
+		"./api/v1alpha1.DatadogMonitor":                          schema__api_v1alpha1_DatadogMonitor(ref),
+		"./api/v1alpha1.DatadogMonitorCondition":                 schema__api_v1alpha1_DatadogMonitorCondition(ref),
+		"./api/v1alpha1.DeploymentStatus":                        schema__api_v1alpha1_DeploymentStatus(ref),
+		"./api/v1alpha1.DogstatsdConfig":                         schema__api_v1alpha1_DogstatsdConfig(ref),
+		"./api/v1alpha1.ExternalMetricsConfig":                   schema__api_v1alpha1_ExternalMetricsConfig(ref),
+		"./api/v1alpha1.ImageConfig":                             schema__api_v1alpha1_ImageConfig(ref),
+		"./api/v1alpha1.KubeStateMetricsCore":                    schema__api_v1alpha1_KubeStateMetricsCore(ref),
+		"./api/v1alpha1.LogSpec":                                 schema__api_v1alpha1_LogSpec(ref),
+		"./api/v1alpha1.NetworkPolicySpec":                       schema__api_v1alpha1_NetworkPolicySpec(ref),
+		"./api/v1alpha1.NodeAgentConfig":                         schema__api_v1alpha1_NodeAgentConfig(ref),
+		"./api/v1alpha1.OrchestratorExplorerConfig":              schema__api_v1alpha1_OrchestratorExplorerConfig(ref),
+		"./api/v1alpha1.ProcessSpec":                             schema__api_v1alpha1_ProcessSpec(ref),
+		"./api/v1alpha1.RbacConfig":                              schema__api_v1alpha1_RbacConfig(ref),
+		"./api/v1alpha1.RuntimeSecuritySpec":                     schema__api_v1alpha1_RuntimeSecuritySpec(ref),
+		"./api/v1alpha1.Secret":                                  schema__api_v1alpha1_Secret(ref),
+		"./api/v1alpha1.SecuritySpec":                            schema__api_v1alpha1_SecuritySpec(ref),
+		"./api/v1alpha1.SyscallMonitorSpec":                      schema__api_v1alpha1_SyscallMonitorSpec(ref),
+		"./api/v1alpha1.SystemProbeSpec":                         schema__api_v1alpha1_SystemProbeSpec(ref),
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -88,7 +88,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_APMSpec(ref common.ReferenceCa
 					"unixDomainSocket": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UnixDomainSocket socket configuration ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.APMUnixDomainSocketSpec"),
+							Ref:         ref("./api/v1alpha1.APMUnixDomainSocketSpec"),
 						},
 					},
 					"env": {
@@ -122,11 +122,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_APMSpec(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.APMUnixDomainSocketSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"./api/v1alpha1.APMUnixDomainSocketSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_APMUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_APMUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -153,7 +153,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_APMUnixDomainSocketSpec(ref co
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_AdmissionControllerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_AdmissionControllerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -187,7 +187,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_AdmissionControllerConfig(ref 
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_AgentCredentials(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_AgentCredentials(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -211,7 +211,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_AgentCredentials(ref common.Re
 					"apiSecret": {
 						SchemaProps: spec.SchemaProps{
 							Description: "APISecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"apiKeyExistingSecret\".",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.Secret"),
+							Ref:         ref("./api/v1alpha1.Secret"),
 						},
 					},
 					"appKey": {
@@ -231,7 +231,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_AgentCredentials(ref common.Re
 					"appSecret": {
 						SchemaProps: spec.SchemaProps{
 							Description: "APPSecret Use existing Secret which stores API key instead of creating a new one. If set, this parameter takes precedence over \"apiKey\" and \"appKeyExistingSecret\".",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.Secret"),
+							Ref:         ref("./api/v1alpha1.Secret"),
 						},
 					},
 					"token": {
@@ -252,11 +252,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_AgentCredentials(ref common.Re
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.Secret"},
+			"./api/v1alpha1.Secret"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_CRISocketConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_CRISocketConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -283,7 +283,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_CRISocketConfig(ref common.Ref
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ClusterAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ClusterAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -292,13 +292,13 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ClusterAgentConfig(ref common.
 				Properties: map[string]spec.Schema{
 					"externalMetrics": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.ExternalMetricsConfig"),
+							Ref: ref("./api/v1alpha1.ExternalMetricsConfig"),
 						},
 					},
 					"admissionController": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the Admission Controller",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.AdmissionControllerConfig"),
+							Ref:         ref("./api/v1alpha1.AdmissionControllerConfig"),
 						},
 					},
 					"clusterChecksEnabled": {
@@ -331,7 +331,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ClusterAgentConfig(ref common.
 					"confd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Confd Provide additional cluster check configurations. Each key will become a file in /conf.d see https://docs.datadoghq.com/agent/autodiscovery/ for more details.",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"env": {
@@ -402,11 +402,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ClusterAgentConfig(ref common.
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.AdmissionControllerConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.ExternalMetricsConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"./api/v1alpha1.AdmissionControllerConfig", "./api/v1alpha1.ConfigDirSpec", "./api/v1alpha1.ExternalMetricsConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ClusterChecksRunnerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ClusterChecksRunnerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -498,7 +498,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ClusterChecksRunnerConfig(ref 
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ComplianceSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ComplianceSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -521,18 +521,18 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ComplianceSpec(ref common.Refe
 					"configDir": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Config dir containing compliance benchmarks",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"./api/v1alpha1.ConfigDirSpec", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ConfigDirSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ConfigDirSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -552,7 +552,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ConfigDirSpec(ref common.Refer
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ConfigFileConfigMapSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ConfigFileConfigMapSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -579,7 +579,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ConfigFileConfigMapSpec(ref co
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_CustomConfigSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_CustomConfigSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -596,18 +596,18 @@ func schema_DataDog_datadog_operator_api_v1alpha1_CustomConfigSpec(ref common.Re
 					"configMap": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConfigMap name of a ConfigMap used to mount the configuration file",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigFileConfigMapSpec"),
+							Ref:         ref("./api/v1alpha1.ConfigFileConfigMapSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigFileConfigMapSpec"},
+			"./api/v1alpha1.ConfigFileConfigMapSpec"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DSDUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DSDUnixDomainSocketSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -634,7 +634,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DSDUnixDomainSocketSpec(ref co
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetDeploymentStrategy(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DaemonSetDeploymentStrategy(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -651,7 +651,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetDeploymentStrategy(re
 					"rollingUpdate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the rolling updater strategy of the DaemonSet or the ExtendedDaemonSet",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetRollingUpdateSpec"),
+							Ref:         ref("./api/v1alpha1.DaemonSetRollingUpdateSpec"),
 						},
 					},
 					"canary": {
@@ -670,11 +670,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetDeploymentStrategy(re
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetRollingUpdateSpec", "github.com/DataDog/extendeddaemonset/api/v1alpha1.ExtendedDaemonSetSpecStrategyCanary", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
+			"./api/v1alpha1.DaemonSetRollingUpdateSpec", "github.com/DataDog/extendeddaemonset/api/v1alpha1.ExtendedDaemonSetSpecStrategyCanary", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetRollingUpdateSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DaemonSetRollingUpdateSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -720,7 +720,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetRollingUpdateSpec(ref
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DaemonSetStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -796,7 +796,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DaemonSetStatus(ref common.Ref
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgent(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogAgent(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -824,23 +824,23 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgent(ref common.Refere
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpec"),
+							Ref: ref("./api/v1alpha1.DatadogAgentSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentStatus"),
+							Ref: ref("./api/v1alpha1.DatadogAgentStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./api/v1alpha1.DatadogAgentSpec", "./api/v1alpha1.DatadogAgentStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogAgentCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -896,7 +896,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentCondition(ref comm
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -906,31 +906,31 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpec(ref common.Re
 					"credentials": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the credentials needed to run Agents. If not set, then the credentials set in the DatadogOperator will be used",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.AgentCredentials"),
+							Ref:         ref("./api/v1alpha1.AgentCredentials"),
 						},
 					},
 					"features": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Features running on the Agent and Cluster Agent",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogFeatures"),
+							Ref:         ref("./api/v1alpha1.DatadogFeatures"),
 						},
 					},
 					"agent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The desired state of the Agent as an extended daemonset Contains the Node Agent configuration and deployment strategy",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecAgentSpec"),
+							Ref:         ref("./api/v1alpha1.DatadogAgentSpecAgentSpec"),
 						},
 					},
 					"clusterAgent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The desired state of the Cluster Agent as a deployment",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterAgentSpec"),
+							Ref:         ref("./api/v1alpha1.DatadogAgentSpecClusterAgentSpec"),
 						},
 					},
 					"clusterChecksRunner": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The desired state of the Cluster Checks Runner as a deployment",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec"),
+							Ref:         ref("./api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec"),
 						},
 					},
 					"clusterName": {
@@ -951,11 +951,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpec(ref common.Re
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.AgentCredentials", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecAgentSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterAgentSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogFeatures"},
+			"./api/v1alpha1.AgentCredentials", "./api/v1alpha1.DatadogAgentSpecAgentSpec", "./api/v1alpha1.DatadogAgentSpecClusterAgentSpec", "./api/v1alpha1.DatadogAgentSpecClusterChecksRunnerSpec", "./api/v1alpha1.DatadogFeatures"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -972,7 +972,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref 
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The container image of the Datadog Agent",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig"),
+							Ref:         ref("./api/v1alpha1.ImageConfig"),
 						},
 					},
 					"daemonsetName": {
@@ -985,19 +985,19 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref 
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Agent configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NodeAgentConfig"),
+							Ref:         ref("./api/v1alpha1.NodeAgentConfig"),
 						},
 					},
 					"rbac": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RBAC configuration of the Agent",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig"),
+							Ref:         ref("./api/v1alpha1.RbacConfig"),
 						},
 					},
 					"deploymentStrategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Update strategy configuration for the DaemonSet",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetDeploymentStrategy"),
+							Ref:         ref("./api/v1alpha1.DaemonSetDeploymentStrategy"),
 						},
 					},
 					"additionalAnnotations": {
@@ -1088,43 +1088,43 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref 
 					"apm": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Trace Agent configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.APMSpec"),
+							Ref:         ref("./api/v1alpha1.APMSpec"),
 						},
 					},
 					"log": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Log Agent configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.LogSpec"),
+							Ref:         ref("./api/v1alpha1.LogSpec"),
 						},
 					},
 					"process": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Process Agent configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ProcessSpec"),
+							Ref:         ref("./api/v1alpha1.ProcessSpec"),
 						},
 					},
 					"systemProbe": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SystemProbe configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.SystemProbeSpec"),
+							Ref:         ref("./api/v1alpha1.SystemProbeSpec"),
 						},
 					},
 					"security": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Security Agent configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.SecuritySpec"),
+							Ref:         ref("./api/v1alpha1.SecuritySpec"),
 						},
 					},
 					"customConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow to put custom configuration for the agent, corresponding to the datadog.yaml config file See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 					"networkPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provide Agent Network Policy configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec"),
+							Ref:         ref("./api/v1alpha1.NetworkPolicySpec"),
 						},
 					},
 				},
@@ -1132,11 +1132,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecAgentSpec(ref 
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.APMSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetDeploymentStrategy", "github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.LogSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.NodeAgentConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.ProcessSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.SecuritySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.SystemProbeSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodDNSConfig"},
+			"./api/v1alpha1.APMSpec", "./api/v1alpha1.CustomConfigSpec", "./api/v1alpha1.DaemonSetDeploymentStrategy", "./api/v1alpha1.ImageConfig", "./api/v1alpha1.LogSpec", "./api/v1alpha1.NetworkPolicySpec", "./api/v1alpha1.NodeAgentConfig", "./api/v1alpha1.ProcessSpec", "./api/v1alpha1.RbacConfig", "./api/v1alpha1.SecuritySpec", "./api/v1alpha1.SystemProbeSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodDNSConfig"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1146,7 +1146,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSp
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The container image of the Datadog Cluster Agent",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig"),
+							Ref:         ref("./api/v1alpha1.ImageConfig"),
 						},
 					},
 					"deploymentName": {
@@ -1159,19 +1159,19 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSp
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Cluster Agent configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ClusterAgentConfig"),
+							Ref:         ref("./api/v1alpha1.ClusterAgentConfig"),
 						},
 					},
 					"customConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow to put custom configuration for the agent, corresponding to the datadog-cluster.yaml config file",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 					"rbac": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RBAC configuration of the Datadog Cluster Agent",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig"),
+							Ref:         ref("./api/v1alpha1.RbacConfig"),
 						},
 					},
 					"replicas": {
@@ -1260,7 +1260,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSp
 					"networkPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provide Cluster Agent Network Policy configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec"),
+							Ref:         ref("./api/v1alpha1.NetworkPolicySpec"),
 						},
 					},
 				},
@@ -1268,11 +1268,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterAgentSp
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterAgentConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
+			"./api/v1alpha1.ClusterAgentConfig", "./api/v1alpha1.CustomConfigSpec", "./api/v1alpha1.ImageConfig", "./api/v1alpha1.NetworkPolicySpec", "./api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogAgentSpecClusterChecksRunnerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1282,7 +1282,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksR
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The container image of the Datadog Cluster Checks Runner",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig"),
+							Ref:         ref("./api/v1alpha1.ImageConfig"),
 						},
 					},
 					"deploymentName": {
@@ -1295,19 +1295,19 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksR
 					"config": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Agent configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ClusterChecksRunnerConfig"),
+							Ref:         ref("./api/v1alpha1.ClusterChecksRunnerConfig"),
 						},
 					},
 					"customConfig": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Allow to put custom configuration for the agent, corresponding to the datadog.yaml config file See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 					"rbac": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RBAC configuration of the Datadog Cluster Checks Runner",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig"),
+							Ref:         ref("./api/v1alpha1.RbacConfig"),
 						},
 					},
 					"replicas": {
@@ -1396,7 +1396,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksR
 					"networkPolicy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provide Cluster Checks Runner Network Policy configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec"),
+							Ref:         ref("./api/v1alpha1.NetworkPolicySpec"),
 						},
 					},
 				},
@@ -1404,11 +1404,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentSpecClusterChecksR
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.ClusterChecksRunnerConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.ImageConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.NetworkPolicySpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
+			"./api/v1alpha1.ClusterChecksRunnerConfig", "./api/v1alpha1.CustomConfigSpec", "./api/v1alpha1.ImageConfig", "./api/v1alpha1.NetworkPolicySpec", "./api/v1alpha1.RbacConfig", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.Toleration"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogAgentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1418,19 +1418,19 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentStatus(ref common.
 					"agent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Agent as an extended daemonset",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetStatus"),
+							Ref:         ref("./api/v1alpha1.DaemonSetStatus"),
 						},
 					},
 					"clusterAgent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Cluster Agent as a deployment",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus"),
+							Ref:         ref("./api/v1alpha1.DeploymentStatus"),
 						},
 					},
 					"clusterChecksRunner": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Cluster Checks Runner as a deployment",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus"),
+							Ref:         ref("./api/v1alpha1.DeploymentStatus"),
 						},
 					},
 					"conditions": {
@@ -1448,7 +1448,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentStatus(ref common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentCondition"),
+										Ref: ref("./api/v1alpha1.DatadogAgentCondition"),
 									},
 								},
 							},
@@ -1458,11 +1458,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogAgentStatus(ref common.
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.DaemonSetStatus", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogAgentCondition", "github.com/DataDog/datadog-operator/api/v1alpha1.DeploymentStatus"},
+			"./api/v1alpha1.DaemonSetStatus", "./api/v1alpha1.DatadogAgentCondition", "./api/v1alpha1.DeploymentStatus"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogFeatures(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogFeatures(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1472,24 +1472,24 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogFeatures(ref common.Ref
 					"orchestratorExplorer": {
 						SchemaProps: spec.SchemaProps{
 							Description: "OrchestratorExplorer configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.OrchestratorExplorerConfig"),
+							Ref:         ref("./api/v1alpha1.OrchestratorExplorerConfig"),
 						},
 					},
 					"kubeStateMetricsCore": {
 						SchemaProps: spec.SchemaProps{
 							Description: "KubeStateMetricsCore configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.KubeStateMetricsCore"),
+							Ref:         ref("./api/v1alpha1.KubeStateMetricsCore"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.KubeStateMetricsCore", "github.com/DataDog/datadog-operator/api/v1alpha1.OrchestratorExplorerConfig"},
+			"./api/v1alpha1.KubeStateMetricsCore", "./api/v1alpha1.OrchestratorExplorerConfig"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetric(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogMetric(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1517,23 +1517,23 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetric(ref common.Refer
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricSpec"),
+							Ref: ref("./api/v1alpha1.DatadogMetricSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricStatus"),
+							Ref: ref("./api/v1alpha1.DatadogMetricStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMetricStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./api/v1alpha1.DatadogMetricSpec", "./api/v1alpha1.DatadogMetricStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetricCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogMetricCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1589,7 +1589,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMetricCondition(ref com
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitor(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogMonitor(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1617,23 +1617,23 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitor(ref common.Refe
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorSpec"),
+							Ref: ref("./api/v1alpha1.DatadogMonitorSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorStatus"),
+							Ref: ref("./api/v1alpha1.DatadogMonitorStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DatadogMonitorStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./api/v1alpha1.DatadogMonitorSpec", "./api/v1alpha1.DatadogMonitorStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitorCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DatadogMonitorCondition(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1689,7 +1689,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DatadogMonitorCondition(ref co
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DeploymentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DeploymentStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1778,7 +1778,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DeploymentStatus(ref common.Re
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_DogstatsdConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_DogstatsdConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1795,18 +1795,18 @@ func schema_DataDog_datadog_operator_api_v1alpha1_DogstatsdConfig(ref common.Ref
 					"unixDomainSocket": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the Dogstatsd Unix Domain Socket ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DSDUnixDomainSocketSpec"),
+							Ref:         ref("./api/v1alpha1.DSDUnixDomainSocketSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.DSDUnixDomainSocketSpec"},
+			"./api/v1alpha1.DSDUnixDomainSocketSpec"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ExternalMetricsConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ExternalMetricsConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1854,7 +1854,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ExternalMetricsConfig(ref comm
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ImageConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ImageConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1897,7 +1897,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ImageConfig(ref common.Referen
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_KubeStateMetricsCore(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_KubeStateMetricsCore(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1914,18 +1914,18 @@ func schema_DataDog_datadog_operator_api_v1alpha1_KubeStateMetricsCore(ref commo
 					"conf": {
 						SchemaProps: spec.SchemaProps{
 							Description: "To override the configuration for the default Kubernetes State Metrics Core check. Must point to a ConfigMap containing a valid cluster check configuration.",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"),
+							Ref:         ref("./api/v1alpha1.CustomConfigSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.CustomConfigSpec"},
+			"./api/v1alpha1.CustomConfigSpec"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_LogSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_LogSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -1987,7 +1987,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_LogSpec(ref common.ReferenceCa
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_NetworkPolicySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_NetworkPolicySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2007,7 +2007,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_NetworkPolicySpec(ref common.R
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_NodeAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_NodeAgentConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2037,13 +2037,13 @@ func schema_DataDog_datadog_operator_api_v1alpha1_NodeAgentConfig(ref common.Ref
 					"confd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Confd configuration allowing to specify config files for custom checks placed under /etc/datadog-agent/conf.d/. See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"checksd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Checksd configuration allowing to specify custom checks placed under /etc/datadog-agent/checks.d/ See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"podLabelsAsTags": {
@@ -2182,13 +2182,13 @@ func schema_DataDog_datadog_operator_api_v1alpha1_NodeAgentConfig(ref common.Ref
 					"criSocket": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure the CRI Socket",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.CRISocketConfig"),
+							Ref:         ref("./api/v1alpha1.CRISocketConfig"),
 						},
 					},
 					"dogstatsd": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Configure Dogstatsd",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.DogstatsdConfig"),
+							Ref:         ref("./api/v1alpha1.DogstatsdConfig"),
 						},
 					},
 					"tolerations": {
@@ -2220,11 +2220,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_NodeAgentConfig(ref common.Ref
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.CRISocketConfig", "github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.DogstatsdConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"./api/v1alpha1.CRISocketConfig", "./api/v1alpha1.ConfigDirSpec", "./api/v1alpha1.DogstatsdConfig", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_OrchestratorExplorerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_OrchestratorExplorerConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2241,7 +2241,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_OrchestratorExplorerConfig(ref
 					"scrubbing": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Option to disable scrubbing of sensitive container data (passwords, tokens, etc. ).",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.Scrubbing"),
+							Ref:         ref("./api/v1alpha1.Scrubbing"),
 						},
 					},
 					"additionalEndpoints": {
@@ -2281,11 +2281,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_OrchestratorExplorerConfig(ref
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.Scrubbing"},
+			"./api/v1alpha1.Scrubbing"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_ProcessSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ProcessSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2341,7 +2341,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_ProcessSpec(ref common.Referen
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_RbacConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_RbacConfig(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2368,7 +2368,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_RbacConfig(ref common.Referenc
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_RuntimeSecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_RuntimeSecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2385,24 +2385,24 @@ func schema_DataDog_datadog_operator_api_v1alpha1_RuntimeSecuritySpec(ref common
 					"policiesDir": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConfigDir containing security policies",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec"),
+							Ref:         ref("./api/v1alpha1.ConfigDirSpec"),
 						},
 					},
 					"syscallMonitor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Syscall monitor configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.SyscallMonitorSpec"),
+							Ref:         ref("./api/v1alpha1.SyscallMonitorSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.ConfigDirSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.SyscallMonitorSpec"},
+			"./api/v1alpha1.ConfigDirSpec", "./api/v1alpha1.SyscallMonitorSpec"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_Secret(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_Secret(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2430,7 +2430,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_Secret(ref common.ReferenceCal
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2440,13 +2440,13 @@ func schema_DataDog_datadog_operator_api_v1alpha1_SecuritySpec(ref common.Refere
 					"compliance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Compliance configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.ComplianceSpec"),
+							Ref:         ref("./api/v1alpha1.ComplianceSpec"),
 						},
 					},
 					"runtime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Runtime security configuration",
-							Ref:         ref("github.com/DataDog/datadog-operator/api/v1alpha1.RuntimeSecuritySpec"),
+							Ref:         ref("./api/v1alpha1.RuntimeSecuritySpec"),
 						},
 					},
 					"env": {
@@ -2480,11 +2480,11 @@ func schema_DataDog_datadog_operator_api_v1alpha1_SecuritySpec(ref common.Refere
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/v1alpha1.ComplianceSpec", "github.com/DataDog/datadog-operator/api/v1alpha1.RuntimeSecuritySpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"./api/v1alpha1.ComplianceSpec", "./api/v1alpha1.RuntimeSecuritySpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_SyscallMonitorSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_SyscallMonitorSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -2504,7 +2504,7 @@ func schema_DataDog_datadog_operator_api_v1alpha1_SyscallMonitorSpec(ref common.
 	}
 }
 
-func schema_DataDog_datadog_operator_api_v1alpha1_SystemProbeSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_SystemProbeSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -610,10 +610,6 @@ func runtimeSecurityAgentMountVolume() []corev1.VolumeMount {
 func defaultEnvVars(extraEnv map[string]string) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
-			Name:  "DD_CLUSTER_NAME",
-			Value: "",
-		},
-		{
 			Name:  "DD_HEALTH_PORT",
 			Value: "5555",
 		},
@@ -2546,7 +2542,6 @@ func Test_newExtendedDaemonSetFromInstance_SystemProbe(t *testing.T) {
 
 func Test_newExtendedDaemonSetFromInstance_Orchestrator(t *testing.T) {
 	orchestratorPodSpec := defaultOrchestratorPodSpec()
-
 	dda := test.NewDefaultedDatadogAgent("bar", "foo", &test.NewDatadogAgentOptions{
 		UseEDS:                      true,
 		ClusterAgentEnabled:         true,

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -2542,7 +2542,6 @@ func Test_newExtendedDaemonSetFromInstance_SystemProbe(t *testing.T) {
 }
 
 func Test_newExtendedDaemonSetFromInstance_Orchestrator(t *testing.T) {
-	orchestratorPodSpec := defaultOrchestratorPodSpec()
 	dda := test.NewDefaultedDatadogAgent("bar", "foo", &test.NewDatadogAgentOptions{
 		UseEDS:                      true,
 		ClusterAgentEnabled:         true,

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -527,6 +527,10 @@ func getEnvVarsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Env
 func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]corev1.EnvVar, error) {
 	envVars := []corev1.EnvVar{
 		{
+			Name:  datadoghqv1alpha1.DDClusterName,
+			Value: dda.Spec.ClusterName,
+		},
+		{
 			Name:  datadoghqv1alpha1.DDLogLevel,
 			Value: getLogLevel(dda),
 		},
@@ -610,10 +614,6 @@ func getEnvVarsForAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar, e
 	}
 
 	envVars := []corev1.EnvVar{
-		{
-			Name:  datadoghqv1alpha1.DDClusterName,
-			Value: spec.ClusterName,
-		},
 		{
 			Name:  datadoghqv1alpha1.DDHealthPort,
 			Value: strconv.Itoa(int(datadoghqv1alpha1.DefaultAgentHealthPort)),

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -527,10 +527,6 @@ func getEnvVarsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Env
 func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]corev1.EnvVar, error) {
 	envVars := []corev1.EnvVar{
 		{
-			Name:  datadoghqv1alpha1.DDClusterName,
-			Value: dda.Spec.ClusterName,
-		},
-		{
 			Name:  datadoghqv1alpha1.DDLogLevel,
 			Value: getLogLevel(dda),
 		},
@@ -546,6 +542,13 @@ func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]c
 			Name:  datadoghqv1alpha1.KubernetesEnvvarName,
 			Value: "yes",
 		},
+	}
+
+	if dda.Spec.ClusterName != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDClusterName,
+			Value: dda.Spec.ClusterName,
+		})
 	}
 
 	if needAPIKey {


### PR DESCRIPTION
### What does this PR do?

Should fix: https://github.com/DataDog/datadog-operator/issues/229

### Motivation

https://github.com/DataDog/datadog-operator/issues/229
We only propagate the clusterName to the core agent and the DCA. But other agent might benefit as well. The process-agent tagger and orchestrator explorer need the cluster name.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
