### PR TITLE
Support KSMCore in DCA mode

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -47,6 +47,7 @@ const (
 	defaultClusterChecksEnabled                          bool   = false
 	DefaultKubeStateMetricsCoreConf                      string = "kube-state-metrics-core-config"
 	defaultKubeStateMetricsCoreEnabled                   bool   = false
+	defaultKubeStateMetricsCoreClusterCheck              bool   = false
 	defaultPrometheusScrapeEnabled                       bool   = false
 	defaultPrometheusScrapeServiceEndpoints              bool   = false
 	defaultClusterAgentReplicas                          int32  = 1
@@ -216,6 +217,10 @@ func IsDefaultedKubeStateMetricsCore(ksmCore *KubeStateMetricsCore) bool {
 	}
 
 	if ksmCore.Enabled == nil {
+		return false
+	}
+
+	if ksmCore.ClusterCheck == nil {
 		return false
 	}
 
@@ -830,6 +835,10 @@ func DefaultDatadogFeatureKubeStateMetricsCore(ksmCore *KubeStateMetricsCore) *K
 
 	if ksmCore.Enabled == nil {
 		ksmCore.Enabled = NewBoolPointer(defaultKubeStateMetricsCoreEnabled)
+	}
+
+	if ksmCore.ClusterCheck == nil {
+		ksmCore.ClusterCheck = NewBoolPointer(defaultKubeStateMetricsCoreClusterCheck)
 	}
 
 	return ksmCore

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -83,7 +83,7 @@ func TestDefaultFeatures(t *testing.T) {
 				Containers: NewBoolPointer(true),
 			},
 		},
