### PR TITLE
[controllers/datadogagent] Ensure ClusterRoles and ClusterRoleBindings are deleted

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -923,9 +923,6 @@ func (r *Reconciler) manageClusterAgentRBACs(logger logr.Logger, dda *datadoghqv
 
 func (r *Reconciler) createClusterAgentClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) (reconcile.Result, error) {
 	clusterRole := buildClusterAgentClusterRole(dda, name, agentVersion)
-	if err := SetOwnerReference(dda, clusterRole, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
 	logger.V(1).Info("createClusterAgentClusterRole", "clusterRole.name", clusterRole.Name)
 	event := buildEventInfo(clusterRole.Name, clusterRole.Namespace, clusterRoleKind, datadog.CreationEvent)
 	r.recordEvent(dda, event)
@@ -945,9 +942,6 @@ func (r *Reconciler) createClusterAgentRole(logger logr.Logger, dda *datadoghqv1
 
 func (r *Reconciler) createAgentClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) (reconcile.Result, error) {
 	clusterRole := buildAgentClusterRole(dda, name, agentVersion)
-	if err := SetOwnerReference(dda, clusterRole, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
 	logger.V(1).Info("createAgentClusterRole", "clusterRole.name", clusterRole.Name)
 	event := buildEventInfo(clusterRole.Name, clusterRole.Namespace, clusterRoleKind, datadog.CreationEvent)
 	r.recordEvent(dda, event)
@@ -957,9 +951,6 @@ func (r *Reconciler) createAgentClusterRole(logger logr.Logger, dda *datadoghqv1
 
 func (r *Reconciler) createClusterCheckRunnerClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) (reconcile.Result, error) {
 	clusterRole := buildClusterCheckRunnerClusterRole(dda, name, agentVersion)
-	if err := SetOwnerReference(dda, clusterRole, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
 	logger.V(1).Info("createAgentClusterRole", "clusterRole.name", clusterRole.Name)
 	event := buildEventInfo(clusterRole.Name, clusterRole.Namespace, clusterRoleKind, datadog.CreationEvent)
 	r.recordEvent(dda, event)

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -2,7 +2,6 @@ package datadogagent
 
 import (
 	"context"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -99,9 +98,6 @@ func (r *Reconciler) createServiceAccount(logger logr.Logger, dda *datadoghqv1al
 
 func (r *Reconciler) createClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, info roleBindingInfo, agentVersion string) (reconcile.Result, error) {
 	clusterRoleBinding := buildClusterRoleBinding(dda, info, agentVersion)
-	if err := SetOwnerReference(dda, clusterRoleBinding, r.scheme); err != nil {
-		return reconcile.Result{}, err
-	}
 	logger.V(1).Info("createClusterRoleBinding", "clusterRoleBinding.name", clusterRoleBinding.Name)
 	event := buildEventInfo(clusterRoleBinding.Name, clusterRoleBinding.Namespace, clusterRoleBindingKind, datadog.CreationEvent)
 	r.recordEvent(dda, event)

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -199,3 +199,11 @@ func isOwnerBasedOnLabels(dda *datadoghqv1alpha1.DatadogAgent, labels map[string
 	isPartOfDDA := labels[kubernetes.AppKubernetesPartOfLabelKey] == dda.Namespace+"-"+dda.Name
 	return isManagedByOperator && isPartOfDDA
 }
+
+func rbacNamesForDda(dda *datadoghqv1alpha1.DatadogAgent) []string {
+	return []string{
+		getAgentRbacResourcesName(dda),
+		getClusterAgentRbacResourcesName(dda),
+		getClusterChecksRunnerRbacResourcesName(dda),
+	}
+}

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -2,6 +2,8 @@ package datadogagent
 
 import (
 	"context"
+
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -114,9 +116,11 @@ func (r *Reconciler) cleanupClusterRole(logger logr.Logger, client client.Client
 		}
 		return reconcile.Result{}, err
 	}
-	if !CheckOwnerReference(dda, clusterRole) {
+
+	if !isOwnerBasedOnLabels(dda, clusterRole.Labels) {
 		return reconcile.Result{}, nil
 	}
+
 	logger.V(1).Info("deleteClusterRole", "clusterRole.name", clusterRole.Name, "clusterRole.Namespace", clusterRole.Namespace)
 	event := buildEventInfo(clusterRole.Name, clusterRole.Namespace, clusterRoleKind, datadog.DeletionEvent)
 	r.recordEvent(dda, event)
@@ -132,9 +136,11 @@ func (r *Reconciler) cleanupClusterRoleBinding(logger logr.Logger, client client
 		}
 		return reconcile.Result{}, err
 	}
-	if !CheckOwnerReference(dda, clusterRoleBinding) {
+
+	if !isOwnerBasedOnLabels(dda, clusterRoleBinding.Labels) {
 		return reconcile.Result{}, nil
 	}
+
 	logger.V(1).Info("deleteClusterRoleBinding", "clusterRoleBinding.name", clusterRoleBinding.Name, "clusterRoleBinding.Namespace", clusterRoleBinding.Namespace)
 	event := buildEventInfo(clusterRoleBinding.Name, clusterRoleBinding.Namespace, clusterRoleBindingKind, datadog.DeletionEvent)
 	r.recordEvent(dda, event)
@@ -180,4 +186,16 @@ func (r *Reconciler) updateIfNeededClusterRoleBinding(logger logr.Logger, dda *d
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// isOwnerBasedOnLabels returns whether a DatadogAgent is the owner of a
+// resource based on its labels.
+// DatadogAgent objects are namespace-scoped. Some resources like cluster roles
+// and cluster role bindings are not. This means that the DatadogAgent objects
+// cannot be set as owner ref for those. For those objects, we can use their
+// labels to know whether a DatadogAgent object owns them.
+func isOwnerBasedOnLabels(dda *datadoghqv1alpha1.DatadogAgent, labels map[string]string) bool {
+	isManagedByOperator := labels[kubernetes.AppKubernetesManageByLabelKey] == "datadog-operator"
+	isPartOfDDA := labels[kubernetes.AppKubernetesPartOfLabelKey] == dda.Namespace+"-"+dda.Name
+	return isManagedByOperator && isPartOfDDA
 }

--- a/controllers/datadogagent/common_rbac_test.go
+++ b/controllers/datadogagent/common_rbac_test.go
@@ -1,0 +1,162 @@
+package datadogagent
+
+import (
+	"context"
+	"github.com/DataDog/datadog-operator/api/v1alpha1"
+	"github.com/DataDog/datadog-operator/api/v1alpha1/test"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	assert "github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_cleanupClusterRole(t *testing.T) {
+	tests := []struct {
+		name              string
+		dda               *v1alpha1.DatadogAgent
+		clusterRoleLabels map[string]string
+		expectToBeDeleted bool
+	}{
+		{
+			name: "ClusterRole belongs to DatadogAgent",
+			dda:  test.NewDefaultedDatadogAgent("some_namespace", "some_name", nil),
+			clusterRoleLabels: map[string]string{
+				kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
+				kubernetes.AppKubernetesPartOfLabelKey:   "some_namespace-some_name",
+			},
+			expectToBeDeleted: true,
+		},
+		{
+			name: "ClusterRole does not belong to DatadogAgent (not managed by operator)",
+			dda:  test.NewDefaultedDatadogAgent("some_namespace", "some_name", nil),
+			clusterRoleLabels: map[string]string{
+				kubernetes.AppKubernetesManageByLabelKey: "not-the-datadog-operator",
+				kubernetes.AppKubernetesPartOfLabelKey:   "some_namespace-some_name",
+			},
+			expectToBeDeleted: false,
+		},
+		{
+			name: "ClusterRole does not belong to DatadogAgent (belongs to other)",
+			dda:  test.NewDefaultedDatadogAgent("some_namespace", "some_name", nil),
+			clusterRoleLabels: map[string]string{
+				kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
+				kubernetes.AppKubernetesPartOfLabelKey:   "other-datadog-agent",
+			},
+			expectToBeDeleted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterRole := rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   getAgentRbacResourcesName(tt.dda),
+					Labels: tt.clusterRoleLabels,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithObjects(&clusterRole).Build()
+			r := newReconcilerForRbacTests(fakeClient)
+
+			_, err := r.cleanupClusterRole(
+				logf.Log.WithName(tt.name), r.client, tt.dda, getAgentRbacResourcesName(tt.dda),
+			)
+			assert.NoError(t, err)
+
+			err = fakeClient.Get(
+				context.TODO(), types.NamespacedName{Name: getAgentRbacResourcesName(tt.dda)}, &rbacv1.ClusterRole{},
+			)
+			if tt.expectToBeDeleted {
+				assert.True(t, err != nil && apierrors.IsNotFound(err), "ClusterRole not deleted")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_cleanupClusterRoleBinding(t *testing.T) {
+	tests := []struct {
+		name                     string
+		dda                      *v1alpha1.DatadogAgent
+		clusterRoleBindingLabels map[string]string
+		expectToBeDeleted        bool
+	}{
+		{
+			name: "ClusterRoleBinding belongs to DatadogAgent",
+			dda:  test.NewDefaultedDatadogAgent("some_namespace", "some_name", nil),
+			clusterRoleBindingLabels: map[string]string{
+				kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
+				kubernetes.AppKubernetesPartOfLabelKey:   "some_namespace-some_name",
+			},
+			expectToBeDeleted: true,
+		},
+		{
+			name: "ClusterRoleBinding does not belong to DatadogAgent (not managed by operator)",
+			dda:  test.NewDefaultedDatadogAgent("some_namespace", "some_name", nil),
+			clusterRoleBindingLabels: map[string]string{
+				kubernetes.AppKubernetesManageByLabelKey: "not-the-datadog-operator",
+				kubernetes.AppKubernetesPartOfLabelKey:   "some_namespace-some_name",
+			},
+			expectToBeDeleted: false,
+		},
+		{
+			name: "ClusterRoleBinding does not belong to DatadogAgent (belongs to other)",
+			dda:  test.NewDefaultedDatadogAgent("some_namespace", "some_name", nil),
+			clusterRoleBindingLabels: map[string]string{
+				kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
+				kubernetes.AppKubernetesPartOfLabelKey:   "other-datadog-agent",
+			},
+			expectToBeDeleted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterRoleBinding := rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   getAgentRbacResourcesName(tt.dda),
+					Labels: tt.clusterRoleBindingLabels,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithObjects(&clusterRoleBinding).Build()
+			reconciler := newReconcilerForRbacTests(fakeClient)
+
+			_, err := reconciler.cleanupClusterRoleBinding(
+				logf.Log.WithName(tt.name), reconciler.client, tt.dda, getAgentRbacResourcesName(tt.dda),
+			)
+			assert.NoError(t, err)
+
+			err = fakeClient.Get(
+				context.TODO(), types.NamespacedName{Name: getAgentRbacResourcesName(tt.dda)}, &rbacv1.ClusterRoleBinding{},
+			)
+			if tt.expectToBeDeleted {
+				assert.True(t, err != nil && apierrors.IsNotFound(err), "ClusterRoleBinding not deleted")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newReconcilerForRbacTests(client client.Client) *Reconciler {
+	reconcilerScheme := scheme.Scheme
+	reconcilerScheme.AddKnownTypes(rbacv1.SchemeGroupVersion, &rbacv1.ClusterRoleBinding{}, &rbacv1.ClusterRole{})
+
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{})
+
+	return &Reconciler{
+		client:   client,
+		scheme:   reconcilerScheme,
+		recorder: recorder,
+	}
+}

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -308,9 +308,6 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if !hasAllNodeLevelRbacResources(clusterRole.Rules) {
 					return fmt.Errorf("bad cluster role, should contain all node level rbac resources, current: %v", clusterRole.Rules)
 				}
-				if !CheckOwnerReference(datadogAgent, clusterRole) {
-					return fmt.Errorf("bad cluster role, should be owned by the datadog operator, current owners: %v", clusterRole.OwnerReferences)
-				}
 
 				return nil
 			},
@@ -352,9 +349,6 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesName}, clusterRoleBinding); err != nil {
 					return err
-				}
-				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
-					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 				return nil
 			},
@@ -1255,10 +1249,6 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					return err
 				}
 
-				if !CheckOwnerReference(datadogAgent, clusterRole) {
-					return fmt.Errorf("bad clusterRole, should be owned by the datadog operator, current owners: %v", clusterRole.OwnerReferences)
-				}
-
 				return nil
 			},
 		},
@@ -1405,10 +1395,6 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					return err
 				}
 
-				if !CheckOwnerReference(datadogAgent, clusterRole) {
-					return fmt.Errorf("bad clusterRole, should be owned by the datadog operator, current owners: %v", clusterRole.OwnerReferences)
-				}
-
 				return nil
 			},
 		},
@@ -1463,10 +1449,6 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
 					return err
-				}
-
-				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
-					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 
 				return nil
@@ -1545,10 +1527,6 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
 					return err
-				}
-
-				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
-					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 
 				return nil
@@ -2041,10 +2019,6 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
 					return err
-				}
-
-				if !CheckOwnerReference(datadogAgent, clusterRoleBinding) {
-					return fmt.Errorf("bad clusterRoleBinding, should be owned by the datadog operator, current owners: %v", clusterRoleBinding.OwnerReferences)
 				}
 
 				return nil

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -308,6 +308,9 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				if !hasAllNodeLevelRbacResources(clusterRole.Rules) {
 					return fmt.Errorf("bad cluster role, should contain all node level rbac resources, current: %v", clusterRole.Rules)
 				}
+				if !isOwnerBasedOnLabels(datadogAgent, clusterRole.Labels) {
+					return fmt.Errorf("bad cluster role, ownership labels not properly set")
+				}
 
 				return nil
 			},
@@ -349,6 +352,9 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesName}, clusterRoleBinding); err != nil {
 					return err
+				}
+				if !isOwnerBasedOnLabels(datadogAgent, clusterRoleBinding.Labels) {
+					return fmt.Errorf("bad clusterRoleBinding, ownership labels not properly set")
 				}
 				return nil
 			},
@@ -1249,6 +1255,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					return err
 				}
 
