### PR TITLE
Fix cluster-agent defaulting to enable it by default

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -107,6 +107,10 @@ func DefaultDatadogAgent(dda *DatadogAgent) *DatadogAgentStatus {
 		DefaultOverride: &DatadogAgentSpec{},
 	}
 
+	// Features
+	// default features because it might have an impact on the other defaulting
+	dso.DefaultOverride.Features = *DefaultFeatures(dda)
+
 	// Cluster Agent
 	dso.DefaultOverride.ClusterAgent = *DefaultDatadogAgentSpecClusterAgent(&dda.Spec.ClusterAgent)
 
@@ -115,9 +119,6 @@ func DefaultDatadogAgent(dda *DatadogAgent) *DatadogAgentStatus {
 
 	// CLC
 	dso.DefaultOverride.ClusterChecksRunner = *DefaultDatadogAgentSpecClusterChecksRunner(&dda.Spec.ClusterChecksRunner)
-
-	// Features
-	dso.DefaultOverride.Features = *DefaultFeatures(dda)
 
 	// Creds
 	if dda.Spec.Credentials == nil {
@@ -903,7 +904,7 @@ func DefaultDatadogFeatureNetworkMonitoring(ft *DatadogFeatures) *NetworkMonitor
 // return the defaulted DatadogAgentSpecClusterAgentSpec to update the status
 func DefaultDatadogAgentSpecClusterAgent(clusterAgent *DatadogAgentSpecClusterAgentSpec) *DatadogAgentSpecClusterAgentSpec {
 	if IsEqualStruct(*clusterAgent, DatadogAgentSpecClusterAgentSpec{}) {
-		clusterAgent.Enabled = NewBoolPointer(false)
+		clusterAgent.Enabled = NewBoolPointer(true)
 		return clusterAgent
 	}
 

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -262,10 +262,10 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 			name: "empty field",
 			dca:  DatadogAgentSpecClusterAgentSpec{},
 			overrideExpected: &DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: NewBoolPointer(true),
 			},
 			internalDefaulted: DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: NewBoolPointer(true),
 			},
 		},
 		{

--- a/api/v1alpha1/test/new.go
+++ b/api/v1alpha1/test/new.go
@@ -252,6 +252,10 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			if len(options.ClusterAgentEnvVars) != 0 {
 				ad.Spec.ClusterAgent.Config.Env = options.ClusterAgentEnvVars
 			}
+		} else {
+			ad.Spec.ClusterAgent = datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: datadoghqv1alpha1.NewBoolPointer(false),
+			}
 		}
 
 		if options.ClusterChecksRunnerEnabled {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - --enable-leader-election
         - --pprof
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         env:
         - name: POD_NAME

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1930,6 +1930,18 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 			Name:      "DD_API_KEY",
 			ValueFrom: apiKeyValue(),
 		},
