### PR TITLE
[dca] add daemonsets list/watch for the cluster-agent

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1354,7 +1354,7 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 
 		rbacRules = append(rbacRules, rbacv1.PolicyRule{
 			APIGroups: []string{datadoghqv1alpha1.AppsAPIGroup},
-			Resources: []string{datadoghqv1alpha1.DeploymentsResource, datadoghqv1alpha1.ReplicasetsResource},
+			Resources: []string{datadoghqv1alpha1.DeploymentsResource, datadoghqv1alpha1.ReplicasetsResource, datadoghqv1alpha1.DaemonsetsResource},
 			Verbs:     []string{datadoghqv1alpha1.GetVerb, datadoghqv1alpha1.ListVerb, datadoghqv1alpha1.WatchVerb},
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Adds the daemonsets rbac rules. We already define them here: https://github.com/DataDog/datadog-operator/blob/6a0a7333b9c176651291c8bc6a521b38a39be650/controllers/datadogagent/clusteragent.go#L1270-L1272. But they are only support `GET` while for the orchestrator explorer we need `LIST` and `WATCH` as well.

Related agent PR: https://github.com/DataDog/datadog-agent/pull/8119 (collects daemonsets on the DCA)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
