### PR TITLE
Improve support for environment autodiscovery by removing explicit setting of DOCKER_HOST by default with Agent 7.27+

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -13,6 +13,7 @@ core,"github.com/DataDog/datadog-api-client-go/api/v1/datadog",Apache-2.0
 core,"github.com/DataDog/extendeddaemonset/api/v1alpha1",Apache-2.0
 core,"github.com/DataDog/extendeddaemonset/pkg/config",Apache-2.0
 core,"github.com/DataDog/extendeddaemonset/pkg/controller/metrics",Apache-2.0
+core,"github.com/Masterminds/semver/v3",MIT
 core,"github.com/PuerkitoBio/purell",NewBSD
 core,"github.com/PuerkitoBio/urlesc",NewBSD
 core,"github.com/andybalholm/brotli",MIT

--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -8,8 +8,10 @@ package v1alpha1
 import (
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-operator/pkg/utils"
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -498,7 +500,7 @@ func DefaultDatadogAgentSpecAgent(agent *DatadogAgentSpecAgentSpec) *DatadogAgen
 	}
 
 	DefaultDatadogAgentSpecAgentImage(&agent.Image)
-	DefaultDatadogAgentSpecAgentConfig(&agent.Config)
+	DefaultDatadogAgentSpecAgentConfig(agent)
 	DefaultDatadogAgentSpecRbacConfig(&agent.Rbac)
 	agent.DeploymentStrategy = DefaultDatadogAgentSpecDatadogAgentStrategy(agent.DeploymentStrategy)
 	DefaultDatadogAgentSpecAgentApm(&agent.Apm)
