### PR TITLE
Fix APM HostPort configuration

### DIFF
--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -885,3 +885,49 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultDatadogAgentSpecAgentApm(t *testing.T) {
+	tests := []struct {
+		input *DatadogAgentSpecAgentSpec
+		name  string
+		want  *APMSpec
+	}{
+		{
+			name: "APM not set",
+			input: &DatadogAgentSpecAgentSpec{
+				Enabled: NewBoolPointer(true),
+			},
+			want: &APMSpec{
+				Enabled: NewBoolPointer(false),
+			},
+		},
+		{
+			name: "APM not enabled",
+			input: &DatadogAgentSpecAgentSpec{
+				Apm: &APMSpec{
+					Enabled: NewBoolPointer(false),
+				},
+			},
+			want: &APMSpec{},
+		},
+		{
+			name: "APM enabled",
+			input: &DatadogAgentSpecAgentSpec{
+				Apm: &APMSpec{
+					Enabled: NewBoolPointer(true),
+				},
+			},
+			want: &APMSpec{
+				HostPort:         NewInt32Pointer(8126),
+				UnixDomainSocket: &APMUnixDomainSocketSpec{Enabled: NewBoolPointer(false)},
+				LivenessProbe:    getDefaultAPMAgentLivenessProbe(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DefaultDatadogAgentSpecAgentApm(tt.input)
+			assert.True(t, IsEqualStruct(got, tt.want), "TestDefaultDatadogAgentSpecAgentApm defaulting \ndiff = %s", cmp.Diff(got, tt.want))
+		})
+	}
+}

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1120,7 +1120,7 @@ func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"trace-agent", "--config=" + agentConfigFile},
 		Resources:       corev1.ResourceRequirements{},
-		Ports:           []corev1.ContainerPort{{Name: "traceport", ContainerPort: 8126, Protocol: "TCP"}},
+		Ports:           []corev1.ContainerPort{{Name: "traceport", ContainerPort: 8126, Protocol: "TCP", HostPort: 8126}},
 		Env:             defaultAPMContainerEnvVars(),
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -327,6 +327,7 @@ func getAPMAgentContainers(dda *datadoghqv1alpha1.DatadogAgent, image string) ([
 		ContainerPort: *dda.Spec.Agent.Apm.HostPort,
 		Name:          "traceport",
 		Protocol:      corev1.ProtocolTCP,
+		HostPort:      *dda.Spec.Agent.Apm.HostPort,
 	}
 
 	apmContainer := corev1.Container{


### PR DESCRIPTION
### What does this PR do?

When APM enable, configure automaticaly the TCP port as a `HostPort`.

Fixes: #312

### Motivation

Allow the usage of APM in applicative pod with the TCP communication.

### Additional Notes

N/A

### Describe your test plan

Deploy the the agent with 
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
#...
spec:
  #...
  agent:
    # ...
    apm:
      enabled: true
```

the port `8126` on the `trace-agent` container should be created with the hostPort option.
