### PR TITLE
fix clusterrolebinding update

### DIFF
--- a/controllers/datadogagent/agent_rbac.go
+++ b/controllers/datadogagent/agent_rbac.go
@@ -65,7 +65,7 @@ func (r *Reconciler) manageAgentRBACs(logger logr.Logger, dda *datadoghqv1alpha1
 		return reconcile.Result{}, err
 	}
 
-	return r.udpateIfNeededAgentClusterRoleBinding(logger, dda, rbacResourcesName, rbacResourcesName, serviceAccountName, agentVersion, clusterRoleBinding)
+	return r.updateIfNeededClusterRoleBinding(logger, dda, rbacResourcesName, rbacResourcesName, serviceAccountName, agentVersion, clusterRoleBinding)
 }
 
 // cleanupAgentRbacResources deletes ClusterRole, ClusterRoleBindings, and ServiceAccount of the Agent

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -823,7 +823,7 @@ func (r *Reconciler) manageClusterAgentRBACs(logger logr.Logger, dda *datadoghqv
 		}
 		return reconcile.Result{}, err
 	}
-	if result, err := r.udpateIfNeededClusterAgentClusterRoleBinding(logger, dda, rbacResourcesName, serviceAccountName, clusterAgentVersion, clusterRoleBinding); err != nil {
+	if result, err := r.updateIfNeededClusterRoleBinding(logger, dda, rbacResourcesName, rbacResourcesName, serviceAccountName, clusterAgentVersion, clusterRoleBinding); err != nil {
 		return result, err
 	}
 
@@ -996,30 +996,6 @@ func (r *Reconciler) updateIfNeededClusterAgentRole(logger logr.Logger, dda *dat
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) udpateIfNeededClusterAgentClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, serviceAccountName, agentVersion string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (reconcile.Result, error) {
-	info := roleBindingInfo{
-		name:               name,
-		roleName:           name,
-		serviceAccountName: serviceAccountName,
-	}
-	newClusterRoleBinding := buildClusterRoleBinding(dda, info, agentVersion)
-	if !apiequality.Semantic.DeepEqual(newClusterRoleBinding.Subjects, clusterRoleBinding.Subjects) || !apiequality.Semantic.DeepEqual(newClusterRoleBinding.RoleRef, clusterRoleBinding.RoleRef) {
-		updatedClusterRoleBinding := clusterRoleBinding.DeepCopy()
-		{
-			updatedClusterRoleBinding.Labels = newClusterRoleBinding.Labels
-			updatedClusterRoleBinding.RoleRef = newClusterRoleBinding.RoleRef
-			updatedClusterRoleBinding.Subjects = newClusterRoleBinding.Subjects
-		}
-		logger.V(1).Info("updateClusterAgentClusterRoleBinding", "clusterRoleBinding.name", updatedClusterRoleBinding.Name, "serviceAccount", serviceAccountName)
-		if err := r.client.Update(context.TODO(), updatedClusterRoleBinding); err != nil {
-			return reconcile.Result{}, err
-		}
-		event := buildEventInfo(updatedClusterRoleBinding.Name, updatedClusterRoleBinding.Namespace, clusterRoleKind, datadog.UpdateEvent)
-		r.recordEvent(dda, event)
-	}
-	return reconcile.Result{}, nil
-}
-
 func (r *Reconciler) updateIfNeededAgentClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string, clusterRole *rbacv1.ClusterRole) (reconcile.Result, error) {
 	newClusterRole := buildAgentClusterRole(dda, name, agentVersion)
 	if !apiequality.Semantic.DeepEqual(newClusterRole.Rules, clusterRole.Rules) {
@@ -1041,30 +1017,6 @@ func (r *Reconciler) updateIfNeededClusterCheckRunnerClusterRole(logger logr.Log
 			return reconcile.Result{}, err
 		}
 		event := buildEventInfo(newClusterRole.Name, newClusterRole.Namespace, clusterRoleKind, datadog.UpdateEvent)
-		r.recordEvent(dda, event)
-	}
-	return reconcile.Result{}, nil
-}
-
-func (r *Reconciler) udpateIfNeededAgentClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, roleName, serviceAccountName, agentVersion string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (reconcile.Result, error) {
-	info := roleBindingInfo{
-		name:               name,
-		roleName:           roleName,
-		serviceAccountName: serviceAccountName,
-	}
-	newClusterRoleBinding := buildClusterRoleBinding(dda, info, agentVersion)
-	if !apiequality.Semantic.DeepEqual(newClusterRoleBinding.Subjects, clusterRoleBinding.Subjects) || !apiequality.Semantic.DeepEqual(newClusterRoleBinding.RoleRef, clusterRoleBinding.RoleRef) {
-		updatedClusterRoleBinding := clusterRoleBinding.DeepCopy()
-		{
-			updatedClusterRoleBinding.Labels = newClusterRoleBinding.Labels
-			updatedClusterRoleBinding.RoleRef = newClusterRoleBinding.RoleRef
-			updatedClusterRoleBinding.Subjects = newClusterRoleBinding.Subjects
-		}
-		logger.V(1).Info("updateAgentClusterRoleBinding", "clusterRoleBinding.name", updatedClusterRoleBinding.Name, "serviceAccount", serviceAccountName)
-		if err := r.client.Update(context.TODO(), updatedClusterRoleBinding); err != nil {
-			return reconcile.Result{}, err
-		}
-		event := buildEventInfo(updatedClusterRoleBinding.Name, newClusterRoleBinding.Namespace, clusterRoleKind, datadog.UpdateEvent)
 		r.recordEvent(dda, event)
 	}
 	return reconcile.Result{}, nil

--- a/controllers/datadogagent/clusterchecksrunner_rbac.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac.go
@@ -66,7 +66,7 @@ func (r *Reconciler) manageClusterChecksRunnerRBACs(logger logr.Logger, dda *dat
 		return reconcile.Result{}, err
 	}
 
-	if result, err := r.udpateIfNeededAgentClusterRoleBinding(logger, dda, rbacResourcesName, rbacResourcesName, serviceAccountName, agentVersion, clusterRoleBinding); err != nil {
+	if result, err := r.updateIfNeededClusterRoleBinding(logger, dda, rbacResourcesName, rbacResourcesName, serviceAccountName, agentVersion, clusterRoleBinding); err != nil {
 		return result, err
 	}
 

--- a/controllers/datadogagent/kubestatemetrics.go
+++ b/controllers/datadogagent/kubestatemetrics.go
@@ -112,25 +112,6 @@ func (r *Reconciler) updateIfNeededKubeStateMetricsClusterRole(logger logr.Logge
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) updateIfNeededKubeStateMetricsClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, clusterRoleBindingName, roleName, serviceAccountName, version string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (reconcile.Result, error) {
-	info := roleBindingInfo{
-		name:               clusterRoleBindingName,
-		roleName:           roleName,
-		serviceAccountName: serviceAccountName,
-	}
-	newClusterRoleBinding := buildClusterRoleBinding(dda, info, version)
-	if !apiequality.Semantic.DeepEqual(newClusterRoleBinding.Subjects, clusterRoleBinding.Subjects) || !apiequality.Semantic.DeepEqual(newClusterRoleBinding.RoleRef, clusterRoleBinding.RoleRef) {
-		logger.V(1).Info("updateKubeStateMetricsClusterRoleBinding", "clusterRoleBinding.name", clusterRoleBinding.Name)
-		if err := r.client.Update(context.TODO(), newClusterRoleBinding); err != nil {
-			return reconcile.Result{}, err
-		}
-		event := buildEventInfo(newClusterRoleBinding.Name, newClusterRoleBinding.Namespace, clusterRoleKind, datadog.UpdateEvent)
-		r.recordEvent(dda, event)
-	}
-
-	return reconcile.Result{}, nil
-}
-
 func (r *Reconciler) createOrUpdateKubeStateMetricsCoreRBAC(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, serviceAccountName, componentVersion, nameSuffix string) (reconcile.Result, error) {
 	kubeStateMetricsRBACName := kubeStateMetricsRBACPrefix + nameSuffix
 	kubeStateMetricsClusterRole := &rbacv1.ClusterRole{}
@@ -157,7 +138,7 @@ func (r *Reconciler) createOrUpdateKubeStateMetricsCoreRBAC(logger logr.Logger, 
 		return reconcile.Result{}, err
 	}
 
-	return r.updateIfNeededKubeStateMetricsClusterRoleBinding(logger, dda, kubeStateMetricsRBACName, kubeStateMetricsRBACName, serviceAccountName, componentVersion, kubeStateMetricsClusterRoleBinding)
+	return r.updateIfNeededClusterRoleBinding(logger, dda, kubeStateMetricsRBACName, kubeStateMetricsRBACName, serviceAccountName, componentVersion, kubeStateMetricsClusterRoleBinding)
 }
 
 func (r *Reconciler) cleanupKubeStateMetricsCoreRBAC(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, nameSuffix string) (reconcile.Result, error) {

--- a/controllers/datadogagent/orchestrator.go
+++ b/controllers/datadogagent/orchestrator.go
@@ -89,25 +89,6 @@ func (r *Reconciler) updateIfNeededOrchestratorExplorerClusterRole(logger logr.L
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) updateIfNeededOrchestratorExplorerClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, clusterRoleBindingName, roleName, serviceAccountName, version string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (reconcile.Result, error) {
-	info := roleBindingInfo{
-		name:               clusterRoleBindingName,
-		roleName:           roleName,
-		serviceAccountName: serviceAccountName,
-	}
-	newClusterRoleBinding := buildClusterRoleBinding(dda, info, version)
-	if !apiequality.Semantic.DeepEqual(newClusterRoleBinding.Subjects, clusterRoleBinding.Subjects) || !apiequality.Semantic.DeepEqual(newClusterRoleBinding.RoleRef, clusterRoleBinding.RoleRef) {
-		logger.V(1).Info("updateOrchestratorClusterRoleBinding", "clusterRoleBinding.name", clusterRoleBinding.Name)
-		if err := r.client.Update(context.TODO(), newClusterRoleBinding); err != nil {
-			return reconcile.Result{}, err
-		}
-		event := buildEventInfo(newClusterRoleBinding.Name, newClusterRoleBinding.Namespace, clusterRoleKind, datadog.UpdateEvent)
-		r.recordEvent(dda, event)
-	}
-
-	return reconcile.Result{}, nil
-}
-
 func (r *Reconciler) createOrUpdateOrchestratorCoreRBAC(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, serviceAccountName, componentVersion, nameSuffix string) (reconcile.Result, error) {
 	orchestratorRBACName := orchestratorExplorerRBACPrefix + nameSuffix
 	orchestratorClusterRole := &rbacv1.ClusterRole{}
@@ -134,7 +115,7 @@ func (r *Reconciler) createOrUpdateOrchestratorCoreRBAC(logger logr.Logger, dda 
 		return reconcile.Result{}, err
 	}
 
-	return r.updateIfNeededOrchestratorExplorerClusterRoleBinding(logger, dda, orchestratorRBACName, orchestratorRBACName, serviceAccountName, componentVersion, orchestratorClusterRoleBinding)
+	return r.updateIfNeededClusterRoleBinding(logger, dda, orchestratorRBACName, orchestratorRBACName, serviceAccountName, componentVersion, orchestratorClusterRoleBinding)
 }
 
 func (r *Reconciler) cleanupOrchestratorCoreRBAC(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, nameSuffix string) (reconcile.Result, error) {


### PR DESCRIPTION
### What does this PR do?

ClusterRoleBinding can't be update if we change its RoleRef because this field
is immutable.

To fix the issue, we now do `Delete` and `Create`. 

This PR also refactor the code base to define only one function responsible of updating a ClusterRoleBinding.

### Motivation

In operator v0.7, the clusterchecksrunner has its owner clusterrole (not shared with the agent ds).
So to migrate from Operator v0.6, the ClusterRoleBinding need to be updated. but a simple `Update()`
doesn't work due to the `RoleRef` immutability 

### Additional Notes

N/A

### Describe your test plan

1. Deploy the operator v0.6.0
1. Deploy the DatadogAgent with clusterchecksrunner enabled.
1. Chek the status of the DatadogAgent, it should be `Active=true` like here
   ```console
   NAME            ACTIVE   AGENT                CLUSTER-AGENT     CLUSTER-CHECKS-RUNNER   AGE
   datadog-agent   True     Running (15/15/15)   Running (2/2/2)   Running (3/3/3)          3m
   ```
1. Update the operator to use v0.7.0(-rc.x)
1. Wait that the new operator instance get the leadership
1. The status of the DatadogAgent should still be `Active=true`
1. You can also check that the ClusterRoleBinding has been recreated. (timestamp)
 
