### PR TITLE
[controller] Allow restricting certain DatadogAgent features 

### DIFF
--- a/api/v1alpha1/test/new.go
+++ b/api/v1alpha1/test/new.go
@@ -41,6 +41,7 @@ type NewDatadogAgentOptions struct {
 	ClusterChecksEnabled             bool
 	KubeStateMetricsCore             *datadoghqv1alpha1.KubeStateMetricsCore
 	NodeAgentConfig                  *datadoghqv1alpha1.NodeAgentConfig
+	LogEnabled                       bool
 	APMEnabled                       bool
 	ProcessEnabled                   bool
 	ProcessCollectionEnabled         bool
@@ -258,6 +259,10 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 
 		if options.NodeAgentConfig != nil {
 			ad.Spec.Agent.Config = *options.NodeAgentConfig
+		}
+
+		if options.LogEnabled {
+			ad.Spec.Agent.Log.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
 		}
 
 		if options.APMEnabled {

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -141,7 +141,7 @@ func (r *Reconciler) createNewExtendedDaemonSet(logger logr.Logger, dda *datadog
 	// ExtendedDaemonSet up to date didn't exist yet, create a new one
 	var newEDS *edsdatadoghqv1alpha1.ExtendedDaemonSet
 	var hashEDS string
-	if newEDS, hashEDS, err = newExtendedDaemonSetFromInstance(logger, dda, nil); err != nil {
+	if newEDS, hashEDS, err = newExtendedDaemonSetFromInstance(logger, dda, nil, &r.options); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -169,7 +169,7 @@ func (r *Reconciler) createNewDaemonSet(logger logr.Logger, dda *datadoghqv1alph
 	// DaemonSet up to date didn't exist yet, create a new one
 	var newDS *appsv1.DaemonSet
 	var hashDS string
-	if newDS, hashDS, err = newDaemonSetFromInstance(logger, dda, nil); err != nil {
+	if newDS, hashDS, err = newDaemonSetFromInstance(logger, dda, nil, &r.options); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -192,7 +192,7 @@ func (r *Reconciler) createNewDaemonSet(logger logr.Logger, dda *datadoghqv1alph
 
 func (r *Reconciler) updateExtendedDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, eds *edsdatadoghqv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
 	now := metav1.NewTime(time.Now())
-	newEDS, newHashEDS, err := newExtendedDaemonSetFromInstance(logger, dda, eds.Spec.Selector)
+	newEDS, newHashEDS, err := newExtendedDaemonSetFromInstance(logger, dda, eds.Spec.Selector, &r.options)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -237,7 +237,7 @@ func (r *Reconciler) updateDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.
 	// Update values from current DS in any case
 	newStatus.Agent = updateDaemonSetStatus(ds, newStatus.Agent, nil)
 
-	newDS, newHashDS, err := newDaemonSetFromInstance(logger, dda, ds.Spec.Selector)
+	newDS, newHashDS, err := newDaemonSetFromInstance(logger, dda, ds.Spec.Selector, &r.options)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -408,8 +408,8 @@ func buildAgentNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, name string) *
 }
 
 // newExtendedDaemonSetFromInstance creates an ExtendedDaemonSet from a given DatadogAgent
-func newExtendedDaemonSetFromInstance(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*edsdatadoghqv1alpha1.ExtendedDaemonSet, string, error) {
-	template, err := newAgentPodTemplate(logger, dda, selector)
+func newExtendedDaemonSetFromInstance(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector, options *ReconcilerOptions) (*edsdatadoghqv1alpha1.ExtendedDaemonSet, string, error) {
+	template, err := newAgentPodTemplate(logger, dda, selector, options)
 	if err != nil {
 		return nil, "", err
 	}
@@ -440,8 +440,8 @@ func newExtendedDaemonSetFromInstance(logger logr.Logger, dda *datadoghqv1alpha1
 }
 
 // newDaemonSetFromInstance creates a DaemonSet from a given DatadogAgent
-func newDaemonSetFromInstance(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*appsv1.DaemonSet, string, error) {
-	template, err := newAgentPodTemplate(logger, dda, selector)
+func newDaemonSetFromInstance(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector, options *ReconcilerOptions) (*appsv1.DaemonSet, string, error) {
+	template, err := newAgentPodTemplate(logger, dda, selector, options)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
### What does this PR do?

Introduces additional CLI options to allow restricting:
- DatadogAgent features, such as running system-probe container
- Container image registries
- Using specific host storage path for temp storage in logs agent.

### Motivation

Better support for managed Kubernetes environments.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
