### PR TITLE
Fix KSM core RBAC issue with Events

### DIFF
--- a/controllers/datadogagent/clusterchecksrunner_rbac.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac.go
@@ -70,6 +70,10 @@ func (r *Reconciler) manageClusterChecksRunnerRBACs(logger logr.Logger, dda *dat
 			return reconcile.Result{}, err
 		}
 
+		if result, err := r.updateIfNeededKubeStateMetricsClusterRole(logger, dda, kubeStateMetricsRBACName, clusterChecksRunnerVersion, kubeStateMetricsClusterRole); err != nil {
+			return result, err
+		}
+
 		kubeStateMetricsClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: kubeStateMetricsRBACName}, kubeStateMetricsClusterRoleBinding); err != nil {
 			if errors.IsNotFound(err) {

--- a/controllers/datadogagent/clusterchecksrunner_rbac_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac_test.go
@@ -1,0 +1,164 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2019 Datadog, Inc.
+
+package datadogagent
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
+	test "github.com/DataDog/datadog-operator/api/v1alpha1/test"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestReconciler_manageClusterChecksRunnerRBACs(t *testing.T) {
+	t.Helper()
+	logf.SetLogger(logf.ZapLogger(true))
+	logger := logf.Log.Logger
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconciler_manageClusterChecksRunnerRBACs"})
+	forwarders := dummyManager{}
+
+	s := scheme.Scheme
+	if err := datadoghqv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add DatadogAgent scheme: %v", err)
+	}
+
+	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogAgent{})
+
+	ddaName := "foo"
+	ddaNamespace := "bar"
+	ddaDefaultOptions := &test.NewDatadogAgentOptions{
+		ClusterAgentEnabled:  true,
+		ClusterChecksEnabled: true,
+		KubeStateMetricsCore: &datadoghqv1alpha1.KubeStateMetricsCore{
+			Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+		},
+	}
+	ddaDefault := test.NewDefaultedDatadogAgent(ddaNamespace, ddaName, ddaDefaultOptions)
+
+	agentVersion := getAgentVersion(ddaDefault)
+	serviceAccountName := getClusterChecksRunnerServiceAccount(ddaDefault)
+	serviceAccount := buildServiceAccount(ddaDefault, serviceAccountName, agentVersion)
+	roleName := getAgentRbacResourcesName(ddaDefault)
+	rbacResourcesName := getClusterChecksRunnerRbacResourcesName(ddaDefault)
+	clusterRoleBindingInfo := roleBindingInfo{
+		name:               rbacResourcesName,
+		roleName:           roleName,
+		serviceAccountName: serviceAccountName,
+	}
+	clusterRoleBinding := buildClusterRoleBinding(ddaDefault, clusterRoleBindingInfo, agentVersion)
+
+	clusterRoleRBAC := buildKubeStateMetricsCoreRBAC(ddaDefault, kubeStateMetricsRBACName, agentVersion)
+
+	type fields struct {
+		options     ReconcilerOptions
+		client      client.Client
+		versionInfo *version.Info
+		scheme      *runtime.Scheme
+		log         logr.Logger
+		recorder    record.EventRecorder
+		forwarders  datadog.MetricForwardersManager
+	}
+	type args struct {
+		logger logr.Logger
+		dda    *datadoghqv1alpha1.DatadogAgent
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     reconcile.Result
+		wantErr  bool
+		wantFunc func(t *testing.T, client client.Client)
+	}{
+		{
+			name: "test KSM ClusterRole creation",
+			args: args{
+				logger: logger,
+				dda:    ddaDefault,
+			},
+			fields: fields{
+				client:     fake.NewFakeClientWithScheme(s, serviceAccount, clusterRoleBinding),
+				scheme:     s,
+				recorder:   recorder,
+				forwarders: forwarders,
+			},
+			want: reconcile.Result{
+				Requeue: true,
+			},
+			wantErr: false,
+			wantFunc: func(t *testing.T, client client.Client) {
+				clusterRole := &rbacv1.ClusterRole{}
+				if err := client.Get(context.TODO(), types.NamespacedName{Name: kubeStateMetricsRBACName}, clusterRole); errors.IsNotFound(err) {
+					t.Errorf("ClusterRole %s sould be present", kubeStateMetricsRBACName)
+				}
+			},
+		},
+		{
+			name: "test KSM ClusterRoleBindingRBAC creation",
+			args: args{
+				logger: logger,
+				dda:    ddaDefault,
+			},
+			fields: fields{
+				client:     fake.NewFakeClientWithScheme(s, serviceAccount, clusterRoleBinding, clusterRoleRBAC),
+				scheme:     s,
+				recorder:   recorder,
+				forwarders: forwarders,
+			},
+			want: reconcile.Result{
+				Requeue: false,
+			},
+			wantErr: false,
+			wantFunc: func(t *testing.T, client client.Client) {
+				clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+				if err := client.Get(context.TODO(), types.NamespacedName{Name: kubeStateMetricsRBACName}, clusterRoleBinding); errors.IsNotFound(err) {
+					t.Errorf("ClusterRoleBinding %s sould be present", kubeStateMetricsRBACName)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				options:     tt.fields.options,
+				client:      tt.fields.client,
+				versionInfo: tt.fields.versionInfo,
+				scheme:      tt.fields.scheme,
+				log:         tt.fields.log,
+				recorder:    tt.fields.recorder,
+				forwarders:  tt.fields.forwarders,
+			}
+			got, err := r.manageClusterChecksRunnerRBACs(tt.args.logger, tt.args.dda)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Reconciler.manageClusterChecksRunnerRBACs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Reconciler.manageClusterChecksRunnerRBACs() = %v, want %v", got, tt.want)
+			}
+			if tt.wantFunc != nil {
+				tt.wantFunc(t, r.client)
+			}
+		})
+	}
+}