+				if !isOwnerBasedOnLabels(datadogAgent, clusterRole.Labels) {
+					return fmt.Errorf("bad clusterRole, ownership labels not properly set")
+				}
+
 				return nil
 			},
 		},
@@ -1395,6 +1405,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					return err
 				}
 
+				if !isOwnerBasedOnLabels(datadogAgent, clusterRole.Labels) {
+					return fmt.Errorf("bad clusterRole, ownership labels not properly set")
+				}
+
 				return nil
 			},
 		},
@@ -1449,6 +1463,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
 					return err
+				}
+
+				if !isOwnerBasedOnLabels(datadogAgent, clusterRoleBinding.Labels) {
+					return fmt.Errorf("bad clusterRoleBinding, ownership labels not properly set")
 				}
 
 				return nil
@@ -1527,6 +1545,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
 					return err
+				}
+
+				if !isOwnerBasedOnLabels(datadogAgent, clusterRoleBinding.Labels) {
+					return fmt.Errorf("bad clusterRoleBinding, ownership labels not properly set")
 				}
 
 				return nil
@@ -2019,6 +2041,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				datadogAgent := &datadoghqv1alpha1.DatadogAgent{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, datadogAgent); err != nil {
 					return err
+				}
+
+				if !isOwnerBasedOnLabels(datadogAgent, clusterRoleBinding.Labels) {
+					return fmt.Errorf("bad cluster role, ownership labels not properly set")
 				}
 
 				return nil

