### PR TITLE
[datadogmonitor] make improvements to kubectl get output

### DIFF
--- a/api/v1alpha1/datadogmonitor_types.go
+++ b/api/v1alpha1/datadogmonitor_types.go
@@ -118,6 +118,12 @@ type DatadogMonitorStatus struct {
 	Created *metav1.Time `json:"created,omitempty"`
 	// MonitorState is the overall state of monitor
 	MonitorState DatadogMonitorState `json:"monitorState,omitempty"`
+	// MonitorStateLastUpdateTime is the last time the monitor state updated
+	MonitorStateLastUpdateTime *metav1.Time `json:"monitorStateLastUpdateTime,omitempty"`
+	// MonitorStateLastTransitionTime is the last time the monitor state changed
+	MonitorStateLastTransitionTime *metav1.Time `json:"monitorStateLastTransitionTime,omitempty"`
+	// SyncStatus shows the health of syncing the monitor state to Datadog
+	SyncStatus SyncStatusMessage `json:"syncStatus,omitempty"`
 	// TriggeredState only includes details for monitor groups that are triggering
 	TriggeredState []DatadogMonitorTriggeredState `json:"triggeredState,omitempty"`
 	// DowntimeStatus defines whether the monitor is downtimed
@@ -187,6 +193,20 @@ const (
 	DatadogMonitorStateUnknown DatadogMonitorState = "Unknown"
 )
 
+// SyncStatusMessage is the message reflecting the health of monitor state syncs to Datadog
+type SyncStatusMessage string
+
+const (
+	// SyncStatusOK means syncing is OK
+	SyncStatusOK SyncStatusMessage = "OK"
+	// SyncStatusValidateError means there is a monitor validation error
+	SyncStatusValidateError SyncStatusMessage = "error validating monitor"
+	// SyncStatusUpdateError means there is a monitor update error
+	SyncStatusUpdateError SyncStatusMessage = "error updating monitor"
+	// SyncStatusGetError means there is an error getting the monitor
+	SyncStatusGetError SyncStatusMessage = "error getting monitor"
+)
+
 // DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
 // The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
 type DatadogMonitorTriggeredState struct {
@@ -208,8 +228,10 @@ type DatadogMonitorDowntimeStatus struct {
 // +kubebuilder:resource:path=datadogmonitors,scope=Namespaced
 // +kubebuilder:printcolumn:name="id",type="string",JSONPath=".status.id"
 // +kubebuilder:printcolumn:name="monitor state",type="string",JSONPath=".status.monitorState"
-// +kubebuilder:printcolumn:name="created",type="string",JSONPath=".status.conditions[?(@.type=='Created')].lastUpdateTime"
-// +kubebuilder:printcolumn:name="last updated",type="string",JSONPath=".status.conditions[?(@.type=='Updated')].lastUpdateTime"
+// +kubebuilder:printcolumn:name="last transition",type="string",JSONPath=".status.monitorStateLastTransitionTime"
+// +kubebuilder:printcolumn:name="last sync",type="string",format="date",JSONPath=".status.monitorStateLastUpdateTime"
+// +kubebuilder:printcolumn:name="sync status",type="string",JSONPath=".status.syncStatus"
+// +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:openapi-gen=true
 // +genclient
 type DatadogMonitor struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1263,6 +1263,14 @@ func (in *DatadogMonitorStatus) DeepCopyInto(out *DatadogMonitorStatus) {
 		in, out := &in.Created, &out.Created
 		*out = (*in).DeepCopy()
 	}
+	if in.MonitorStateLastUpdateTime != nil {
+		in, out := &in.MonitorStateLastUpdateTime, &out.MonitorStateLastUpdateTime
+		*out = (*in).DeepCopy()
+	}
+	if in.MonitorStateLastTransitionTime != nil {
+		in, out := &in.MonitorStateLastTransitionTime, &out.MonitorStateLastTransitionTime
+		*out = (*in).DeepCopy()
+	}
 	if in.TriggeredState != nil {
 		in, out := &in.TriggeredState, &out.TriggeredState
 		*out = make([]DatadogMonitorTriggeredState, len(*in))

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -23,12 +23,19 @@ spec:
     - jsonPath: .status.monitorState
       name: monitor state
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Created')].lastUpdateTime
-      name: created
+    - jsonPath: .status.monitorStateLastTransitionTime
+      name: last transition
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Updated')].lastUpdateTime
-      name: last updated
+    - format: date
+      jsonPath: .status.monitorStateLastUpdateTime
+      name: last sync
       type: string
+    - jsonPath: .status.syncStatus
+      name: sync status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -237,10 +244,24 @@ spec:
               monitorState:
                 description: MonitorState is the overall state of monitor
                 type: string
+              monitorStateLastTransitionTime:
+                description: MonitorStateLastTransitionTime is the last time the monitor
+                  state changed
+                format: date-time
+                type: string
+              monitorStateLastUpdateTime:
+                description: MonitorStateLastUpdateTime is the last time the monitor
+                  state updated
+                format: date-time
+                type: string
               primary:
                 description: Primary defines whether the monitor is managed by the
                   Kubernetes custom resource (true) or outside Kubernetes (false)
                 type: boolean
+              syncStatus:
+                description: SyncStatus shows the health of syncing the monitor state
+                  to Datadog
+                type: string
               triggeredState:
                 description: TriggeredState only includes details for monitor groups
                   that are triggering

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -13,12 +13,19 @@ spec:
   - JSONPath: .status.monitorState
     name: monitor state
     type: string
-  - JSONPath: .status.conditions[?(@.type=='Created')].lastUpdateTime
-    name: created
+  - JSONPath: .status.monitorStateLastTransitionTime
+    name: last transition
     type: string
-  - JSONPath: .status.conditions[?(@.type=='Updated')].lastUpdateTime
-    name: last updated
+  - JSONPath: .status.monitorStateLastUpdateTime
+    format: date
+    name: last sync
     type: string
+  - JSONPath: .status.syncStatus
+    name: sync status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
   group: datadoghq.com
   names:
     kind: DatadogMonitor
@@ -232,10 +239,24 @@ spec:
             monitorState:
               description: MonitorState is the overall state of monitor
               type: string
+            monitorStateLastTransitionTime:
+              description: MonitorStateLastTransitionTime is the last time the monitor
+                state changed
+              format: date-time
+              type: string
+            monitorStateLastUpdateTime:
+              description: MonitorStateLastUpdateTime is the last time the monitor
+                state updated
+              format: date-time
+              type: string
             primary:
               description: Primary defines whether the monitor is managed by the Kubernetes
                 custom resource (true) or outside Kubernetes (false)
               type: boolean
+            syncStatus:
+              description: SyncStatus shows the health of syncing the monitor state
+                to Datadog
+              type: string
             triggeredState:
               description: TriggeredState only includes details for monitor groups
                 that are triggering

--- a/controllers/datadogmonitor/controller_test.go
+++ b/controllers/datadogmonitor/controller_test.go
@@ -387,6 +387,7 @@ func newRequest(ns, name string) reconcile.Request {
 func Test_convertStateToStatus(t *testing.T) {
 	triggerTs := int64(1612244495)
 	secondTriggerTs := triggerTs + 300
+	now := metav1.Unix(secondTriggerTs, 0)
 
 	okState := datadogapiclientv1.MONITOROVERALLSTATES_OK
 	alertState := datadogapiclientv1.MONITOROVERALLSTATES_ALERT
@@ -593,7 +594,7 @@ func Test_convertStateToStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			convertStateToStatus(tt.monitor(), tt.status)
+			convertStateToStatus(tt.monitor(), tt.status, now)
 
 			assert.Equal(t, tt.wantStatus.TriggeredState, tt.status.TriggeredState)
 			assert.Equal(t, tt.wantStatus.MonitorState, tt.status.MonitorState)

--- a/controllers/datadogmonitor/finalizer.go
+++ b/controllers/datadogmonitor/finalizer.go
@@ -14,6 +14,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 )
 
 const (
@@ -55,8 +56,10 @@ func (r *Reconciler) finalizeDatadogMonitor(logger logr.Logger, dm *datadoghqv1a
 			logger.Error(err, "failed to finalize monitor", "Monitor ID", fmt.Sprint(dm.Status.ID))
 			return
 		}
+		logger.Info("Successfully finalized DatadogMonitor", "Monitor ID", fmt.Sprint(dm.Status.ID))
+		event := buildEventInfo(dm.Name, dm.Namespace, datadog.DeletionEvent)
+		r.recordEvent(dm, event)
 	}
-	logger.Info("Successfully finalized DatadogMonitor", "Monitor ID", fmt.Sprint(dm.Status.ID))
 }
 
 func (r *Reconciler) addFinalizer(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) error {


### PR DESCRIPTION
### What does this PR do?

Improve output of `kubectl get datadogmonitor` from

```
$ k get datadogmonitor -n datadog
NAME                   ID         MONITOR STATE   MONITOR CREATED              LAST UPDATED
datadog-monitor-test   33025468   No Data         2021-03-29T17:00:10Z         2021-03-29T16:58:10Z
```


to

```
NAME                     ID         MONITOR STATE   LAST TRANSITION        LAST SYNC              SYNC STATUS                AGE
datadog-monitor-test     33025468   Alert           2021-03-29T17:32:47Z   2021-03-30T12:52:47Z   OK                         19h
datadog-monitor-test-2   33071874   Alert           2021-03-30T12:37:52Z   2021-03-30T12:40:53Z   error validating monitor   6m46s
```


### Motivation

Better user experience

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Build operator, install CRDs, apply `examples/datadogmonitor/datadog-monitor-test.yaml` and ensure `k get` output is as expected. To see an error under `SYNC STATUS`, try updating the example CRD with an invalid query.