### PR TITLE
add missing permissions

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -31,3 +31,15 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
### What does this PR do?

Add missing permissions in leader election role used in deploys with kustomize

### Motivation

```
{"level":"ERROR","ts":"2021-05-03T14:59:27Z","logger":"controller-runtime.manager.controller.datadogagent","msg":"Reconciler error","reconciler group":"datadoghq.com","reconciler kind":"DatadogAgent","name":"datadog","namespace":"datadog","error":"clusterroles.rbac.authorization.k8s.io \"datadog-agent\" is forbidden: user \"system:serviceaccount:datadog:datadog-operator-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:datadog\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"coordination.k8s.io\"], Resources:[\"leases\"], Verbs:[\"get\"]}"}
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
