### PR TITLE
Use a single entrypoint for the datadog agent docker image

### DIFF
--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -441,6 +441,47 @@ func Test_mergeAnnotationsLabels(t *testing.T) {
 	}
 }
 
+func Test_hasAgentSingleEntryPoint(t *testing.T) {
+	tests := []struct {
+		imageName string
+		want      bool
+	}{
+		{
+			imageName: "gcr.io/datadoghq/agent:latest",
+			want:      true,
+		},
+		{
+			imageName: "gcr.io/datadoghq/agent:7.29.0",
+			want:      false,
+		},
+		{
+			imageName: "gcr.io/datadoghq/agent:7.30.0",
+			want:      true,
+		},
+		{
+			imageName: "gcr.io/datadoghq/agent:6.29.0",
+			want:      false,
+		},
+		{
+			imageName: "gcr.io/datadoghq/agent:6.30.0",
+			want:      true,
+		},
+		{
+			imageName: "gcr.io/datadoghq/agent:6.30.0-jmx",
+			want:      true,
+		},
+		{
+			imageName: "gcr.io/datadoghq/agent:7.29.0-rc.8-jmx",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.imageName, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasAgentSingleEntrypoint(tt.imageName))
+		})
+	}
+}
+
 func Test_imageHasTag(t *testing.T) {
 	cases := map[string]bool{
 		"foo:bar":             true,

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -14,7 +14,7 @@ func IsAboveMinVersion(version, minVersion string) bool {
 		return false
 	}
 
-	c, err := semver.NewConstraint(">= " + minVersion)
+	c, err := semver.NewConstraint("^" + minVersion)
 	if err != nil {
 		return false
 	}

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -32,6 +32,16 @@ func TestCompareVersion(t *testing.T) {
 			minVersion: "7.28.0",
 			expected:   false,
 		},
+		{
+			version:    "6.30.0",
+			minVersion: "7.28.0",
+			expected:   false,
+		},
+		{
+			version:    "7.28.0",
+			minVersion: "6.30.0",
+			expected:   false,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.version, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Use a single entrypoint for the datadog agent docker image.

### Motivation

GKE auto-pilot requires to have a fixed entrypoint in the docker image.

### Additional Notes

This new version of the operator requires an agent docker image that includes DataDog/datadog-agent#8490.
It is the operator counter part of DataDog/helm-charts#289.

### Describe your test plan

Spawn an agent thanks to this version of the operator once with `7.29.0` and once with `7.30.0`.
In the former case, we should have `command:` for containers in the pod spec as we’re used to.
In the later case, there shouldn’t be any `command:` for any container anymore. It should be replaced by an `ENTRYPOINT` environment variable for each container.
