### PR TITLE
Improve defaulting when spec.Agent|ClusterAgent empty

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -32,8 +32,12 @@ const (
 	defaultUseDogStatsDSocketVolume         bool   = false
 	defaultHostDogstatsdSocketName          string = "statsd.sock"
 	defaultHostDogstatsdSocketPath          string = "/var/run/datadog"
+	defaultAgentEnabled                     bool   = true
+	defaultClusterAgentEnabled              bool   = true
+	defaultClusterChecksRunnerEnabled       bool   = false
 	defaultApmEnabled                       bool   = false
 	defaultApmHostPort                      int32  = 8126
+	defaultExternalMetricsEnabled           bool   = false
 	defaultSystemProbeEnabled               bool   = false
 	defaultSystemProbeOOMKillEnabled        bool   = false
 	defaultSystemProbeTCPQueueLengthEnabled bool   = false
@@ -163,7 +167,7 @@ func FeatureOverride(dda *DatadogAgentSpec, dso *DatadogAgentSpec) {
 func DefaultDatadogAgentSpecAgent(agent *DatadogAgentSpecAgentSpec) *DatadogAgentSpecAgentSpec {
 	// If the Agent is not specified in the spec, disable it.
 	if IsEqualStruct(*agent, DatadogAgentSpecAgentSpec{}) {
-		agent.Enabled = NewBoolPointer(true)
+		agent.Enabled = NewBoolPointer(defaultAgentEnabled)
 
 		if !BoolValue(agent.Enabled) {
 			return agent
@@ -172,7 +176,7 @@ func DefaultDatadogAgentSpecAgent(agent *DatadogAgentSpecAgentSpec) *DatadogAgen
 
 	agentOverride := &DatadogAgentSpecAgentSpec{}
 	if agent.Enabled == nil {
-		agent.Enabled = NewBoolPointer(true)
+		agent.Enabled = NewBoolPointer(defaultAgentEnabled)
 		agentOverride.Enabled = agent.Enabled
 	}
 
@@ -929,7 +933,7 @@ func DefaultDatadogFeatureNetworkMonitoring(ft *DatadogFeatures) *NetworkMonitor
 // return the defaulted DatadogAgentSpecClusterAgentSpec to update the status
 func DefaultDatadogAgentSpecClusterAgent(clusterAgent *DatadogAgentSpecClusterAgentSpec) *DatadogAgentSpecClusterAgentSpec {
 	if IsEqualStruct(*clusterAgent, DatadogAgentSpecClusterAgentSpec{}) {
-		clusterAgent.Enabled = NewBoolPointer(true)
+		clusterAgent.Enabled = NewBoolPointer(defaultClusterAgentEnabled)
 
 		if !BoolValue(clusterAgent.Enabled) {
 			return clusterAgent
@@ -940,7 +944,7 @@ func DefaultDatadogAgentSpecClusterAgent(clusterAgent *DatadogAgentSpecClusterAg
 
 	if clusterAgent.Enabled == nil {
 		// Cluster Agent is enabled by default unless undeclared then it is set to false.
-		clusterAgent.Enabled = NewBoolPointer(true)
+		clusterAgent.Enabled = NewBoolPointer(defaultClusterAgentEnabled)
 		clusterAgentOverride.Enabled = clusterAgent.Enabled
 	}
 
@@ -1016,7 +1020,7 @@ func DefaultDatadogAgentSpecClusterAgentConfig(dca *DatadogAgentSpecClusterAgent
 // DefaultExternalMetrics defaults the External Metrics Server's config in the Cluster Agent's config
 func DefaultExternalMetrics(conf *ClusterAgentConfig) *ExternalMetricsConfig {
 	if conf.ExternalMetrics == nil {
-		conf.ExternalMetrics = &ExternalMetricsConfig{Enabled: NewBoolPointer(false)}
+		conf.ExternalMetrics = &ExternalMetricsConfig{Enabled: NewBoolPointer(defaultExternalMetricsEnabled)}
 
 		if !BoolValue(conf.ExternalMetrics.Enabled) {
 			return conf.ExternalMetrics
@@ -1025,7 +1029,7 @@ func DefaultExternalMetrics(conf *ClusterAgentConfig) *ExternalMetricsConfig {
 
 	extMetricsOverride := &ExternalMetricsConfig{}
 	if conf.ExternalMetrics.Enabled == nil {
-		conf.ExternalMetrics.Enabled = NewBoolPointer(true)
+		conf.ExternalMetrics.Enabled = NewBoolPointer(defaultExternalMetricsEnabled)
 		extMetricsOverride.Enabled = conf.ExternalMetrics.Enabled
 	}
 
@@ -1098,18 +1102,18 @@ func DefaultDatadogClusterAgentImage(dca *DatadogAgentSpecClusterAgentSpec, name
 // return the defaulted DatadogAgentSpecClusterChecksRunnerSpec
 func DefaultDatadogAgentSpecClusterChecksRunner(clusterChecksRunner *DatadogAgentSpecClusterChecksRunnerSpec) *DatadogAgentSpecClusterChecksRunnerSpec {
 	if IsEqualStruct(clusterChecksRunner, DatadogAgentSpecClusterChecksRunnerSpec{}) {
-		clusterChecksRunner.Enabled = NewBoolPointer(false)
+		clusterChecksRunner.Enabled = NewBoolPointer(defaultClusterChecksRunnerEnabled)
 
 		if !BoolValue(clusterChecksRunner.Enabled) {
 			return clusterChecksRunner
 		}
 	}
 
+	clcOverride := &DatadogAgentSpecClusterChecksRunnerSpec{}
 	if clusterChecksRunner.Enabled == nil {
-		clusterChecksRunner.Enabled = NewBoolPointer(true)
+		clusterChecksRunner.Enabled = NewBoolPointer(defaultClusterChecksRunnerEnabled)
+		clcOverride.Enabled = clusterChecksRunner.Enabled
 	}
-
-	clcOverride := &DatadogAgentSpecClusterChecksRunnerSpec{Enabled: clusterChecksRunner.Enabled}
 
 	if img := DefaultDatadogAgentSpecClusterChecksRunnerImage(clusterChecksRunner, defaultAgentImageName, defaultAgentImageTag); !IsEqualStruct(img, ImageConfig{}) {
 		clcOverride.Image = img

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -348,6 +348,7 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
+						Enabled:           NewBoolPointer(true),
 						WpaController:     true,
 						UseDatadogMetrics: true,
 					},
@@ -371,8 +372,7 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
-						Enabled: NewBoolPointer(true),
-						Port:    NewInt32Pointer(8443),
+						Port: NewInt32Pointer(8443),
 					},
 				},
 			},
@@ -716,14 +716,14 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 		{
 			name: "sparse conf",
 			clc: DatadogAgentSpecClusterChecksRunnerSpec{
-				Config: &ClusterChecksRunnerConfig{},
+				Enabled: NewBoolPointer(true),
+				Config:  &ClusterChecksRunnerConfig{},
 				Image: &ImageConfig{
 					Name: "gcr.io/datadog/agent:latest",
 					Tag:  defaultAgentImageTag,
 				},
 			},
 			overrideExpected: &DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					PullPolicy: &defaultImagePullPolicy,
 				},
@@ -760,6 +760,7 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 		{
 			name: "some conf",
 			clc: DatadogAgentSpecClusterChecksRunnerSpec{
+				Enabled: NewBoolPointer(true),
 				Config: &ClusterChecksRunnerConfig{
 					LogLevel:   NewStringPointer("DEBUG"),
 					HealthPort: NewInt32Pointer(1664),
@@ -770,7 +771,6 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 				},
 			},
 			overrideExpected: &DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					PullPolicy: &defaultImagePullPolicy,
 				},

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -268,13 +268,13 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 		internalDefaulted DatadogAgentSpecClusterAgentSpec
 	}{
 		{
-			name: "empty field",
-			dca:  DatadogAgentSpecClusterAgentSpec{},
-			overrideExpected: &DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(true),
+			name: "disable field",
+			dca: DatadogAgentSpecClusterAgentSpec{
+				Enabled: NewBoolPointer(false),
 			},
+			overrideExpected: &DatadogAgentSpecClusterAgentSpec{},
 			internalDefaulted: DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: NewBoolPointer(false),
 			},
 		},
 		{
@@ -366,7 +366,6 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(true)},
 			},
 			overrideExpected: &DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					Tag: defaultClusterAgentImageTag,
 				},
@@ -427,11 +426,11 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 		internalDefaulted DatadogAgentSpecAgentSpec
 	}{
 		{
-			name:  "empty field",
-			agent: DatadogAgentSpecAgentSpec{},
-			overrideExpected: &DatadogAgentSpecAgentSpec{
+			name: "agent disabled field",
+			agent: DatadogAgentSpecAgentSpec{
 				Enabled: NewBoolPointer(false),
 			},
+			overrideExpected: &DatadogAgentSpecAgentSpec{},
 			internalDefaulted: DatadogAgentSpecAgentSpec{
 				Enabled: NewBoolPointer(false),
 			},

--- a/api/v1alpha1/test/new.go
+++ b/api/v1alpha1/test/new.go
@@ -107,7 +107,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		},
 	}
 	ad.Spec = datadoghqv1alpha1.DatadogAgentSpec{
-		Credentials: &datadoghqv1alpha1.AgentCredentials{Token: "token-foo"},
+		Credentials: DefaultCredentials(),
 		Agent: datadoghqv1alpha1.DatadogAgentSpecAgentSpec{
 			Image: &datadoghqv1alpha1.ImageConfig{
 				Name:       defaultImage,
@@ -403,6 +403,17 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 	}
 	_ = datadoghqv1alpha1.DefaultDatadogAgent(ad)
 	return ad
+}
+
+// DefaultCredentials generate an AgentCredentials instance for test purpose
+func DefaultCredentials() *datadoghqv1alpha1.AgentCredentials {
+	return &datadoghqv1alpha1.AgentCredentials{
+		DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
+			APIKey: "0000000000000000000000",
+			AppKey: "0000000000000000000000",
+		},
+		Token: "token-foo",
+	}
 }
 
 // NewExtendedDaemonSetOptions set of option for the ExtendedDaemonset creation

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -442,8 +442,11 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 	}
 
 	// Add other volumes
-	volumes = append(volumes, dda.Spec.ClusterAgent.Config.Volumes...)
-	volumeMounts = append(volumeMounts, dda.Spec.ClusterAgent.Config.VolumeMounts...)
+	if dda.Spec.ClusterAgent.Config != nil {
+		volumes = append(volumes, dda.Spec.ClusterAgent.Config.Volumes...)
+		volumeMounts = append(volumeMounts, dda.Spec.ClusterAgent.Config.VolumeMounts...)
+	}
+
 	envs, err := getEnvVarsForClusterAgent(logger, dda)
 	if err != nil {
 		return corev1.PodTemplateSpec{}, err
@@ -763,7 +766,10 @@ func getClusterAgentMetricsProviderPort(config datadoghqv1alpha1.ClusterAgentCon
 }
 
 func getAdmissionControllerServiceName(dda *datadoghqv1alpha1.DatadogAgent) string {
-	if isClusterAgentEnabled(dda.Spec.ClusterAgent) && dda.Spec.ClusterAgent.Config.AdmissionController != nil && dda.Spec.ClusterAgent.Config.AdmissionController.ServiceName != nil {
+	if isClusterAgentEnabled(dda.Spec.ClusterAgent) &&
+		dda.Spec.ClusterAgent.Config != nil &&
+		dda.Spec.ClusterAgent.Config.AdmissionController != nil &&
+		dda.Spec.ClusterAgent.Config.AdmissionController.ServiceName != nil {
 		return *dda.Spec.ClusterAgent.Config.AdmissionController.ServiceName
 	}
 	return datadoghqv1alpha1.DefaultAdmissionServiceName

--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -110,6 +110,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, request reconcile.Re
 	if err != nil {
 		return result, err
 	}
+
 	newStatus := instance.Status.DeepCopy()
 	reconcileFuncs :=
 		[]reconcileFuncInterface{

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -258,7 +258,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 							Annotations: map[string]string{"annotations-foo-key": "annotations-bar-value"},
 						},
 						Spec: datadoghqv1alpha1.DatadogAgentSpec{
-							Credentials:  &datadoghqv1alpha1.AgentCredentials{Token: "token-foo"},
+							Credentials:  test.DefaultCredentials(),
 							Agent:        datadoghqv1alpha1.DatadogAgentSpecAgentSpec{},
 							ClusterAgent: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{},
 						},

--- a/controllers/datadogagent_controller_test.go
+++ b/controllers/datadogagent_controller_test.go
@@ -125,18 +125,16 @@ var _ = Describe("DatadogAgent Controller", func() {
 				UseEDS:                       false,
 				ClusterAgentDisabled:         true,
 				APIKey:                       "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg",
+				AppKey:                       "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg-dsddsd",
 				OrchestratorExplorerDisabled: true,
 			}
 
-			agent := testutils.NewDatadogAgent(namespace, name, "datadog/agent:7.21.0", options)
+			agent := testutils.NewDatadogAgent(namespace, name, "", options)
 			Expect(k8sClient.Create(context.Background(), agent)).Should(Succeed())
 
 			agent = &datadoghqv1alpha1.DatadogAgent{}
 			getObjectAndCheck(agent, key, func() bool {
-				if agent.Status.Agent == nil {
-					return false
-				}
-				if agent.Status.Agent.CurrentHash == "" {
+				if agent.Status.Agent == nil || agent.Status.Agent.CurrentHash == "" {
 					return false
 				}
 				for _, condition := range agent.Status.Conditions {
@@ -195,9 +193,9 @@ var _ = Describe("DatadogAgent Controller", func() {
 				}, nil)
 			})
 
-			By("Disabling Process", func() {
+			By("Enabled Process", func() {
 				checkAgentUpdateOnDaemonSet(key, dsKey, func(agent *datadoghqv1alpha1.DatadogAgent) {
-					agent.Spec.Agent.Process.Enabled = datadoghqv1alpha1.NewBoolPointer(false)
+					agent.Spec.Agent.Process.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
 				}, nil)
 			})
 		})
@@ -217,7 +215,8 @@ var _ = Describe("DatadogAgent Controller", func() {
 		}
 
 		It("It should create Deployment", func() {
-			agent := testutils.NewDatadogAgent(namespace, name, "datadog/agent:7.22.0", &testutils.NewDatadogAgentOptions{APIKey: "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg"})
+			options := &testutils.NewDatadogAgentOptions{APIKey: "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg", AppKey: "xnfdsjgdjcxlg42rqmzxzvdsgjdfklg-23678264"}
+			agent := testutils.NewDatadogAgent(namespace, name, "datadog/agent:7.22.0", options)
 			Expect(k8sClient.Create(context.Background(), agent)).Should(Succeed())
 
 			var agentClusterAgentHash string

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -17,6 +17,7 @@ import (
 type NewDatadogAgentOptions struct {
 	ExtraLabels                  map[string]string
 	ExtraAnnotations             map[string]string
+	AgentDisabled                bool
 	ClusterAgentDisabled         bool
 	OrchestratorExplorerDisabled bool
 	UseEDS                       bool
@@ -88,6 +89,10 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 
 		if options.AppKey != "" {
 			ad.Spec.Credentials.AppKey = options.AppKey
+		}
+
+		if options.AgentDisabled {
+			ad.Spec.Agent.Enabled = datadoghqv1alpha1.NewBoolPointer(false)
 		}
 
 		if options.UseEDS && datadoghqv1alpha1.BoolValue(ad.Spec.Agent.Enabled) {


### PR DESCRIPTION
### What does this PR do?

* Improve agent defaulting by enabling it if `spec.Agent` is empty.
* Improve ClusterAgent defaulting by enabling it if `spec.ClusterAgent`
  is empty.
* Fix credentials verification function.

### Motivation

DatadogAgent should valide even if only "spec.Credentials" and `spec.Features` are
provided.

### Additional Notes

N/A

### Describe your test plan

Deploy the example: `examples/datadogagent/datadog-agent-with-credential-secret.yaml`

Expected results:
* ClusterAgent should be deployed
* Agent should be deployed
