### PR TITLE
Fix hack/redhat-bundle.sh script for OSX user

### DIFF
--- a/hack/redhat-bundle.sh
+++ b/hack/redhat-bundle.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source "$(dirname $0)/os-env.sh"
+
 ROOT=$(git rev-parse --show-toplevel)
 RH_BUNDLE_PATH="$ROOT/bundle-redhat"
 RH_BUNDLE_DOCKERFILE="$ROOT/bundle.redhat.Dockerfile"
@@ -25,13 +27,16 @@ LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.delivery.backport=true
 EOF
 
-sed -i 's/operators.operatorframework.io.bundle.package.v1=datadog-operator/operators.operatorframework.io.bundle.package.v1=datadog-operator-certified/g' "$RH_BUNDLE_DOCKERFILE"
-sed -i 's#COPY bundle/#COPY bundle-redhat/#g' "$RH_BUNDLE_DOCKERFILE"
+$SED 's/operators.operatorframework.io.bundle.package.v1=datadog-operator/operators.operatorframework.io.bundle.package.v1=datadog-operator-certified/g' "$RH_BUNDLE_DOCKERFILE"
+$SED 's#COPY bundle/#COPY bundle-redhat/#g' "$RH_BUNDLE_DOCKERFILE"
 
 # Patch annotations.yaml
-sed -i 's/operators.operatorframework.io.bundle.package.v1: datadog-operator/operators.operatorframework.io.bundle.package.v1: datadog-operator-certified/g' "$RH_BUNDLE_PATH/metadata/annotations.yaml"
+$SED 's/operators.operatorframework.io.bundle.package.v1: datadog-operator/operators.operatorframework.io.bundle.package.v1: datadog-operator-certified/g' "$RH_BUNDLE_PATH/metadata/annotations.yaml"
 
 # Patch CSV
-sed -i 's#image: datadog/operator:#image: registry.connect.redhat.com/datadog/operator:#g' "$RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml"
+$SED 's#image: datadog/operator:#image: registry.connect.redhat.com/datadog/operator:#g' "$RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml"
 # Patch images in DatadogAgent examples for bundle validation
-sed -i 's#gcr.io/datadoghq/#datadog/#g' "$RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml"
+$SED 's#gcr.io/datadoghq/#datadog/#g' "$RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml"
+
+# Cleanup .bak files
+find $RH_BUNDLE_PATH -name "*.bak" -type f -delete


### PR DESCRIPTION
### What does this PR do?

Fix hack/redhat-bundle.sh for osx users.

### Motivation

Fix redhat markeplace releasing

### Additional Notes

N/A

### Describe your test plan

Run `make bundle-redhat-build` and check that all the `.bak` files have
been deleted.
