### PR TITLE
Add missing argument to process-agent

### DIFF
--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1156,6 +1156,7 @@ func defaultOrchestratorPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodS
 				Command: []string{
 					"process-agent",
 					"--config=/etc/datadog-agent/datadog.yaml",
+					"--sysprobe-config=/etc/datadog-agent/system-probe.yaml",
 				},
 				Resources:    corev1.ResourceRequirements{},
 				Env:          defaultOrchestratorEnvVars(dda),

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -280,7 +280,7 @@ func getAPMAgentContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Contai
 		ImagePullPolicy: *agentSpec.Image.PullPolicy,
 		Command: []string{
 			"trace-agent",
-			"--config=/etc/datadog-agent/datadog.yaml",
+			fmt.Sprintf("--config=%s", datadoghqv1alpha1.AgentCustomConfigVolumePath),
 		},
 
 		Ports: []corev1.ContainerPort{
@@ -310,7 +310,8 @@ func getProcessContainers(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.Contain
 		ImagePullPolicy: *agentSpec.Image.PullPolicy,
 		Command: []string{
 			"process-agent",
-			"--config=/etc/datadog-agent/datadog.yaml",
+			fmt.Sprintf("--config=%s", datadoghqv1alpha1.AgentCustomConfigVolumePath),
+			fmt.Sprintf("--sysprobe-config=%s", datadoghqv1alpha1.SystemProbeConfigVolumePath),
 		},
 		Env:          envVars,
 		VolumeMounts: getVolumeMountsForProcessAgent(dda),
@@ -377,7 +378,7 @@ func getSecurityAgentContainer(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Con
 		Command: []string{
 			"security-agent",
 			"start",
-			"-c=/etc/datadog-agent/datadog.yaml",
+			fmt.Sprintf("-c=%s", datadoghqv1alpha1.AgentCustomConfigVolumePath),
 		},
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
### What does this PR do?

* Add missing `--sysprobe-config` argument to the `process-agent`.
* Use `const value` for the configuration files in `container` spec creation.

### Motivation

Fix process-agent configuration.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy the agent with `process-agent` and `system-probe` enable. Check that the `process-agent` have the `--sysprobe-config` argument.