--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -57,6 +57,17 @@ func (r *Reconciler) finalizeDad(reqLogger logr.Logger, dda *datadoghqv1alpha1.D
 	if err != nil {
 		reqLogger.Error(err, "Could not delete Metrics Server API Service")
 	}
+
+	for _, rbacName := range rbacNamesForDda(dda) {
+		if _, err = r.cleanupClusterRoleBinding(reqLogger, r.client, dda, rbacName); err != nil {
+			reqLogger.Error(err, "Could not delete cluster role binding", "name", rbacName)
+		}
+
+		if _, err = r.cleanupClusterRole(reqLogger, r.client, dda, rbacName); err != nil {
+			reqLogger.Error(err, "Could not delete cluster role", "name", rbacName)
+		}
+	}
+
 	r.forwarders.Unregister(dda)
 	reqLogger.Info("Successfully finalized DatadogAgent")
 }

--- a/controllers/datadogagent/finalizer_test.go
+++ b/controllers/datadogagent/finalizer_test.go
@@ -1,0 +1,85 @@
+package datadogagent
+
+import (
+	"context"
+	"fmt"
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
+	"github.com/DataDog/datadog-operator/api/v1alpha1/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"testing"
+)
+
+func Test_handleFinalizer(t *testing.T) {
+	// TODO: This tests that the associated cluster roles and cluster role
+	// bindings are deleted when the dda is marked to be deleted. However, the
+	// finalizer does more than that.
+
+	now := metav1.Now()
+	dda := test.NewDefaultedDatadogAgent("some_namespace", "some_name", nil)
+	dda.DeletionTimestamp = &now // Mark for deletion
+
+	var clusterRoles []*rbacv1.ClusterRole
+	var clusterRoleBindings []*rbacv1.ClusterRoleBinding
+	for _, resourceName := range rbacNamesForDda(dda) {
+		clusterRoles = append(clusterRoles, buildClusterRole(dda, true, resourceName, ""))
+		clusterRoleBindings = append(clusterRoleBindings, buildClusterRoleBinding(
+			dda, roleBindingInfo{name: resourceName}, "",
+		))
+	}
+
+	initialKubeObjects := []client.Object{dda}
+	for _, clusterRole := range clusterRoles {
+		initialKubeObjects = append(initialKubeObjects, clusterRole)
+	}
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		initialKubeObjects = append(initialKubeObjects, clusterRoleBinding)
+	}
+
+	reconciler := reconcilerForFinalizerTest(initialKubeObjects)
+	_, err := reconciler.handleFinalizer(logf.Log.WithName("Handle Finalizer test"), dda)
+	assert.NoError(t, err)
+
+	// Check that the cluster roles associated with the Datadog Agent have been deleted
+	for _, clusterRole := range clusterRoles {
+		err = reconciler.client.Get(context.TODO(), types.NamespacedName{Name: clusterRole.Name}, &rbacv1.ClusterRole{})
+		assert.True(
+			t, err != nil && apierrors.IsNotFound(err), fmt.Sprintf("ClusterRole %s not deleted", clusterRole.Name),
+		)
+	}
+
+	// Check that the cluster role bindings associated with the Datadog Agent have been deleted
+	for _, clusterRoleBinding := range clusterRoleBindings {
+		err = reconciler.client.Get(
+			context.TODO(), types.NamespacedName{Name: clusterRoleBinding.Name}, &rbacv1.ClusterRoleBinding{},
+		)
+		assert.True(
+			t, err != nil && apierrors.IsNotFound(err), fmt.Sprintf("ClusterRoleBinding %s not deleted", clusterRoleBinding.Name),
+		)
+	}
+}
+
+func reconcilerForFinalizerTest(initialKubeObjects []client.Object) Reconciler {
+	reconcilerScheme := scheme.Scheme
+	reconcilerScheme.AddKnownTypes(rbacv1.SchemeGroupVersion, &rbacv1.ClusterRoleBinding{}, &rbacv1.ClusterRole{})
+	reconcilerScheme.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogAgent{})
+
+	fakeClient := fake.NewClientBuilder().WithObjects(initialKubeObjects...).WithScheme(reconcilerScheme).Build()
+
+	return Reconciler{
+		client:     fakeClient,
+		scheme:     reconcilerScheme,
+		recorder:   record.NewBroadcaster().NewRecorder(reconcilerScheme, corev1.EventSource{}),
+		forwarders: dummyManager{},
+	}
+
+}