+		{
+			Name:      "DD_CLUSTER_AGENT_AUTH_TOKEN",
+			ValueFrom: authTokenValue(),
+		},
+		{
+			Name:  "DD_CLUSTER_AGENT_ENABLED",
+			Value: "true",
+		},
+		{
+			Name:  "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME",
+			Value: "foo-cluster-agent",
+		},
 	}
 
 	return corev1.PodSpec{
@@ -3526,6 +3538,7 @@ func Test_newExtendedDaemonSetFromInstance_SecurityAgent_Runtime(t *testing.T) {
 func Test_newExtendedDaemonSetFromInstance_KubeletConfiguration(t *testing.T) {
 	dda := test.NewDefaultedDatadogAgent("bar", "foo", &test.NewDatadogAgentOptions{
 		UseEDS:                       true,
+		ClusterAgentEnabled:          true,
 		OrchestratorExplorerDisabled: true,
 	})
 

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -46,11 +46,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func init() {
-	const resourcesName = "foo"
-	const resourcesNamespace = "bar"
-}
-
 func TestReconcileDatadogAgent_createNewExtendedDaemonSet(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileDatadogAgent_createNewExtendedDaemonSet"})

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -841,7 +841,7 @@ func getEnvVarsForAgent(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent)
 
 	if isClusterAgentEnabled(dda.Spec.ClusterAgent) {
 		clusterEnv := envForClusterAgentConnection(dda)
-		if datadoghqv1alpha1.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled) {
+		if spec.ClusterAgent.Config != nil && datadoghqv1alpha1.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled) {
 			if !datadoghqv1alpha1.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
 				clusterEnv = append(clusterEnv, corev1.EnvVar{
 					Name:  datadoghqv1alpha1.DDExtraConfigProviders,

--- a/controllers/datadogagent_controller_test.go
+++ b/controllers/datadogagent_controller_test.go
@@ -123,6 +123,7 @@ var _ = Describe("DatadogAgent Controller", func() {
 		It("It should create DaemonSet", func() {
 			options := &testutils.NewDatadogAgentOptions{
 				UseEDS:                       false,
+				ClusterAgentDisabled:         true,
 				APIKey:                       "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg",
 				OrchestratorExplorerDisabled: true,
 			}
@@ -216,7 +217,7 @@ var _ = Describe("DatadogAgent Controller", func() {
 		}
 
 		It("It should create Deployment", func() {
-			agent := testutils.NewDatadogAgent(namespace, name, "datadog/agent:7.22.0", &testutils.NewDatadogAgentOptions{ClusterAgentEnabled: true, APIKey: "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg"})
+			agent := testutils.NewDatadogAgent(namespace, name, "datadog/agent:7.22.0", &testutils.NewDatadogAgentOptions{APIKey: "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg"})
 			Expect(k8sClient.Create(context.Background(), agent)).Should(Succeed())
 
 			var agentClusterAgentHash string

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -17,7 +17,7 @@ import (
 type NewDatadogAgentOptions struct {
 	ExtraLabels                  map[string]string
 	ExtraAnnotations             map[string]string
-	ClusterAgentEnabled          bool
+	ClusterAgentDisabled         bool
 	OrchestratorExplorerDisabled bool
 	UseEDS                       bool
 	APIKey                       string
@@ -112,7 +112,7 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 			}
 		}
 
-		if options.ClusterAgentEnabled {
+		if !options.ClusterAgentDisabled {
 			ad.Spec.ClusterAgent = datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
 				Config: &datadoghqv1alpha1.ClusterAgentConfig{},
 				Image: &datadoghqv1alpha1.ImageConfig{
@@ -120,6 +120,10 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 					PullPolicy:  &pullPolicy,
 					PullSecrets: &[]v1.LocalObjectReference{},
 				},
+			}
+		} else {
+			ad.Spec.ClusterAgent = datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: datadoghqv1alpha1.NewBoolPointer(false),
 			}
 		}
 

--- a/examples/datadogagent/datadog-agent-with-credential-secret.yaml
+++ b/examples/datadogagent/datadog-agent-with-credential-secret.yaml
@@ -1,0 +1,20 @@
+# ----------------------------------------------------------#
+# Example about how to use an existing secret to store the  #
+# Datadog credentials                                       #
+# ----------------------------------------------------------#
+# First, create the datadog-secret with the folling command:
+# kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY --from-literal app-key=$DD_APP_KEY
+
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  clusterName: foo
+  credentials:
+    apiSecret:
+      secretName: datadog-secret
+      keyName: api-key
+    appSecret:
+      secretName: datadog-secret
+      keyName: app-key


### PR DESCRIPTION
### What does this PR do?

Fix the default of the cluster-agent to all be defaulted to `enabled:true`.

### Motivation

In a specific when the section "spec.clusterAgent" is not provided
in the DatadogAgent instance, the cluster-agent is not defaulted to
`spec.clusterAgent.enabled:true`.

### Additional Notes

N/A

### Describe your test plan

Deploy the example: `datadog-agent-with-credential-secret.yaml`

The cluster-agent should be deployed. Defaulting value can be also
verified by checking the value of `dataddog.status.defaultOverride.clusterAgent.enabled` 
