### PR TITLE
Fix DCA RBAC for the external metrics provider

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1179,15 +1179,31 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 	}
 
 	if dda.Spec.ClusterAgent.Config.ExternalMetrics != nil && dda.Spec.ClusterAgent.Config.ExternalMetrics.Enabled {
-		rbacRules = append(rbacRules, rbacv1.PolicyRule{
-			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
-			Resources: []string{datadoghqv1alpha1.ConfigMapsResource},
-			ResourceNames: []string{
-				datadoghqv1alpha1.DatadogCustomMetricsResourceName,
-				datadoghqv1alpha1.ExtensionAPIServerAuthResourceName,
+		rbacRules = append(rbacRules,
+			rbacv1.PolicyRule{
+				APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+				Resources: []string{datadoghqv1alpha1.ConfigMapsResource},
+				ResourceNames: []string{
+					datadoghqv1alpha1.DatadogCustomMetricsResourceName,
+				},
+				Verbs: []string{
+					datadoghqv1alpha1.GetVerb,
+					datadoghqv1alpha1.UpdateVerb,
+				},
 			},
-			Verbs: []string{datadoghqv1alpha1.GetVerb, datadoghqv1alpha1.UpdateVerb},
-		})
+			rbacv1.PolicyRule{
+				APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+				Resources: []string{datadoghqv1alpha1.ConfigMapsResource},
+				ResourceNames: []string{
+					datadoghqv1alpha1.ExtensionAPIServerAuthResourceName,
+				},
+				Verbs: []string{
+					datadoghqv1alpha1.GetVerb,
+					datadoghqv1alpha1.ListVerb,
+					datadoghqv1alpha1.WatchVerb,
+				},
+			},
+		)
 
 		if dda.Spec.ClusterAgent.Config.ExternalMetrics.UseDatadogMetrics {
 			rbacRules = append(rbacRules, rbacv1.PolicyRule{
@@ -1376,15 +1392,31 @@ func buildClusterAgentRole(dda *datadoghqv1alpha1.DatadogAgent, name, agentVersi
 	})
 
 	if dda.Spec.ClusterAgent.Config.ExternalMetrics != nil && dda.Spec.ClusterAgent.Config.ExternalMetrics.Enabled {
-		rbacRules = append(rbacRules, rbacv1.PolicyRule{
-			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
-			Resources: []string{datadoghqv1alpha1.ConfigMapsResource},
-			ResourceNames: []string{
-				datadoghqv1alpha1.DatadogCustomMetricsResourceName,
-				datadoghqv1alpha1.ExtensionAPIServerAuthResourceName,
+		rbacRules = append(rbacRules,
+			rbacv1.PolicyRule{
+				APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+				Resources: []string{datadoghqv1alpha1.ConfigMapsResource},
+				ResourceNames: []string{
+					datadoghqv1alpha1.DatadogCustomMetricsResourceName,
+				},
+				Verbs: []string{
+					datadoghqv1alpha1.GetVerb,
+					datadoghqv1alpha1.UpdateVerb,
+				},
 			},
-			Verbs: []string{datadoghqv1alpha1.GetVerb, datadoghqv1alpha1.UpdateVerb},
-		})
+			rbacv1.PolicyRule{
+				APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+				Resources: []string{datadoghqv1alpha1.ConfigMapsResource},
+				ResourceNames: []string{
+					datadoghqv1alpha1.ExtensionAPIServerAuthResourceName,
+				},
+				Verbs: []string{
+					datadoghqv1alpha1.GetVerb,
+					datadoghqv1alpha1.ListVerb,
+					datadoghqv1alpha1.WatchVerb,
+				},
+			},
+		)
 	}
 
 	role.Rules = rbacRules


### PR DESCRIPTION
### What does this PR do?

Fix the DCA RBAC.
Since the migration of the DCA to the `go-client` 1.18, the DCA needs some additional permissions to register an external metrics provider.

### Motivation

Make the operator future proof for the next DCA release.

### Additional Notes

This is a port of DataDog/helm-charts#210.

### Describe your test plan

Check that the external metrics provider works with the `master` branch of the DCA.
