### PR TITLE
[docs/configuration] Fix links to example configs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -411,9 +411,9 @@ spec:
 | registry | Registry to use for all Agent images (default gcr.io/datadoghq). Use public.ecr.aws/datadog for AWS Use docker.io/datadog for DockerHub |
 | site | The site of the Datadog intake to send Agent data to. Set to 'datadoghq.eu' to send data to the EU site. |
 
-[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-logs-apm.yaml
-[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-logs.yaml
-[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-apm.yaml
-[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-clusteragent.yaml
-[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-tolerations.yaml
+[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-all.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-logs-apm.yaml
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-logs.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-apm.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-clusteragent.yaml
+[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-tolerations.yaml

--- a/hack/generate-docs/footer.markdown
+++ b/hack/generate-docs/footer.markdown
@@ -1,7 +1,7 @@
 
-[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-logs-apm.yaml
-[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-logs.yaml
-[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-apm.yaml
-[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-clusteragent.yaml
-[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadog-agent-with-tolerations.yaml
+[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-all.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-logs-apm.yaml
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-logs.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-apm.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-clusteragent.yaml
+[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-tolerations.yaml


### PR DESCRIPTION
### What does this PR do?

Fixes links to examples configs in `docs/configuration.md`.

