### PR TITLE
Rework the creds manager

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -447,6 +447,7 @@ core,"k8s.io/client-go/util/flowcontrol",Apache-2.0
 core,"k8s.io/client-go/util/homedir",Apache-2.0
 core,"k8s.io/client-go/util/jsonpath",Apache-2.0
 core,"k8s.io/client-go/util/keyutil",Apache-2.0
+core,"k8s.io/client-go/util/retry",Apache-2.0
 core,"k8s.io/client-go/util/workqueue",Apache-2.0
 core,"k8s.io/gengo/args",Apache-2.0
 core,"k8s.io/gengo/examples/set-gen/sets",Apache-2.0

--- a/controllers/datadogagent/event.go
+++ b/controllers/datadogagent/event.go
@@ -22,5 +22,7 @@ func buildEventInfo(name, ns, kind string, eventType datadog.EventType) utils.Ev
 // recordEvent calls the metric forwarders to send Datadog events
 func (r *Reconciler) recordEvent(dda *datadoghqv1alpha1.DatadogAgent, info utils.EventInfo) {
 	r.recorder.Event(dda, corev1.EventTypeNormal, info.GetReason(), info.GetMessage())
-	r.forwarders.ProcessEvent(dda, info.GetDDEvent())
+	if r.options.OperatorMetricsEnabled {
+		r.forwarders.ProcessEvent(dda, info.GetDDEvent())
+	}
 }

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -32,6 +32,7 @@ type SetupOptions struct {
 	Creds                    config.Creds
 	HaveCreds                bool
 	DatadogMonitorEnabled    bool
+	OperatorMetricsEnabled   bool
 }
 
 type starterFunc func(logr.Logger, manager.Manager, *version.Info, SetupOptions) error
