### PR TITLE
Update system-probe integration for 7.28.0

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -192,6 +192,9 @@ const (
 	DefaultSeccompProfileName         = "localhost/system-probe"
 	SysteProbeAppArmorAnnotationKey   = "container.apparmor.security.beta.kubernetes.io/system-probe"
 	SysteProbeSeccompAnnotationKey    = "container.seccomp.security.alpha.kubernetes.io/system-probe"
+	SystemProbeOSReleaseDirVolumeName = "host-osrelease"
+	SystemProbeOSReleaseDirVolumePath = "/etc/os-release"
+	SystemProbeOSReleaseDirMountPath  = "/host/etc/os-release"
 
 	// Extra config provider names
 

--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -129,6 +129,8 @@ const (
 	ChecksdVolumePath                  = "/checks.d"
 	ConfigVolumeName                   = "config"
 	ConfigVolumePath                   = "/etc/datadog-agent"
+	AuthVolumeName                     = "datadog-agent-auth"
+	AuthVolumePath                     = "/etc/datadog-agent/auth"
 	ProcVolumeName                     = "procdir"
 	ProcVolumePath                     = "/host/proc"
 	ProcVolumeReadOnly                 = true

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -189,6 +189,12 @@ func defaultSystemProbeVolumes() []corev1.Volume {
 			},
 		},
 		{
+			Name: datadoghqv1alpha1.AuthVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -294,6 +300,12 @@ func complianceSecurityAgentVolumes() []corev1.Volume {
 			},
 		},
 		{
+			Name: datadoghqv1alpha1.AuthVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -376,6 +388,12 @@ func runtimeSecurityAgentVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
 			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.AuthVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -484,6 +502,10 @@ func defaultMountVolume() []corev1.VolumeMount {
 			MountPath: "/var/log/datadog",
 		},
 		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+		},
+		{
 			Name:      "installinfo",
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
@@ -528,6 +550,11 @@ func defaultProcessMountVolumes() []corev1.VolumeMount {
 			MountPath: "/var/log/datadog",
 		},
 		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+			ReadOnly:  true,
+		},
+		{
 			Name:      "cgroups",
 			MountPath: "/host/sys/fs/cgroup",
 			ReadOnly:  true,
@@ -562,6 +589,11 @@ func defaultSystemProbeMountVolume() []corev1.VolumeMount {
 			MountPath: "/var/log/datadog",
 		},
 		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+			ReadOnly:  true,
+		},
+		{
 			Name:      "debugfs",
 			MountPath: "/sys/kernel/debug",
 		},
@@ -587,6 +619,11 @@ func complianceSecurityAgentMountVolume() []corev1.VolumeMount {
 		{
 			Name:      "logdatadog",
 			MountPath: "/var/log/datadog",
+		},
+		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+			ReadOnly:  true,
 		},
 		{
 			Name:      "config",
@@ -635,6 +672,11 @@ func runtimeSecurityAgentMountVolume() []corev1.VolumeMount {
 		{
 			Name:      "logdatadog",
 			MountPath: "/var/log/datadog",
+		},
+		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+			ReadOnly:  true,
 		},
 		{
 			Name:      "config",
@@ -924,6 +966,12 @@ func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 				MountPath: "/var/log/datadog",
 			},
 			{
+				Name:      "datadog-agent-auth",
+				MountPath: "/etc/datadog-agent/auth",
+				ReadOnly:  true,
+			},
+
+			{
 				Name:      "config",
 				MountPath: "/etc/datadog-agent",
 			},
@@ -1120,6 +1168,12 @@ func defaultProcessMount() []corev1.Volume {
 	return []corev1.Volume{
 		{
 			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.AuthVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -1425,6 +1479,10 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 			MountPath: "/var/log/datadog",
 		},
 		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+		},
+		{
 			Name:      "installinfo",
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
@@ -1590,6 +1648,12 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 		Volumes: []corev1.Volume{
 			{
 				Name: datadoghqv1alpha1.LogDatadogVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: datadoghqv1alpha1.AuthVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
@@ -1919,6 +1983,12 @@ func Test_newExtendedDaemonSetFromInstance_CustomConfigMaps(t *testing.T) {
 			},
 		},
 		{
+			Name: datadoghqv1alpha1.AuthVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -2046,6 +2116,12 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 			},
 		},
 		{
+			Name: datadoghqv1alpha1.AuthVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -2122,6 +2198,10 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 			MountPath: "/var/log/datadog",
 		},
 		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+		},
+		{
 			Name:      "installinfo",
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
@@ -2167,6 +2247,11 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 		{
 			Name:      "logdatadog",
 			MountPath: "/var/log/datadog",
+		},
+		{
+			Name:      "datadog-agent-auth",
+			MountPath: "/etc/datadog-agent/auth",
+			ReadOnly:  true,
 		},
 		{
 			Name:      "cgroups",

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -181,6 +181,7 @@ func defaultVolumes() []corev1.Volume {
 }
 
 func defaultSystemProbeVolumes() []corev1.Volume {
+	fileOrCreate := corev1.HostPathFileOrCreate
 	return []corev1.Volume{
 		{
 			Name: datadoghqv1alpha1.LogDatadogVolumeName,
@@ -286,6 +287,15 @@ func defaultSystemProbeVolumes() []corev1.Volume {
 			Name: datadoghqv1alpha1.SystemProbeSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumePath,
+					Type: &fileOrCreate,
+				},
 			},
 		},
 	}
@@ -385,6 +395,7 @@ func complianceSecurityAgentVolumes() []corev1.Volume {
 }
 
 func runtimeSecurityAgentVolumes() []corev1.Volume {
+	fileOrCreate := corev1.HostPathFileOrCreate
 	return []corev1.Volume{
 		{
 			Name: datadoghqv1alpha1.LogDatadogVolumeName,
@@ -490,6 +501,15 @@ func runtimeSecurityAgentVolumes() []corev1.Volume {
 			Name: datadoghqv1alpha1.SystemProbeSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumePath,
+					Type: &fileOrCreate,
+				},
 			},
 		},
 	}
@@ -609,6 +629,11 @@ func defaultSystemProbeMountVolume() []corev1.VolumeMount {
 		{
 			Name:      "procdir",
 			MountPath: "/host/proc",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "host-osrelease",
+			MountPath: "/host/etc/os-release",
 			ReadOnly:  true,
 		},
 	}

--- a/controllers/datadogagent/systemprobe.go
+++ b/controllers/datadogagent/systemprobe.go
@@ -95,7 +95,7 @@ runtime_security_config:
     dir: %s
   syscall_monitor:
     enabled: %v
-remote_tagger: %v
+  remote_tagger: %v
 auth_token_file_path: %s
 `
 

--- a/controllers/datadogagent/systemprobe.go
+++ b/controllers/datadogagent/systemprobe.go
@@ -67,6 +67,8 @@ func buildSystemProbeConfigConfiMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev
 				filepath.Join(datadoghqv1alpha1.SystemProbeSocketVolumePath, "runtime-security.sock"),
 				datadoghqv1alpha1.SecurityAgentRuntimePoliciesDirVolumePath,
 				isSyscallMonitorEnabled(&dda.Spec),
+				isRuntimeSecurityEnabled(&dda.Spec), // For now don't expose the remote_tagger setting to user, since it is an implementation detail.
+				filepath.Join(datadoghqv1alpha1.AuthVolumePath, "token"),
 			),
 		},
 	}
@@ -93,6 +95,8 @@ runtime_security_config:
     dir: %s
   syscall_monitor:
     enabled: %v
+remote_tagger: %v
+auth_token_file_path: %s
 `
 
 func buildSystemProbeSecCompConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.ConfigMap, error) {
@@ -263,6 +267,7 @@ const systemProbeSecCompData = `{
 			"stat64",
 			"statfs",
 			"sysinfo",
+			"tgkill",
 			"umask",
 			"uname",
 			"unlink",
@@ -270,7 +275,10 @@ const systemProbeSecCompData = `{
 			"wait4",
 			"waitid",
 			"waitpid",
-			"write"
+			"write",
+			"getgroups",
+			"getpgrp",
+			"setpgid"
 		],
 		"action": "SCMP_ACT_ALLOW",
 		"args": null

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -844,6 +844,7 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
+		getVolumeForAuth(),
 		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -1169,6 +1170,15 @@ func getVolumeForConfig() corev1.Volume {
 	}
 }
 
+func getVolumeForAuth() corev1.Volume {
+	return corev1.Volume{
+		Name: datadoghqv1alpha1.AuthVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
 func getSecCompRootPath(spec *datadoghqv1alpha1.SystemProbeSpec) string {
 	if spec.SecCompRootPath != "" {
 		return spec.SecCompRootPath
@@ -1230,6 +1240,7 @@ func getVolumeMountsForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volum
 			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
 			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
 		},
+		getVolumeMountForAuth(false),
 		{
 			Name:      datadoghqv1alpha1.InstallInfoVolumeName,
 			SubPath:   datadoghqv1alpha1.InstallInfoVolumeSubPath,
@@ -1339,6 +1350,14 @@ func getVolumeMountForConfig(customConfig *datadoghqv1alpha1.CustomConfigSpec) [
 	return volumeMounts
 }
 
+func getVolumeMountForAuth(readOnly bool) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      datadoghqv1alpha1.AuthVolumeName,
+		MountPath: datadoghqv1alpha1.AuthVolumePath,
+		ReadOnly:  readOnly,
+	}
+}
+
 func getVolumeMountForConfd() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      datadoghqv1alpha1.ConfdVolumeName,
@@ -1363,6 +1382,8 @@ func getVolumeMountsForProcessAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev
 			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
 			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
 		},
+		// Add auth token volume mount
+		getVolumeMountForAuth(true),
 		{
 			Name:      datadoghqv1alpha1.CgroupsVolumeName,
 			MountPath: datadoghqv1alpha1.CgroupsVolumePath,
@@ -1432,6 +1453,8 @@ func getVolumeMountsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Vo
 			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
 			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
 		},
+		// Add auth token volume mount
+		getVolumeMountForAuth(true),
 	}
 
 	// APM UDS
@@ -1462,6 +1485,7 @@ func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1
 			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
 			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
 		},
+		getVolumeMountForAuth(true),
 		{
 			Name:      datadoghqv1alpha1.SystemProbeDebugfsVolumeName,
 			MountPath: datadoghqv1alpha1.SystemProbeDebugfsVolumePath,
@@ -1516,6 +1540,7 @@ func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []core
 			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
 			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
 		},
+		getVolumeMountForAuth(true),
 		{
 			Name:      datadoghqv1alpha1.ConfigVolumeName,
 			MountPath: datadoghqv1alpha1.ConfigVolumePath,

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -138,6 +138,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", nil),
 			want: []corev1.VolumeMount{
 				{Name: "logdatadog", MountPath: "/var/log/datadog"},
+				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
 			},
@@ -147,6 +148,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{CustomConfig: customConfig}),
 			want: []corev1.VolumeMount{
 				{Name: "logdatadog", MountPath: "/var/log/datadog"},
+				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "custom-datadog-yaml", ReadOnly: true, MountPath: "/etc/datadog-agent/datadog.yaml", SubPath: "datadog.yaml", SubPathExpr: ""},
 				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
@@ -157,6 +159,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{VolumeMounts: []corev1.VolumeMount{{Name: "extra", MountPath: "/etc/datadog-agent/extra"}}}),
 			want: []corev1.VolumeMount{
 				{Name: "logdatadog", MountPath: "/var/log/datadog"},
+				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "extra", MountPath: "/etc/datadog-agent/extra"},
 				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
@@ -167,6 +170,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{SecuritySpec: securityCompliance}),
 			want: []corev1.VolumeMount{
 				v1.VolumeMount{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
+				v1.VolumeMount{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
 				v1.VolumeMount{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				v1.VolumeMount{Name: "cgroups", ReadOnly: true, MountPath: "/host/sys/fs/cgroup"},
 				v1.VolumeMount{Name: "passwd", ReadOnly: true, MountPath: "/etc/passwd"},
@@ -183,6 +187,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			dda:  testutils.NewDatadogAgent("foo", "bar", "datadog/agent:7", &testutils.NewDatadogAgentOptions{SecuritySpec: securityRuntime}),
 			want: []corev1.VolumeMount{
 				v1.VolumeMount{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
+				v1.VolumeMount{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
 				v1.VolumeMount{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
 				v1.VolumeMount{Name: "sysprobe-socket-dir", ReadOnly: true, MountPath: "/var/run/sysprobe"},
@@ -195,7 +200,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			got := getVolumeMountsForSecurityAgent(tt.dda)
 
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getVolumeMountsForSecurityAgent() = %#v, want %#v", got, tt.want)
+				t.Errorf("getVolumeMountsForSecurityAgent() = %#v,\n want %#v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

* Update `system-probe` seccomp profile.
* Add `remote_tagger` config in `system-probe.yaml`.
* share auth token between agent to allow communication with the core-agent.

### Motivation

Compatibility with the agent `7.28.0`

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy the agent 7.28.0 with the operator. Enable runtime security.
