### PR TITLE
Remove automatic copy of all labels/annotations from DatadogAgent CRD - now only Datadog tags labels will be copied

### DIFF
--- a/api/v1alpha1/datadogagent_types.go
+++ b/api/v1alpha1/datadogagent_types.go
@@ -154,7 +154,7 @@ type DatadogAgentSpecAgentSpec struct {
 	// AdditionalAnnotations provide annotations that will be added to the Agent Pods.
 	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
 
-	// AdditionalLabels provide labels that will be added to the cluster checks runner Pods.
+	// AdditionalLabels provide labels that will be added to the Agent Pods.
 	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
 
 	// If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"
@@ -847,10 +847,10 @@ type DatadogAgentSpecClusterAgentSpec struct {
 	// Number of the Cluster Agent replicas.
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// AdditionalAnnotations provide annotations that will be added to the cluster-agent Pods.
+	// AdditionalAnnotations provide annotations that will be added to the Cluster Agent Pods.
 	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
 
-	// AdditionalLabels provide labels that will be added to the cluster checks runner Pods.
+	// AdditionalLabels provide labels that will be added to the Cluster Agent Pods.
 	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
 
 	// If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -1069,7 +1069,7 @@ func schema__api_v1alpha1_DatadogAgentSpecAgentSpec(ref common.ReferenceCallback
 					},
 					"additionalLabels": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AdditionalLabels provide labels that will be added to the cluster checks runner Pods.",
+							Description: "AdditionalLabels provide labels that will be added to the Agent Pods.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -1245,7 +1245,7 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceC
 					},
 					"additionalAnnotations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AdditionalAnnotations provide annotations that will be added to the cluster-agent Pods.",
+							Description: "AdditionalAnnotations provide annotations that will be added to the Cluster Agent Pods.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -1261,7 +1261,7 @@ func schema__api_v1alpha1_DatadogAgentSpecClusterAgentSpec(ref common.ReferenceC
 					},
 					"additionalLabels": {
 						SchemaProps: spec.SchemaProps{
-							Description: "AdditionalLabels provide labels that will be added to the cluster checks runner Pods.",
+							Description: "AdditionalLabels provide labels that will be added to the Cluster Agent Pods.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -68,7 +68,7 @@ spec:
                     additionalProperties:
                       type: string
                     description: AdditionalLabels provide labels that will be added
-                      to the cluster checks runner Pods.
+                      to the Agent Pods.
                     type: object
                   apm:
                     description: Trace Agent configuration
@@ -3722,13 +3722,13 @@ spec:
                     additionalProperties:
                       type: string
                     description: AdditionalAnnotations provide annotations that will
-                      be added to the cluster-agent Pods.
+                      be added to the Cluster Agent Pods.
                     type: object
                   additionalLabels:
                     additionalProperties:
                       type: string
                     description: AdditionalLabels provide labels that will be added
-                      to the cluster checks runner Pods.
+                      to the Cluster Agent Pods.
                     type: object
                   affinity:
                     description: If specified, the pod's scheduling constraints.

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -66,7 +66,7 @@ spec:
                   additionalProperties:
                     type: string
                   description: AdditionalLabels provide labels that will be added
-                    to the cluster checks runner Pods.
+                    to the Agent Pods.
                   type: object
                 apm:
                   description: Trace Agent configuration
@@ -3593,13 +3593,13 @@ spec:
                   additionalProperties:
                     type: string
                   description: AdditionalAnnotations provide annotations that will
-                    be added to the cluster-agent Pods.
+                    be added to the Cluster Agent Pods.
                   type: object
                 additionalLabels:
                   additionalProperties:
                     type: string
                   description: AdditionalLabels provide labels that will be added
-                    to the cluster checks runner Pods.
+                    to the Cluster Agent Pods.
                   type: object
                 affinity:
                   description: If specified, the pod's scheduling constraints.

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -482,13 +482,8 @@ func newDaemonsetObjectMetaData(dda *datadoghqv1alpha1.DatadogAgent) metav1.Obje
 	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultAgentResourceSuffix, getAgentVersion(dda))
 	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = dda.Name
 	labels[datadoghqv1alpha1.AgentDeploymentComponentLabelKey] = datadoghqv1alpha1.DefaultAgentResourceSuffix
-	for key, val := range dda.Labels {
-		labels[key] = val
-	}
-	annotations := map[string]string{}
-	for key, val := range dda.Annotations {
-		annotations[key] = val
-	}
+
+	annotations := getDefaultAnnotations(dda)
 
 	return metav1.ObjectMeta{
 		Name:        daemonsetName(dda),

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1695,7 +1695,6 @@ func (tests extendedDaemonSetFromInstanceTestSuite) Run(t *testing.T) {
 }
 
 func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
-
 	defaultDatadogAgent := test.NewDefaultedDatadogAgent("bar", "foo", &test.NewDatadogAgentOptions{UseEDS: true, ClusterAgentEnabled: true})
 
 	// Create a Datadog Agent with a custom host port
@@ -1768,7 +1767,7 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 		},
 		{
 			name:            "with labels and annotations",
-			agentdeployment: test.NewDefaultedDatadogAgent("bar", "foo", &test.NewDatadogAgentOptions{UseEDS: true, ClusterAgentEnabled: true, Labels: map[string]string{"label-foo-key": "label-bar-value"}, Annotations: map[string]string{"annotations-foo-key": "annotations-bar-value"}}),
+			agentdeployment: test.NewDefaultedDatadogAgent("bar", "foo", &test.NewDatadogAgentOptions{UseEDS: true, ClusterAgentEnabled: true, Labels: map[string]string{"label-foo-key": "label-bar-value", "tags.datadoghq.com/env": "test"}, Annotations: map[string]string{"annotations-foo-key": "annotations-bar-value"}}),
 			wantErr:         false,
 			want: &edsdatadoghqv1alpha1.ExtendedDaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1777,16 +1776,14 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "agent",
-						"label-foo-key":                 "label-bar-value",
+						"tags.datadoghq.com/env":        "test",
 						"app.kubernetes.io/instance":    "agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
 						"app.kubernetes.io/part-of":     "foo",
 						"app.kubernetes.io/version":     "",
 					},
-					Annotations: map[string]string{
-						"annotations-foo-key": "annotations-bar-value",
-					},
+					Annotations: map[string]string{},
 				},
 				Spec: edsdatadoghqv1alpha1.ExtendedDaemonSetSpec{
 					Template: corev1.PodTemplateSpec{
@@ -1801,7 +1798,9 @@ func Test_newExtendedDaemonSetFromInstance(t *testing.T) {
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
 								"app.kubernetes.io/part-of":     "foo",
 								"app.kubernetes.io/version":     "",
+								"tags.datadoghq.com/env":        "test",
 							},
+							Annotations: map[string]string{},
 						},
 						Spec: defaultPodSpec(defaultDatadogAgent),
 					},
