### PR TITLE
Add apm_non_local_traffic envvar when apm.enabled

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -83,6 +83,7 @@ const (
 	DDExtraListeners                             = "DD_EXTRA_LISTENERS"
 	DDHostname                                   = "DD_HOSTNAME"
 	DDAPMEnabled                                 = "DD_APM_ENABLED"
+	DDAPMNonLocalTraffic                         = "DD_APM_NON_LOCAL_TRAFFIC"
 	DDPPMReceiverSocket                          = "DD_APM_RECEIVER_SOCKET"
 	DDProcessAgentEnabled                        = "DD_PROCESS_AGENT_ENABLED"
 	DDSystemProbeAgentEnabled                    = "DD_SYSTEM_PROBE_ENABLED"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -911,6 +911,10 @@ func defaultAPMContainerEnvVars() []corev1.EnvVar {
 			Value: "true",
 		},
 		{
+			Name:  "DD_APM_NON_LOCAL_TRAFFIC",
+			Value: "true",
+		},
+		{
 			Name:  "DD_LOG_LEVEL",
 			Value: "INFO",
 		},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -547,6 +547,10 @@ func getEnvVarsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar
 			Name:  datadoghqv1alpha1.DDAPMEnabled,
 			Value: strconv.FormatBool(isAPMEnabled(&dda.Spec)),
 		},
+		{
+			Name:  datadoghqv1alpha1.DDAPMNonLocalTraffic,
+			Value: strconv.FormatBool(true),
+		},
 		getEnvVarDogstatsdSocket(dda),
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add `DD_APM_NON_LOCAL_TRAFFIC` envvar to APM container when `apm.enabled:true`

### Motivation

simplify APM configuration.

### Additional Notes

N/A

### Describe your test plan

Deploy the DatadogAgent APM example. the envvar should be present in the `trace-agent` container.