@@ -72,6 +73,7 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 		Recorder:    mgr.GetEventRecorderFor(agentControllerName),
 		Options: datadogagent.ReconcilerOptions{
 			SupportExtendedDaemonset: options.SupportExtendedDaemonset,
+			OperatorMetricsEnabled:   options.OperatorMetricsEnabled,
 		},
 	}).SetupWithManager(mgr)
 }

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -6,7 +6,6 @@
 package controllers
 
 import (
-	"errors"
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,7 +29,6 @@ const (
 type SetupOptions struct {
 	SupportExtendedDaemonset bool
 	Creds                    config.Creds
-	HaveCreds                bool
 	DatadogMonitorEnabled    bool
 	OperatorMetricsEnabled   bool
 }
@@ -82,10 +80,6 @@ func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, vInfo *version
 	if !options.DatadogMonitorEnabled {
 		logger.Info("Feature disabled, not starting the controller", "controller", monitorControllerName)
 		return nil
-	}
-
-	if !options.HaveCreds {
-		return errors.New("credentials not provided")
 	}
 
 	ddClient, err := datadogclient.InitDatadogClient(options.Creds)

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 
 	// Custom flags
-	var printVersion, pprofActive, supportExtendedDaemonset, datadogMonitorEnabled bool
+	var printVersion, pprofActive, supportExtendedDaemonset, datadogMonitorEnabled, operatorMetricsEnabled bool
 	var logEncoder, secretBackendCommand string
 	var secretBackendArgs stringSlice
 	flag.StringVar(&logEncoder, "logEncoder", "json", "log encoding ('json' or 'console')")
@@ -89,6 +89,7 @@ func main() {
 	flag.BoolVar(&pprofActive, "pprof", false, "Enable pprof endpoint")
 	flag.BoolVar(&supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
 	flag.BoolVar(&datadogMonitorEnabled, "datadogMonitorEnabled", true, "Enable the DatadogMonitor controller")
+	flag.BoolVar(&operatorMetricsEnabled, "operatorMetricsEnabled", true, "Enable sending operator metrics to Datadog")
 
 	// Parsing flags
 	flag.Parse()
@@ -127,7 +128,7 @@ func main() {
 	customSetupHealthChecks(mgr)
 	customSetupEndpoints(pprofActive, mgr)
 
-	creds, err := config.GetCredentials()
+	creds, err := config.NewCredentialManager().GetCredentials()
 	if err != nil {
 		setupLog.Error(err, "Unable to get credentials")
 	}
@@ -137,6 +138,7 @@ func main() {
 		Creds:                    creds,
 		HaveCreds:                err == nil,
 		DatadogMonitorEnabled:    datadogMonitorEnabled,
+		OperatorMetricsEnabled:   operatorMetricsEnabled,
 	}
 
 	// Get some information about Kubernetes version

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 	flag.BoolVar(&printVersion, "version", false, "Print version and exit")
 	flag.BoolVar(&pprofActive, "pprof", false, "Enable pprof endpoint")
 	flag.BoolVar(&supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
-	flag.BoolVar(&datadogMonitorEnabled, "datadogMonitorEnabled", true, "Enable the DatadogMonitor controller")
+	flag.BoolVar(&datadogMonitorEnabled, "datadogMonitorEnabled", false, "Enable the DatadogMonitor controller")
 	flag.BoolVar(&operatorMetricsEnabled, "operatorMetricsEnabled", true, "Enable sending operator metrics to Datadog")
 
 	// Parsing flags
@@ -129,14 +129,14 @@ func main() {
 	customSetupEndpoints(pprofActive, mgr)
 
 	creds, err := config.NewCredentialManager().GetCredentials()
-	if err != nil {
+	if err != nil && datadogMonitorEnabled {
 		setupLog.Error(err, "Unable to get credentials")
+		os.Exit(1)
 	}
 
 	options := controllers.SetupOptions{
 		SupportExtendedDaemonset: supportExtendedDaemonset,
 		Creds:                    creds,
-		HaveCreds:                err == nil,
 		DatadogMonitorEnabled:    datadogMonitorEnabled,
 		OperatorMetricsEnabled:   operatorMetricsEnabled,
 	}

--- a/pkg/config/creds_test.go
+++ b/pkg/config/creds_test.go
@@ -10,102 +10,150 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/pkg/secrets"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_getCredentials(t *testing.T) {
 	tests := []struct {
 		name      string
-		setupFunc func(*secrets.DummyDecryptor)
+		setupFunc func(*secrets.DummyDecryptor, *CredentialManager)
 		want      Creds
 		wantErr   bool
-		wantFunc  func(*testing.T, *secrets.DummyDecryptor)
-		resetFunc func()
+		wantFunc  func(*testing.T, *secrets.DummyDecryptor, *CredentialManager)
+		resetFunc func(*CredentialManager)
 	}{
 		{
-			name:      "creds found, no SB",
-			setupFunc: func(*secrets.DummyDecryptor) { os.Setenv("DD_API_KEY", "foo"); os.Setenv("DD_APP_KEY", "bar") },
-			want:      Creds{APIKey: "foo", AppKey: "bar"},
-			wantErr:   false,
-			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
-			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+			name: "creds found, no SB",
+			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) {
+				os.Setenv("DD_API_KEY", "foo")
+				os.Setenv("DD_APP_KEY", "bar")
+			},
+			want:    Creds{APIKey: "foo", AppKey: "bar"},
+			wantErr: false,
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) {
+				d.AssertNotCalled(t, "Decrypt")
+				cachedCreds, cached := cm.getCredsFromCache()
+				assert.True(t, cached)
+				assert.EqualValues(t, Creds{APIKey: "foo", AppKey: "bar"}, cachedCreds)
+			},
+			resetFunc: func(cm *CredentialManager) {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+		},
+		{
+			name: "creds found in cache",
+			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
+				cm.cacheCreds(Creds{APIKey: "foo", AppKey: "bar"})
+			},
+			want:    Creds{APIKey: "foo", AppKey: "bar"},
+			wantErr: false,
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) {
+				d.AssertNotCalled(t, "Decrypt")
+				cachedCreds, cached := cm.getCredsFromCache()
+				assert.True(t, cached)
+				assert.EqualValues(t, Creds{APIKey: "foo", AppKey: "bar"}, cachedCreds)
+			},
+			resetFunc: func(cm *CredentialManager) {},
 		},
 		{
 			name: "creds found, both encrypted",
-			setupFunc: func(d *secrets.DummyDecryptor) {
+			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
 				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
 				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
 				d.On("Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"}).Once()
 			},
 			want:    Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "DEC[ENC[AppKey]]"},
 			wantErr: false,
-			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor) {
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) {
 				d.AssertCalled(t, "Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"})
+				cachedCreds, cached := cm.getCredsFromCache()
+				assert.True(t, cached)
+				assert.EqualValues(t, Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "DEC[ENC[AppKey]]"}, cachedCreds)
 			},
-			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+			resetFunc: func(cm *CredentialManager) {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+
+			},
 		},
 		{
 			name: "creds found, api key encrypted",
-			setupFunc: func(d *secrets.DummyDecryptor) {
+			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
 				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
 				os.Setenv("DD_APP_KEY", "bar")
 				d.On("Decrypt", []string{"ENC[ApiKey]"}).Once()
 			},
 			want:    Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "bar"},
 			wantErr: false,
-			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor) {
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) {
 				d.AssertCalled(t, "Decrypt", []string{"ENC[ApiKey]"})
+				cachedCreds, cached := cm.getCredsFromCache()
+				assert.True(t, cached)
+				assert.EqualValues(t, Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "bar"}, cachedCreds)
 			},
