### PR TITLE
better handle DD_CLUSTER_NAME env var in cluster agent and cluster worker when not set

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -527,10 +527,6 @@ func getEnvVarsForClusterAgent(logger logr.Logger, dda *datadoghqv1alpha1.Datado
 
 	envVars := []corev1.EnvVar{
 		{
-			Name:  datadoghqv1alpha1.DDClusterName,
-			Value: spec.ClusterName,
-		},
-		{
 			Name:  datadoghqv1alpha1.DDClusterChecksEnabled,
 			Value: datadoghqv1alpha1.BoolToString(spec.ClusterAgent.Config.ClusterChecksEnabled),
 		},
@@ -554,6 +550,13 @@ func getEnvVarsForClusterAgent(logger logr.Logger, dda *datadoghqv1alpha1.Datado
 			Name:  datadoghqv1alpha1.DDCollectKubeEvents,
 			Value: datadoghqv1alpha1.BoolToString(spec.ClusterAgent.Config.CollectEvents),
 		},
+	}
+
+	if spec.ClusterName != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDClusterName,
+			Value: spec.ClusterName,
+		})
 	}
 
 	if complianceEnabled {

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -76,10 +76,6 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
-			Name:  "DD_CLUSTER_NAME",
-			Value: "",
-		},
-		{
 			Name:  "DD_CLUSTER_CHECKS_ENABLED",
 			Value: "false",
 		},
@@ -120,10 +116,6 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 
 func clusterAgentWithAdmissionControllerDefaultEnvVars(serviceName string, unlabelled bool) []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{
-			Name:  "DD_CLUSTER_NAME",
-			Value: "",
-		},
 		{
 			Name:  "DD_CLUSTER_CHECKS_ENABLED",
 			Value: "false",

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -328,10 +328,6 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 	spec := &dda.Spec
 	envVars := []corev1.EnvVar{
 		{
-			Name:  datadoghqv1alpha1.DDClusterName,
-			Value: spec.ClusterName,
-		},
-		{
 			Name:      datadoghqv1alpha1.DDAPIKey,
 			ValueFrom: getAPIKeyFromSecret(dda),
 		},
@@ -395,6 +391,13 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 				},
 			},
 		},
+	}
+
+	if spec.ClusterName != "" {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDClusterName,
+			Value: spec.ClusterName,
+		})
 	}
 
 	if spec.Site != "" {

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -128,10 +128,6 @@ func clusterChecksRunnerDefaultVolumes() []corev1.Volume {
 func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
-			Name:  "DD_CLUSTER_NAME",
-			Value: "",
-		},
-		{
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
 		},


### PR DESCRIPTION
### What does this PR do?

If the cluster name is not set in the `DatadogAgent` spec, don't set the `DD_CLUSTER_NAME` env var in the cluster agent and cluster worker. This changes makes handling the same as is done in the [agent](https://github.com/DataDog/datadog-operator/blob/main/controllers/datadogagent/utils.go#L565).


### Motivation

Prevents issue where `DD_CLUSTER_NAME` is set twice (leading to a race) if the env var is set explicitly in cluster agent or cluster worker config.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy a `DatadogAgent` without `spec.ClusterName` set and make sure `DD_CLUSTER_NAME` env var is not set. 

Also try explicitly setting `DD_CLUSTER_NAME` env var in the config and make sure there are no duplicates.