### PR TITLE
Allow custom VolumeMounts for all agent containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ generate-manifests: controller-gen
 generate: controller-gen generate-openapi generate-docs ## Generate code
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-generate-docs:
+generate-docs: manifests
 	go run ./hack/generate-docs.go
 
 docker-build: generate docker-build-ci ## Build the docker image

--- a/api/v1alpha1/datadogagent_types.go
+++ b/api/v1alpha1/datadogagent_types.go
@@ -295,6 +295,13 @@ type APMSpec struct {
 	// +listMapKey=name
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
+	// Specify additional volume mounts in the APM Agent container
+	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +listMapKey=mountPath
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+
 	// Datadog APM Agent resource requests and limits
 	// Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
 	// Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -391,6 +398,13 @@ type ProcessSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// Specify additional volume mounts in the Process Agent container
+	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +listMapKey=mountPath
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// Datadog Process Agent resource requests and limits
 	// Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class
@@ -528,6 +542,13 @@ type SecuritySpec struct {
 	// +listType=map
 	// +listMapKey=name
 	Env []corev1.EnvVar `json:"env,omitempty"`
+
+	// Specify additional volume mounts in the Security Agent container
+	// +optional
+	// +listType=map
+	// +listMapKey=name
+	// +listMapKey=mountPath
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// Datadog Security Agent resource requests and limits
 	// Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class

--- a/api/v1alpha1/test/new.go
+++ b/api/v1alpha1/test/new.go
@@ -167,6 +167,9 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		}
 		if len(options.VolumeMounts) != 0 {
 			ad.Spec.Agent.Config.VolumeMounts = options.VolumeMounts
+			ad.Spec.Agent.Process.VolumeMounts = options.VolumeMounts
+			ad.Spec.Agent.Apm.VolumeMounts = options.VolumeMounts
+			ad.Spec.Agent.Security.VolumeMounts = options.VolumeMounts
 		}
 		if options.ClusterAgentEnabled {
 			ad.Spec.ClusterAgent = &datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -43,6 +43,13 @@ func (in *APMSpec) DeepCopyInto(out *APMSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)
@@ -1506,6 +1513,13 @@ func (in *ProcessSpec) DeepCopyInto(out *ProcessSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)
@@ -1621,6 +1635,13 @@ func (in *SecuritySpec) DeepCopyInto(out *SecuritySpec) {
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -112,6 +112,28 @@ func schema__api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDe
 							},
 						},
 					},
+					"volumeMounts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+									"mountPath",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify additional volume mounts in the APM Agent container",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
+									},
+								},
+							},
+						},
+					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Datadog APM Agent resource requests and limits Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class Ref: http://kubernetes.io/docs/user-guide/compute-resources/",
@@ -122,7 +144,7 @@ func schema__api_v1alpha1_APMSpec(ref common.ReferenceCallback) common.OpenAPIDe
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.APMUnixDomainSocketSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"./api/v1alpha1.APMUnixDomainSocketSpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -2327,6 +2349,28 @@ func schema__api_v1alpha1_ProcessSpec(ref common.ReferenceCallback) common.OpenA
 							},
 						},
 					},
+					"volumeMounts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+									"mountPath",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify additional volume mounts in the Process Agent container",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
+									},
+								},
+							},
+						},
+					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Datadog Process Agent resource requests and limits Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class Ref: http://kubernetes.io/docs/user-guide/compute-resources/",
@@ -2337,7 +2381,7 @@ func schema__api_v1alpha1_ProcessSpec(ref common.ReferenceCallback) common.OpenA
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -2470,6 +2514,28 @@ func schema__api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.Open
 							},
 						},
 					},
