### PR TITLE
Fix `system-probe` and `process-agent` config arg

### DIFF
--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1082,7 +1082,7 @@ func defaultSystemProbePodSpec() corev1.PodSpec {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"/opt/datadog-agent/embedded/bin/system-probe",
-					"-config=/etc/datadog-agent/system-probe.yaml",
+					"--config=/etc/datadog-agent/system-probe.yaml",
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
@@ -1155,7 +1155,7 @@ func defaultOrchestratorPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodS
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"process-agent",
-					"-config=/etc/datadog-agent/datadog.yaml",
+					"--config=/etc/datadog-agent/datadog.yaml",
 				},
 				Resources:    corev1.ResourceRequirements{},
 				Env:          defaultOrchestratorEnvVars(dda),
@@ -1358,7 +1358,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"/opt/datadog-agent/embedded/bin/system-probe",
-					"-config=/etc/datadog-agent/system-probe.yaml",
+					"--config=/etc/datadog-agent/system-probe.yaml",
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -310,7 +310,7 @@ func getProcessContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Contain
 		ImagePullPolicy: *agentSpec.Image.PullPolicy,
 		Command: []string{
 			"process-agent",
-			"-config=/etc/datadog-agent/datadog.yaml",
+			"--config=/etc/datadog-agent/datadog.yaml",
 		},
 		Env:          envVars,
 		VolumeMounts: getVolumeMountsForProcessAgent(dda),
@@ -335,7 +335,7 @@ func getSystemProbeContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Con
 		ImagePullPolicy: *agentSpec.Image.PullPolicy,
 		Command: []string{
 			"/opt/datadog-agent/embedded/bin/system-probe",
-			fmt.Sprintf("-config=%s", datadoghqv1alpha1.SystemProbeConfigVolumePath),
+			fmt.Sprintf("--config=%s", datadoghqv1alpha1.SystemProbeConfigVolumePath),
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
### What does this PR do?

From version `7.28.0` the `system-probe` agent will not support the
argument `-config` but instead `-c` or `--config`.
After some test `--config` is also supported by version <= 7.27.0.
So to be compatible with any `system-probe` version, the operator
is using `--config` for configuring the `system-probe` container.

Even if the `process-agent` haven't yet migrated to `cobra` fwk. It
it is safer to also use `--config`.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy the agent with the operator. Enable `system-probe` and `process-agent`
Test with image `7.27.0` and `7.28.0-rc.1`. Both install should work.
