### PR TITLE
Discourage putting plain text secrets in the DatadogAgent CRDs

### DIFF
--- a/docs/cluster_agent_setup.md
+++ b/docs/cluster_agent_setup.md
@@ -68,4 +68,4 @@ datadog-cluster-agent-9f9c5c4c-pmhqb         1/1     Running   0          58s
 datadog-agent-hjlbg                          1/1     Running   0          33s
 ```
 
-[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-clusteragent.yaml
+[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-clusteragent.yaml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -293,9 +293,9 @@ spec:
 | features.prometheusScrape.serviceEndpoints | ServiceEndpoints enables generating dedicated checks for service endpoints. |
 | site | The site of the Datadog intake to send Agent data to. Set to 'datadoghq.eu' to send data to the EU site. |
 
-[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-logs-apm.yaml
-[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-logs.yaml
-[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-apm.yaml
-[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-clusteragent.yaml
-[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-tolerations.yaml
+[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-all.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-logs-apm.yaml
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-logs.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-apm.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-clusteragent.yaml
+[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-tolerations.yaml

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -23,6 +23,13 @@ Here are the steps:
    helm install my-datadog-operator datadog/datadog-operator
    ```
 
+1. Create a Kubernetes secret with your API and APP keys
+
+   ```shell
+   kubectl create secret generic datadog-secret --from-literal api-key=<DATADOG_API_KEY> --from-literal app-key=<DATADOG_APP_KEY>
+   ```
+   Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][4]
+
 1. Create a file with the spec of your DatadogAgent deployment configuration. The simplest configuration is:
 
    ```yaml
@@ -32,8 +39,12 @@ Here are the steps:
      name: datadog
    spec:
      credentials:
-       apiKey: <DATADOG_API_KEY>
-       appKey: <DATADOG_APP_KEY>
+       apiSecret:
+         secretName: datadog-secret
+         keyName: api-key
+       appSecret:
+         secretName: datadog-secret
+         keyName: app-key
      agent:
        image:
          name: "gcr.io/datadoghq/agent:latest"
@@ -41,8 +52,6 @@ Here are the steps:
        image:
          name: "gcr.io/datadoghq/cluster-agent:latest"
    ```
-
-   Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][4]
 
 1. Deploy the Datadog agent with the above configuration file:
    ```shell
@@ -55,7 +64,7 @@ The following command deletes all the Kubernetes resources created by the above 
 
 ```shell
 kubectl delete datadogagent datadog
-helm delete datadog
+helm delete my-datadog-operator
 ```
 
 [1]: https://helm.sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,53 +5,29 @@
 Using the Datadog Operator requires the following prerequisites:
 
 - **Kubernetes Cluster version >= v1.14.X**: Tests were done on versions >= `1.14.0`. Still, it should work on versions `>= v1.11.0`. For earlier versions, due to limited CRD support, the operator may not work as expected.
-- [`Helm`][1] for deploying the `Datadog-operator`.
-- [`Kubectl` cli][2] for installing the `Datadog-agent`.
+- [`Helm`][1] for deploying the Datadog Operator.
+- [`Kubectl` cli][2] for installing the `DatadogAgent`.
 
 ## Deploy the Datadog Operator
 
 ### With Helm
 
-To use the Datadog Operator, deploy it in your Kubernetes cluster. Then create a `DatadogAgent` Kubernetes resource that contains the Datadog deployment configuration:
-
-1. Download the [Datadog Operator project zip ball][5]. Source code can be found at [`DataDog/datadog-operator`][6].
-2. Unzip the project, and go into the `./datadog-operator` folder.
-3. Define your namespace and operator:
+To use the Datadog Operator, deploy it in your cluster using the [Datadog Operator Helm chart][3]:
 
    ```shell