@@ -532,52 +534,51 @@ func DefaultDatadogAgentSpecAgentImage(image *ImageConfig) *ImageConfig {
 
 // DefaultDatadogAgentSpecAgentConfig used to default a NodeAgentConfig
 // return the defaulted NodeAgentConfig
-func DefaultDatadogAgentSpecAgentConfig(config *NodeAgentConfig) *NodeAgentConfig {
-	if config == nil {
-		config = &NodeAgentConfig{}
+func DefaultDatadogAgentSpecAgentConfig(agent *DatadogAgentSpecAgentSpec) *NodeAgentConfig {
+	if agent.Config.LogLevel == nil {
+		agent.Config.LogLevel = NewStringPointer(DefaultLogLevel)
 	}
 
-	if config.LogLevel == nil {
-		config.LogLevel = NewStringPointer(DefaultLogLevel)
+	if agent.Config.CollectEvents == nil {
+		agent.Config.CollectEvents = NewBoolPointer(defaultCollectEvents)
 	}
 
-	if config.CollectEvents == nil {
-		config.CollectEvents = NewBoolPointer(defaultCollectEvents)
+	if agent.Config.LeaderElection == nil {
+		agent.Config.LeaderElection = NewBoolPointer(defaultLeaderElection)
 	}
 
-	if config.LeaderElection == nil {
-		config.LeaderElection = NewBoolPointer(defaultLeaderElection)
+	if agent.Config.Resources == nil {
+		agent.Config.Resources = &corev1.ResourceRequirements{}
 	}
 
-	if config.Resources == nil {
-		config.Resources = &corev1.ResourceRequirements{}
+	if agent.Config.CriSocket == nil {
+		agent.Config.CriSocket = &CRISocketConfig{}
 	}
 
-	if config.CriSocket == nil {
-		config.CriSocket = &CRISocketConfig{
-			DockerSocketPath: NewStringPointer(defaultDockerSocketPath),
+	// Don't default Docker/CRI paths with Agent >= 7.27.0
+	// Let Env AD do the work for us
+	agentTag := strings.TrimSuffix(utils.GetTagFromImageName(agent.Image.Name), "-jmx")
+	if !(agentTag == "latest" || utils.IsAboveMinVersion(agentTag, "7.27.0") || utils.IsAboveMinVersion(agentTag, "6.27.0")) {
+		if agent.Config.CriSocket.DockerSocketPath == nil && agent.Config.CriSocket.CriSocketPath == nil {
+			agent.Config.CriSocket.DockerSocketPath = NewStringPointer(defaultDockerSocketPath)
 		}
 	}
 
-	if config.CriSocket.DockerSocketPath == nil {
-		config.CriSocket.DockerSocketPath = NewStringPointer(defaultDockerSocketPath)
+	DefaultConfigDogstatsd(&agent.Config)
+
+	if agent.Config.PodLabelsAsTags == nil {
+		agent.Config.PodLabelsAsTags = map[string]string{}
 	}
 
-	DefaultConfigDogstatsd(config)
-
-	if config.PodLabelsAsTags == nil {
-		config.PodLabelsAsTags = map[string]string{}
+	if agent.Config.PodAnnotationsAsTags == nil {
+		agent.Config.PodAnnotationsAsTags = map[string]string{}
 	}
 
-	if config.PodAnnotationsAsTags == nil {
-		config.PodAnnotationsAsTags = map[string]string{}
+	if agent.Config.Tags == nil {
+		agent.Config.Tags = []string{}
 	}
 
-	if config.Tags == nil {
-		config.Tags = []string{}
-	}
-
-	return config
+	return &agent.Config
 }
 
 // DefaultConfigDogstatsd used to default Dogstatsd config in NodeAgentConfig

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -802,10 +802,6 @@ func defaultEnvVars(extraEnv map[string]string) []corev1.EnvVar {
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
 		},
-		{
-			Name:  "DOCKER_HOST",
-			Value: "unix:///host/var/run/docker.sock",
-		},
 	}
 
 	if ddSite := createEnvFromExtra(extraEnv, "DD_SITE"); ddSite != nil {
@@ -856,10 +852,6 @@ func defaultAPMContainerEnvVars() []corev1.EnvVar {
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
 		},
-		{
-			Name:  "DOCKER_HOST",
-			Value: "unix:///host/var/run/docker.sock",
-		},
 	}
 }
 
@@ -880,10 +872,6 @@ func defaultSystemProbeEnvVars() []corev1.EnvVar {
 					FieldPath: FieldPathStatusHostIP,
 				},
 			},
-		},
-		{
-			Name:  "DOCKER_HOST",
-			Value: "unix:///host/var/run/docker.sock",
 		},
 	}
 }
@@ -946,10 +934,6 @@ func securityAgentEnvVars(compliance, runtime bool, extraEnv map[string]string) 
 		{
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
-		},
-		{
-			Name:  "DOCKER_HOST",
-			Value: "unix:///host/var/run/docker.sock",
 		},
 	}...)
 
@@ -1416,10 +1400,6 @@ func defaultOrchestratorEnvVars(dda *datadoghqv1alpha1.DatadogAgent) []corev1.En
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
 		},
-		{
-			Name:  "DOCKER_HOST",
-			Value: "unix:///host/var/run/docker.sock",
-		},
 	}
 	orchestratorEnvs, _ := orchestrator.EnvVars(&explorerConfig)
 	newVars = append(newVars, orchestratorEnvs...)
@@ -1728,10 +1708,6 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 		{
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
-		},
-		{
-			Name:  "DOCKER_HOST",
-			Value: "unix:///host/var/run/docker.sock",
 		},
 	}
 

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -623,9 +623,11 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 							ClusterAgentEnabled: false,
 							UseEDS:              false,
 							Labels:              map[string]string{"label-foo-key": "label-bar-value"},
-							NodeAgentConfig: datadoghqv1alpha1.DefaultDatadogAgentSpecAgentConfig(&datadoghqv1alpha1.NodeAgentConfig{
-								SecurityContext: &corev1.PodSecurityContext{
-									RunAsUser: datadoghqv1alpha1.NewInt64Pointer(100),
+							NodeAgentConfig: datadoghqv1alpha1.DefaultDatadogAgentSpecAgentConfig(&datadoghqv1alpha1.DatadogAgentSpecAgentSpec{
+								Config: datadoghqv1alpha1.NodeAgentConfig{
+									SecurityContext: &corev1.PodSecurityContext{
+										RunAsUser: datadoghqv1alpha1.NewInt64Pointer(100),
+									},
 								},
 							}),
 						})

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -142,7 +142,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
-				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
+				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run/containerd"},
 			},
 		},
 		{
@@ -154,7 +154,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				{Name: "custom-datadog-yaml", ReadOnly: true, MountPath: "/etc/datadog-agent/datadog.yaml", SubPath: "datadog.yaml", SubPathExpr: ""},
-				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
+				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run/containerd"},
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				{Name: "extra", MountPath: "/etc/datadog-agent/extra"},
-				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
+				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run/containerd"},
 			},
 		},
 		{
@@ -181,8 +181,8 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 				v1.VolumeMount{Name: "passwd", ReadOnly: true, MountPath: "/etc/passwd"},
 				v1.VolumeMount{Name: "group", ReadOnly: true, MountPath: "/etc/group"},
 				v1.VolumeMount{Name: "procdir", ReadOnly: true, MountPath: "/host/proc"},
-				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
-				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/root/var/run"},
+				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run/containerd"},
+				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/root/var/run/containerd"},
 				v1.VolumeMount{Name: "compliancedir", ReadOnly: true, MountPath: "/etc/datadog-agent/compliance.d"},
 			},
 		},
