### PR TITLE
Fix runtime security volumes creation

### DIFF
--- a/api/v1alpha1/datadogagent_default.go
+++ b/api/v1alpha1/datadogagent_default.go
@@ -615,12 +615,18 @@ func DefaultDatadogAgentSpecAgentApmUDS(apm *APMSpec) *APMUnixDomainSocketSpec {
 // DefaultDatadogAgentSpecAgentSystemProbe defaults the System Probe
 // This method can be re-run as part of the FeatureOverride
 func DefaultDatadogAgentSpecAgentSystemProbe(agent *DatadogAgentSpecAgentSpec) *SystemProbeSpec {
+	sysOverride := &SystemProbeSpec{}
+
 	if agent.SystemProbe == nil {
 		agent.SystemProbe = &SystemProbeSpec{Enabled: NewBoolPointer(defaultSystemProbeEnabled)}
-		return agent.SystemProbe
+		sysOverride = agent.SystemProbe
 	}
 
-	sysOverride := &SystemProbeSpec{}
+	if agent.Security != nil && BoolValue(agent.Security.Runtime.Enabled) {
+		agent.SystemProbe.Enabled = agent.Security.Runtime.Enabled
+		sysOverride = agent.SystemProbe
+	}
+
 	if agent.SystemProbe.Enabled == nil {
 		agent.SystemProbe.Enabled = NewBoolPointer(defaultSystemProbeEnabled)
 		sysOverride.Enabled = agent.SystemProbe.Enabled

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1237,15 +1237,20 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 		}
 	}
 
-	if isRuntimeSecurityEnabled(&dda.Spec) && dda.Spec.Agent.Security.Runtime.PoliciesDir != nil {
+	if isRuntimeSecurityEnabled(&dda.Spec) {
 		volumes = append(volumes,
-			getVolumeFromConfigDirSpec(datadoghqv1alpha1.SecurityAgentRuntimeCustomPoliciesVolumeName, dda.Spec.Agent.Security.Runtime.PoliciesDir),
 			corev1.Volume{
 				Name: datadoghqv1alpha1.SecurityAgentRuntimePoliciesDirVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			})
+
+		if dda.Spec.Agent.Security.Runtime.PoliciesDir != nil {
+			volumes = append(volumes,
+				getVolumeFromConfigDirSpec(datadoghqv1alpha1.SecurityAgentRuntimeCustomPoliciesVolumeName, dda.Spec.Agent.Security.Runtime.PoliciesDir),
+			)
+		}
 	}
 
 	volumes = append(volumes, dda.Spec.Agent.Config.Volumes...)
@@ -1768,7 +1773,7 @@ func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []core
 		})
 	}
 
-	if runtimeEnabled {
+	if runtimeEnabled && isSystemProbeEnabled(&dda.Spec) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      datadoghqv1alpha1.SystemProbeSocketVolumeName,
 			MountPath: datadoghqv1alpha1.SystemProbeSocketVolumePath,

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -153,6 +153,8 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 
 			ad.Spec.Features.OrchestratorExplorer.Enabled = datadoghqv1alpha1.NewBoolPointer(false)
 		}
+		// options can have an impact on the defaulting
+		_ = datadoghqv1alpha1.DefaultDatadogAgent(ad)
 	}
 
 	return ad


### PR DESCRIPTION
### What does this PR do?

Bug discovered during the QA of #342.

* Fix defaulting of system-probe if security.runtime is enabled.
* Mount the security-runtime empty dir even if `policydir` is not set.

### Motivation


### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Bug discovered with the following `DatadogAgent` configuration

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: datadog
spec:
  credentials:
    apiKey: REDACTED
    appKey: REDACTED
  agent:
    clusterName: foo
    config:
      kubelet:
        tlsVerify: false
    image:
      name: "gcr.io/datadoghq/agent:latest"
    apm:
      enabled: true
    process:
      enabled: true
      processCollectionEnabled: true
    log:
      enabled: true
    systemProbe:
      bpfDebugEnabled: true
    security:
      runtime:
        enabled: true
```