-   DD_NAMESPACE="datadog"
-   DD_NAMEOP="ddoperator"
-   ```
-
-4. Create the namespace:
-
-   ```shell
-   kubectl create ns $DD_NAMESPACE
-   ```
-
-5. Install the operator with Helm:
-
-   - Helm v2:
-
-   ```shell
-   helm install --name $DD_NAMEOP -n $DD_NAMESPACE .
-   ```
-
-   - Helm v3:
-
-   ```shell
-   helm install $DD_NAMEOP -n $DD_NAMESPACE .
+   helm repo add datadog https://helm.datadoghq.com
+   helm install my-datadog-operator datadog/datadog-operator
    ```
 
 ### With the Operator Lifecycle Manager
 
-The Datadog Operator deployment with [Operator Lifecycle Manager][7] documentation is available at [operatorhub.io][8].
+The Datadog Operator deployment with [Operator Lifecycle Manager][4] documentation is available at [operatorhub.io][5].
 
 #### Override default Operator configuration
 
-The [Operator Lifecycle Manager][7] framework allows overriding default Operator configuration. See the [Subscription Config][9] document for a list of the supported installation configuration parameters.
+The [Operator Lifecycle Manager][4] framework allows overriding default Operator configuration. See the [Subscription Config][6] document for a list of the supported installation configuration parameters.
 
-For example, the Datadog Operator's Pod resources are changed with the following [Operator Lifecycle Manager][7] `Subscription`:
+For example, the Datadog Operator's Pod resources are changed with the following [Operator Lifecycle Manager][4] `Subscription`:
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -76,47 +52,51 @@ spec:
 
 ## Deploy the Datadog Agents with the operator
 
-After deploying the Datadog Operator, create the `DatadogAgent` resource that triggers the Datadog Agent's deployment in your Kubernetes cluster. By creating this resource in the `Datadog-Operator` namespace, the Agent will be deployed as a `DaemonSet` on every `Node` of your cluster.
+After deploying the Datadog Operator, create the `DatadogAgent` resource that triggers the Datadog Agent's deployment in your Kubernetes cluster. By creating this resource, the Agent will be deployed as a `DaemonSet` on every `Node` of your cluster.
 
-The following [`datadog-agent.yaml` file][10] is the simplest configuration for the Datadog Operator:
+1. Create a Kubernetes secret with your API and APP keys
 
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  credentials:
-    apiKey: "<DATADOG_API_KEY>"
-    appKey: "<DATADOG_APP_KEY>"
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-```
+   ```shell
+   kubectl create secret generic datadog-secret --from-literal api-key=<DATADOG_API_KEY> --from-literal app-key=<DATADOG_APP_KEY>
+   ```
+   Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][7]
 
-Replace `<DATADOG_API_KEY>` and `<DATADOG_APP_KEY>` with your [Datadog API and application keys][11], then trigger the Agent installation with the following command:
+1. Create a file with the spec of your DatadogAgent deployment configuration. The simplest configuration is:
 
-```shell
-$ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
-datadogagent.datadoghq.com/datadog created
-```
+   ```yaml
+   apiVersion: datadoghq.com/v1alpha1
+   kind: DatadogAgent
+   metadata:
+     name: datadog
+   spec:
+     credentials:
+       apiSecret:
+         secretName: datadog-secret
+         keyName: api-key
+       appSecret:
+         secretName: datadog-secret
+         keyName: app-key
+     agent:
+       image:
+         name: "gcr.io/datadoghq/agent:latest"
+     clusterAgent:
+       image:
+         name: "gcr.io/datadoghq/cluster-agent:latest"
+   ```
 
