### PR TITLE
[DatadogMonitor] Refactor creds management and support SB

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,10 +32,6 @@ spec:
         imagePullPolicy: Always
         name: manager
         env:
-        - name: DD_API_KEY
-          value: "dummy_api_key"
-        - name: DD_APP_KEY
-          value: "dummy_app_key"
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -6,26 +6,43 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/DataDog/datadog-operator/controllers/datadogagent"
+	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/datadogclient"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
+)
+
+const (
+	agentControllerName   = "DatadogAgent"
+	monitorControllerName = "DatadogMonitor"
 )
 
 // SetupOptions defines options for setting up controllers to ease testing
 type SetupOptions struct {
 	SupportExtendedDaemonset bool
-	APIKey                   string
-	AppKey                   string
+	Creds                    config.Creds
+	HaveCreds                bool
+	DatadogMonitorEnabled    bool
+}
+
+type starterFunc func(logr.Logger, manager.Manager, *version.Info, SetupOptions) error
+
+var controllerStarters = map[string]starterFunc{
+	agentControllerName:   startDatadogAgent,
+	monitorControllerName: startDatadogMonitor,
 }
 
 // SetupControllers starts all controllers (also used by e2e tests)
-// func SetupControllers(mgr manager.Manager, supportExtendedDaemonset bool) error {
-func SetupControllers(mgr manager.Manager, options SetupOptions) error {
+func SetupControllers(logger logr.Logger, mgr manager.Manager, options SetupOptions) error {
 	// Get some information about Kubernetes version
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
@@ -37,34 +54,49 @@ func SetupControllers(mgr manager.Manager, options SetupOptions) error {
 		return fmt.Errorf("unable to get APIServer version: %w", err)
 	}
 
-	if err = (&DatadogAgentReconciler{
+	for controller, starter := range controllerStarters {
+		if err := starter(logger, mgr, versionInfo, options); err != nil {
+			logger.Error(err, "Couldn't start controller", "controller", controller)
+		}
+	}
+
+	return nil
+}
+
+func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, options SetupOptions) error {
+	return (&DatadogAgentReconciler{
 		Client:      mgr.GetClient(),
-		VersionInfo: versionInfo,
-		Log:         ctrl.Log.WithName("controllers").WithName("DatadogAgent"),
+		VersionInfo: vInfo,
+		Log:         ctrl.Log.WithName("controllers").WithName(agentControllerName),
 		Scheme:      mgr.GetScheme(),
-		Recorder:    mgr.GetEventRecorderFor("DatadogAgent"),
+		Recorder:    mgr.GetEventRecorderFor(agentControllerName),
 		Options: datadogagent.ReconcilerOptions{
 			SupportExtendedDaemonset: options.SupportExtendedDaemonset,
 		},
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller DatadogAgent: %w", err)
+	}).SetupWithManager(mgr)
+}
+
+func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, options SetupOptions) error {
+	if !options.DatadogMonitorEnabled {
+		logger.Info("Feature disabled, not starting the controller", "controller", monitorControllerName)
+		return nil
 	}
 
-	ddClient, err := datadogclient.InitDatadogClient(options.APIKey, options.AppKey)
+	if !options.HaveCreds {
+		return errors.New("credentials not provided")
+	}
+
+	ddClient, err := datadogclient.InitDatadogClient(options.Creds)
 	if err != nil {
 		return fmt.Errorf("unable to create Datadog API Client: %w", err)
 	}
 
-	if err = (&DatadogMonitorReconciler{
+	return (&DatadogMonitorReconciler{
 		Client:      mgr.GetClient(),
 		DDClient:    ddClient,
-		VersionInfo: versionInfo,
-		Log:         ctrl.Log.WithName("controllers").WithName("DatadogMonitor"),
+		VersionInfo: vInfo,
+		Log:         ctrl.Log.WithName("controllers").WithName(monitorControllerName),
 		Scheme:      mgr.GetScheme(),
-		Recorder:    mgr.GetEventRecorderFor("DatadogMonitor"),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create controller DatadogMonitor: %w", err)
-	}
-
-	return nil
+		Recorder:    mgr.GetEventRecorderFor(monitorControllerName),
+	}).SetupWithManager(mgr)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 	"github.com/DataDog/datadog-operator/controllers/testutils"
+	"github.com/DataDog/datadog-operator/pkg/config"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -86,11 +87,12 @@ var _ = BeforeSuite(func(done Done) {
 
 	options := SetupOptions{
 		SupportExtendedDaemonset: false,
-		APIKey:                   "dummy_api_key",
-		AppKey:                   "dummy_app_key",
+		Creds:                    config.Creds{APIKey: "dummy_api_key", AppKey: "dummy_app_key"},
+		DatadogMonitorEnabled:    true,
 	}
 
-	err = SetupControllers(mgr, options)
+	logger := logf.Log.Logger
+	err = SetupControllers(logger, mgr, options)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/pkg/config/creds.go
+++ b/pkg/config/creds.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package config
+
+import (
+	"errors"
+	"os"
+
+	"github.com/DataDog/datadog-operator/pkg/secrets"
+)
+
+// Creds holds the api and app keys
+type Creds struct {
+	APIKey string
+	AppKey string
+}
+
+// GetCredentials returns the API and APP keys respectively from the operator configurations
+// This function tries to decrypt the secrets using the secret backend if needed
+// It returns an error if the creds aren't configured or if the secret backend fails to decrypt
+func GetCredentials() (Creds, error) {
+	return getCredentials(secrets.NewSecretBackend())
+}
+
+// getCredentials used to ease testing
+func getCredentials(decryptor secrets.Decryptor) (Creds, error) {
+	apiKey := os.Getenv(DDAPIKeyEnvVar)
+	appKey := os.Getenv(DDAppKeyEnvVar)
+
+	if apiKey == "" || appKey == "" {
+		return Creds{}, errors.New("empty API key and/or App key")
+	}
+
+	var encrypted []string
+	if secrets.IsEnc(apiKey) {
+		encrypted = append(encrypted, apiKey)
+	}
+
+	if secrets.IsEnc(appKey) {
+		encrypted = append(encrypted, appKey)
+	}
+
+	if len(encrypted) == 0 {
+		// Nothing to decrypt
+		return Creds{APIKey: apiKey, AppKey: appKey}, nil
+	}
+
+	decrypted, err := decryptor.Decrypt(encrypted)
+	if err != nil {
+		return Creds{}, err
+	}
+
+	if val, found := decrypted[apiKey]; found {
+		apiKey = val
+	}
+
+	if val, found := decrypted[appKey]; found {
+		appKey = val
+	}
+
+	return Creds{APIKey: apiKey, AppKey: appKey}, nil
+}

--- a/pkg/config/creds_test.go
+++ b/pkg/config/creds_test.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-operator/pkg/secrets"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getCredentials(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupFunc func(*secrets.DummyDecryptor)
+		want      Creds
+		wantErr   bool
+		wantFunc  func(*testing.T, *secrets.DummyDecryptor)
+		resetFunc func()
+	}{
+		{
+			name:      "creds found, no SB",
+			setupFunc: func(*secrets.DummyDecryptor) { os.Setenv("DD_API_KEY", "foo"); os.Setenv("DD_APP_KEY", "bar") },
+			want:      Creds{APIKey: "foo", AppKey: "bar"},
+			wantErr:   false,
+			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
+			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+		},
+		{
+			name: "creds found, both encrypted",
+			setupFunc: func(d *secrets.DummyDecryptor) {
+				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
+				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
+				d.On("Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"}).Once()
+			},
+			want:    Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "DEC[ENC[AppKey]]"},
+			wantErr: false,
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor) {
+				d.AssertCalled(t, "Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"})
+			},
+			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+		},
+		{
+			name: "creds found, api key encrypted",
+			setupFunc: func(d *secrets.DummyDecryptor) {
+				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
+				os.Setenv("DD_APP_KEY", "bar")
+				d.On("Decrypt", []string{"ENC[ApiKey]"}).Once()
+			},
+			want:    Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "bar"},
+			wantErr: false,
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor) {
+				d.AssertCalled(t, "Decrypt", []string{"ENC[ApiKey]"})
+			},
+			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+		},
+		{
+			name: "creds found, app key encrypted",
+			setupFunc: func(d *secrets.DummyDecryptor) {
+				os.Setenv("DD_API_KEY", "foo")
+				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
+				d.On("Decrypt", []string{"ENC[AppKey]"}).Once()
+			},
+			want:    Creds{APIKey: "foo", AppKey: "DEC[ENC[AppKey]]"},
+			wantErr: false,
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor) {
+				d.AssertCalled(t, "Decrypt", []string{"ENC[AppKey]"})
+			},
+			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+		},
+		{
+			name:      "creds not found",
+			setupFunc: func(*secrets.DummyDecryptor) {},
+			want:      Creds{},
+			wantErr:   true,
+			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
+			resetFunc: func() {},
+		},
+		{
+			name:      "app key not found",
+			setupFunc: func(*secrets.DummyDecryptor) { os.Setenv("DD_API_KEY", "foo") },
+			want:      Creds{},
+			wantErr:   true,
+			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
+			resetFunc: func() { os.Unsetenv("DD_API_KEY") },
+		},
+		{
+			name:      "api key not found",
+			setupFunc: func(*secrets.DummyDecryptor) { os.Setenv("DD_APP_KEY", "bar") },
+			want:      Creds{},
+			wantErr:   true,
+			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
+			resetFunc: func() { os.Unsetenv("DD_APP_KEY") },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decryptor := &secrets.DummyDecryptor{}
+			tt.setupFunc(decryptor)
+			got, err := getCredentials(decryptor)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.EqualValues(t, tt.want, got)
+			tt.wantFunc(t, decryptor)
+			tt.resetFunc()
+		})
+	}
+}