-		KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(false)},
+		KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(false), ClusterCheck: NewBoolPointer(false)},
 		PrometheusScrape: &PrometheusScrapeConfig{
 			Enabled:          NewBoolPointer(false),
 			ServiceEndpoints: NewBoolPointer(false),

--- a/api/v1alpha1/datadogagent_types.go
+++ b/api/v1alpha1/datadogagent_types.go
@@ -447,17 +447,21 @@ type ProcessSpec struct {
 }
 
 // KubeStateMetricsCore contains the required parameters to enable and override the configuration
-// of the Kubernetes State Metrics Core (aka v2.0.0) of the check.
+// of the Kubernetes State Metrics Core of the check.
 // +k8s:openapi-gen=true
 type KubeStateMetricsCore struct {
 	// Enable this to start the Kubernetes State Metrics Core check.
-	// Refer to https://github.com/DataDog/datadog-operator/blob/main/docs/kubernetes_state_metrics.md
+	// Refer to https://docs.datadoghq.com/integrations/kubernetes_state_core
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// To override the configuration for the default Kubernetes State Metrics Core check.
 	// Must point to a ConfigMap containing a valid cluster check configuration.
 	Conf *CustomConfigSpec `json:"conf,omitempty"`
+
+	// ClusterCheck configures the Kubernetes State Metrics Core check as a cluster check.
+	// +optional
+	ClusterCheck *bool `json:"clusterCheck,omitempty"`
 }
 
 // OrchestratorExplorerConfig contains the orchestrator explorer configuration.

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -9095,6 +9095,10 @@ spec:
                   kubeStateMetricsCore:
                     description: KubeStateMetricsCore configuration.
                     properties:
+                      clusterCheck:
+                        description: ClusterCheck configures the Kubernetes State
+                          Metrics Core check as a cluster check.
+                        type: boolean
                       conf:
                         description: To override the configuration for the default
                           Kubernetes State Metrics Core check. Must point to a ConfigMap
@@ -9120,7 +9124,7 @@ spec:
                         type: object
                       enabled:
                         description: Enable this to start the Kubernetes State Metrics
-                          Core check. Refer to https://github.com/DataDog/datadog-operator/blob/main/docs/kubernetes_state_metrics.md
+                          Core check. Refer to https://docs.datadoghq.com/integrations/kubernetes_state_core
                         type: boolean
                     type: object
                   logCollection:

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -8787,6 +8787,10 @@ spec:
                 kubeStateMetricsCore:
                   description: KubeStateMetricsCore configuration.
                   properties:
+                    clusterCheck:
+                      description: ClusterCheck configures the Kubernetes State Metrics
+                        Core check as a cluster check.
+                      type: boolean
                     conf:
                       description: To override the configuration for the default Kubernetes
                         State Metrics Core check. Must point to a ConfigMap containing
@@ -8812,7 +8816,7 @@ spec:
                       type: object
                     enabled:
                       description: Enable this to start the Kubernetes State Metrics
-                        Core check. Refer to https://github.com/DataDog/datadog-operator/blob/main/docs/kubernetes_state_metrics.md
+                        Core check. Refer to https://docs.datadoghq.com/integrations/kubernetes_state_core
                       type: boolean
                   type: object
                 logCollection:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: gcr.io/datadoghq/operator
-  newTag: 0.6.0
+  newName: ahmedtest2/operator
+  newTag: ksm
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -138,6 +138,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - replicationcontrollers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - resourcequotas
   verbs:
   - list
@@ -185,6 +192,13 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apiregistration.k8s.io
   resources:
   - apiservices
@@ -225,16 +239,19 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - replicationcontrollers
+  - statefulsets
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
   - apps
+  - extensions
   resources:
-  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
   verbs:
-  - get
   - list
   - watch
 - apiGroups:
@@ -320,6 +337,13 @@ rules:
   - jobs
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
   - list
   - watch
 - apiGroups:
@@ -424,6 +448,13 @@ rules:
   - '*'
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
   - list
   - watch
 - apiGroups:
@@ -561,3 +592,11 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -255,6 +255,7 @@ func (r *Reconciler) manageClusterAgentDependencies(logger logr.Logger, dda *dat
 	if shouldReturn(result, err) {
 		return result, err
 	}
+
 	result, err = r.manageKubeStateMetricsCore(logger, dda)
 	if shouldReturn(result, err) {
 		return result, err
@@ -782,6 +783,17 @@ func (r *Reconciler) manageClusterAgentRBACs(logger logr.Logger, dda *datadoghqv
 			return r.createClusterAgentRoleBinding(logger, dda, info, clusterAgentVersion)
 		}
 		return reconcile.Result{}, err
+	}
+
+	clusterAgentSuffix := "cluster-agent"
+	if isKSMCoreEnabled(dda) && !isKSMCoreClusterCheck(dda) {
+		if result, err := r.createOrUpdateKubeStateMetricsCoreRBAC(logger, dda, serviceAccountName, clusterAgentVersion, clusterAgentSuffix); err != nil {
+			return result, err
+		}
+	} else {
+		if result, err := r.cleanupKubeStateMetricsCoreRBAC(logger, dda, clusterAgentVersion, clusterAgentSuffix); err != nil {
+			return result, err
+		}
 	}
 
 	metricsProviderEnabled := isMetricsProviderEnabled(dda.Spec.ClusterAgent)

--- a/controllers/datadogagent/clusterchecksrunner_rbac_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac_test.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+var kubeStateMetricsRBACName = kubeStateMetricsRBACPrefix + "check-runners"
+
 func TestReconciler_manageClusterChecksRunnerRBACs(t *testing.T) {
 	t.Helper()
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))

--- a/controllers/datadogagent/kubestatemetrics_test.go
+++ b/controllers/datadogagent/kubestatemetrics_test.go
@@ -19,7 +19,7 @@ func TestBuildKubeStateMetricsCoreRBAC(t *testing.T) {
 		},
 	}
 	// verify that default RBAC is sufficient
-	rbac := buildKubeStateMetricsCoreRBAC(dda, kubeStateMetricsRBACName, "1.2.3")
+	rbac := buildKubeStateMetricsCoreRBAC(dda, kubeStateMetricsRBACPrefix, "1.2.3")
 	yamlFile, err := ioutil.ReadFile("./testdata/ksm_clusterrole.yaml")
 	require.NoError(t, err)
 	c := rbacv1.ClusterRole{}
@@ -47,7 +47,8 @@ instances:
 		Spec: datadoghqv1alpha1.DatadogAgentSpec{
 			Features: datadoghqv1alpha1.DatadogFeatures{
 				KubeStateMetricsCore: &datadoghqv1alpha1.KubeStateMetricsCore{
-					Enabled: &enabledBool,
+					Enabled:      &enabledBool,
+					ClusterCheck: &enabledBool,
 				},
 			},
 		},
