### PR TITLE
Deactivate DSD in CLC Runners - udpate DCA to new liveness/readiness

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -59,6 +59,7 @@ const (
 	DDLogsConfigContainerCollectAll              = "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL"
 	DDLogsContainerCollectUsingFiles             = "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE"
 	DDLogsConfigOpenFilesLimit                   = "DD_LOGS_CONFIG_OPEN_FILES_LIMIT"
+	DDDogstatsdEnabled                           = "DD_USE_DOGSTATSD"
 	DDDogstatsdOriginDetection                   = "DD_DOGSTATSD_ORIGIN_DETECTION"
 	DDDogstatsdPort                              = "DD_DOGSTATSD_PORT"
 	DDDogstatsdSocket                            = "DD_DOGSTATSD_SOCKET"

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -482,20 +482,10 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 			Name:          "metricsapi",
 			Protocol:      "TCP",
 		})
-		probe := &corev1.Probe{
-			Handler: corev1.Handler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/healthz",
-					Port: intstr.IntOrString{
-						IntVal: port,
-					},
-					Scheme: corev1.URISchemeHTTPS,
-				},
-			},
-		}
-		container.LivenessProbe = probe
-		container.ReadinessProbe = probe
 	}
+
+	container.LivenessProbe = getDefaultLivenessProbe()
+	container.ReadinessProbe = getDefaultReadinessProbe()
 
 	if clusterAgentSpec.Config.Resources != nil {
 		container.Resources = *clusterAgentSpec.Config.Resources

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -357,6 +357,10 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 			Value: "false",
 		},
 		{
+			Name:  datadoghqv1alpha1.DDDogstatsdEnabled,
+			Value: "false",
+		},
+		{
 			Name:  datadoghqv1alpha1.DDEnableMetadataCollection,
 			Value: "false",
 		},

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -168,6 +168,10 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 			Value: "false",
 		},
 		{
+			Name:  "DD_USE_DOGSTATSD",
+			Value: "false",
+		},
+		{
 			Name:  "DD_ENABLE_METADATA_COLLECTION",
 			Value: "false",
 		},
@@ -216,15 +220,6 @@ func (test clusterChecksRunnerDeploymentFromInstanceTest) Run(t *testing.T) {
 		cmp.Diff(got, test.want))
 }
 
-type clusterChecksRunnerDeploymentFromInstanceTestSuite []clusterChecksRunnerDeploymentFromInstanceTest
-
-func (tests clusterChecksRunnerDeploymentFromInstanceTestSuite) Run(t *testing.T) {
-	t.Helper()
-	for _, tt := range tests {
-		t.Run(tt.name, tt.Run)
-	}
-}
-
 func Test_newClusterChecksRunnerDeploymentFromInstance_UserVolumes(t *testing.T) {
 	userVolumes := []corev1.Volume{
 		{
@@ -269,7 +264,8 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_UserVolumes(t *testing.T)
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo-cluster-checks-runner",
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-checks-runner",
 					"app.kubernetes.io/instance":    "cluster-checks-runner",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
@@ -347,7 +343,8 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_EnvVars(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "bar",
 				Name:      "foo-cluster-checks-runner",
-				Labels: map[string]string{"agent.datadoghq.com/name": "foo",
+				Labels: map[string]string{
+					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-checks-runner",
 					"app.kubernetes.io/instance":    "cluster-checks-runner",
 					"app.kubernetes.io/managed-by":  "datadog-operator",


### PR DESCRIPTION
### What does this PR do?

- Deactivate DSD in CLC Runners 
- Udpate DCA to new liveness/readiness

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Deploy an Agent with CLC Runner activated, make sure nothing listens on port 8125 inside CLC container.
- Check Cluster Agent container has liveness/readiness targeting port 5555 `/live` and `/ready`.