@@ -194,7 +194,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 				v1.VolumeMount{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
 				v1.VolumeMount{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				v1.VolumeMount{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
-				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run"},
+				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run/containerd"},
 				v1.VolumeMount{Name: "sysprobe-socket-dir", ReadOnly: true, MountPath: "/var/run/sysprobe"},
 				v1.VolumeMount{Name: "runtimepoliciesdir", ReadOnly: true, MountPath: "/etc/datadog-agent/runtime-security.d"},
 			},
@@ -205,7 +205,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			got := getVolumeMountsForSecurityAgent(tt.dda)
 
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getVolumeMountsForSecurityAgent() = %#v,\n want %#v", got, tt.want)
+				t.Errorf("getVolumeMountsForSecurityAgent() = %v", cmp.Diff(tt.want, got))
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/DataDog/datadog-api-client-go v1.0.0-beta.18
 	github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/go-logr/logr v0.3.0
 	github.com/go-openapi/spec v0.20.3

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/DataDog/datadog-go v4.4.0+incompatible h1:R7WqXWP4fIOAqWJtUKmSfuc7eDs
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,10 +5,29 @@
 
 package utils
 
+import "strings"
+
 // GetMax returns the larger of two int64 values
 func GetMax(val1, val2 int64) int64 {
 	if val1 >= val2 {
 		return val1
 	}
 	return val2
+}
+
+// GetTagFromImageName returns a tag from a full image name
+// it should cover most cases
+func GetTagFromImageName(imageName string) string {
+	parts := strings.Split(imageName, ":")
+	if len(parts) <= 1 {
+		return "latest"
+	}
+
+	// / are not allowed in tags, we probably caught a :port/<> without tag
+	tag := parts[len(parts)-1]
+	if strings.Contains(tag, "/") {
+		return "latest"
+	}
+
+	return tag
 }

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package utils
+
+import "github.com/Masterminds/semver/v3"
+
+// IsAboveMinVersion uses semver to check if `version` is >= minVersion
+func IsAboveMinVersion(version, minVersion string) bool {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+
+	c, err := semver.NewConstraint(">= " + minVersion)
+	if err != nil {
+		return false
+	}
+
+	return c.Check(v)
+}

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2021 Datadog, Inc.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareVersion(t *testing.T) {
+	testCases := []struct {
+		version    string
+		minVersion string
+		expected   bool
+	}{
+		{
+			version:    "7.27.0",
+			minVersion: "7.26.0-rc.5",
+			expected:   true,
+		},
+		{
+			version:    "6.27.0",
+			minVersion: "6.28.0",
+			expected:   false,
+		},
+		{
+			version:    "foobar",
+			minVersion: "7.28.0",
+			expected:   false,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.version, func(t *testing.T) {
+			result := IsAboveMinVersion(test.version, test.minVersion)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Deploy Agent >= 7.27 with Operator, `DOCKER_HOST` should not be set and `/var/run` should be mounted to `/host/var/run`
- Deploy Agent < 7.27 with Operator, `DOCKER_HOST` should be set and `/var/run` should be mounted to `/host/var/run`
