### PR TITLE
Remove Metrics Server APIService in finalizer

### DIFF
--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -53,6 +53,10 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, dda *datadoghqv1alph
 }
 
 func (r *Reconciler) finalizeDad(reqLogger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) {
+	_, err := r.cleanupMetricsServerAPIService(reqLogger, dda)
+	if err != nil {
+		reqLogger.Error(err,"Could not delete Metrics Server API Service")
+	}
 	r.forwarders.Unregister(dda)
 	reqLogger.Info("Successfully finalized DatadogAgent")
 }


### PR DESCRIPTION
### What does this PR do?

Call `cleanupMetricsServerAPIService` function in datadogagent finalizer.

### Motivation

Starting in Kubernetes 1.20 version, when deleting the `datadogagent` resource, or delete the datadog namespace, the metrics service APIService is not removed, leading to a stuck namespace state at Terminating.

```
NAME                                   SERVICE                                        AVAILABLE                 AGE
v1beta1.external.metrics.k8s.io        datadog/datadog-cluster-agent-metrics-server   False (ServiceNotFound)   2m15s
```

I did not found this scenario in Kubernetes version <= 1.19.

### Additional Notes

I'm not sure if I'm calling the `cleanupMetricsServerAPIService` in the best spot. Open for feedback.

### Describe your test plan

You can test this issue by creating a testing cluster (eg: using kind) with Kubernetes version >= 1.20 and deploy the Datadog Operator. Remove the `datadogagent` resource or delete the datadog namespace and check if the apiservice is removed. 

Repeat the same step but deploying Datadog Operator with this fix, the APIService will be removed upon deleting `datadogagent` resource. 