### PR TITLE
Standardize image defaulting

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -318,9 +318,4 @@ const (
 	ClusterRoleKind    = "ClusterRole"
 	RoleKind           = "Role"
 	ServiceAccountKind = "ServiceAccount"
-
-	// Container Registries
-
-	DefaultImageRegistry = "gcr.io/datadoghq"
-	JMXTagSuffix         = "-jmx"
 )

--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -241,7 +241,8 @@ func DefaultDatadogAgentSpecAgentImage(agent *DatadogAgentSpecAgentSpec, name, t
 		imgOverride.Name = agent.Image.Name
 	}
 
-	if agent.Image.Tag == "" {
+	// Only default Tag if not already present in the image.Name
+	if !defaulting.IsImageNameContainsTag(agent.Image.Name) && agent.Image.Tag == "" {
 		agent.Image.Tag = tag
 		imgOverride.Tag = agent.Image.Tag
 	}
@@ -1082,7 +1083,8 @@ func DefaultDatadogClusterAgentImage(dca *DatadogAgentSpecClusterAgentSpec, name
 		imgOverride.Name = dca.Image.Name
 	}
 
-	if dca.Image.Tag == "" {
+	// Only default Tag if not already present in the image.Name
+	if !defaulting.IsImageNameContainsTag(dca.Image.Name) && dca.Image.Tag == "" {
 		dca.Image.Tag = tag
 		imgOverride.Tag = dca.Image.Tag
 	}
@@ -1150,7 +1152,8 @@ func DefaultDatadogAgentSpecClusterChecksRunnerImage(clc *DatadogAgentSpecCluste
 		imgOverride.Name = clc.Image.Name
 	}
 
-	if clc.Image.Tag == "" {
+	// Only default Tag if not already present in the image.Name
+	if !defaulting.IsImageNameContainsTag(clc.Image.Name) && clc.Image.Tag == "" {
 		clc.Image.Tag = tag
 		imgOverride.Tag = clc.Image.Tag
 	}

--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/utils"
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,8 +22,6 @@ import (
 // default values
 const (
 	defaultLogLevel                         string = "INFO"
-	defaultAgentImageTag                    string = "7.28.0"
-	defaultClusterAgentImageTag             string = "1.12.0"
 	defaultAgentImageName                   string = "agent"
 	defaultClusterAgentImageName            string = "cluster-agent"
 	defaultCollectEvents                    bool   = false
@@ -189,7 +188,7 @@ func DefaultDatadogAgentSpecAgent(agent *DatadogAgentSpecAgentSpec) *DatadogAgen
 		agentOverride.UseExtendedDaemonset = agent.UseExtendedDaemonset
 	}
 
-	if img := DefaultDatadogAgentSpecAgentImage(agent, defaultAgentImageName, defaultAgentImageTag); !IsEqualStruct(*img, ImageConfig{}) {
+	if img := DefaultDatadogAgentSpecAgentImage(agent, defaultAgentImageName, defaulting.AgentLatestVersion); !IsEqualStruct(*img, ImageConfig{}) {
 		agentOverride.Image = img
 	}
 
@@ -955,7 +954,7 @@ func DefaultDatadogAgentSpecClusterAgent(clusterAgent *DatadogAgentSpecClusterAg
 	if clusterAgent.Image == nil {
 		clusterAgent.Image = &ImageConfig{}
 	}
-	if img := DefaultDatadogClusterAgentImage(clusterAgent, defaultClusterAgentImageName, defaultClusterAgentImageTag); !IsEqualStruct(*img, ImageConfig{}) {
+	if img := DefaultDatadogClusterAgentImage(clusterAgent, defaultClusterAgentImageName, defaulting.ClusterAgentLatestVersion); !IsEqualStruct(*img, ImageConfig{}) {
 		clusterAgentOverride.Image = img
 	}
 
@@ -1119,7 +1118,7 @@ func DefaultDatadogAgentSpecClusterChecksRunner(clusterChecksRunner *DatadogAgen
 		clcOverride.Enabled = clusterChecksRunner.Enabled
 	}
 
-	if img := DefaultDatadogAgentSpecClusterChecksRunnerImage(clusterChecksRunner, defaultAgentImageName, defaultAgentImageTag); !IsEqualStruct(img, ImageConfig{}) {
+	if img := DefaultDatadogAgentSpecClusterChecksRunnerImage(clusterChecksRunner, defaultAgentImageName, defaulting.AgentLatestVersion); !IsEqualStruct(img, ImageConfig{}) {
 		clcOverride.Image = img
 	}
 

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -570,7 +570,6 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				Enabled:              NewBoolPointer(true),
 				UseExtendedDaemonset: NewBoolPointer(false),
 				Image: &ImageConfig{
-					Tag:        defaulting.AgentLatestVersion, // TODO fix this in the patch cycle
 					PullPolicy: &defaultImagePullPolicy,
 				},
 				Config: &NodeAgentConfig{
@@ -621,7 +620,6 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				UseExtendedDaemonset: NewBoolPointer(false),
 				Image: &ImageConfig{
 					Name:        "gcr.io/datadog/agent:6.26.0",
-					Tag:         defaulting.AgentLatestVersion,
 					PullPolicy:  &defaultImagePullPolicy,
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},

--- a/api/v1alpha1/datadogagent_default_test.go
+++ b/api/v1alpha1/datadogagent_default_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	assert "github.com/stretchr/testify/require"
@@ -290,7 +291,7 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:       defaultClusterAgentImageName,
-					Tag:        defaultClusterAgentImageTag,
+					Tag:        defaulting.ClusterAgentLatestVersion,
 					PullPolicy: &defaultImagePullPolicy,
 				},
 				Config: &ClusterAgentConfig{
@@ -314,7 +315,7 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        defaultClusterAgentImageName,
-					Tag:         defaultClusterAgentImageTag,
+					Tag:         defaulting.ClusterAgentLatestVersion,
 					PullPolicy:  &defaultImagePullPolicy,
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
@@ -368,7 +369,7 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 			},
 			overrideExpected: &DatadogAgentSpecClusterAgentSpec{
 				Image: &ImageConfig{
-					Tag: defaultClusterAgentImageTag,
+					Tag: defaulting.ClusterAgentLatestVersion,
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
@@ -380,7 +381,7 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        "foo",
-					Tag:         defaultClusterAgentImageTag,
+					Tag:         defaulting.ClusterAgentLatestVersion,
 					PullPolicy:  (*corev1.PullPolicy)(NewStringPointer("Always")),
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
@@ -445,7 +446,7 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				UseExtendedDaemonset: NewBoolPointer(false),
 				Image: &ImageConfig{
 					Name:       defaultAgentImageName,
-					Tag:        defaultAgentImageTag,
+					Tag:        defaulting.AgentLatestVersion,
 					PullPolicy: &defaultImagePullPolicy,
 				},
 				Config: &NodeAgentConfig{
@@ -491,7 +492,7 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				UseExtendedDaemonset: NewBoolPointer(false),
 				Image: &ImageConfig{
 					Name:        defaultAgentImageName,
-					Tag:         defaultAgentImageTag,
+					Tag:         defaulting.AgentLatestVersion,
 					PullPolicy:  &defaultImagePullPolicy,
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
@@ -569,7 +570,7 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				Enabled:              NewBoolPointer(true),
 				UseExtendedDaemonset: NewBoolPointer(false),
 				Image: &ImageConfig{
-					Tag:        defaultAgentImageTag, // TODO fix this in the patch cycle
+					Tag:        defaulting.AgentLatestVersion, // TODO fix this in the patch cycle
 					PullPolicy: &defaultImagePullPolicy,
 				},
 				Config: &NodeAgentConfig{
@@ -620,7 +621,7 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				UseExtendedDaemonset: NewBoolPointer(false),
 				Image: &ImageConfig{
 					Name:        "gcr.io/datadog/agent:6.26.0",
-					Tag:         defaultAgentImageTag,
+					Tag:         defaulting.AgentLatestVersion,
 					PullPolicy:  &defaultImagePullPolicy,
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
@@ -720,7 +721,7 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 				Config:  &ClusterChecksRunnerConfig{},
 				Image: &ImageConfig{
 					Name: "gcr.io/datadog/agent:latest",
-					Tag:  defaultAgentImageTag,
+					Tag:  defaulting.AgentLatestVersion,
 				},
 			},
 			overrideExpected: &DatadogAgentSpecClusterChecksRunnerSpec{
@@ -741,7 +742,7 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        "gcr.io/datadog/agent:latest",
-					Tag:         defaultAgentImageTag,
+					Tag:         defaulting.AgentLatestVersion,
 					PullPolicy:  &defaultImagePullPolicy,
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
@@ -767,7 +768,7 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 				},
 				Image: &ImageConfig{
 					Name: "agent",
-					Tag:  defaultAgentImageTag,
+					Tag:  defaulting.AgentLatestVersion,
 				},
 			},
 			overrideExpected: &DatadogAgentSpecClusterChecksRunnerSpec{
@@ -786,7 +787,7 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 				Enabled: NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        "agent",
-					Tag:         defaultAgentImageTag,
+					Tag:         defaulting.AgentLatestVersion,
 					PullPolicy:  &defaultImagePullPolicy,
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},

--- a/api/v1alpha1/datadogagent_types.go
+++ b/api/v1alpha1/datadogagent_types.go
@@ -1232,9 +1232,9 @@ type DatadogAgentSpecClusterChecksRunnerSpec struct {
 // +k8s:openapi-gen=true
 type ImageConfig struct {
 	// Define the image to use:
-	// Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7
-	// Use "datadog/dogstatsd:latest" for Standalone Datadog Agent DogStatsD6
-	// Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent
+	// Use "gcr.io/datadoghq/agent" for Datadog Agent 7
+	// Use "datadog/dogstatsd" for Standalone Datadog Agent DogStatsD
+	// Use "gcr.io/datadoghq/cluster-agent" for Datadog Cluster Agent
 	// Use "agent" with the registry and tag configurations for <registry>/agent:<tag>
 	// Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>
 	Name string `json:"name,omitempty"`

--- a/api/v1alpha1/test/new.go
+++ b/api/v1alpha1/test/new.go
@@ -15,6 +15,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
@@ -23,7 +24,7 @@ var (
 	// apiVersion datadoghqv1alpha1 api version
 	apiVersion   = fmt.Sprintf("%s/%s", datadoghqv1alpha1.GroupVersion.Group, datadoghqv1alpha1.GroupVersion.Version)
 	pullPolicy   = corev1.PullIfNotPresent
-	defaultImage = "gcr.io/datadoghq/agent:latest"
+	defaultImage = defaulting.GetLatestAgentImage()
 )
 
 // NewDatadogAgentOptions set of option for the DatadogAgent creation

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -2259,7 +2259,7 @@ func schema__api_v1alpha1_ImageConfig(ref common.ReferenceCallback) common.OpenA
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Define the image to use: Use \"gcr.io/datadoghq/agent:latest\" for Datadog Agent 7 Use \"datadog/dogstatsd:latest\" for Standalone Datadog Agent DogStatsD6 Use \"gcr.io/datadoghq/cluster-agent:latest\" for Datadog Cluster Agent Use \"agent\" with the registry and tag configurations for <registry>/agent:<tag> Use \"cluster-agent\" with the registry and tag configurations for <registry>/cluster-agent:<tag>",
+							Description: "Define the image to use: Use \"gcr.io/datadoghq/agent\" for Datadog Agent 7 Use \"datadog/dogstatsd\" for Standalone Datadog Agent DogStatsD Use \"gcr.io/datadoghq/cluster-agent\" for Datadog Cluster Agent Use \"agent\" with the registry and tag configurations for <registry>/agent:<tag> Use \"cluster-agent\" with the registry and tag configurations for <registry>/cluster-agent:<tag>",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/cmd/kubectl-datadog/agent/upgrade/upgrade.go
+++ b/cmd/kubectl-datadog/agent/upgrade/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-operator/api/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/plugin/common"
 
 	"github.com/spf13/cobra"
@@ -22,9 +23,9 @@ import (
 var (
 	image          string
 	latest         bool
-	latestImage    = "gcr.io/datadoghq/agent:latest"
+	latestImage    = defaulting.GetLatestAgentImage()
 	upgradeExample = `
-  # upgrade the version of the datadog agent to latest
+  # upgrade the version of the datadog agent to known release (%[2]s)
   %[1]s upgrade --latest
 
   # upgrade the version of the datadog agent defined in DatadogAgent named foo to latest
@@ -58,7 +59,7 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "upgrade [flags]",
 		Short:        "Upgrade the Datadog Agent version",
-		Example:      fmt.Sprintf(upgradeExample, "kubectl datadog agent"),
+		Example:      fmt.Sprintf(upgradeExample, "kubectl datadog agent", defaulting.AgentLatestVersion),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {
@@ -72,7 +73,7 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&image, "image", "i", "", "The image of the Datadog Agent")
-	cmd.Flags().BoolVarP(&latest, "latest", "l", false, "Upgrade to gcr.io/datadoghq/agent:latest")
+	cmd.Flags().BoolVarP(&latest, "latest", "l", false, fmt.Sprintf("Upgrade to %s", defaulting.GetLatestAgentImage()))
 
 	o.ConfigFlags.AddFlags(cmd.Flags())
 

--- a/cmd/kubectl-datadog/agent/upgrade/upgrade_test.go
+++ b/cmd/kubectl-datadog/agent/upgrade/upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -106,7 +107,7 @@ func Test_options_upgrade(t *testing.T) {
 				_ = c.Create(context.TODO(), dd)
 				return dd
 			},
-			image:   "gcr.io/datadoghq/agent:latest",
+			image:   defaulting.GetLatestAgentImage(),
 			wantErr: false,
 			wantFunc: func(c client.Client, image string) error {
 				dd := &datadoghqv1alpha1.DatadogAgent{}

--- a/cmd/kubectl-datadog/clusteragent/upgrade/upgrade.go
+++ b/cmd/kubectl-datadog/clusteragent/upgrade/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-operator/api/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/plugin/common"
 
 	"github.com/spf13/cobra"
@@ -22,12 +23,12 @@ import (
 var (
 	image          string
 	latest         bool
-	latestImage    = "gcr.io/datadoghq/cluster-agent:latest"
+	latestImage    = defaulting.GetLatestClusterAgentImage()
 	upgradeExample = `
-  # upgrade the version of the datadog cluster agent to latest
+  # upgrade the version of the datadog cluster agent to latest known release %[2]s
   %[1]s upgrade --latest
 
-  # upgrade the version of the datadog cluster agent defined in DatadogAgent named foo to latest
+  # upgrade the version of the datadog cluster agent defined in DatadogAgent named "foo" to latest
   %[1]s upgrade foo --latest
 
   # upgrade the datadog cluster agent with a custom image
@@ -58,7 +59,7 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "upgrade [flags]",
 		Short:        "Upgrade the Datadog Cluster Agent version",
-		Example:      fmt.Sprintf(upgradeExample, "kubectl datadog clusteragent"),
+		Example:      fmt.Sprintf(upgradeExample, "kubectl datadog clusteragent", defaulting.ClusterAgentLatestVersion),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.complete(c, args); err != nil {
@@ -72,7 +73,7 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&image, "image", "i", "", "The image of the Datadog Cluster Agent")
-	cmd.Flags().BoolVarP(&latest, "latest", "l", false, "Upgrade to gcr.io/datadoghq/cluster-agent:latest")
+	cmd.Flags().BoolVarP(&latest, "latest", "l", false, fmt.Sprintf("Upgrade to %s", defaulting.GetLatestClusterAgentImage()))
 
 	o.ConfigFlags.AddFlags(cmd.Flags())
 

--- a/cmd/kubectl-datadog/clusteragent/upgrade/upgrade_test.go
+++ b/cmd/kubectl-datadog/clusteragent/upgrade/upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,7 +42,7 @@ func Test_options_upgrade(t *testing.T) {
 				_ = c.Create(context.TODO(), dd)
 				return dd
 			},
-			image:   "gcr.io/datadoghq/cluster-agent:latest",
+			image:   defaulting.GetLatestClusterAgentImage(),
 			wantErr: false,
 			wantFunc: func(c client.Client, image string) error {
 				dd := &datadoghqv1alpha1.DatadogAgent{}

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -3897,9 +3897,9 @@ spec:
                           JMX.
                         type: boolean
                       name:
-                        description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                          for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone
-                          Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                        description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                          for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                          Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                           for Datadog Cluster Agent Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag> Use "cluster-agent"
                           with the registry and tag configurations for <registry>/cluster-agent:<tag>'
@@ -7584,9 +7584,9 @@ spec:
                           JMX.
                         type: boolean
                       name:
-                        description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                          for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone
-                          Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                        description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                          for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                          Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                           for Datadog Cluster Agent Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag> Use "cluster-agent"
                           with the registry and tag configurations for <registry>/cluster-agent:<tag>'
@@ -10387,9 +10387,9 @@ spec:
                           JMX.
                         type: boolean
                       name:
-                        description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                          for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone
-                          Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                        description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                          for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                          Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                           for Datadog Cluster Agent Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag> Use "cluster-agent"
                           with the registry and tag configurations for <registry>/cluster-agent:<tag>'
@@ -14917,9 +14917,9 @@ spec:
                               JMX.
                             type: boolean
                           name:
-                            description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                              for Datadog Agent 7 Use "datadog/dogstatsd:latest" for
-                              Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                            description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                              for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                              Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                               for Datadog Cluster Agent Use "agent" with the registry
                               and tag configurations for <registry>/agent:<tag> Use
                               "cluster-agent" with the registry and tag configurations
@@ -18741,9 +18741,9 @@ spec:
                               JMX.
                             type: boolean
                           name:
-                            description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                              for Datadog Agent 7 Use "datadog/dogstatsd:latest" for
-                              Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                            description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                              for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                              Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                               for Datadog Cluster Agent Use "agent" with the registry
                               and tag configurations for <registry>/agent:<tag> Use
                               "cluster-agent" with the registry and tag configurations
@@ -21659,9 +21659,9 @@ spec:
                               JMX.
                             type: boolean
                           name:
-                            description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                              for Datadog Agent 7 Use "datadog/dogstatsd:latest" for
-                              Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                            description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                              for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                              Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                               for Datadog Cluster Agent Use "agent" with the registry
                               and tag configurations for <registry>/agent:<tag> Use
                               "cluster-agent" with the registry and tag configurations

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -3771,9 +3771,9 @@ spec:
                       description: Define whether the Agent image should support JMX.
                       type: boolean
                     name:
-                      description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                        for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone
-                        Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                      description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                        for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                        Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                         for Datadog Cluster Agent Use "agent" with the registry and
                         tag configurations for <registry>/agent:<tag> Use "cluster-agent"
                         with the registry and tag configurations for <registry>/cluster-agent:<tag>'
@@ -7331,9 +7331,9 @@ spec:
                       description: Define whether the Agent image should support JMX.
                       type: boolean
                     name:
-                      description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                        for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone
-                        Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                      description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                        for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                        Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                         for Datadog Cluster Agent Use "agent" with the registry and
                         tag configurations for <registry>/agent:<tag> Use "cluster-agent"
                         with the registry and tag configurations for <registry>/cluster-agent:<tag>'
@@ -10044,9 +10044,9 @@ spec:
                       description: Define whether the Agent image should support JMX.
                       type: boolean
                     name:
-                      description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                        for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone
-                        Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                      description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                        for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                        Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                         for Datadog Cluster Agent Use "agent" with the registry and
                         tag configurations for <registry>/agent:<tag> Use "cluster-agent"
                         with the registry and tag configurations for <registry>/cluster-agent:<tag>'
@@ -14432,9 +14432,9 @@ spec:
                             JMX.
                           type: boolean
                         name:
-                          description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                            for Datadog Agent 7 Use "datadog/dogstatsd:latest" for
-                            Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                          description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                            for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                            Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                             for Datadog Cluster Agent Use "agent" with the registry
                             and tag configurations for <registry>/agent:<tag> Use
                             "cluster-agent" with the registry and tag configurations
@@ -18114,9 +18114,9 @@ spec:
                             JMX.
                           type: boolean
                         name:
-                          description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                            for Datadog Agent 7 Use "datadog/dogstatsd:latest" for
-                            Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                          description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                            for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                            Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                             for Datadog Cluster Agent Use "agent" with the registry
                             and tag configurations for <registry>/agent:<tag> Use
                             "cluster-agent" with the registry and tag configurations
@@ -20941,9 +20941,9 @@ spec:
                             JMX.
                           type: boolean
                         name:
-                          description: 'Define the image to use: Use "gcr.io/datadoghq/agent:latest"
-                            for Datadog Agent 7 Use "datadog/dogstatsd:latest" for
-                            Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest"
+                          description: 'Define the image to use: Use "gcr.io/datadoghq/agent"
+                            for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone
+                            Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent"
                             for Datadog Cluster Agent Use "agent" with the registry
                             and tag configurations for <registry>/agent:<tag> Use
                             "cluster-agent" with the registry and tag configurations

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 	test "github.com/DataDog/datadog-operator/api/v1alpha1/test"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/orchestrator"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
@@ -1116,7 +1117,7 @@ func addEnvVar(currentVars []corev1.EnvVar, varName string, varValue string) []c
 func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 	apmContainer := corev1.Container{
 		Name:            "trace-agent",
-		Image:           "gcr.io/datadoghq/agent:latest",
+		Image:           defaulting.GetLatestAgentImage(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"trace-agent", "--config=" + agentConfigFile},
 		Resources:       corev1.ResourceRequirements{},
@@ -1190,7 +1191,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 		InitContainers: []corev1.Container{
 			{
 				Name:            "init-volume",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1204,7 +1205,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 			},
 			{
 				Name:            "init-config",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1214,7 +1215,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 			},
 			{
 				Name:            "seccomp-setup",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"cp", "/etc/config/system-probe-seccomp.json", "/host/var/lib/kubelet/seccomp/system-probe"},
@@ -1233,7 +1234,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 		Containers: []corev1.Container{
 			{
 				Name:            "agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"agent",
@@ -1254,7 +1255,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 			},
 			{
 				Name:            "system-probe",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"system-probe",
@@ -1315,7 +1316,7 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 		InitContainers: []corev1.Container{
 			{
 				Name:            "init-volume",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1329,7 +1330,7 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 			},
 			{
 				Name:            "init-config",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1341,7 +1342,7 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 		Containers: []corev1.Container{
 			{
 				Name:            "agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"agent",
@@ -1362,7 +1363,7 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 			},
 			{
 				Name:            "system-probe",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"system-probe",
@@ -1394,7 +1395,7 @@ func defaultPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSpec {
 		InitContainers: []corev1.Container{
 			{
 				Name:            "init-volume",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1408,7 +1409,7 @@ func defaultPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSpec {
 			},
 			{
 				Name:            "init-config",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1420,7 +1421,7 @@ func defaultPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:            "agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"agent",
@@ -1441,7 +1442,7 @@ func defaultPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSpec {
 			},
 			{
 				Name:            "process-agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"process-agent",
@@ -1666,7 +1667,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 		InitContainers: []corev1.Container{
 			{
 				Name:            "init-volume",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1675,7 +1676,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 			},
 			{
 				Name:            "init-config",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1685,7 +1686,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 			},
 			{
 				Name:            "seccomp-setup",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"cp", "/etc/config/system-probe-seccomp.json", "/host/var/lib/kubelet/seccomp/system-probe"},
@@ -1704,7 +1705,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 		Containers: []corev1.Container{
 			{
 				Name:            "agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"agent",
@@ -1725,7 +1726,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 			},
 			{
 				Name:            "system-probe",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"system-probe",
@@ -1749,7 +1750,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 			},
 			{
 				Name:            "security-agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"security-agent",
@@ -1777,7 +1778,7 @@ func complianceSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 		InitContainers: []corev1.Container{
 			{
 				Name:            "init-volume",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1791,7 +1792,7 @@ func complianceSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 			},
 			{
 				Name:            "init-config",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1803,7 +1804,7 @@ func complianceSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:            "agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"agent",
@@ -1824,7 +1825,7 @@ func complianceSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 			},
 			{
 				Name:            "security-agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"security-agent",
@@ -1949,7 +1950,7 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 		InitContainers: []corev1.Container{
 			{
 				Name:            "init-volume",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1963,7 +1964,7 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 			},
 			{
 				Name:            "init-config",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -1975,7 +1976,7 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 		Containers: []corev1.Container{
 			{
 				Name:            "agent",
-				Image:           "gcr.io/datadoghq/agent:latest",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command: []string{
 					"agent",

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -454,7 +454,7 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 		Containers: []corev1.Container{
 			{
 				Name:            "cluster-agent",
-				Image:           getImage(clusterAgentSpec.Image, dda.Spec.Registry, true),
+				Image:           getImage(clusterAgentSpec.Image, dda.Spec.Registry),
 				ImagePullPolicy: *clusterAgentSpec.Image.PullPolicy,
 				Ports: []corev1.ContainerPort{
 					{

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -8,6 +8,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/v1alpha1/test"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/orchestrator"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
 	"github.com/go-logr/logr"
@@ -32,7 +33,7 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 		Containers: []v1.Container{
 			{
 				Name:            "cluster-agent",
-				Image:           "gcr.io/datadoghq/cluster-agent:1.12.0",
+				Image:           defaulting.GetLatestClusterAgentImage(),
 				ImagePullPolicy: v1.PullIfNotPresent,
 				Resources:       v1.ResourceRequirements{},
 				Ports: []v1.ContainerPort{

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -260,7 +260,7 @@ func newClusterChecksRunnerPodTemplate(dda *datadoghqv1alpha1.DatadogAgent, labe
 	spec := &dda.Spec
 	volumeMounts := getVolumeMountsForClusterChecksRunner(dda)
 	envVars := getEnvVarsForClusterChecksRunner(dda)
-	image := getImage(clusterChecksRunnerSpec.Image, spec.Registry, true)
+	image := getImage(clusterChecksRunnerSpec.Image, spec.Registry)
 
 	newPodTemplate := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/datadogagent/clusterchecksrunner_rbac_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2019 Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 package datadogagent
 

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -8,6 +8,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 	test "github.com/DataDog/datadog-operator/api/v1alpha1/test"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
 	assert "github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func clusterChecksRunnerDefaultPodSpec() corev1.PodSpec {
 		InitContainers: []corev1.Container{
 			{
 				Name:            "init-config",
-				Image:           "gcr.io/datadoghq/agent:7.28.0",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Command:         []string{"bash", "-c"},
@@ -37,7 +38,7 @@ func clusterChecksRunnerDefaultPodSpec() corev1.PodSpec {
 		Containers: []corev1.Container{
 			{
 				Name:            "cluster-checks-runner",
-				Image:           "gcr.io/datadoghq/agent:7.28.0",
+				Image:           defaulting.GetLatestAgentImage(),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Resources:       corev1.ResourceRequirements{},
 				Env:             clusterChecksRunnerDefaultEnvVars(),

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -19,6 +19,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/orchestrator"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
@@ -2342,15 +2343,15 @@ func getImage(imageSpec *datadoghqv1alpha1.ImageConfig, registry *string, checkJ
 
 	image := "/" + imageSpec.Name + ":" + imageSpec.Tag
 
-	if checkJMX && imageSpec.JmxEnabled && !strings.HasSuffix(imageSpec.Tag, datadoghqv1alpha1.JMXTagSuffix) {
-		image += datadoghqv1alpha1.JMXTagSuffix
+	if checkJMX && imageSpec.JmxEnabled && !strings.HasSuffix(imageSpec.Tag, defaulting.JMXTagSuffix) {
+		image += defaulting.JMXTagSuffix
 	}
 
 	if registry != nil {
 		return *registry + image
 	}
 
-	return datadoghqv1alpha1.DefaultImageRegistry + image
+	return defaulting.DefaultImageRegistry + image
 }
 
 // getReplicas returns the desired replicas of a

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -2330,13 +2329,9 @@ func addBoolPointerEnVar(b *bool, varName string, varList []corev1.EnvVar) []cor
 	return varList
 }
 
-// imageHasTag identifies whether an image string contains a tag suffix
-// Ref: https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
-var imageHasTag = regexp.MustCompile(`.+:[\w][\w.-]{0,127}$`)
-
 // getImage builds the image string based on ImageConfig and the registry configuration.
 func getImage(imageSpec *datadoghqv1alpha1.ImageConfig, registry *string) string {
-	if imageHasTag.MatchString(imageSpec.Name) {
+	if defaulting.IsImageNameContainsTag(imageSpec.Name) {
 		// The image name corresponds to a full image string
 		return imageSpec.Name
 	}

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -450,24 +450,6 @@ func Test_mergeAnnotationsLabels(t *testing.T) {
 	}
 }
 
-func Test_imageHasTag(t *testing.T) {
-	cases := map[string]bool{
-		"foo:bar":             true,
-		"foo/bar:baz":         true,
-		"foo/bar:baz:tar":     true,
-		"foo/bar:baz-tar":     true,
-		"foo/bar:baz_tar":     true,
-		"foo/bar:baz.tar":     true,
-		"foo/foo/bar:baz:tar": true,
-		"foo":                 false,
-		":foo":                false,
-		"foo:foo/bar":         false,
-	}
-	for tc, expected := range cases {
-		assert.Equal(t, expected, imageHasTag.MatchString(tc))
-	}
-}
-
 func Test_getImage(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -473,7 +473,6 @@ func Test_getImage(t *testing.T) {
 		name      string
 		imageSpec *datadoghqv1alpha1.ImageConfig
 		registry  *string
-		checkJMX  bool
 		want      string
 	}{
 		{
@@ -482,7 +481,6 @@ func Test_getImage(t *testing.T) {
 				Name: defaulting.GetLatestAgentImage(),
 			},
 			registry: nil,
-			checkJMX: false,
 			want:     defaulting.GetLatestAgentImage(),
 		},
 		{
@@ -492,7 +490,6 @@ func Test_getImage(t *testing.T) {
 				Tag:  "7",
 			},
 			registry: datadoghqv1alpha1.NewStringPointer("public.ecr.aws/datadog"),
-			checkJMX: false,
 			want:     "public.ecr.aws/datadog/agent:7",
 		},
 		{
@@ -502,7 +499,6 @@ func Test_getImage(t *testing.T) {
 				Tag:  "latest",
 			},
 			registry: datadoghqv1alpha1.NewStringPointer("gcr.io/datadoghq"),
-			checkJMX: false,
 			want:     "docker.io/datadog/agent:7.28.1-rc.3",
 		},
 		{
@@ -512,7 +508,6 @@ func Test_getImage(t *testing.T) {
 				Tag:  "latest",
 			},
 			registry: nil,
-			checkJMX: false,
 			want:     "gcr.io/datadoghq/agent:latest",
 		},
 		{
@@ -523,8 +518,17 @@ func Test_getImage(t *testing.T) {
 				JmxEnabled: true,
 			},
 			registry: nil,
-			checkJMX: true,
 			want:     defaulting.GetLatestAgentImageJMX(),
+		},
+		{
+			name: "cluster-agent",
+			imageSpec: &datadoghqv1alpha1.ImageConfig{
+				Name:       "cluster-agent",
+				Tag:        defaulting.ClusterAgentLatestVersion,
+				JmxEnabled: false,
+			},
+			registry: nil,
+			want:     defaulting.GetLatestClusterAgentImage(),
 		},
 		{
 			name: "do not duplicate jmx",
@@ -534,7 +538,6 @@ func Test_getImage(t *testing.T) {
 				JmxEnabled: true,
 			},
 			registry: nil,
-			checkJMX: true,
 			want:     "gcr.io/datadoghq/agent:latest-jmx",
 		},
 		{
@@ -545,13 +548,12 @@ func Test_getImage(t *testing.T) {
 				JmxEnabled: true,
 			},
 			registry: nil,
-			checkJMX: false,
 			want:     "gcr.io/datadoghq/agent:latest-jmx",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, getImage(tt.imageSpec, tt.registry, tt.checkJMX))
+			assert.Equal(t, tt.want, getImage(tt.imageSpec, tt.registry))
 		})
 	}
 }

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -7,6 +7,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/v1alpha1/test"
 	"github.com/DataDog/datadog-operator/controllers/testutils"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -478,11 +479,11 @@ func Test_getImage(t *testing.T) {
 		{
 			name: "backward compatible",
 			imageSpec: &datadoghqv1alpha1.ImageConfig{
-				Name: "gcr.io/datadoghq/agent:latest",
+				Name: defaulting.GetLatestAgentImage(),
 			},
 			registry: nil,
 			checkJMX: false,
-			want:     "gcr.io/datadoghq/agent:latest",
+			want:     defaulting.GetLatestAgentImage(),
 		},
 		{
 			name: "nominal case",
@@ -518,12 +519,12 @@ func Test_getImage(t *testing.T) {
 			name: "add jmx",
 			imageSpec: &datadoghqv1alpha1.ImageConfig{
 				Name:       "agent",
-				Tag:        "latest",
+				Tag:        defaulting.AgentLatestVersion,
 				JmxEnabled: true,
 			},
 			registry: nil,
 			checkJMX: true,
-			want:     "gcr.io/datadoghq/agent:latest-jmx",
+			want:     defaulting.GetLatestAgentImageJMX(),
 		},
 		{
 			name: "do not duplicate jmx",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,7 @@ spec:
 | agent.hostNetwork | Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false. |
 | agent.hostPID | Use the host's pid namespace. Optional: Default to false. |
 | agent.image.jmxEnabled | Define whether the Agent image should support JMX. |
-| agent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent Use "agent" with the registry and tag configurations for <registry>/agent:<tag> Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag> |
+| agent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent" for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent" for Datadog Cluster Agent Use "agent" with the registry and tag configurations for <registry>/agent:<tag> Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag> |
 | agent.image.pullPolicy | The Kubernetes pull policy: Use Always, Never or IfNotPresent. |
 | agent.image.pullSecrets | It is possible to specify docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
 | agent.image.tag | Define the image version to use: To be used if the Name field does not correspond to a full image string. |
@@ -298,7 +298,7 @@ spec:
 | clusterAgent.deploymentName | Name of the Cluster Agent Deployment to create or migrate from. |
 | clusterAgent.enabled | Enabled |
 | clusterAgent.image.jmxEnabled | Define whether the Agent image should support JMX. |
-| clusterAgent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent Use "agent" with the registry and tag configurations for <registry>/agent:<tag> Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag> |
+| clusterAgent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent" for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent" for Datadog Cluster Agent Use "agent" with the registry and tag configurations for <registry>/agent:<tag> Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag> |
 | clusterAgent.image.pullPolicy | The Kubernetes pull policy: Use Always, Never or IfNotPresent. |
 | clusterAgent.image.pullSecrets | It is possible to specify docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
 | clusterAgent.image.tag | Define the image version to use: To be used if the Name field does not correspond to a full image string. |
@@ -360,7 +360,7 @@ spec:
 | clusterChecksRunner.deploymentName | Name of the cluster checks deployment to create or migrate from. |
 | clusterChecksRunner.enabled | Enabled |
 | clusterChecksRunner.image.jmxEnabled | Define whether the Agent image should support JMX. |
-| clusterChecksRunner.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7 Use "datadog/dogstatsd:latest" for Standalone Datadog Agent DogStatsD6 Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent Use "agent" with the registry and tag configurations for <registry>/agent:<tag> Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag> |
+| clusterChecksRunner.image.name | Define the image to use: Use "gcr.io/datadoghq/agent" for Datadog Agent 7 Use "datadog/dogstatsd" for Standalone Datadog Agent DogStatsD Use "gcr.io/datadoghq/cluster-agent" for Datadog Cluster Agent Use "agent" with the registry and tag configurations for <registry>/agent:<tag> Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag> |
 | clusterChecksRunner.image.pullPolicy | The Kubernetes pull policy: Use Always, Never or IfNotPresent. |
 | clusterChecksRunner.image.pullSecrets | It is possible to specify docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
 | clusterChecksRunner.image.tag | Define the image version to use: To be used if the Name field does not correspond to a full image string. |

--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -1,11 +1,17 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2012 Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 package defaulting
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+// ContainerRegistry represent a container registry URL
+type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
@@ -14,24 +20,114 @@ const (
 	ClusterAgentLatestVersion = "1.14.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
-	GCRContainerRegistry = "gcr.io/datadoghq"
+	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"
+	// DockerHubContainerRegistry correspond to the datadoghq docker.io registry
+	DockerHubContainerRegistry ContainerRegistry = "docker.io/datadog"
+	// PublicECSContainerRegistry correspond to the datadoghq PublicECSContainerRegistry registry
+	PublicECSContainerRegistry ContainerRegistry = "public.ecr.aws/datadog"
 	// DefaultImageRegistry correspond to the datadoghq containers registry
 	DefaultImageRegistry = GCRContainerRegistry
 	// JMXTagSuffix prefix tag for agent JMX images
 	JMXTagSuffix = "-jmx"
+
+	agentImageName        = "agent"
+	clusterAgentImageName = "cluster-agent"
 )
 
+// Image represent a container image information
+type Image struct {
+	registry  ContainerRegistry
+	imageName string
+	tag       string
+	isJMX     bool
+}
+
+// NewImage return a new Image instance
+func NewImage(name, tag string, isJMX bool) *Image {
+	return &Image{
+		registry:  DefaultImageRegistry,
+		imageName: name,
+		tag:       strings.TrimSuffix(tag, JMXTagSuffix),
+		isJMX:     strings.HasSuffix(tag, JMXTagSuffix) || isJMX,
+	}
+}
+
+// ImageOptions use to allow extra Image configuration
+type ImageOptions func(*Image)
+
 // GetLatestAgentImage return the latest stable agent release version
-func GetLatestAgentImage() string {
-	return fmt.Sprintf("%s/agent:%s", DefaultImageRegistry, AgentLatestVersion)
+func GetLatestAgentImage(opts ...ImageOptions) string {
+	image := &Image{
+		registry:  DefaultImageRegistry,
+		imageName: agentImageName,
+		tag:       AgentLatestVersion,
+	}
+	processOptions(image, opts...)
+	return image.String()
 }
 
 // GetLatestAgentImageJMX return the latest JMX stable agent release version
-func GetLatestAgentImageJMX() string {
-	return fmt.Sprintf("%s%s", GetLatestAgentImage(), JMXTagSuffix)
+func GetLatestAgentImageJMX(opts ...ImageOptions) string {
+	image := &Image{
+		registry:  DefaultImageRegistry,
+		imageName: agentImageName,
+		tag:       AgentLatestVersion,
+	}
+	processOptions(image, opts...)
+	image.tag = fmt.Sprintf("%s%s", image.tag, JMXTagSuffix)
+	return image.String()
 }
 
 // GetLatestClusterAgentImage return the latest stable agent release version
-func GetLatestClusterAgentImage() string {
-	return fmt.Sprintf("%s/cluster-agent:%s", DefaultImageRegistry, ClusterAgentLatestVersion)
+func GetLatestClusterAgentImage(opts ...ImageOptions) string {
+	image := &Image{
+		registry:  DefaultImageRegistry,
+		imageName: clusterAgentImageName,
+		tag:       ClusterAgentLatestVersion,
+	}
+	processOptions(image, opts...)
+	return image.String()
+}
+
+// WithRegistry ImageOptions to specify the container registry
+func WithRegistry(registry ContainerRegistry) ImageOptions {
+	return func(image *Image) {
+		image.registry = registry
+	}
+}
+
+// WithTag ImageOptions to specify the container image tag.
+func WithTag(tag string) ImageOptions {
+	return func(image *Image) {
+		image.tag = tag
+	}
+}
+
+// WithImageName ImageOptions to specify the image name
+func WithImageName(name string) ImageOptions {
+	return func(image *Image) {
+		image.imageName = name
+	}
+}
+
+// WithJMX ImageOptions to specify if the JMX prefix should be added
+func WithJMX(jmx bool) ImageOptions {
+	return func(image *Image) {
+		image.isJMX = jmx
+	}
+}
+
+func processOptions(image *Image, opts ...ImageOptions) {
+	for _, option := range opts {
+		option(image)
+	}
+}
+
+// String return the string representation of an image
+func (i *Image) String() string {
+	suffix := ""
+	if i.isJMX {
+		suffix = JMXTagSuffix
+	}
+	return fmt.Sprintf("%s/%s:%s%s", i.registry, i.imageName, i.tag, suffix)
 }

--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -7,6 +7,7 @@ package defaulting
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -33,6 +34,16 @@ const (
 	agentImageName        = "agent"
 	clusterAgentImageName = "cluster-agent"
 )
+
+// imageHasTag identifies whether an image string contains a tag suffix
+// Ref: https://github.com/distribution/distribution/blob/v2.7.1/reference/reference.go
+var imageHasTag = regexp.MustCompile(`.+:[\w][\w.-]{0,127}$`)
+
+// IsImageNameContainsTag return true if the image name contains a tag
+func IsImageNameContainsTag(name string) bool {
+	// The image name corresponds to a full image string
+	return imageHasTag.MatchString(name)
+}
 
 // Image represent a container image information
 type Image struct {

--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2012 Datadog, Inc.
+
+package defaulting
+
+import "fmt"
+
+const (
+	// AgentLatestVersion correspond to the latest stable agent release
+	AgentLatestVersion = "7.30.0"
+	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
+	ClusterAgentLatestVersion = "1.14.0"
+
+	// GCRContainerRegistry correspond to the datadoghq GCR registry
+	GCRContainerRegistry = "gcr.io/datadoghq"
+	// DefaultImageRegistry correspond to the datadoghq containers registry
+	DefaultImageRegistry = GCRContainerRegistry
+	// JMXTagSuffix prefix tag for agent JMX images
+	JMXTagSuffix = "-jmx"
+)
+
+// GetLatestAgentImage return the latest stable agent release version
+func GetLatestAgentImage() string {
+	return fmt.Sprintf("%s/agent:%s", DefaultImageRegistry, AgentLatestVersion)
+}
+
+// GetLatestAgentImageJMX return the latest JMX stable agent release version
+func GetLatestAgentImageJMX() string {
+	return fmt.Sprintf("%s%s", GetLatestAgentImage(), JMXTagSuffix)
+}
+
+// GetLatestClusterAgentImage return the latest stable agent release version
+func GetLatestClusterAgentImage() string {
+	return fmt.Sprintf("%s/cluster-agent:%s", DefaultImageRegistry, ClusterAgentLatestVersion)
+}

--- a/pkg/defaulting/images_test.go
+++ b/pkg/defaulting/images_test.go
@@ -1,26 +1,179 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-2012 Datadog, Inc.
+// Copyright 2016-present Datadog, Inc.
 
 package defaulting
 
-import "testing"
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
 
 func TestGetLatestAgentImage(t *testing.T) {
 	tests := []struct {
 		name string
+		opts []ImageOptions
 		want string
 	}{
 		{
-			name: "default",
-			want: "gcr.io/datadoghq/agent:7.30.0",
+			name: "default registry",
+			want: fmt.Sprintf("gcr.io/datadoghq/agent:%s", AgentLatestVersion),
+		},
+
+		{
+			name: "docker.io",
+			opts: []ImageOptions{
+				WithRegistry(DockerHubContainerRegistry),
+			},
+			want: fmt.Sprintf("docker.io/datadog/agent:%s", AgentLatestVersion),
+		},
+		{
+			name: "with tag",
+			opts: []ImageOptions{
+				WithTag("latest"),
+			},
+			want: "gcr.io/datadoghq/agent:latest",
+		},
+		{
+			name: "with image name",
+			opts: []ImageOptions{
+				WithImageName("foo"),
+				WithTag("latest"),
+			},
+			want: "gcr.io/datadoghq/foo:latest",
+		},
+		{
+			name: "with jmx",
+			opts: []ImageOptions{
+				WithImageName("foo"),
+				WithTag("latest"),
+				WithJMX(true),
+			},
+			want: "gcr.io/datadoghq/foo:latest-jmx",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetLatestAgentImage(); got != tt.want {
+			if got := GetLatestAgentImage(tt.opts...); got != tt.want {
 				t.Errorf("GetLatestAgentImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLatestAgentImageJMX(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []ImageOptions
+		want string
+	}{
+		{
+			name: "default registry",
+			want: fmt.Sprintf("gcr.io/datadoghq/agent:%s-jmx", AgentLatestVersion),
+		},
+
+		{
+			name: "docker.io",
+			opts: []ImageOptions{
+				WithRegistry(DockerHubContainerRegistry),
+			},
+			want: fmt.Sprintf("docker.io/datadog/agent:%s-jmx", AgentLatestVersion),
+		},
+		{
+			name: "with tag",
+			opts: []ImageOptions{
+				WithTag("latest"),
+			},
+			want: "gcr.io/datadoghq/agent:latest-jmx",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLatestAgentImageJMX(tt.opts...); got != tt.want {
+				t.Errorf("GetLatestAgentImageJMX() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLatestClusterAgentImage(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []ImageOptions
+		want string
+	}{
+		{
+			name: "default registry",
+			want: fmt.Sprintf("gcr.io/datadoghq/cluster-agent:%s", ClusterAgentLatestVersion),
+		},
+
+		{
+			name: "docker.io",
+			opts: []ImageOptions{
+				WithRegistry(DockerHubContainerRegistry),
+			},
+			want: fmt.Sprintf("docker.io/datadog/cluster-agent:%s", ClusterAgentLatestVersion),
+		},
+		{
+			name: "with tag",
+			opts: []ImageOptions{
+				WithTag("latest"),
+			},
+			want: "gcr.io/datadoghq/cluster-agent:latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLatestClusterAgentImage(tt.opts...); got != tt.want {
+				t.Errorf("GetLatestClusterAgentImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewImage(t *testing.T) {
+	type args struct {
+		name  string
+		tag   string
+		isJMX bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "default",
+			args: args{
+				name: "foo",
+				tag:  "bar",
+			},
+			want: "gcr.io/datadoghq/foo:bar",
+		},
+		{
+			name: "jmx option",
+			args: args{
+				name:  "foo",
+				tag:   "bar",
+				isJMX: true,
+			},
+			want: "gcr.io/datadoghq/foo:bar-jmx",
+		},
+		{
+			name: "jmx tag",
+			args: args{
+				name: "foo",
+				tag:  "bar-jmx",
+			},
+			want: "gcr.io/datadoghq/foo:bar-jmx",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewImage(tt.args.name, tt.args.tag, tt.args.isJMX).String(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewImage() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/defaulting/images_test.go
+++ b/pkg/defaulting/images_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetLatestAgentImage(t *testing.T) {
@@ -176,5 +178,23 @@ func TestNewImage(t *testing.T) {
 				t.Errorf("NewImage() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsImageNameContainsTag(t *testing.T) {
+	cases := map[string]bool{
+		"foo:bar":             true,
+		"foo/bar:baz":         true,
+		"foo/bar:baz:tar":     true,
+		"foo/bar:baz-tar":     true,
+		"foo/bar:baz_tar":     true,
+		"foo/bar:baz.tar":     true,
+		"foo/foo/bar:baz:tar": true,
+		"foo":                 false,
+		":foo":                false,
+		"foo:foo/bar":         false,
+	}
+	for tc, expected := range cases {
+		assert.Equal(t, expected, IsImageNameContainsTag(tc))
 	}
 }

--- a/pkg/defaulting/images_test.go
+++ b/pkg/defaulting/images_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2012 Datadog, Inc.
+
+package defaulting
+
+import "testing"
+
+func TestGetLatestAgentImage(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "default",
+			want: "gcr.io/datadoghq/agent:7.30.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetLatestAgentImage(); got != tt.want {
+				t.Errorf("GetLatestAgentImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Update defaulting images logic and have a dedicated package for defaulting.

The idea here is to update the Agent and Cluster-Agent image version with 
the lastest stable version each time we release the Operator. 

### Motivation

Keep up-to-date the agent and cluster-agent when deploying a new Operator version.

### Additional Notes

N/A

### Describe your test plan

Deploy the example `examples/datadogagent/datadog-agent-with-credential-secret.yaml` 

* Check that the Agent image tag is `7.30.0` 
* Check that the Cluster-Agent image tag is `1.14.0`