+					"volumeMounts": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+									"mountPath",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify additional volume mounts in the Security Agent container",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
+									},
+								},
+							},
+						},
+					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Datadog Security Agent resource requests and limits Make sure to keep requests and limits equal to keep the pods in the Guaranteed QoS class Ref: http://kubernetes.io/docs/user-guide/compute-resources/",
@@ -2480,7 +2546,7 @@ func schema__api_v1alpha1_SecuritySpec(ref common.ReferenceCallback) common.Open
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ComplianceSpec", "./api/v1alpha1.RuntimeSecuritySpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
+			"./api/v1alpha1.ComplianceSpec", "./api/v1alpha1.RuntimeSecuritySpec", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -242,6 +242,52 @@ spec:
                               value: /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
                             type: string
                         type: object
+                      volumeMounts:
+                        description: Specify additional volume mounts in the APM Agent
+                          container
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - mountPath
+                        x-kubernetes-list-type: map
                     type: object
                   config:
                     description: Agent configuration
@@ -2577,6 +2623,52 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
+                      volumeMounts:
+                        description: Specify additional volume mounts in the Process
+                          Agent container
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - mountPath
+                        x-kubernetes-list-type: map
                     type: object
                   rbac:
                     description: RBAC configuration of the Agent
@@ -2777,6 +2869,52 @@ spec:
                                 type: boolean
                             type: object
                         type: object
+                      volumeMounts:
+                        description: Specify additional volume mounts in the Security
+                          Agent container
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - mountPath
+                        x-kubernetes-list-type: map
                     type: object
                   systemProbe:
                     description: SystemProbe configuration

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -232,6 +232,47 @@ spec:
                             /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
                           type: string
                       type: object
+                    volumeMounts:
+                      description: Specify additional volume mounts in the APM Agent
+                        container
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
                   type: object
                 config:
                   description: Agent configuration
@@ -2492,6 +2533,47 @@ spec:
                             https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
+                    volumeMounts:
+                      description: Specify additional volume mounts in the Process
+                        Agent container
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
                   type: object
                 rbac:
                   description: RBAC configuration of the Agent
@@ -2685,6 +2767,47 @@ spec:
                               type: boolean
                           type: object
                       type: object
+                    volumeMounts:
+                      description: Specify additional volume mounts in the Security
+                        Agent container
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted. Behaves similarly
+                              to SubPath but environment variable references $(VAR_NAME)
+                              are expanded using the container's environment. Defaults
+                              to "" (volume's root). SubPathExpr and SubPath are mutually
+                              exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
                   type: object
                 systemProbe:
                   description: SystemProbe configuration

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1316,6 +1316,9 @@ func getVolumeMountsForProcessAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []
 	// Add configuration mount
 	volumeMounts = append(volumeMounts, getVolumeMountForConfig(spec.Agent.CustomConfig)...)
 
+	// Add extra volume mounts
+	volumeMounts = append(volumeMounts, spec.Agent.Process.VolumeMounts...)
+
 	// Cri socket volume
 	if spec.Agent.Config.CriSocket != nil {
 		path := ""
@@ -1366,6 +1369,9 @@ func getVolumeMountsForAPMAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []core
 
 	// Add configuration volumesMount default and custom config (datadog.yaml) volume
 	volumeMounts = append(volumeMounts, getVolumeMountForConfig(spec.Agent.CustomConfig)...)
+
+	// Add extra volume mounts
+	volumeMounts = append(volumeMounts, spec.Agent.Apm.VolumeMounts...)
 
 	return volumeMounts
 }
@@ -1470,6 +1476,9 @@ func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []core
 		volumeMount := getVolumeMountFromCustomConfigSpec(spec.Agent.CustomConfig, datadoghqv1alpha1.AgentCustomConfigVolumeName, datadoghqv1alpha1.AgentCustomConfigVolumePath, datadoghqv1alpha1.AgentCustomConfigVolumeSubPath)
 		volumeMounts = append(volumeMounts, volumeMount)
 	}