--- a/pkg/datadogclient/client.go
+++ b/pkg/datadogclient/client.go
@@ -24,8 +24,8 @@ type DatadogClient struct {
 }
 
 // InitDatadogClient initializes the Datadog API Client and establishes credentials
-func InitDatadogClient(apiKey, appKey string) (DatadogClient, error) {
-	if apiKey == "" || appKey == "" {
+func InitDatadogClient(creds config.Creds) (DatadogClient, error) {
+	if creds.APIKey == "" || creds.AppKey == "" {
 		return DatadogClient{}, errors.New("error obtaining API key and/or app key")
 	}
 
@@ -35,10 +35,10 @@ func InitDatadogClient(apiKey, appKey string) (DatadogClient, error) {
 		datadogapiclientv1.ContextAPIKeys,
 		map[string]datadogapiclientv1.APIKey{
 			"apiKeyAuth": {
-				Key: apiKey,
+				Key: creds.APIKey,
 			},
 			"appKeyAuth": {
-				Key: appKey,
+				Key: creds.AppKey,
 			},
 		},
 	)

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -5,7 +5,12 @@
 
 package secrets
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
 
 // Decryptor is used to decrypt encrypted secrets
 // Decryptor is implemented by SecretBackend
@@ -26,4 +31,19 @@ type SecretBackend struct {
 type Secret struct {
 	Value    string `json:"value,omitempty"`
 	ErrorMsg string `json:"error,omitempty"`
+}
+
+// DummyDecryptor can be used in other packages to mock the secret backend
+type DummyDecryptor struct {
+	mock.Mock
+}
+
+// Decrypt is used for testing
+func (d *DummyDecryptor) Decrypt(secrets []string) (map[string]string, error) {
+	d.Called(secrets)
+	res := map[string]string{}
+	for _, secret := range secrets {
+		res[secret] = fmt.Sprintf("DEC[%s]", secret)
+	}
+	return res, nil
 }


### PR DESCRIPTION
### What does this PR do?

- Add an argument to disable the `DatadogMonitor` controller
- Centralise the credentials management in the operator, which will allow the `DatadogMonitor` controller to get creds via secret backend
- If one of the controllers couldn't start, we don't `os.Exit(1)` anymore (example: if you don't provide creds, `DatadogMonitor` won't start, but `DatadogAgent` will do. 

### Motivation

- `DatadogMonitor` supports SB now
- `DatadogMonitor` can be disabled

### Additional Notes

- A follow-up PR (or commit) to revamp the metrics forwarder will come up next

### Describe your test plan

- Do not provide creds, this should prevent `DatadogMonitor` from starting but shouldn't affect `DatadogAgent`
- Try to provide creds via secret backend, `DatadogMonitor` should be able to get them and start (you can use a secret mount + `readsecret.sh`)
- Configure the `datadogMonitorEnabled` operator argument, make sure `DatadogMonitor` doesn't start
