### PR TITLE
Use an EmptyDir volume shared between all the agents for logs so that `agent flare` can gather the logs of all of them.

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -113,6 +113,8 @@ const (
 
 	// Datadog volume names and mount paths
 
+	LogDatadogVolumeName               = "logdatadog"
+	LogDatadogVolumePath               = "/var/log/datadog"
 	APMSocketVolumeName                = "apmsocket"
 	APMSocketVolumePath                = "/var/run/datadog/apm"
 	InstallInfoVolumeName              = "installinfo"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -118,6 +118,12 @@ func defaultReadinessProbe() *corev1.Probe {
 func defaultVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -174,6 +180,12 @@ func defaultVolumes() []corev1.Volume {
 
 func defaultSystemProbeVolumes() []corev1.Volume {
 	return []corev1.Volume{
+		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -274,6 +286,12 @@ func defaultSystemProbeVolumes() []corev1.Volume {
 func complianceSecurityAgentVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -354,6 +372,12 @@ func complianceSecurityAgentVolumes() []corev1.Volume {
 
 func runtimeSecurityAgentVolumes() []corev1.Volume {
 	return []corev1.Volume{
+		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -454,6 +478,10 @@ func runtimeSecurityAgentVolumes() []corev1.Volume {
 func defaultMountVolume() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
+			Name:      "logdatadog",
+			MountPath: "/var/log/datadog",
+		},
+		{
 			Name:      "installinfo",
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
@@ -494,6 +522,10 @@ func defaultMountVolume() []corev1.VolumeMount {
 func defaultProcessMountVolumes() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
+			Name:      "logdatadog",
+			MountPath: "/var/log/datadog",
+		},
+		{
 			Name:      "cgroups",
 			MountPath: "/host/sys/fs/cgroup",
 			ReadOnly:  true,
@@ -524,6 +556,10 @@ func defaultProcessMountVolumes() []corev1.VolumeMount {
 func defaultSystemProbeMountVolume() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
+			Name:      "logdatadog",
+			MountPath: "/var/log/datadog",
+		},
+		{
 			Name:      "debugfs",
 			MountPath: "/sys/kernel/debug",
 		},
@@ -546,6 +582,10 @@ func defaultSystemProbeMountVolume() []corev1.VolumeMount {
 
 func complianceSecurityAgentMountVolume() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
+		{
+			Name:      "logdatadog",
+			MountPath: "/var/log/datadog",
+		},
 		{
 			Name:      "config",
 			MountPath: "/etc/datadog-agent",
@@ -590,6 +630,10 @@ func complianceSecurityAgentMountVolume() []corev1.VolumeMount {
 
 func runtimeSecurityAgentMountVolume() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
+		{
+			Name:      "logdatadog",
+			MountPath: "/var/log/datadog",
+		},
 		{
 			Name:      "config",
 			MountPath: "/etc/datadog-agent",
@@ -930,6 +974,10 @@ func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 		Env:             defaultAPMContainerEnvVars(),
 		VolumeMounts: []corev1.VolumeMount{
 			{
+				Name:      "logdatadog",
+				MountPath: "/var/log/datadog",
+			},
+			{
 				Name:      "config",
 				MountPath: "/etc/datadog-agent",
 			},
@@ -1119,6 +1167,12 @@ func defaultOrchestratorPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodS
 
 func defaultProcessMount() []corev1.Volume {
 	return []corev1.Volume{
+		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -1656,6 +1710,12 @@ func Test_newExtendedDaemonSetFromInstance_CustomConfigMaps(t *testing.T) {
 	customConfigMapsPodSpec := defaultPodSpec()
 	customConfigMapsPodSpec.Volumes = []corev1.Volume{
 		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1780,6 +1840,12 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 
 	customConfigMapCustomDatadogYamlSpec.Volumes = []corev1.Volume{
 		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1843,6 +1909,10 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 		},
 	}
 	customConfigMapCustomDatadogYamlSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+		{
+			Name:      "logdatadog",
+			MountPath: "/var/log/datadog",
+		},
 		{
 			Name:      "installinfo",
 			SubPath:   "install_info",

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -820,6 +820,12 @@ func getEnvVarsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.E
 func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 	volumes := []corev1.Volume{
 		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1194,6 +1200,10 @@ func getVolumeMountsForAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []corev1.
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
 		{
+			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
+			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
+		},
+		{
 			Name:      datadoghqv1alpha1.InstallInfoVolumeName,
 			SubPath:   datadoghqv1alpha1.InstallInfoVolumeSubPath,
 			MountPath: datadoghqv1alpha1.InstallInfoVolumePath,
@@ -1317,6 +1327,10 @@ func getVolumeMountsForProcessAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
 		{
+			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
+			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
+		},
+		{
 			Name:      datadoghqv1alpha1.CgroupsVolumeName,
 			MountPath: datadoghqv1alpha1.CgroupsVolumePath,
 			ReadOnly:  true,
@@ -1377,7 +1391,12 @@ func getVolumeMountsForProcessAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []
 // getVolumeMountsForAgent defines mounted volumes for the Process Agent
 func getVolumeMountsForAPMAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []corev1.VolumeMount {
 	// Default mounted volumes
-	volumeMounts := []corev1.VolumeMount{}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
+			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
+		},
+	}
 
 	// APM UDS
 	if datadoghqv1alpha1.BoolValue(spec.Agent.Apm.UnixDomainSocket.Enabled) {
@@ -1400,6 +1419,10 @@ func getVolumeMountsForAPMAgent(spec *datadoghqv1alpha1.DatadogAgentSpec) []core
 func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
+			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
+		},
 		{
 			Name:      datadoghqv1alpha1.SystemProbeDebugfsVolumeName,
 			MountPath: datadoghqv1alpha1.SystemProbeDebugfsVolumePath,
@@ -1450,6 +1473,10 @@ func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1
 // getVolumeMountsForSecurityAgent defines mounted volumes for the Security Agent
 func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
+			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
+		},
 		{
 			Name:      datadoghqv1alpha1.ConfigVolumeName,
 			MountPath: datadoghqv1alpha1.ConfigVolumePath,

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -137,6 +137,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			name: "default volumeMounts",
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", nil),
 			want: []corev1.VolumeMount{
+				{Name: "logdatadog", MountPath: "/var/log/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
 			},
@@ -145,6 +146,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			name: "custom config volumeMounts",
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{CustomConfig: customConfig}),
 			want: []corev1.VolumeMount{
+				{Name: "logdatadog", MountPath: "/var/log/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "custom-datadog-yaml", ReadOnly: true, MountPath: "/etc/datadog-agent/datadog.yaml", SubPath: "datadog.yaml", SubPathExpr: ""},
 				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
@@ -154,6 +156,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			name: "extra volumeMounts",
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{VolumeMounts: []corev1.VolumeMount{{Name: "extra", MountPath: "/etc/datadog-agent/extra"}}}),
 			want: []corev1.VolumeMount{
+				{Name: "logdatadog", MountPath: "/var/log/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "extra", MountPath: "/etc/datadog-agent/extra"},
 				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
@@ -163,6 +166,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			name: "compliance volumeMounts",
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{SecuritySpec: securityCompliance}),
 			want: []corev1.VolumeMount{
+				v1.VolumeMount{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 				v1.VolumeMount{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				v1.VolumeMount{Name: "cgroups", ReadOnly: true, MountPath: "/host/sys/fs/cgroup"},
 				v1.VolumeMount{Name: "passwd", ReadOnly: true, MountPath: "/etc/passwd"},
@@ -178,6 +182,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			name: "compliance volumeMounts",
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{SecuritySpec: securityRuntime}),
 			want: []corev1.VolumeMount{
+				v1.VolumeMount{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 				v1.VolumeMount{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
 				v1.VolumeMount{Name: "sysprobe-socket-dir", ReadOnly: true, MountPath: "/var/run/sysprobe"},


### PR DESCRIPTION
### What does this PR do?

Use an EmptyDir volume shared between all the agents for logs so that `agent flare` can gather the logs of all of them.

### Motivation

### Additional Notes

This is the port of DataDog/helm-charts#193.

### Describe your test plan

Deploy the agent with the operator, run `agent flare` and check that the flare contains the logs of all the agents and not only those of the core agent.