-			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+			resetFunc: func(cm *CredentialManager) {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
 		},
 		{
 			name: "creds found, app key encrypted",
-			setupFunc: func(d *secrets.DummyDecryptor) {
+			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
 				os.Setenv("DD_API_KEY", "foo")
 				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
 				d.On("Decrypt", []string{"ENC[AppKey]"}).Once()
 			},
 			want:    Creds{APIKey: "foo", AppKey: "DEC[ENC[AppKey]]"},
 			wantErr: false,
-			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor) {
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) {
 				d.AssertCalled(t, "Decrypt", []string{"ENC[AppKey]"})
+				cachedCreds, cached := cm.getCredsFromCache()
+				assert.True(t, cached)
+				assert.EqualValues(t, Creds{APIKey: "foo", AppKey: "DEC[ENC[AppKey]]"}, cachedCreds)
 			},
-			resetFunc: func() { os.Unsetenv("DD_API_KEY"); os.Unsetenv("DD_APP_KEY") },
+			resetFunc: func(cm *CredentialManager) {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
 		},
 		{
 			name:      "creds not found",
-			setupFunc: func(*secrets.DummyDecryptor) {},
+			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) {},
 			want:      Creds{},
 			wantErr:   true,
-			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
-			resetFunc: func() {},
+			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) { d.AssertNotCalled(t, "Decrypt") },
+			resetFunc: func(cm *CredentialManager) {},
 		},
 		{
 			name:      "app key not found",
-			setupFunc: func(*secrets.DummyDecryptor) { os.Setenv("DD_API_KEY", "foo") },
+			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) { os.Setenv("DD_API_KEY", "foo") },
 			want:      Creds{},
 			wantErr:   true,
-			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
-			resetFunc: func() { os.Unsetenv("DD_API_KEY") },
+			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) { d.AssertNotCalled(t, "Decrypt") },
+			resetFunc: func(cm *CredentialManager) { os.Unsetenv("DD_API_KEY") },
 		},
 		{
 			name:      "api key not found",
-			setupFunc: func(*secrets.DummyDecryptor) { os.Setenv("DD_APP_KEY", "bar") },
+			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) { os.Setenv("DD_APP_KEY", "bar") },
 			want:      Creds{},
 			wantErr:   true,
-			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor) { d.AssertNotCalled(t, "Decrypt") },
-			resetFunc: func() { os.Unsetenv("DD_APP_KEY") },
+			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) { d.AssertNotCalled(t, "Decrypt") },
+			resetFunc: func(cm *CredentialManager) { os.Unsetenv("DD_APP_KEY") },
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			credsManager := NewCredentialManager()
 			decryptor := &secrets.DummyDecryptor{}
-			tt.setupFunc(decryptor)
-			got, err := getCredentials(decryptor)
+			credsManager.secretBackend = decryptor
+			tt.setupFunc(decryptor, credsManager)
+			got, err := credsManager.GetCredentials()
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.EqualValues(t, tt.want, got)
-			tt.wantFunc(t, decryptor)
-			tt.resetFunc()
+			tt.wantFunc(t, decryptor, credsManager)
+			tt.resetFunc(credsManager)
 		})
 	}
 }

