### PR TITLE
Fix process collection config option

### DIFF
--- a/examples/datadogagent/datadog-agent-all.yaml
+++ b/examples/datadogagent/datadog-agent-all.yaml
@@ -13,7 +13,7 @@ spec:
       enabled: true
     process:
       enabled: true
-      processCollection: true
+      processCollectionEnabled: true
     log:
       enabled: true
     systemProbe:


### PR DESCRIPTION
### What does this PR do?

As stated in the docs, the config option to enable process monitoring is `agent.process.processCollectionEnabled`, not `agent.process.processCollection`

The current example is broken. This PR fixes it.