@@ -56,7 +57,7 @@ instances:
 	cm, err := buildKSMCoreConfigMap(dda)
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%s-%s", dda.Name, datadoghqv1alpha1.DefaultKubeStateMetricsCoreConf), cm.Name)
-	require.Equal(t, cm.Data[ksmCoreCheckName], defaultKSMCoreConfigMap)
+	require.Equal(t, cm.Data[ksmCoreCheckName], ksmCheckConfig(true))
 
 	// override case configData
 	dda.Spec.Features.KubeStateMetricsCore.Conf = &datadoghqv1alpha1.CustomConfigSpec{

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1838,6 +1838,10 @@ func isKSMCoreEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	return datadoghqv1alpha1.BoolValue(dda.Spec.Features.KubeStateMetricsCore.Enabled)
 }
 
+func isKSMCoreClusterCheck(dda *datadoghqv1alpha1.DatadogAgent) bool {
+	return isKSMCoreEnabled(dda) && datadoghqv1alpha1.BoolValue(dda.Spec.Features.KubeStateMetricsCore.ClusterCheck)
+}
+
 func prometheusScrapeEnvVars(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{}
 	if dda.Spec.Features.PrometheusScrape == nil {

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -126,14 +126,16 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=resourcequotas,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=services,verbs=list;watch
-// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=list;watch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;watch
-// +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=list;watch
-// +kubebuilder:rbac:groups=apps,resources=replicationcontrollers,verbs=list;watch
+// +kubebuilder:rbac:groups=apps;extensions,resources=daemonsets;deployments;replicasets,verbs=list;watch
+// +kubebuilder:rbac:groups="",resources=replicationcontrollers,verbs=list;watch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=list;watch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=list;watch
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=list;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=list;watch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=list;watch
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=list;watch
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses;volumeattachments,verbs=list;watch
 
 // Reconcile loop for DatadogAgent.
 func (r *DatadogAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,10 +289,11 @@ spec:
 | credentials.appSecret.secretName | SecretName is the name of the secret. |
 | credentials.token | This needs to be at least 32 characters a-zA-z. It is a preshared key between the node agents and the cluster agent. |
 | credentials.useSecretBackend | UseSecretBackend use the Agent secret backend feature for retreiving all credentials needed by the different components: Agent, Cluster, Cluster-Checks. If `useSecretBackend: true`, other credential parameters will be ignored. default value is false. |
+| features.kubeStateMetricsCore.clusterCheck | ClusterCheck configures the Kubernetes State Metrics Core check as a cluster check. |
 | features.kubeStateMetricsCore.conf.configData | ConfigData corresponds to the configuration file content. |
 | features.kubeStateMetricsCore.conf.configMap.fileKey | FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content. |
 | features.kubeStateMetricsCore.conf.configMap.name | Name the ConfigMap name. |
-| features.kubeStateMetricsCore.enabled | Enable this to start the Kubernetes State Metrics Core check. Refer to https://github.com/DataDog/datadog-operator/blob/main/docs/kubernetes_state_metrics.md |
+| features.kubeStateMetricsCore.enabled | Enable this to start the Kubernetes State Metrics Core check. Refer to https://docs.datadoghq.com/integrations/kubernetes_state_core |
 | features.logCollection.containerCollectUsingFiles | Collect logs from files in `/var/log/pods instead` of using the container runtime API. Collecting logs from files is usually the most efficient way of collecting logs. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default is true |
 | features.logCollection.containerLogsPath | Allows log collection from the container log path. Set to a different path if you are not using the Docker runtime. See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest Defaults to `/var/lib/docker/containers` |
 | features.logCollection.enabled | Enable this option to activate Datadog Agent log collection. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup |


### PR DESCRIPTION
### What does this PR do?

- Support running KSM core in the Cluster Agent (default mode).
- Fixed KSM RBACs
- Refactored the KSM code cluster-check mode

### Motivation

The default mode should only require deploying the Cluster Agent

### Describe your test plan

Configure the `kubeStateMetricsCore` feature section in the `DatadogAgent` spec
```
  features:
    kubeStateMetricsCore:
      enabled: true
```