### PR TITLE
remove fallback logic for credentials

### DIFF
--- a/api/v1alpha1/datadogagent_types.go
+++ b/api/v1alpha1/datadogagent_types.go
@@ -32,9 +32,8 @@ type DatadogFeatures struct {
 // DatadogAgentSpec defines the desired state of DatadogAgent.
 // +k8s:openapi-gen=true
 type DatadogAgentSpec struct {
-	// Configure the credentials needed to run Agents. If not set, then the credentials
-	// set in the DatadogOperator will be used.
-	Credentials AgentCredentials `json:"credentials,omitempty"`
+	// Configure the credentials needed to run Agents.
+	Credentials AgentCredentials `json:"credentials"`
 
 	// Features running on the Agent and Cluster Agent.
 	// +optional

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -951,7 +951,7 @@ func schema__api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"credentials": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Configure the credentials needed to run Agents. If not set, then the credentials set in the DatadogOperator will be used.",
+							Description: "Configure the credentials needed to run Agents.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("./api/v1alpha1.AgentCredentials"),
 						},
@@ -996,6 +996,7 @@ func schema__api_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallback) common.
 						},
 					},
 				},
+				Required: []string{"credentials"},
 			},
 		},
 		Dependencies: []string{

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -8906,8 +8906,7 @@ spec:
                   Cluster Checks Runner easily.
                 type: string
               credentials:
-                description: Configure the credentials needed to run Agents. If not
-                  set, then the credentials set in the DatadogOperator will be used.
+                description: Configure the credentials needed to run Agents.
                 properties:
                   apiKey:
                     description: 'APIKey Set this to your Datadog API key before the
@@ -9105,6 +9104,8 @@ spec:
                 description: The site of the Datadog intake to send Agent data to.
                   Set to 'datadoghq.eu' to send data to the EU site.
                 type: string
+            required:
+            - credentials
             type: object
           status:
             description: DatadogAgentStatus defines the observed state of DatadogAgent.

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -8613,8 +8613,7 @@ spec:
                 Checks Runner easily.
               type: string
             credentials:
-              description: Configure the credentials needed to run Agents. If not
-                set, then the credentials set in the DatadogOperator will be used.
+              description: Configure the credentials needed to run Agents.
               properties:
                 apiKey:
                   description: 'APIKey Set this to your Datadog API key before the
@@ -8810,6 +8809,8 @@ spec:
               description: The site of the Datadog intake to send Agent data to. Set
                 to 'datadoghq.eu' to send data to the EU site.
               type: string
+          required:
+          - credentials
           type: object
         status:
           description: DatadogAgentStatus defines the observed state of DatadogAgent.

--- a/controllers/datadogagent/secret.go
+++ b/controllers/datadogagent/secret.go
@@ -8,7 +8,6 @@ package datadogagent
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -22,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
-	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/condition"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 )

--- a/controllers/datadogagent/secret.go
+++ b/controllers/datadogagent/secret.go
@@ -128,16 +128,12 @@ func (r *Reconciler) cleanupSecret(namespace, name string, dda *datadoghqv1alpha
 
 func dataFromCredentials(credentials *datadoghqv1alpha1.DatadogCredentials) map[string][]byte {
 	data := make(map[string][]byte)
-	// Create secret using DatadogAgent credentials if it exists, otherwise use Datadog Operator env var
+	// Create secret using DatadogAgent credentials if it exists
 	if credentials.APIKey != "" {
 		data[datadoghqv1alpha1.DefaultAPIKeyKey] = []byte(credentials.APIKey)
-	} else if os.Getenv(config.DDAPIKeyEnvVar) != "" {
-		data[datadoghqv1alpha1.DefaultAPIKeyKey] = []byte(os.Getenv(config.DDAPIKeyEnvVar))
 	}
 	if credentials.AppKey != "" {
 		data[datadoghqv1alpha1.DefaultAPPKeyKey] = []byte(credentials.AppKey)
-	} else if os.Getenv(config.DDAppKeyEnvVar) != "" {
-		data[datadoghqv1alpha1.DefaultAPPKeyKey] = []byte(os.Getenv(config.DDAppKeyEnvVar))
 	}
 
 	return data

--- a/controllers/datadogagent/secret_agent.go
+++ b/controllers/datadogagent/secret_agent.go
@@ -58,6 +58,6 @@ func newAgentSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) (*corev1.S
 // needAgentSecret checks if a secret should be used or created due to the cluster agent being defined, or if any api or app key
 // is configured, AND the secret backend is not used
 func needAgentSecret(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	return (dda.Spec.ClusterAgent != nil || (dda.Spec.Credentials.APIKey != "" || os.Getenv(config.DDAPIKeyEnvVar) != "") || (dda.Spec.Credentials.AppKey != "" || os.Getenv(config.DDAppKeyEnvVar) != "")) &&
+	return (dda.Spec.ClusterAgent != nil || dda.Spec.Credentials.APIKey != "" || dda.Spec.Credentials.AppKey != "") &&
 		!datadoghqv1alpha1.BoolValue(dda.Spec.Credentials.UseSecretBackend)
 }

--- a/controllers/datadogagent/secret_agent.go
+++ b/controllers/datadogagent/secret_agent.go
@@ -7,14 +7,12 @@ package datadogagent
 
 import (
 	"fmt"
-	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
-	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/go-logr/logr"
 )

--- a/controllers/datadogagent/secret_test.go
+++ b/controllers/datadogagent/secret_test.go
@@ -35,33 +35,18 @@ func TestNewAgentSecret(t *testing.T) {
 			fields: fields{
 				DatadogAgentAPIKey: "adflkajdflkjalkcmlkdjacsf",
 				DatadogAgentAppKey: "sgfggtdhfghfghfghfgbdfdgs",
-				APIKeyEnvVar:       "",
-				AppKeyEnvVar:       "",
 			},
 			wantAPIKey: "adflkajdflkjalkcmlkdjacsf",
 			wantAppKey: "sgfggtdhfghfghfghfgbdfdgs",
 		},
 		{
-			name: "API and App keys are set in env vars",
+			name: "API and App keys are empty in the DatadogAgent",
 			fields: fields{
 				DatadogAgentAPIKey: "",
 				DatadogAgentAppKey: "",
-				APIKeyEnvVar:       "zzkjhcoiksncoiquwnzidufnq",
-				AppKeyEnvVar:       "podpogoasdkgpoqiweposdfop",
 			},
-			wantAPIKey: "zzkjhcoiksncoiquwnzidufnq",
-			wantAppKey: "podpogoasdkgpoqiweposdfop",
-		},
-		{
-			name: "API and App keys are set in both the DatadogAgent and env vars",
-			fields: fields{
-				DatadogAgentAPIKey: "adflkajdflkjalkcmlkdjacsf",
-				DatadogAgentAppKey: "sgfggtdhfghfghfghfgbdfdgs",
-				APIKeyEnvVar:       "zzkjhcoiksncoiquwnzidufnq",
-				AppKeyEnvVar:       "podpogoasdkgpoqiweposdfop",
-			},
-			wantAPIKey: "adflkajdflkjalkcmlkdjacsf",
-			wantAppKey: "sgfggtdhfghfghfghfgbdfdgs",
+			wantAPIKey: "",
+			wantAppKey: "",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Do not use (or look for) credentials set in the Operator for DatadogAgent. (Only depend on the DatadogAgent spec.)

### Motivation

The fallback wasn't working properly; removing for now to revisit whether to include this later.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Make sure credentials are required in the DatadogAgent spec and that when included, it works properly