### PR TITLE
Automate `datadog` krew plugin releasing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,3 +48,7 @@ jobs:
         env:
           COMMIT_TAG: ${{steps.tag.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update new plugin version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.40
+        with:
+          krew_template_file: dist/datadog-plugin.yaml


### PR DESCRIPTION
### What does this PR do?

Automate `datadog` krew plugin releasing in [krew-index|https://github.com/kubernetes-sigs/krew-index] repo.

It will generate automatically a PR, that will be merge automatically if only version,sha,uri change in the PR, like: https://github.com/kubernetes-sigs/krew-index/pull/1433

### Motivation

Limit releasing actions 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Difficult to test, from the action documentation, it will only public official release but not RC.
