### PR TITLE
Fix unwanted Resources deletion

### DIFF
--- a/controllers/datadogagent/common_configmap.go
+++ b/controllers/datadogagent/common_configmap.go
@@ -116,7 +116,7 @@ func (r *Reconciler) cleanupConfigMap(logger logr.Logger, dda *datadoghqv1alpha1
 		}
 		return reconcile.Result{}, err
 	}
-	if !ownedByDatadogOperator(configmap.OwnerReferences) {
+	if !CheckOwnerReference(dda, configmap) {
 		return reconcile.Result{}, nil
 	}
 	logger.V(1).Info("deleteConfigMap", "configMap.name", configmap.Name, "configMap.Namespace", configmap.Namespace)

--- a/controllers/datadogagent/common_networkpolicy.go
+++ b/controllers/datadogagent/common_networkpolicy.go
@@ -47,7 +47,7 @@ func (r *Reconciler) cleanupNetworkPolicy(logger logr.Logger, dda *datadoghqv1al
 		return reconcile.Result{}, err
 	}
 
-	if !ownedByDatadogOperator(policy.OwnerReferences) {
+	if !CheckOwnerReference(dda, policy) {
 		return reconcile.Result{}, nil
 	}
 

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -116,7 +116,7 @@ func (r *Reconciler) cleanupClusterRole(logger logr.Logger, client client.Client
 		}
 		return reconcile.Result{}, err
 	}
-	if !ownedByDatadogOperator(clusterRole.OwnerReferences) {
+	if !CheckOwnerReference(dda, clusterRole) {
 		return reconcile.Result{}, nil
 	}
 	logger.V(1).Info("deleteClusterRole", "clusterRole.name", clusterRole.Name, "clusterRole.Namespace", clusterRole.Namespace)
@@ -134,7 +134,7 @@ func (r *Reconciler) cleanupClusterRoleBinding(logger logr.Logger, client client
 		}
 		return reconcile.Result{}, err
 	}
-	if !ownedByDatadogOperator(clusterRoleBinding.OwnerReferences) {
+	if !CheckOwnerReference(dda, clusterRoleBinding) {
 		return reconcile.Result{}, nil
 	}
 	logger.V(1).Info("deleteClusterRoleBinding", "clusterRoleBinding.name", clusterRoleBinding.Name, "clusterRoleBinding.Namespace", clusterRoleBinding.Namespace)
@@ -152,7 +152,7 @@ func (r *Reconciler) cleanupServiceAccount(logger logr.Logger, client client.Cli
 		}
 		return reconcile.Result{}, err
 	}
-	if !ownedByDatadogOperator(serviceAccount.OwnerReferences) {
+	if !CheckOwnerReference(dda, serviceAccount) {
 		return reconcile.Result{}, nil
 	}
 	logger.V(1).Info("deleteServiceAccount", "serviceAccount.name", serviceAccount.Name, "serviceAccount.Namespace", serviceAccount.Namespace)

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -287,6 +287,11 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			want:    reconcile.Result{Requeue: true},
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
 				clusterRole := &rbacv1.ClusterRole{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesName}, clusterRole); err != nil {
 					return err
@@ -297,7 +302,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if !hasAllNodeLevelRbacResources(clusterRole.Rules) {
 					return fmt.Errorf("bad cluster role, should contain all node level rbac resources, current: %v", clusterRole.Rules)
 				}
-				if !ownedByDatadogOperator(clusterRole.OwnerReferences) {
+				if !CheckOwnerReference(datadogAgent, clusterRole) {
 					return fmt.Errorf("bad cluster role, should be owned by the datadog operator, current owners: %v", clusterRole.OwnerReferences)
 				}
 
@@ -332,12 +337,17 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
 			wantFunc: func(c client.Client) error {
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
 				rbacResourcesName := "foo-agent"
 				clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesName}, clusterRoleBinding); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(clusterRoleBinding.OwnerReferences) {
+				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
 					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 				return nil
@@ -382,7 +392,13 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: rbacResourcesName}, serviceAccount); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(serviceAccount.OwnerReferences) {
+
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, serviceAccount) {
 					return fmt.Errorf("bad serviceAccount, should be owned by the datadog operator, current owners: %v", serviceAccount.OwnerReferences)
 				}
 				return nil
@@ -1109,7 +1125,13 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: "foo-cluster-agent"}, pdb); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(pdb.OwnerReferences) {
+
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, pdb) {
 					return fmt.Errorf("bad PDB, should be owned by the datadog operator, current owners: %v", pdb.OwnerReferences)
 				}
 
@@ -1165,7 +1187,13 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if !hasAllClusterLevelRbacResources(clusterRole.Rules) {
 					return fmt.Errorf("bad cluster role, should contain all cluster level rbac resources, current: %v", clusterRole.Rules)
 				}
-				if !ownedByDatadogOperator(clusterRole.OwnerReferences) {
+
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, clusterRole) {
 					return fmt.Errorf("bad clusterRole, should be owned by the datadog operator, current owners: %v", clusterRole.OwnerReferences)
 				}
 
