### PR TITLE
Only copy runtime policies when enabled

### DIFF
--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -458,6 +458,8 @@ func getConfigInitContainers(spec *datadoghqv1alpha1.DatadogAgentSpec, volumeMou
 		MountPath: "/opt/datadog-agent",
 	}}
 
+	copyCommands := []string{"cp -vnr /etc/datadog-agent /opt"}
+
 	if isRuntimeSecurityEnabled(spec) && spec.Agent.Security.Runtime.PoliciesDir != nil {
 		configVolumeMounts = append(
 			configVolumeMounts,
@@ -470,15 +472,13 @@ func getConfigInitContainers(spec *datadoghqv1alpha1.DatadogAgentSpec, volumeMou
 				MountPath: "/opt/datadog-agent/runtime-security.d",
 			},
 		)
+		copyCommands = append(copyCommands, "cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/")
 	}
 
 	return []corev1.Container{
 		getInitContainer(
 			spec, "init-volume",
-			[]string{
-				"cp -vnr /etc/datadog-agent /opt",
-				"cp -v /etc/datadog-agent-runtime-policies/* /opt/datadog-agent/runtime-security.d/",
-			}, configVolumeMounts, nil,
+			copyCommands, configVolumeMounts, nil,
 			image,
 		),
 		getInitContainer(


### PR DESCRIPTION
### What does this PR do?

Only copy the runtime security policies when runtime security is enabled

### Motivation

When runtime security is not enabled, one init container fails:
```
$ k logs datadog-agent-kmr2q -c init-volume -n datadog
cp: cannot stat '/etc/datadog-agent-runtime-policies/*': No such file or directory
```