### PR TITLE
fix version check to work with release candidates

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -310,7 +310,9 @@ func DefaultDatadogAgentSpecAgentConfig(agent *DatadogAgentSpecAgentSpec) *NodeA
 	// Let Env AD do the work for us
 	// Image is defaulted prior to this function.
 	agentTag := strings.TrimSuffix(utils.GetTagFromImageName(agent.Image.Name), "-jmx")
-	if !(agentTag == "latest" || utils.IsAboveMinVersion(agentTag, "7.27.0") || utils.IsAboveMinVersion(agentTag, "6.27.0")) {
+	// Check against image tag + "-0"; otherwise prelease versions are not compared.
+	// (See https://github.com/Masterminds/semver#working-with-prerelease-versions)
+	if !(agentTag == "latest" || utils.IsAboveMinVersion(agentTag, "7.27.0-0") || utils.IsAboveMinVersion(agentTag, "6.27.0-0")) {
 		if socketOverride := DefaultContainerSocket(agent.Config); !IsEqualStruct(socketOverride, CRISocketConfig{}) {
 			configOverride.CriSocket = socketOverride
 		}

--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -55,7 +55,7 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, dda *datadoghqv1alph
 func (r *Reconciler) finalizeDad(reqLogger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) {
 	_, err := r.cleanupMetricsServerAPIService(reqLogger, dda)
 	if err != nil {
-		reqLogger.Error(err,"Could not delete Metrics Server API Service")
+		reqLogger.Error(err, "Could not delete Metrics Server API Service")
 	}
 	r.forwarders.Unregister(dda)
 	reqLogger.Info("Successfully finalized DatadogAgent")

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -23,6 +23,31 @@ func TestCompareVersion(t *testing.T) {
 			expected:   true,
 		},
 		{
+			version:    "7.29.0-rc.5",
+			minVersion: "7.27.0-0",
+			expected:   true,
+		},
+		{
+			version:    "7.30.0",
+			minVersion: "7.27.1-0",
+			expected:   true,
+		},
+		{
+			version:    "7.25.0",
+			minVersion: "7.27.1-0",
+			expected:   false,
+		},
+		{
+			version:    "6.27.0",
+			minVersion: "6.28.0-0",
+			expected:   false,
+		},
+		{
+			version:    "6.28.1",
+			minVersion: "6.28.0-0",
+			expected:   true,
+		},
+		{
 			version:    "6.27.0",
 			minVersion: "6.28.0",
 			expected:   false,


### PR DESCRIPTION
### What does this PR do?

Defaulting was not behaving properly for prelease/release candidate images because of image tag comparison using `semver`. If `-0` is added to the `minVersion` image being compared then prelease image tags are compared.

Ref: https://github.com/Masterminds/semver#working-with-prerelease-versions

### Motivation

Unexpected behavior when testing an agent release candidate

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test a datadog agent release candidate image with `DatadogAgent` in a non-Docker environment. Make sure that the `DOCKER_HOST` env var is not automatically set in the agent containers and the `docker` check does not run.