### PR TITLE
Set runtime security custom policy using config map

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -190,10 +190,11 @@ const (
 
 	HostCriSocketPathPrefix = "/host"
 
-	SecurityAgentRuntimePoliciesDirVolumeName  = "runtimepoliciesdir"
-	SecurityAgentRuntimePoliciesDirVolumePath  = "/etc/datadog-agent/runtime-security.d"
-	SecurityAgentComplianceConfigDirVolumeName = "compliancedir"
-	SecurityAgentComplianceConfigDirVolumePath = "/etc/datadog-agent/compliance.d"
+	SecurityAgentRuntimeCustomPoliciesVolumeName = "customruntimepolicies"
+	SecurityAgentRuntimePoliciesDirVolumeName    = "runtimepoliciesdir"
+	SecurityAgentRuntimePoliciesDirVolumePath    = "/etc/datadog-agent/runtime-security.d"
+	SecurityAgentComplianceConfigDirVolumeName   = "compliancedir"
+	SecurityAgentComplianceConfigDirVolumePath   = "/etc/datadog-agent/compliance.d"
 
 	ClusterAgentCustomConfigVolumeName    = "custom-datadog-yaml"
 	ClusterAgentCustomConfigVolumePath    = "/etc/datadog-agent/datadog-cluster.yaml"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1069,7 +1069,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
-				Args:            []string{"cp -r /etc/datadog-agent /opt"},
+				Args:            []string{"cp -vnr /etc/datadog-agent /opt;cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      datadoghqv1alpha1.ConfigVolumeName,
@@ -1184,7 +1184,7 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
-				Args:            []string{"cp -r /etc/datadog-agent /opt"},
+				Args:            []string{"cp -vnr /etc/datadog-agent /opt;cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      datadoghqv1alpha1.ConfigVolumeName,
@@ -1257,7 +1257,7 @@ func defaultPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSpec {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
-				Args:            []string{"cp -r /etc/datadog-agent /opt"},
+				Args:            []string{"cp -vnr /etc/datadog-agent /opt;cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      datadoghqv1alpha1.ConfigVolumeName,
@@ -1470,7 +1470,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
-				Args:            []string{"cp -r /etc/datadog-agent /opt"},
+				Args:            []string{"cp -vnr /etc/datadog-agent /opt;cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      datadoghqv1alpha1.ConfigVolumeName,
@@ -1579,7 +1579,7 @@ func complianceSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
-				Args:            []string{"cp -r /etc/datadog-agent /opt"},
+				Args:            []string{"cp -vnr /etc/datadog-agent /opt;cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      datadoghqv1alpha1.ConfigVolumeName,
@@ -1771,7 +1771,7 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
-				Args:            []string{"cp -r /etc/datadog-agent /opt"},
+				Args:            []string{"cp -vnr /etc/datadog-agent /opt;cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      datadoghqv1alpha1.ConfigVolumeName,

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -31,7 +31,7 @@ func clusterChecksRunnerDefaultPodSpec() corev1.PodSpec {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
-				Args:            []string{"cp -r /etc/datadog-agent /opt"},
+				Args:            []string{"cp -vnr /etc/datadog-agent /opt;cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      datadoghqv1alpha1.ConfigVolumeName,

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -758,7 +758,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, &test.NewDatadogAgentOptions{ProcessEnabled: true, SystemProbeEnabled: true, ClusterAgentEnabled: false, UseEDS: false, Labels: map[string]string{"label-foo-key": "label-bar-value"}})
 					_ = c.Create(context.TODO(), dda)
 					createAgentDependencies(c, dda)
-					configCM, _ := buildSystemProbeConfigConfiMap(dda)
+					configCM, _ := buildSystemProbeConfigConfigMap(dda)
 					_ = c.Create(context.TODO(), configCM)
 				},
 			},
@@ -2480,7 +2480,7 @@ func hasAllNodeLevelRbacResources(policyRules []rbacv1.PolicyRule) bool {
 }
 
 func createSystemProbeDependencies(c client.Client, dda *datadoghqv1alpha1.DatadogAgent) {
-	configCM, _ := buildSystemProbeConfigConfiMap(dda)
+	configCM, _ := buildSystemProbeConfigConfigMap(dda)
 	securityCM, _ := buildSystemProbeSecCompConfigMap(dda)
 	_ = c.Create(context.TODO(), configCM)
 	_ = c.Create(context.TODO(), securityCM)

--- a/controllers/datadogagent/systemprobe.go
+++ b/controllers/datadogagent/systemprobe.go
@@ -24,7 +24,7 @@ const (
 )
 
 func (r *Reconciler) manageSystemProbeDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
-	result, err := r.manageConfigMap(logger, dda, getSystemProbeConfigConfigMapName(dda), buildSystemProbeConfigConfiMap)
+	result, err := r.manageConfigMap(logger, dda, getSystemProbeConfigConfigMapName(dda), buildSystemProbeConfigConfigMap)
 	if shouldReturn(result, err) {
 		return result, err
 	}
@@ -64,7 +64,7 @@ func getSystemProbeConfigFileName(dda *datadoghqv1alpha1.DatadogAgent) string {
 	return datadoghqv1alpha1.SystemProbeConfigVolumeSubPath
 }
 
-func buildSystemProbeConfigConfiMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.ConfigMap, error) {
+func buildSystemProbeConfigConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.ConfigMap, error) {
 	if !shouldCreateSystemProbeConfigConfigMap(dda) {
 		return nil, nil
 	}

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -196,7 +196,6 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 				v1.VolumeMount{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				v1.VolumeMount{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run/containerd"},
 				v1.VolumeMount{Name: "sysprobe-socket-dir", ReadOnly: true, MountPath: "/var/run/sysprobe"},
-				v1.VolumeMount{Name: "runtimepoliciesdir", ReadOnly: true, MountPath: "/etc/datadog-agent/runtime-security.d"},
 			},
 		},
 	}


### PR DESCRIPTION
Allow either adding a custom policy for runtime security or overriding the default one through a configmap.
Motivation

The default policy is part of the base image but was overridden by the configmap. Every time we bumped the
default policy we had to also bump the configmap. As the policy is tied to the runtime security agent, it
introduced hard to address compatibilities issues.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