--- a/controllers/datadogagent/testdata/ksm_clusterrole.yaml
+++ b/controllers/datadogagent/testdata/ksm_clusterrole.yaml
@@ -11,17 +11,18 @@ rules:
       - ""
     resources:
       - configmaps
-      - secrets
-      - nodes
-      - pods
-      - services
-      - resourcequotas
-      - replicationcontrollers
+      - endpoints
+      - events
       - limitranges
+      - namespaces
+      - nodes
       - persistentvolumeclaims
       - persistentvolumes
-      - namespaces
-      - endpoints
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+      - secrets
+      - services
     verbs:
       - list
       - watch
@@ -37,10 +38,10 @@ rules:
   - apigroups:
       - apps
     resources:
-      - statefulsets
       - daemonsets
       - deployments
       - replicasets
+      - statefulsets
     verbs:
       - list
       - watch
@@ -105,8 +106,8 @@ rules:
   - apigroups:
       - networking.k8s.io
     resources:
-      - networkpolicies
       - ingresses
+      - networkpolicies
     verbs:
       - list
       - watch

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -434,6 +435,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/zorkian/go-datadog-api v2.29.0+incompatible h1:uZZg0POZ6tLmVFtjUSaTZYwR6Q6RrHx6f/blTEDn8dA=
 github.com/zorkian/go-datadog-api v2.29.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=


### PR DESCRIPTION
### What does this PR do?

* Fix missing RBAC for `Events` in the KSM core check `ClusterRole`
* Fix `ClusterRole` update when the permissions change.
* Add unit-test to validate the create of the `ClusterRole` and `ClusterRoleBinding` 

### Motivation

Fixes: #253 

### Additional Notes

N/A

### Describe your test plan

Deploy the Agents with the Operator, and enable the `kubeStateMetricsCore` check.

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  credentials:
    apiSecret:
      keyName: api-key
      secretName: datadog
    appSecret:
      keyName: app-key
      secretName: datadog
  features:
    kubeStateMetricsCore:
      enabled: true
  agent:
    image:
      name: "gcr.io/datadoghq/agent:7.26.0"
    config:
      tolerations:
        - operator: Exists
  clusterAgent:
    image:
      name: "gcr.io/datadoghq/cluster-agent:1.11.0"
    config:
      clusterChecksEnabled: true
  clusterChecksRunner:
    image:
      name: gcr.io/datadoghq/agent:7.26.0
```

To test the update:
* deploy the operator v0.5
* create the DatadogAgent. the `kubeStateMetricsCore` should failed and the `ClusterRole` should not contains the `Events` Rbac.
* Update the operator with the QA version. the `ClusterRole` should be updated, and the Events RBAC added.