### PR TITLE
Check Scrubbing for default only if OrchestratorExplorer is enabled

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -194,16 +194,18 @@ func IsDefaultedOrchestratorExplorer(orc *OrchestratorExplorerConfig) bool {
 		return false
 	}
 
-	if orc.Scrubbing == nil {
-		return false
-	}
-
-	if orc.Scrubbing.Containers == nil {
-		return false
-	}
-
 	if orc.Enabled == nil {
 		return false
+	}
+
+	if BoolValue(orc.Enabled) {
+		if orc.Scrubbing == nil {
+			return false
+		}
+
+		if orc.Scrubbing.Containers == nil {
+			return false
+		}
 	}
 
 	return true


### PR DESCRIPTION
### What does this PR do?

`IsDefaultedOrchestratorExplorer` would return `false` for the following
config, since `Scrubbing` would be `nil`:

```
orchestratorExplorer:
  enabled: false
```

Unfortunately, this caused the CR to never be reconciled, since the
defaulting does not add `Scrubbing` if the orchestrator explorer is
disabled.

To work around this, now we only check that `Scrubbing` is defaulted
when the orchestrator explorer is enabled.

### Describe your test plan

Create a `DatadogAgent` with `spec.features.orchestratorExplorer.enabled` set to `false`. Check that agent pods actually get deployed, meaning that the CR was reconciled successfully. Note that taking an existing `DatadogAgent` with the orchestrator explorer enabled, and then disabling it, is not enough to test this change, as the default was already applied.