### PR TITLE
Improve UDS sockets fix - keep backward compatibility

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -26,11 +26,11 @@ const (
 	defaultDockerSocketPath               string = "/var/run/docker.sock"
 	defaultDogstatsdOriginDetection       bool   = false
 	defaultUseDogStatsDSocketVolume       bool   = false
-	defaultDogstatsdSocketName            string = "statsd.sock"
-	defaultDogstatsdSocketPath            string = "/var/run/datadog"
+	defaultHostDogstatsdSocketName        string = "statsd.sock"
+	defaultHostDogstatsdSocketPath        string = "/var/run/datadog"
 	defaultApmEnabled                     bool   = false
-	defaultApmSocketName                  string = "apm.sock"
-	defaultApmSocketPath                  string = "/var/run/datadog"
+	defaultHostApmSocketName              string = "apm.sock"
+	defaultHostApmSocketPath              string = "/var/run/datadog"
 	defaultLogEnabled                     bool   = false
 	defaultLogsConfigContainerCollectAll  bool   = false
 	defaultLogsContainerCollectUsingFiles bool   = true
@@ -583,7 +583,7 @@ func DefaultConfigDogstatsdUDS(uds *DSDUnixDomainSocketSpec) *DSDUnixDomainSocke
 	}
 
 	if uds.HostFilepath == nil {
-		socketPath := path.Join(defaultDogstatsdSocketPath, defaultDogstatsdSocketName)
+		socketPath := path.Join(defaultHostDogstatsdSocketPath, defaultHostDogstatsdSocketName)
 		uds.HostFilepath = &socketPath
 	}
 	return uds
@@ -699,7 +699,7 @@ func DefaultDatadogAgentSpecAgentApmUDS(uds *APMUnixDomainSocketSpec) *APMUnixDo
 	}
 
 	if uds.HostFilepath == nil {
-		socketPath := path.Join(defaultApmSocketPath, defaultApmSocketName)
+		socketPath := path.Join(defaultHostApmSocketPath, defaultHostApmSocketName)
 		uds.HostFilepath = &socketPath
 	}
 	return uds

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDefaultConfigDogstatsd(t *testing.T) {
-	defaultPath := path.Join(defaultDogstatsdSocketPath, defaultDogstatsdSocketName)
+	defaultPath := path.Join(defaultHostDogstatsdSocketPath, defaultHostDogstatsdSocketName)
 	defaultAgentConfig := NodeAgentConfig{
 		Dogstatsd: &DogstatsdConfig{
 			DogstatsdOriginDetection: NewBoolPointer(false),

--- a/api/v1alpha1/datadogagent_types.go
+++ b/api/v1alpha1/datadogagent_types.go
@@ -316,7 +316,7 @@ type APMUnixDomainSocketSpec struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Define the host APM socket filepath used when APM over Unix Domain Socket is enabled
-	// (default value: /var/run/datadog/apm/apm.sock)
+	// (default value: /var/run/datadog/apm.sock)
 	// ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
 	// +optional
 	HostFilepath *string `json:"hostFilepath,omitempty"`
@@ -742,7 +742,7 @@ type DSDUnixDomainSocketSpec struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// Define the host APM socket filepath used when APM over Unix Domain Socket is enabled
-	// (default value: /var/run/datadog/statsd/statsd.sock)
+	// (default value: /var/run/datadog/statsd.sock)
 	// ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/
 	// +optional
 	HostFilepath *string `json:"hostFilepath,omitempty"`

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -143,7 +143,7 @@ func schema__api_v1alpha1_APMUnixDomainSocketSpec(ref common.ReferenceCallback) 
 					},
 					"hostFilepath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/apm/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
+							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -624,7 +624,7 @@ func schema__api_v1alpha1_DSDUnixDomainSocketSpec(ref common.ReferenceCallback) 
 					},
 					"hostFilepath": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/statsd/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
+							Description: "Define the host APM socket filepath used when APM over Unix Domain Socket is enabled (default value: /var/run/datadog/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -239,7 +239,7 @@ spec:
                           hostFilepath:
                             description: 'Define the host APM socket filepath used
                               when APM over Unix Domain Socket is enabled (default
-                              value: /var/run/datadog/apm/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
+                              value: /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
                             type: string
                         type: object
                     type: object
@@ -307,8 +307,8 @@ spec:
                               hostFilepath:
                                 description: 'Define the host APM socket filepath
                                   used when APM over Unix Domain Socket is enabled
-                                  (default value: /var/run/datadog/statsd/statsd.sock)
-                                  ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
+                                  (default value: /var/run/datadog/statsd.sock) ref:
+                                  https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
                                 type: string
                             type: object
                         type: object

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -229,7 +229,7 @@ spec:
                         hostFilepath:
                           description: 'Define the host APM socket filepath used when
                             APM over Unix Domain Socket is enabled (default value:
-                            /var/run/datadog/apm/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
+                            /var/run/datadog/apm.sock) ref: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables'
                           type: string
                       type: object
                   type: object
@@ -296,7 +296,7 @@ spec:
                             hostFilepath:
                               description: 'Define the host APM socket filepath used
                                 when APM over Unix Domain Socket is enabled (default
-                                value: /var/run/datadog/statsd/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
+                                value: /var/run/datadog/statsd.sock) ref: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/'
                               type: string
                           type: object
                       type: object

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -35,8 +35,8 @@ const (
 	authDelegatorName         string = "%s-auth-delegator"
 	datadogOperatorName       string = "DatadogAgent"
 	externalMetricsReaderName string = "%s-metrics-reader"
-	localDogstatsdSocketPath  string = "/var/run/datadog"
-	localAPMSocketPath        string = "/var/run/datadog"
+	localDogstatsdSocketPath  string = "/var/run/datadog/statsd"
+	localAPMSocketPath        string = "/var/run/datadog/apm"
 )
 
 func init() {


### PR DESCRIPTION
### What does this PR do?

Improve fix from #224 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Activate `agent.apm.unixDomainSocket.enabled` and `agent.config.dogstatsd.unixDomainSocket.enabled`, check that both sockets on host are stored in `/var/run/datadog` and in container at `/var/run/datadog/<statsd|apm>`