### PR TITLE
Fix make deploy due to last-applied annotation size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from a cluster
 
 deploy: manifests kustomize ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply --force-conflicts --server-side -f -
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 manifests: generate-manifests patch-crds ## Generate manifestcd s e.g. CRD, RBAC etc.
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ run: generate lint manifests ## Run against the configured Kubernetes cluster in
 
 
 install: manifests kustomize ## Install CRDs into a cluster
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl apply --force-conflicts --server-side -f -
 
 
 uninstall: manifests kustomize ## Uninstall CRDs from a cluster
@@ -67,7 +67,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from a cluster
 
 deploy: manifests kustomize ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | kubectl apply --force-conflicts --server-side -f -
 
 manifests: generate-manifests patch-crds ## Generate manifestcd s e.g. CRD, RBAC etc.
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --enable-leader-election
         - --pprof
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         env:
         - name: POD_NAME


### PR DESCRIPTION
### What does this PR do?

The `DatadogAgent` CRD can be install with `kubectl apply` with the
classic client side merge mechanism because the `last-apply` annotation
used by the `kubectl apply` command is generating a too long annotation
value for the CRD.

Current solution is to use the `server-side` merge management for
the kubectl apply command. Or use the `kubectl create` command.

### Motivation

Fix `make deploy` command

### Additional Notes

N/A
### Describe your test plan

On a kubernetes 1.18+ cluster, install the operator with the command
`make deploy`
