### PR TITLE
[README] Fix github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datadog Operator
 
-![badge](https://action-badges.now.sh/datadog/datadog-operator)
+![badge](https://github.com/DataDog/datadog-operator/actions/workflows/main.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/datadog/datadog-operator)](https://goreportcard.com/report/github.com/datadog/datadog-operator)
 [![codecov](https://codecov.io/gh/datadog/datadog-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/datadog/datadog-operator)
 


### PR DESCRIPTION
### What does this PR do?

Fixes the github actions badge. The `action-badges.now.sh` that we were using only works for repos that use the `master` branch