-You can check the state of the `DatadogAgent` ressource with:
-
-```shell
-kubectl get -n $DD_NAMESPACE dd datadog
-NAME            ACTIVE   AGENT             CLUSTER-AGENT   CLUSTER-CHECKS-RUNNER   AGE
-datadog-agent   True     Running (2/2/2)                                           110m
-```
+1. Deploy the Datadog agent with the above configuration file:
+   ```shell
+   kubectl apply -f agent_spec=/path/to/your/datadog-agent.yaml
+   ```
 
 In a 2-worker-nodes cluster, you should see the Agent pods created on each node.
 
 ```shell
-$ kubectl get -n $DD_NAMESPACE daemonset
+$ kubectl get daemonset
 NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
 datadog-agent   2         2         2       2            2           <none>          5m30s
 
-$ kubectl get -n $DD_NAMESPACE pod -owide
+$ kubectl get pod -owide
 NAME                                         READY   STATUS    RESTARTS   AGE     IP            NODE
 agent-datadog-operator-d897fc9b-7wbsf        1/1     Running   0          1h      10.244.2.11   kind-worker
 datadog-agent-k26tp                          1/1     Running   0          5m59s   10.244.2.13   kind-worker
@@ -125,25 +105,31 @@ datadog-agent-zcxx7                          1/1     Running   0          5m59s 
 
 ### Tolerations
 
-Update your [`datadog-agent.yaml` file][12] with the following configuration to add the toleration in the `Daemonset.spec.template` of your `DaemonSet` :
+Update your [`datadog-agent.yaml` file][8] with the following configuration to add the toleration in the `Daemonset.spec.template` of your `DaemonSet` :
 
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  credentials:
-    apiKey: "<DATADOG_API_KEY>"
-    appKey: "<DATADOG_APP_KEY>"
-  agent:
-    image:
-      name: "gcr.io/datadoghq/agent:latest"
-    config:
-      tolerations:
-       - operator: Exists
-```
-
+   ```yaml
+   apiVersion: datadoghq.com/v1alpha1
+   kind: DatadogAgent
+   metadata:
+     name: datadog
+   spec:
+     credentials:
+       apiSecret:
+         secretName: datadog-secret
+         keyName: api-key
+       appSecret:
+         secretName: datadog-secret
+         keyName: app-key
+     agent:
+       image:
+         name: "gcr.io/datadoghq/agent:latest"
+       config:
+         tolerations:
+          - operator: Exists
+     clusterAgent:
+       image:
+         name: "gcr.io/datadoghq/cluster-agent:latest"
+   ```
 Apply this new configuration:
 
 ```shell
@@ -154,11 +140,11 @@ datadogagent.datadoghq.com/datadog updated
 The DaemonSet update can be validated by looking at the new desired pod value:
 
 ```shell
-$ kubectl get -n $DD_NAMESPACE daemonset
+$ kubectl get daemonset
 NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
 datadog-agent   3         3         3       3            3           <none>          7m31s
 
-$ kubectl get -n $DD_NAMESPACE pod
+$ kubectl get pod
 NAME                                         READY   STATUS     RESTARTS   AGE
 agent-datadog-operator-d897fc9b-7wbsf        1/1     Running    0          15h
 datadog-agent-5ctrq                          1/1     Running    0          7m43s
@@ -175,25 +161,21 @@ datadog-agent-zvdbw                          1/1     Running    0          8m1s
 The following command deletes all the Kubernetes resources created by the Datadog Operator and the linked `DatadogAgent` `datadog`.
 
 ```shell
-$ kubectl delete -n $DD_NAMESPACE datadogagent datadog
+$ kubectl delete datadogagent datadog
 datadogagent.datadoghq.com/datadog deleted
 ```
 
-You can then remove the Datadog-Operator with the `helm delete` command:
+You can then remove the Datadog Operator with the `helm delete` command:
 
 ```shell
-helm delete $DD_NAMEOP -n $DD_NAMESPACE
+helm delete my-datadog-operator
 ```
 
 [1]: https://helm.sh
 [2]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
-[3]: https://www.openshift.com/learn/topics/operators
-[4]: https://github.com/operator-framework/operator-sdk
-[5]: https://github.com/DataDog/datadog-operator/releases/latest
-[6]: https://github.com/DataDog/datadog-operator
-[7]: https://olm.operatorframework.io/
-[8]: https://operatorhub.io/operator/datadog-operator
-[9]: https://github.com/operator-framework/operator-lifecycle-manager/blob/main/doc/design/subscription-config.md#subscription-config
-[10]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent.yaml
-[11]: https://app.datadoghq.com/account/settings#api
-[12]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-tolerations.yaml
+[3]: https://artifacthub.io/packages/helm/datadog/datadog-operator
+[4]: https://olm.operatorframework.io/
+[5]: https://operatorhub.io/operator/datadog-operator
+[6]: https://github.com/operator-framework/operator-lifecycle-manager/blob/main/doc/design/subscription-config.md#subscription-config
+[7]: https://app.datadoghq.com/account/settings#api
+[8]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-tolerations.yaml


### PR DESCRIPTION
For the Getting Started and Installation part of the docs, we shouldn't be promoting putting plain text secrets in resource definitions, so people can embrace good practices like GitOps, keeping their K8s configuration in Git