+
+	// Add extra volume mounts
+	volumeMounts = append(volumeMounts, spec.Agent.Security.VolumeMounts...)
 
 	// Cri socket volume
 	if spec.Agent.Config.CriSocket != nil {

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -147,6 +147,15 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			},
 		},
 		{
+			name: "extra volumeMounts",
+			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{VolumeMounts: []corev1.VolumeMount{{Name: "extra", MountPath: "/etc/datadog-agent/extra"}}}),
+			want: []corev1.VolumeMount{
+				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
+				{Name: "extra", MountPath: "/etc/datadog-agent/extra"},
+				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
+			},
+		},
+		{
 			name: "compliance volumeMounts",
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{SecuritySpec: securityCompliance}),
 			want: []corev1.VolumeMount{

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -23,6 +23,7 @@ type NewDatadogAgentOptions struct {
 	AppKey              string
 	CustomConfig        *datadoghqv1alpha1.CustomConfigSpec
 	SecuritySpec        *datadoghqv1alpha1.SecuritySpec
+	VolumeMounts        []v1.VolumeMount
 }
 
 var (
@@ -37,6 +38,7 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 			Namespace: ns,
 		},
 	}
+
 	ad.Spec = datadoghqv1alpha1.DatadogAgentSpec{
 		Credentials: datadoghqv1alpha1.AgentCredentials{
 			APIKey: "",
@@ -121,12 +123,18 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 			}
 		}
 
+		ad.Spec.Agent.Config.VolumeMounts = options.VolumeMounts
+		ad.Spec.Agent.Process.VolumeMounts = options.VolumeMounts
+		ad.Spec.Agent.Apm.VolumeMounts = options.VolumeMounts
+
 		if options.CustomConfig != nil {
 			ad.Spec.Agent.CustomConfig = options.CustomConfig
 		}
 
 		if options.SecuritySpec != nil {
 			ad.Spec.Agent.Security = *options.SecuritySpec
+		} else {
+			ad.Spec.Agent.Security.VolumeMounts = options.VolumeMounts
 		}
 	}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ spec:
 | agent.apm.resources.requests | Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |
 | agent.apm.unixDomainSocket.enabled | Enable APM over Unix Domain Socket ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables |
 | agent.apm.unixDomainSocket.hostFilepath | Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables |
+| agent.apm.volumeMounts | Specify additional volume mounts in the APM Agent container |
 | agent.config.checksd.configMapName | ConfigMapName name of a ConfigMap used to mount a directory |
 | agent.config.collectEvents | Enables this to start event collection from the Kubernetes API ref: https://docs.datadoghq.com/agent/kubernetes/event_collection/ |
 | agent.config.confd.configMapName | ConfigMapName name of a ConfigMap used to mount a directory |
@@ -112,6 +113,7 @@ spec:
 | agent.process.processCollectionEnabled | false (default): Only collect containers if available. true: collect process information as well |
 | agent.process.resources.limits | Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |
 | agent.process.resources.requests | Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ |
+| agent.process.volumeMounts | Specify additional volume mounts in the Process Agent container |
 | agent.rbac.create | Used to configure RBAC resources creation |
 | agent.rbac.serviceAccountName | Used to set up the service account name to use Ignored if the field Create is true |
 | agent.security.compliance.checkInterval | Check interval |
@@ -123,6 +125,7 @@ spec:
 | agent.security.runtime.enabled | Enables runtime security features |
 | agent.security.runtime.policiesDir.configMapName | ConfigMapName name of a ConfigMap used to mount a directory |
 | agent.security.runtime.syscallMonitor.enabled | Enabled enables syscall monitor |
+| agent.security.volumeMounts | Specify additional volume mounts in the Security Agent container |
 | agent.systemProbe.appArmorProfileName | AppArmorProfileName specify a apparmor profile |
 | agent.systemProbe.bpfDebugEnabled | BPFDebugEnabled logging for kernel debug |
 | agent.systemProbe.collectDNSStats | CollectDNSStats enables DNS stat collection |


### PR DESCRIPTION
### What does this PR do?

Previously, it was only possible for the main agent container to have
user-specified VolumeMounts. This commit adds the possibility for each
container (process, apm, security) to have their own, specified
separately.

### Motivation

Internally, we want to have the agent auth_token in a different path, and we want that token to be available to all agents.

### Describe your test plan

Specify a VolumeMount for each of the agents, and check that those volumes get mounted as specified.
