### PR TITLE
Add missing NET_RAW Cap for CVE-2020-14386 mitigation

### DIFF
--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1041,7 +1041,7 @@ func defaultSystemProbePodSpec() corev1.PodSpec {
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"},
+						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK"},
 					},
 				},
 				Resources:    corev1.ResourceRequirements{},
@@ -1311,7 +1311,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"},
+						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK"},
 					},
 				},
 				Resources:    corev1.ResourceRequirements{},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -340,7 +340,15 @@ func getSystemProbeContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Con
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "IPC_LOCK"},
+				Add: []corev1.Capability{
+					"SYS_ADMIN",
+					"SYS_RESOURCE",
+					"SYS_PTRACE",
+					"NET_ADMIN",
+					"NET_BROADCAST",
+					"NET_RAW",
+					"IPC_LOCK",
+				},
 			},
 		},
 		Env:          systemProbeEnvVars,


### PR DESCRIPTION
### What does this PR do?

Add missing `NET_RAW` capability to the system-probe container.
This capability is now requiered with CRIO due to a patch remediation
for the CVE-2020-14386.

### Motivation

Allow the system-probe to start or recent openshift cluster.

### Additional Notes

N/A

### Describe your test plan

Deploy the Agent with system-probe enabled on Openshift dedicated. 
The container should start.