@@ -2283,11 +2282,8 @@ func Test_ExtraParameters(t *testing.T) {
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
 					"app.kubernetes.io/part-of":     "foo",
 					"app.kubernetes.io/version":     "",
-					"bar":                           "foo",
 				},
-				Annotations: map[string]string{
-					"foo": "bar",
-				},
+				Annotations: map[string]string{},
 			},
 			Spec: edsdatadoghqv1alpha1.ExtendedDaemonSetSpec{
 				Template: corev1.PodTemplateSpec{
@@ -2304,9 +2300,7 @@ func Test_ExtraParameters(t *testing.T) {
 							"app.kubernetes.io/version":     "",
 							"pod-foo":                       "bar",
 						},
-						Annotations: map[string]string{
-							"pod-bar": "foo",
-						},
+						Annotations: map[string]string{"pod-bar": "foo"},
 					},
 					Spec: podSpec,
 				},
@@ -2456,7 +2450,6 @@ func Test_newExtendedDaemonSetFromInstance_DaemonSetNameAndSelector(t *testing.T
 }
 
 func Test_newExtendedDaemonSetFromInstance_LogsEnabled(t *testing.T) {
-
 	dda := test.NewDefaultedDatadogAgent("bar", "foo", &test.NewDatadogAgentOptions{
 		UseEDS:              true,
 		ClusterAgentEnabled: true,

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -164,16 +164,9 @@ func (r *Reconciler) updateClusterAgentDeployment(logger logr.Logger, dda *datad
 
 // newClusterAgentDeploymentFromInstance creates a Cluster Agent Deployment from a given DatadogAgent
 func newClusterAgentDeploymentFromInstance(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, selector *metav1.LabelSelector) (*appsv1.Deployment, string, error) {
-	labels := map[string]string{
-		datadoghqv1alpha1.AgentDeploymentNameLabelKey:      dda.Name,
-		datadoghqv1alpha1.AgentDeploymentComponentLabelKey: datadoghqv1alpha1.DefaultClusterAgentResourceSuffix,
-	}
-	for key, val := range dda.Labels {
-		labels[key] = val
-	}
-	for key, val := range getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda)) {
-		labels[key] = val
-	}
+	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
+	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = dda.Name
+	labels[datadoghqv1alpha1.AgentDeploymentComponentLabelKey] = datadoghqv1alpha1.DefaultClusterAgentResourceSuffix
 
 	if selector != nil {
 		for key, val := range selector.MatchLabels {
@@ -188,11 +181,7 @@ func newClusterAgentDeploymentFromInstance(logger logr.Logger, dda *datadoghqv1a
 		}
 	}
 
-	annotations := map[string]string{}
-	for key, val := range dda.Annotations {
-		annotations[key] = val
-	}
-
+	annotations := getDefaultAnnotations(dda)
 	dcaPodTemplate, err := newClusterAgentPodTemplate(logger, dda, labels, annotations)
 	if err != nil {
 		return nil, "", err

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -214,7 +214,8 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
 					Name:      "foo-cluster-agent",
-					Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					Labels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
 						"app.kubernetes.io/instance":    "cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -257,7 +258,8 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
 					Name:      "foo-cluster-agent",
-					Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					Labels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
 						"app.kubernetes.io/instance":    "cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -303,14 +305,13 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"label-foo-key":                 "label-bar-value",
 						"app.kubernetes.io/instance":    "cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
 						"app.kubernetes.io/part-of":     "foo",
 						"app.kubernetes.io/version":     "",
 					},
-					Annotations: map[string]string{"annotations-foo-key": "annotations-bar-value"},
+					Annotations: map[string]string{},
 				},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
@@ -318,14 +319,13 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"label-foo-key":                 "label-bar-value",
 								"app.kubernetes.io/instance":    "cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
 								"app.kubernetes.io/part-of":     "foo",
 								"app.kubernetes.io/version":     "",
 							},
-							Annotations: map[string]string{"annotations-foo-key": "annotations-bar-value"},
+							Annotations: map[string]string{},
 						},
 						Spec: clusterAgentDefaultPodSpec(),
 					},
