### PR TITLE
Default ClusterChecksRunner if ClusterChecksEnabled == true

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -135,6 +135,10 @@ func IsDefaultedDatadogAgent(ad *DatadogAgent) bool {
 		if ad.Spec.ClusterAgent.Replicas == nil {
 			return false
 		}
+
+		if BoolValue(ad.Spec.ClusterAgent.Config.ClusterChecksEnabled) && ad.Spec.ClusterChecksRunner == nil {
+			return false
+		}
 	}
 
 	if ad.Spec.ClusterChecksRunner != nil {


### PR DESCRIPTION
### What does this PR do?

Creating a DatadogAgent with ClusterChecksEnabled did not have an
equivalent effect of creating a DatadogAgent without
ClusterChecksEnabled and then updating it to have ClusterChecksEnabled
set to true. This happened because, in the latter, the object was
already considered defaulted, but did not have a ClusterChecksRunner
spec.

Now, when we check the ClusterAgent spec, we also check that
ClusterChecksRunner is also set when applicable.

### Motivation

Fixes #232.

### Describe your test plan

See #232.