@@ -1306,7 +1334,13 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if !hasAdmissionRbacResources(clusterRole.Rules) {
 					return fmt.Errorf("bad cluster role, should contain cluster level rbac resources needed by the admission controller, current: %v", clusterRole.Rules)
 				}
-				if !ownedByDatadogOperator(clusterRole.OwnerReferences) {
+
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, clusterRole) {
 					return fmt.Errorf("bad clusterRole, should be owned by the datadog operator, current owners: %v", clusterRole.OwnerReferences)
 				}
 
@@ -1360,7 +1394,12 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesNameClusterAgent}, clusterRoleBinding); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(clusterRoleBinding.OwnerReferences) {
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
 					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 
@@ -1436,7 +1475,12 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: "foo-cluster-agent-auth-delegator"}, clusterRoleBinding); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(clusterRoleBinding.OwnerReferences) {
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
 					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 
@@ -1517,7 +1561,12 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: rbacResourcesNameClusterAgent}, serviceAccount); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(serviceAccount.OwnerReferences) {
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, serviceAccount) {
 					return fmt.Errorf("bad serviceAccount, should be owned by the datadog operator, current owners: %v", serviceAccount.OwnerReferences)
 				}
 
@@ -1787,7 +1836,12 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: rbacResourcesNameClusterChecksRunner}, pdb); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(pdb.OwnerReferences) {
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, pdb) {
 					return fmt.Errorf("bad PDB, should be owned by the datadog operator, current owners: %v", pdb.OwnerReferences)
 				}
 
@@ -1905,7 +1959,13 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesNameClusterChecksRunner}, clusterRoleBinding); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(clusterRoleBinding.OwnerReferences) {
+
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
 					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 
@@ -1969,7 +2029,13 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: rbacResourcesNameClusterChecksRunner}, serviceAccount); err != nil {
 					return err
 				}
-				if !ownedByDatadogOperator(serviceAccount.OwnerReferences) {
+
+				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
+				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
+					return err
+				}
+
+				if !CheckOwnerReference(datadogAgent, serviceAccount) {
 					return fmt.Errorf("bad serviceAccount, should be owned by the datadog operator, current owners: %v", serviceAccount.OwnerReferences)
 				}
 

--- a/controllers/datadogagent/poddisruptionbudget.go
+++ b/controllers/datadogagent/poddisruptionbudget.go
@@ -74,7 +74,7 @@ func (r *Reconciler) createPDB(logger logr.Logger, dda *datadoghqv1alpha1.Datado
 }
 
 func (r *Reconciler) updateIfNeededPDB(dda *datadoghqv1alpha1.DatadogAgent, currentPDB *policyv1.PodDisruptionBudget, builder pdbBuilder) (reconcile.Result, error) {
-	if !ownedByDatadogOperator(currentPDB.OwnerReferences) {
+	if !CheckOwnerReference(dda, currentPDB) {
 		return reconcile.Result{}, nil
 	}
 	newPDB := builder(dda)
@@ -108,7 +108,7 @@ func (r *Reconciler) cleanupPDB(dda *datadoghqv1alpha1.DatadogAgent, pdbName str
 		}
 		return reconcile.Result{}, err
 	}
-	if ownedByDatadogOperator(pdb.OwnerReferences) {
+	if CheckOwnerReference(dda, pdb) {
 		err = r.client.Delete(context.TODO(), pdb)
 	}
 

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -36,7 +36,6 @@ import (
 
 const (
 	authDelegatorName         string = "%s-auth-delegator"
-	datadogOperatorName       string = "DatadogAgent"
 	externalMetricsReaderName string = "%s-metrics-reader"
 	localDogstatsdSocketPath  string = "/var/run/datadog/statsd"
 	localAPMSocketPath        string = "/var/run/datadog/apm"
@@ -1950,21 +1949,17 @@ func updateDeploymentStatus(dep *appsv1.Deployment, depStatus *datadoghqv1alpha1
 	return depStatus
 }
 
-func ownedByDatadogOperator(owners []metav1.OwnerReference) bool {
-	for _, owner := range owners {
-		if owner.Kind == datadogOperatorName {
-			return true
-		}
-	}
-	return false
-}
-
 func getLogLevel(dda *datadoghqv1alpha1.DatadogAgent) string {
 	logLevel := datadoghqv1alpha1.DefaultLogLevel
 	if dda.Spec.Agent.Config.LogLevel != nil {
 		logLevel = *dda.Spec.Agent.Config.LogLevel
 	}
 	return logLevel
+}
+
+// CheckOwnerReference return true if owner is the owner of the object
+func CheckOwnerReference(owner, object metav1.Object) bool {
+	return metav1.IsControlledBy(object, owner)
 }
 
 // SetOwnerReference sets owner as a OwnerReference.


### PR DESCRIPTION
### What does this PR do?

This PR avoid resources deletion not owned by the DatadogAgent Resource instance.

### Motivation

Fix: #237

The Datadog-operator was deleting resources without checking if it was the Owner of these resources.

### Additional Notes

N/A

### Describe your test plan

You can follow the test plan proposed in #237 
