### PR TITLE
Use pod name as cluster check runner ID

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -78,6 +78,7 @@ const (
 	DDKubeStateMetricsCoreConfigMap              = "DD_KUBE_STATE_METRICS_CORE_CONFIGMAP_NAME"
 	DDClcRunnerEnabled                           = "DD_CLC_RUNNER_ENABLED"
 	DDClcRunnerHost                              = "DD_CLC_RUNNER_HOST"
+	DDClcRunnerID                                = "DD_CLC_RUNNER_ID"
 	DDExtraConfigProviders                       = "DD_EXTRA_CONFIG_PROVIDERS"
 	DDExtraListeners                             = "DD_EXTRA_LISTENERS"
 	DDHostname                                   = "DD_HOSTNAME"

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -180,6 +180,14 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 				},
 			},
 		},
+		{
+			Name: "DD_CLC_RUNNER_ID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
 	}
 }
 
@@ -380,14 +388,17 @@ func Test_getPodAffinity(t *testing.T) {
 			affinity: nil,
 			want: &corev1.Affinity{
 				PodAntiAffinity: &corev1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"agent.datadoghq.com/component": "cluster-checks-runner",
+							Weight: 50,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"agent.datadoghq.com/component": "cluster-checks-runner",
+									},
 								},
+								TopologyKey: "kubernetes.io/hostname",
 							},
-							TopologyKey: "kubernetes.io/hostname",
 						},
 					},
 				},

--- a/controllers/datadogagent/const.go
+++ b/controllers/datadogagent/const.go
@@ -15,6 +15,9 @@ const (
 	// FieldPathStatusPodIP used as FieldPath to retrieve the pod ip
 	FieldPathStatusPodIP = "status.podIP"
 
+	// FieldPathMetaName used as FieldPath to retrieve the pod name
+	FieldPathMetaName = "metadata.name"
+
 	// kind names definition
 	extendedDaemonSetKind   = "ExtendedDaemonSet"
 	daemonSetKind           = "DaemonSet"


### PR DESCRIPTION
### What does this PR do?

Use the pod name as cluster check runner ID to allow deploying multiple cluster check runners on the same node. (Requires agent 7.27.0+)

### Additional Notes

Related to https://github.com/DataDog/helm-charts/pull/275

### Describe your test plan

`agent clusterchecks` should show how the cluster agent identifies the runners by their pod names