### PR DESCRIPTION
### What does this PR do?

We set the DatadogAgent object as the owner of the ClusterRoles and the ClusterRoleBindings that it creates. The reason to do that is to make sure that a cascade delete of the DatadogAgent will also delete its associated ClusterRoles and ClusterRoleBindings. However, that does not happen because DatadogAgent is namespace-scoped, while ClusterRoles and ClusterRoleBindings are not. When assigning the owner reference, Kubernetes raises a warning, and at delete time, it simply ignores that reference. The result is that ClusterRoles and ClusterRoleBindings are never deleted. Also, when a DatadogAgent is created with the same name as a previous one, the owner reference is not updated and still points to the old one.

This PR solves the issue. Instead of using owner references, it uses annotations to know if a given ClusterRole or ClusterRoleBinding was created by a particular DatadogAgent. The owned ClusterRoles and ClusterRoleBindings are now deleted in the finalizer.

A couple of things to notice that we should probably address in separate PRs:
- Upgrading the operator to a version that includes the fix will not remove old ClusterRoles and ClusterRoleBindings. We'll need additional tooling to do that.
- I think that, because of the names that the operator choses when creating ClusterRoles and ClusterRoleBindings, it does not support creating 2 different DatadogAgents with the same name in different namespaces. It's because the names do not encode the namespace, only the name.

### Describe your test plan

1) Create a DatadogAgent and wait until everything is deployed and ready.
2) Check with `kubectl get clusterroles` that these 3 are there `agentname-agent`, `agentname-cluster-agent`, `agentname-cluster-checks-runner` (Replace agentname with the real one). Check also that `kubectl get clusterrolebindings` returns 3 with the same names.
3) Delete the DatadogAgent created in step 1.
4) Check with `kubectl get clusterroles` and `kubectl get clusterrolebindings` that the ones mentioned in step 2 have been deleted.

