### PR TITLE
add host /etc/*-release files to agent container

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -122,9 +122,9 @@ const (
 	DDExternalMetricsProviderAppKey              = "DD_EXTERNAL_METRICS_PROVIDER_APP_KEY"
 	DDAuthTokenFilePath                          = "DD_AUTH_TOKEN_FILE_PATH"
 
-	// KubernetesEnvvarName Env var used by the Datadog Agent container entrypoint
+	// KubernetesEnvVarName Env var used by the Datadog Agent container entrypoint
 	// to add kubelet config provider and listener
-	KubernetesEnvvarName = "KUBERNETES"
+	KubernetesEnvVarName = "KUBERNETES"
 
 	// Datadog volume names and mount paths
 
@@ -188,6 +188,12 @@ const (
 	AgentCustomConfigVolumeSubPath     = "datadog.yaml"
 	KubeletCAVolumeName                = "kubelet-ca"
 	DefaultKubeletAgentCAPath          = "/var/run/host-kubelet-ca.crt"
+	LSBReleaseDirVolumeName            = "host-lsbrelease"
+	LSBReleaseDirVolumePath            = "/etc/lsb-release"
+	LSBReleaseDirMountPath             = "/host/etc/lsb-release"
+	OSReleaseDirVolumeName             = "host-osrelease"
+	OSReleaseDirVolumePath             = "/etc/os-release"
+	OSReleaseDirMountPath              = "/host/etc/os-release"
 
 	HostCriSocketPathPrefix = "/host"
 
@@ -206,9 +212,6 @@ const (
 	DefaultSeccompProfileName         = "localhost/system-probe"
 	SysteProbeAppArmorAnnotationKey   = "container.apparmor.security.beta.kubernetes.io/system-probe"
 	SysteProbeSeccompAnnotationKey    = "container.seccomp.security.alpha.kubernetes.io/system-probe"
-	SystemProbeOSReleaseDirVolumeName = "host-osrelease"
-	SystemProbeOSReleaseDirVolumePath = "/etc/os-release"
-	SystemProbeOSReleaseDirMountPath  = "/host/etc/os-release"
 
 	// Extra config provider names
 

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -289,10 +289,10 @@ func defaultSystemProbeVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumeName,
+			Name: datadoghqv1alpha1.OSReleaseDirVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumePath,
+					Path: datadoghqv1alpha1.OSReleaseDirVolumePath,
 					Type: &fileOrCreate,
 				},
 			},
@@ -503,10 +503,10 @@ func runtimeSecurityAgentVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumeName,
+			Name: datadoghqv1alpha1.OSReleaseDirVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumePath,
+					Path: datadoghqv1alpha1.OSReleaseDirVolumePath,
 					Type: &fileOrCreate,
 				},
 			},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -621,7 +621,7 @@ func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]c
 			Value: getLogLevel(dda),
 		},
 		{
-			Name:  datadoghqv1alpha1.KubernetesEnvvarName,
+			Name:  datadoghqv1alpha1.KubernetesEnvVarName,
 			Value: "yes",
 		},
 	}
@@ -912,6 +912,8 @@ func getEnvVarsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.E
 
 // getVolumesForAgent defines volumes for the Agent
 func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
+	fileOrCreate := corev1.HostPathFileOrCreate
+
 	volumes := []corev1.Volume{
 		{
 			Name: datadoghqv1alpha1.LogDatadogVolumeName,
@@ -946,6 +948,24 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/sys/fs/cgroup",
+				},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.OSReleaseDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: datadoghqv1alpha1.OSReleaseDirVolumePath,
+					Type: &fileOrCreate,
+				},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.LSBReleaseDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: datadoghqv1alpha1.LSBReleaseDirVolumePath,
+					Type: &fileOrCreate,
 				},
 			},
 		},
@@ -1025,7 +1045,6 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 	}
 
 	if isSystemProbeEnabled(&dda.Spec) {
-		fileOrCreate := corev1.HostPathFileOrCreate
 		systemProbeVolumes := []corev1.Volume{
 			{
 				Name: datadoghqv1alpha1.SystemProbeDebugfsVolumeName,
@@ -1039,15 +1058,6 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 				Name: datadoghqv1alpha1.SystemProbeSocketVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			},
-			{
-				Name: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: datadoghqv1alpha1.SystemProbeOSReleaseDirVolumePath,
-						Type: &fileOrCreate,
-					},
 				},
 			},
 		}
@@ -1353,6 +1363,16 @@ func getVolumeMountsForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volum
 			MountPath: datadoghqv1alpha1.CgroupsVolumePath,
 			ReadOnly:  datadoghqv1alpha1.CgroupsVolumeReadOnly,
 		},
+		{
+			Name:      datadoghqv1alpha1.LSBReleaseDirVolumeName,
+			MountPath: datadoghqv1alpha1.LSBReleaseDirMountPath,
+			ReadOnly:  true,
+		},
+		{
+			Name:      datadoghqv1alpha1.OSReleaseDirVolumeName,
+			MountPath: datadoghqv1alpha1.OSReleaseDirMountPath,
+			ReadOnly:  true,
+		},
 	}
 
 	// Kubelet volumeMounts
@@ -1591,8 +1611,8 @@ func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1
 			ReadOnly:  true,
 		},
 		{
-			Name:      datadoghqv1alpha1.SystemProbeOSReleaseDirVolumeName,
-			MountPath: datadoghqv1alpha1.SystemProbeOSReleaseDirMountPath,
+			Name:      datadoghqv1alpha1.OSReleaseDirVolumeName,
+			MountPath: datadoghqv1alpha1.OSReleaseDirMountPath,
 			ReadOnly:  true,
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Mounts host /etc/*-release files to agent container

### Motivation

Feature request

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Exec onto agent container and run `ls /host/etc/` and/or `cat /host/etc/*-release` to make sure files are mounted correctly