--- a/pkg/config/creds_test.go
+++ b/pkg/config/creds_test.go
@@ -17,7 +17,7 @@ import (
 func Test_getCredentials(t *testing.T) {
 	tests := []struct {
 		name      string
-		setupFunc func(*secrets.DummyDecryptor, *CredentialManager)
+		setupFunc func(*CredentialManager) *secrets.DummyDecryptor
 		want      Creds
 		wantErr   bool
 		wantFunc  func(*testing.T, *secrets.DummyDecryptor, *CredentialManager)
@@ -25,9 +25,10 @@ func Test_getCredentials(t *testing.T) {
 	}{
 		{
 			name: "creds found, no SB",
-			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) {
+			setupFunc: func(*CredentialManager) *secrets.DummyDecryptor {
 				os.Setenv("DD_API_KEY", "foo")
 				os.Setenv("DD_APP_KEY", "bar")
+				return secrets.NewDummyDecryptor(0)
 			},
 			want:    Creds{APIKey: "foo", AppKey: "bar"},
 			wantErr: false,
@@ -44,8 +45,9 @@ func Test_getCredentials(t *testing.T) {
 		},
 		{
 			name: "creds found in cache",
-			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
+			setupFunc: func(cm *CredentialManager) *secrets.DummyDecryptor {
 				cm.cacheCreds(Creds{APIKey: "foo", AppKey: "bar"})
+				return secrets.NewDummyDecryptor(0)
 			},
 			want:    Creds{APIKey: "foo", AppKey: "bar"},
 			wantErr: false,
@@ -59,10 +61,12 @@ func Test_getCredentials(t *testing.T) {
 		},
 		{
 			name: "creds found, both encrypted",
-			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
+			setupFunc: func(cm *CredentialManager) *secrets.DummyDecryptor {
 				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
 				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
+				d := secrets.NewDummyDecryptor(0)
 				d.On("Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"}).Once()
+				return d
 			},
 			want:    Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "DEC[ENC[AppKey]]"},
 			wantErr: false,
@@ -80,10 +84,12 @@ func Test_getCredentials(t *testing.T) {
 		},
 		{
 			name: "creds found, api key encrypted",
-			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
+			setupFunc: func(cm *CredentialManager) *secrets.DummyDecryptor {
 				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
 				os.Setenv("DD_APP_KEY", "bar")
+				d := secrets.NewDummyDecryptor(0)
 				d.On("Decrypt", []string{"ENC[ApiKey]"}).Once()
+				return d
 			},
 			want:    Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "bar"},
 			wantErr: false,
@@ -100,10 +106,12 @@ func Test_getCredentials(t *testing.T) {
 		},
 		{
 			name: "creds found, app key encrypted",
-			setupFunc: func(d *secrets.DummyDecryptor, cm *CredentialManager) {
+			setupFunc: func(cm *CredentialManager) *secrets.DummyDecryptor {
 				os.Setenv("DD_API_KEY", "foo")
 				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
+				d := secrets.NewDummyDecryptor(0)
 				d.On("Decrypt", []string{"ENC[AppKey]"}).Once()
+				return d
 			},
 			want:    Creds{APIKey: "foo", AppKey: "DEC[ENC[AppKey]]"},
 			wantErr: false,
@@ -120,35 +128,83 @@ func Test_getCredentials(t *testing.T) {
 		},
 		{
 			name:      "creds not found",
-			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) {},
+			setupFunc: func(*CredentialManager) *secrets.DummyDecryptor { return secrets.NewDummyDecryptor(0) },
 			want:      Creds{},
 			wantErr:   true,
 			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) { d.AssertNotCalled(t, "Decrypt") },
 			resetFunc: func(cm *CredentialManager) {},
 		},
 		{
-			name:      "app key not found",
-			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) { os.Setenv("DD_API_KEY", "foo") },
+			name: "app key not found",
+			setupFunc: func(*CredentialManager) *secrets.DummyDecryptor {
+				os.Setenv("DD_API_KEY", "foo")
+				return secrets.NewDummyDecryptor(0)
+			},
 			want:      Creds{},
 			wantErr:   true,
 			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) { d.AssertNotCalled(t, "Decrypt") },
 			resetFunc: func(cm *CredentialManager) { os.Unsetenv("DD_API_KEY") },
 		},
 		{
-			name:      "api key not found",
-			setupFunc: func(*secrets.DummyDecryptor, *CredentialManager) { os.Setenv("DD_APP_KEY", "bar") },
+			name: "api key not found",
+			setupFunc: func(*CredentialManager) *secrets.DummyDecryptor {
+				os.Setenv("DD_APP_KEY", "bar")
+				return secrets.NewDummyDecryptor(0)
+			},
 			want:      Creds{},
 			wantErr:   true,
 			wantFunc:  func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) { d.AssertNotCalled(t, "Decrypt") },
 			resetFunc: func(cm *CredentialManager) { os.Unsetenv("DD_APP_KEY") },
 		},
+		{
+			name: "creds found, decrypted after 3 retries",
+			setupFunc: func(cm *CredentialManager) *secrets.DummyDecryptor {
+				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
+				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
+				d := secrets.NewDummyDecryptor(3)
+				d.On("Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"}).Times(3)
+				return d
+			},
+			want:    Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "DEC[ENC[AppKey]]"},
+			wantErr: false,
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) {
+				d.AssertCalled(t, "Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"})
+				d.AssertNumberOfCalls(t, "Decrypt", 3)
+				cachedCreds, cached := cm.getCredsFromCache()
+				assert.True(t, cached)
+				assert.EqualValues(t, Creds{APIKey: "DEC[ENC[ApiKey]]", AppKey: "DEC[ENC[AppKey]]"}, cachedCreds)
+			},
+			resetFunc: func(cm *CredentialManager) {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+		},
+		{
+			name: "creds found, cannot be decrypted",
+			setupFunc: func(cm *CredentialManager) *secrets.DummyDecryptor {
+				os.Setenv("DD_API_KEY", "ENC[ApiKey]")
+				os.Setenv("DD_APP_KEY", "ENC[AppKey]")
+				d := secrets.NewDummyDecryptor(-1)
+				d.On("Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"}).Once()
+				return d
+			},
+			want:    Creds{},
+			wantErr: true,
+			wantFunc: func(t *testing.T, d *secrets.DummyDecryptor, cm *CredentialManager) {
+				d.AssertCalled(t, "Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"})
+				d.AssertNumberOfCalls(t, "Decrypt", 1)
+			},
+			resetFunc: func(cm *CredentialManager) {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			credsManager := NewCredentialManager()
-			decryptor := &secrets.DummyDecryptor{}
+			decryptor := tt.setupFunc(credsManager)
 			credsManager.secretBackend = decryptor
-			tt.setupFunc(decryptor, credsManager)
 			got, err := credsManager.GetCredentials()
 			assert.Equal(t, tt.wantErr, err != nil)
 			assert.EqualValues(t, tt.want, got)

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -496,6 +496,7 @@ func (mf *metricsForwarder) getCredentials(dda *datadoghqv1alpha1.DatadogAgent) 
 	if err != nil {
 		if errors.Is(err, ErrEmptyAPIKey) || errors.Is(err, ErrEmptyAPPKey) {
 			// Fallback to the operator config in this case
+			mf.logger.Info("API and/or APP key aren't defined in the Custom Resource, getting credentials from the operator config")
 			var creds config.Creds
 			creds, err = mf.credsManager.GetCredentials()
 			return creds.APIKey, creds.AppKey, err

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -52,7 +51,7 @@ func NewSecretBackend() *SecretBackend {
 // Decrypt tries to decrypt a given string slice using the secret backend command
 func (sb *SecretBackend) Decrypt(encrypted []string) (map[string]string, error) {
 	if !sb.isConfigured() {
-		return nil, errors.New("secret backend command not configured")
+		return nil, NewDecryptorError("secret backend command not configured", false)
 	}
 
 	return sb.fetchSecret(encrypted)
@@ -62,7 +61,7 @@ func (sb *SecretBackend) Decrypt(encrypted []string) (map[string]string, error) 
 func (sb *SecretBackend) fetchSecret(encrypted []string) (map[string]string, error) {
 	handles, err := extractHandles(encrypted)
 	if err != nil {
-		return nil, err
+		return nil, NewDecryptorError(err.Error(), false)
 	}
 
 	payload := map[string]interface{}{
@@ -72,31 +71,31 @@ func (sb *SecretBackend) fetchSecret(encrypted []string) (map[string]string, err
 
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
-		return nil, fmt.Errorf("could not serialize secrets IDs to fetch secrets: %v", err)
+		return nil, NewDecryptorError(err.Error(), false)
 	}
 
 	output, err := sb.execCommand(string(jsonPayload))
 	if err != nil {
-		return nil, err
+		return nil, NewDecryptorError(err.Error(), true)
 	}
 
 	secrets := map[string]Secret{}
 	err = json.Unmarshal(output, &secrets)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal 'secret_backend_command' output: %v", err)
+		return nil, NewDecryptorError(err.Error(), true)
 	}
 
 	decrypted := map[string]string{}
 	for _, handle := range handles {
 		secretHandle, found := secrets[handle]
 		if !found {
-			return nil, fmt.Errorf("secret handle '%s' was not decrypted by the secret_backend_command", handle)
+			return nil, NewDecryptorError(fmt.Sprintf("secret handle '%s' was not decrypted by the secret_backend_command", handle), false)
 		}
 		if secretHandle.ErrorMsg != "" {
-			return nil, fmt.Errorf("an error occurred while decrypting '%s': %s", handle, secretHandle.ErrorMsg)
+			return nil, NewDecryptorError(fmt.Sprintf("an error occurred while decrypting '%s': %s", handle, secretHandle.ErrorMsg), false)
 		}
 		if secretHandle.Value == "" {
-			return nil, fmt.Errorf("decrypted secret for '%s' is empty", handle)
+			return nil, NewDecryptorError(fmt.Sprintf("decrypted secret for '%s' is empty", handle), false)
 		}
 
 		decrypted[encFormat(handle)] = secretHandle.Value

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -51,7 +52,7 @@ func NewSecretBackend() *SecretBackend {
 // Decrypt tries to decrypt a given string slice using the secret backend command
 func (sb *SecretBackend) Decrypt(encrypted []string) (map[string]string, error) {
 	if !sb.isConfigured() {
-		return nil, NewDecryptorError("secret backend command not configured", false)
+		return nil, NewDecryptorError(errors.New("secret backend command not configured"), false)
 	}
 
 	return sb.fetchSecret(encrypted)
@@ -61,7 +62,7 @@ func (sb *SecretBackend) Decrypt(encrypted []string) (map[string]string, error) 
 func (sb *SecretBackend) fetchSecret(encrypted []string) (map[string]string, error) {
 	handles, err := extractHandles(encrypted)
 	if err != nil {
-		return nil, NewDecryptorError(err.Error(), false)
+		return nil, NewDecryptorError(err, false)
 	}
 
 	payload := map[string]interface{}{
@@ -71,31 +72,31 @@ func (sb *SecretBackend) fetchSecret(encrypted []string) (map[string]string, err
 
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
-		return nil, NewDecryptorError(err.Error(), false)
+		return nil, NewDecryptorError(err, false)
 	}
 
 	output, err := sb.execCommand(string(jsonPayload))
 	if err != nil {
-		return nil, NewDecryptorError(err.Error(), true)
+		return nil, NewDecryptorError(err, true)
 	}
 
 	secrets := map[string]Secret{}
 	err = json.Unmarshal(output, &secrets)
 	if err != nil {
-		return nil, NewDecryptorError(err.Error(), true)
+		return nil, NewDecryptorError(err, true)
 	}
 
 	decrypted := map[string]string{}
 	for _, handle := range handles {
 		secretHandle, found := secrets[handle]
 		if !found {
-			return nil, NewDecryptorError(fmt.Sprintf("secret handle '%s' was not decrypted by the secret_backend_command", handle), false)
+			return nil, NewDecryptorError(fmt.Errorf("secret handle '%s' was not decrypted by the secret_backend_command", handle), false)
 		}
 		if secretHandle.ErrorMsg != "" {
-			return nil, NewDecryptorError(fmt.Sprintf("an error occurred while decrypting '%s': %s", handle, secretHandle.ErrorMsg), false)
+			return nil, NewDecryptorError(fmt.Errorf("an error occurred while decrypting '%s': %s", handle, secretHandle.ErrorMsg), false)
 		}
 		if secretHandle.Value == "" {
-			return nil, NewDecryptorError(fmt.Sprintf("decrypted secret for '%s' is empty", handle), false)
+			return nil, NewDecryptorError(fmt.Errorf("decrypted secret for '%s' is empty", handle), false)
 		}
 
 		decrypted[encFormat(handle)] = secretHandle.Value


### PR DESCRIPTION
### What does this PR do?

- Disable/Enable the metrics forwarder via `operatorMetricsEnabled`
- The metrics forwarder uses `pkg/config` to get creds from the operator config as a fallback
- Add a creds caching in `GetCredentials`
- Add an exp backoff in `GetCredentials`
- Disable Datadog Monitor by default
- Restart the operator if Datadog Monitor is enabled + no creds provided 

### Motivation

Follow-up on https://github.com/DataDog/datadog-operator/pull/245

### Describe your test plan

- Set the `operatorMetricsEnabled` operator argument to `false`, make sure the metrics forwarder doesn't start
- Enable Datadog Monitor by default, make sure the operator starts only when creds are provided