@@ -415,7 +415,8 @@ func Test_newClusterAgentDeploymentMountKSMCore(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo-cluster-agent",
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
 					"app.kubernetes.io/instance":    "cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -461,7 +462,8 @@ func Test_newClusterAgentPrometheusScrapeEnabled(t *testing.T) {
 			ClusterAgentEnabled: true,
 			Features: &datadoghqv1alpha1.DatadogFeatures{
 				OrchestratorExplorer: &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true)},
-				PrometheusScrape:     &datadoghqv1alpha1.PrometheusScrapeConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true), ServiceEndpoints: datadoghqv1alpha1.NewBoolPointer(true)}},
+				PrometheusScrape:     &datadoghqv1alpha1.PrometheusScrapeConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true), ServiceEndpoints: datadoghqv1alpha1.NewBoolPointer(true)},
+			},
 		},
 	)
 
@@ -477,7 +479,8 @@ func Test_newClusterAgentPrometheusScrapeEnabled(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo-cluster-agent",
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
 					"app.kubernetes.io/instance":    "cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -553,7 +556,8 @@ func Test_newClusterAgentDeploymentFromInstance_UserVolumes(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo-cluster-agent",
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
 					"app.kubernetes.io/instance":    "cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -626,7 +630,8 @@ func Test_newClusterAgentDeploymentFromInstance_EnvVars(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo-cluster-agent",
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
 					"app.kubernetes.io/instance":    "cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -689,7 +694,8 @@ func Test_newClusterAgentDeploymentFromInstance_CustomDeploymentName(t *testing.
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      customDeploymentName,
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
 					"app.kubernetes.io/instance":    "cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -881,7 +887,8 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
 					Name:      "foo-cluster-agent",
-					Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					Labels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
 						"app.kubernetes.io/instance":    "cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -930,7 +937,8 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
 					Name:      "foo-cluster-agent",
-					Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					Labels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
 						"app.kubernetes.io/instance":    "cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -1100,7 +1108,8 @@ func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T)
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
 					Name:      "foo-cluster-agent",
-					Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					Labels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
 						"app.kubernetes.io/instance":    "cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -1150,7 +1159,8 @@ func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T)
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "bar",
 					Name:      "foo-cluster-agent",
-					Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+					Labels: map[string]string{
+						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
 						"app.kubernetes.io/instance":    "cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -1189,7 +1199,6 @@ func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T)
 }
 
 func Test_newClusterAgentDeploymentFromInstance_Compliance(t *testing.T) {
-
 	podSpec := clusterAgentDefaultPodSpec()
 	podSpec.Containers[0].Env = addEnvVar(podSpec.Containers[0].Env, "DD_COMPLIANCE_CONFIG_ENABLED", "true")
 
@@ -1211,7 +1220,8 @@ func Test_newClusterAgentDeploymentFromInstance_Compliance(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo-cluster-agent",
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
 					"app.kubernetes.io/instance":    "cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -156,16 +156,9 @@ func (r *Reconciler) updateClusterChecksRunnerDeployment(logger logr.Logger, dda
 func newClusterChecksRunnerDeploymentFromInstance(
 	dda *datadoghqv1alpha1.DatadogAgent,
 	selector *metav1.LabelSelector) (*appsv1.Deployment, string, error) {
-	labels := map[string]string{
-		datadoghqv1alpha1.AgentDeploymentNameLabelKey:      dda.Name,
-		datadoghqv1alpha1.AgentDeploymentComponentLabelKey: datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix,
-	}
-	for key, val := range dda.Labels {
-		labels[key] = val
-	}
-	for key, val := range getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix, getClusterChecksRunnerVersion(dda)) {
-		labels[key] = val
-	}
+	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix, getClusterChecksRunnerVersion(dda))
+	labels[datadoghqv1alpha1.AgentDeploymentNameLabelKey] = dda.Name
+	labels[datadoghqv1alpha1.AgentDeploymentComponentLabelKey] = datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix
 
 	if selector != nil {
 		for key, val := range selector.MatchLabels {
@@ -180,11 +173,7 @@ func newClusterChecksRunnerDeploymentFromInstance(
 		}
 	}
 
-	annotations := map[string]string{}
-	for key, val := range dda.Annotations {
-		annotations[key] = val
-	}
-
+	annotations := getDefaultAnnotations(dda)
 	dca := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        getClusterChecksRunnerName(dda),

--- a/controllers/datadogagent/const.go
+++ b/controllers/datadogagent/const.go
@@ -30,4 +30,7 @@ const (
 	serviceKind             = "Service"
 	apiServiceKind          = "APIService"
 	networkPolicyKind       = "NetworkPolicy"
+
+	// Datadog tags prefix
+	datadogTagPrefix = "tags.datadoghq.com"
 )

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1738,13 +1738,20 @@ func getDefaultLabels(dda *datadoghqv1alpha1.DatadogAgent, instanceName, version
 	labels[kubernetes.AppKubernetesPartOfLabelKey] = dda.Name
 	labels[kubernetes.AppKubernetesVersionLabelKey] = version
 	labels[kubernetes.AppKubernetesManageByLabelKey] = "datadog-operator"
+
+	// Copy Datadog labels from DDA Labels
+	for k, v := range dda.Labels {
+		if strings.HasPrefix(k, datadogTagPrefix) {
+			labels[k] = v
+		}
+	}
+
 	return labels
 }
 
-func getDefaultAnnotations(dda *datadoghqv1alpha1.DatadogAgent) map[string]string {
-	// TODO implement this method
-	_ = dda.Annotations
-	return make(map[string]string)
+func getDefaultAnnotations(*datadoghqv1alpha1.DatadogAgent) map[string]string {
+	// Currently we don't have any annotation to set by default
+	return map[string]string{}
 }
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ spec:
 | Parameter | Description |
 | --------- | ----------- |
 | agent.additionalAnnotations | AdditionalAnnotations provide annotations that will be added to the Agent Pods. |
-| agent.additionalLabels | AdditionalLabels provide labels that will be added to the cluster checks runner Pods. |
+| agent.additionalLabels | AdditionalLabels provide labels that will be added to the Agent Pods. |
 | agent.apm.enabled | Enable this to enable APM and tracing, on port 8126. See also: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host |
 | agent.apm.env | The Datadog Agent supports many environment variables. See also: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables |
 | agent.apm.hostPort | Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this. |
@@ -185,8 +185,8 @@ spec:
 | agent.systemProbe.securityContext.windowsOptions.gmsaCredentialSpecName | GMSACredentialSpecName is the name of the GMSA credential spec to use. |
 | agent.systemProbe.securityContext.windowsOptions.runAsUserName | The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. |
 | agent.useExtendedDaemonset | UseExtendedDaemonset use ExtendedDaemonset for Agent deployment. default value is false. |
-| clusterAgent.additionalAnnotations | AdditionalAnnotations provide annotations that will be added to the cluster-agent Pods. |
-| clusterAgent.additionalLabels | AdditionalLabels provide labels that will be added to the cluster checks runner Pods. |
+| clusterAgent.additionalAnnotations | AdditionalAnnotations provide annotations that will be added to the Cluster Agent Pods. |
+| clusterAgent.additionalLabels | AdditionalLabels provide labels that will be added to the Cluster Agent Pods. |
 | clusterAgent.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution | The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred. |
 | clusterAgent.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms | Required. A list of node selector terms. The terms are ORed. |
 | clusterAgent.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution | The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred. |


### PR DESCRIPTION
### What does this PR do?

Remove automatic copy of all labels/annotations from DatadogAgent CRD as it triggered copying of unwanted labels (like last-applied) and overwriting others (like kubernetes.io labels)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy Agent through Operator, set custom Labels/Annotations on DatadogAgent object, make sure these Labels/Annotations are not present on created DS/Deployment except Datadog tags labels.
