### PR TITLE
Fix PV and PVC rbac for orchestrator explorer

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1359,17 +1359,6 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 				datadoghqv1alpha1.GetVerb,
 			},
 		})
-
-		// PV and PVC
-		rbacRules = append(rbacRules, rbacv1.PolicyRule{
-			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
-			Resources: []string{datadoghqv1alpha1.PersistentVolumesResource, datadoghqv1alpha1.PersistentVolumeClaimsResource},
-			Verbs: []string{
-				datadoghqv1alpha1.ListVerb,
-				datadoghqv1alpha1.WatchVerb,
-				datadoghqv1alpha1.GetVerb,
-			},
-		})
 	}
 
 	if isComplianceEnabled(&dda.Spec) {

--- a/controllers/datadogagent/orchestrator.go
+++ b/controllers/datadogagent/orchestrator.go
@@ -153,7 +153,11 @@ func buildOrchestratorExplorerRBAC(dda *datadoghqv1alpha1.DatadogAgent, name, ve
 			APIGroups:     []string{datadoghqv1alpha1.CoreAPIGroup},
 			Resources:     []string{datadoghqv1alpha1.ConfigMapsResource},
 			ResourceNames: []string{datadoghqv1alpha1.DatadogClusterIDResourceName},
-			Verbs:         []string{datadoghqv1alpha1.GetVerb, datadoghqv1alpha1.CreateVerb, datadoghqv1alpha1.UpdateVerb},
+			Verbs: []string{
+				datadoghqv1alpha1.GetVerb,
+				datadoghqv1alpha1.CreateVerb,
+				datadoghqv1alpha1.UpdateVerb,
+			},
 		},
 		{
 			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
@@ -165,13 +169,26 @@ func buildOrchestratorExplorerRBAC(dda *datadoghqv1alpha1.DatadogAgent, name, ve
 		},
 		{
 			APIGroups: []string{datadoghqv1alpha1.AppsAPIGroup},
-			Resources: []string{datadoghqv1alpha1.DeploymentsResource, datadoghqv1alpha1.ReplicasetsResource, datadoghqv1alpha1.DaemonsetsResource, datadoghqv1alpha1.StatefulsetsResource},
+			Resources: []string{
+				datadoghqv1alpha1.DeploymentsResource,
+				datadoghqv1alpha1.ReplicasetsResource,
+				datadoghqv1alpha1.DaemonsetsResource,
+				datadoghqv1alpha1.StatefulsetsResource,
+			},
 		},
 		{
 			APIGroups: []string{datadoghqv1alpha1.BatchAPIGroup},
 			Resources: []string{
 				datadoghqv1alpha1.JobsResource,
 				datadoghqv1alpha1.CronjobsResource,
+			},
+		},
+
+		{
+			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+			Resources: []string{
+				datadoghqv1alpha1.PersistentVolumesResource,
+				datadoghqv1alpha1.PersistentVolumeClaimsResource,
 			},
 		},
 	}

--- a/controllers/datadogagent/testdata/orchestrator_clusterrole.yaml
+++ b/controllers/datadogagent/testdata/orchestrator_clusterrole.yaml
@@ -52,3 +52,11 @@ rules:
     verbs:
       - list
       - watch
+  - apigroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs:
+      - list
+      - watch


### PR DESCRIPTION
### What does this PR do?

Move PV and PVC rbac in the dedicated ClusterRole that can bind the role
to the cluster-agent or cluster-check-runners depending if cluster-checks
are enabled.

### Motivation

PV and PVC rbac was applied only to the cluster-agent. If the user decide
to the the check as cluster-checks the runner will not have the permission.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Try to deploy the orchestrator explorer with cluster-checks enabled.

