### PR TITLE
[controllers/datadogagent] Fix watch of ClusterRoles and ClusterRoleBindings

### DIFF
--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -379,7 +379,7 @@ func buildAgentNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, name string) *
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					kubernetes.AppKubernetesInstanceLabelKey: datadoghqv1alpha1.DefaultAgentResourceSuffix,
-					kubernetes.AppKubernetesPartOfLabelKey:   dda.Namespace + "-" + dda.Name,
+					kubernetes.AppKubernetesPartOfLabelKey:   NewPartOfLabelValue(dda).String(),
 				},
 			},
 			Ingress: ingressRules,

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1526,7 +1526,7 @@ func buildClusterAgentNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, name st
 					PodSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							kubernetes.AppKubernetesInstanceLabelKey: datadoghqv1alpha1.DefaultAgentResourceSuffix,
-							kubernetes.AppKubernetesPartOfLabelKey:   dda.Namespace + "-" + dda.Name,
+							kubernetes.AppKubernetesPartOfLabelKey:   NewPartOfLabelValue(dda).String(),
 						},
 					},
 				},
@@ -1549,7 +1549,7 @@ func buildClusterAgentNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, name st
 					PodSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							kubernetes.AppKubernetesInstanceLabelKey: datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix,
-							kubernetes.AppKubernetesPartOfLabelKey:   dda.Namespace + "-" + dda.Name,
+							kubernetes.AppKubernetesPartOfLabelKey:   NewPartOfLabelValue(dda).String(),
 						},
 					},
 				},
@@ -1580,7 +1580,7 @@ func buildClusterAgentNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, name st
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					kubernetes.AppKubernetesInstanceLabelKey: datadoghqv1alpha1.DefaultClusterAgentResourceSuffix,
-					kubernetes.AppKubernetesPartOfLabelKey:   dda.Namespace + "-" + dda.Name,
+					kubernetes.AppKubernetesPartOfLabelKey:   NewPartOfLabelValue(dda).String(),
 				},
 			},
 			Ingress: ingressRules,

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -602,7 +602,7 @@ func buildClusterChecksRunnerNetworkPolicy(dda *datadoghqv1alpha1.DatadogAgent, 
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					kubernetes.AppKubernetesInstanceLabelKey: datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix,
-					kubernetes.AppKubernetesPartOfLabelKey:   dda.Namespace + "-" + dda.Name,
+					kubernetes.AppKubernetesPartOfLabelKey:   NewPartOfLabelValue(dda).String(),
 				},
 			},
 			Egress: egressRules,

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -196,7 +196,7 @@ func (r *Reconciler) updateIfNeededClusterRoleBinding(logger logr.Logger, dda *d
 // labels to know whether a DatadogAgent object owns them.
 func isOwnerBasedOnLabels(dda *datadoghqv1alpha1.DatadogAgent, labels map[string]string) bool {
 	isManagedByOperator := labels[kubernetes.AppKubernetesManageByLabelKey] == "datadog-operator"
-	isPartOfDDA := labels[kubernetes.AppKubernetesPartOfLabelKey] == dda.Namespace+"-"+dda.Name
+	isPartOfDDA := labels[kubernetes.AppKubernetesPartOfLabelKey] == NewPartOfLabelValue(dda).String()
 	return isManagedByOperator && isPartOfDDA
 }
 

--- a/controllers/datadogagent/labels.go
+++ b/controllers/datadogagent/labels.go
@@ -1,0 +1,60 @@
+package datadogagent
+
+import (
+	"strings"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	partOfSplitChar        string = "-"
+	partOfEscapedSplitChar string = "--"
+)
+
+// PartOfLabelValue is helpful to work with the "app.kubernetes.io/part-of"
+// label. We use that label to track the of an object when we can't use owner
+// references (cannot be used across namespaces).
+// In order to identify an owner, we encode its namespace and name in the value
+// of the label separated with a "-". Because names and namespaces can contain
+// "-" too, we escape them. There are not any characters that are allowed in
+// labels but not in names and namespaces so escaping is needed.
+type PartOfLabelValue struct {
+	Value string
+}
+
+// NewPartOfLabelValue creates an instance of PartOfLabelValue from a
+// DatadogAgent.
+func NewPartOfLabelValue(dda *datadoghqv1alpha1.DatadogAgent) *PartOfLabelValue {
+	value := strings.ReplaceAll(dda.Namespace, partOfSplitChar, partOfEscapedSplitChar) +
+		partOfSplitChar +
+		strings.ReplaceAll(dda.Name, partOfSplitChar, partOfEscapedSplitChar)
+
+	return &PartOfLabelValue{Value: value}
+}
+
+// NamespacedName returns the NamespaceName that corresponds to the value of a
+// part-of label.
+func (partOfLabelValue *PartOfLabelValue) NamespacedName() types.NamespacedName {
+	l := len(partOfLabelValue.Value)
+	for i, c := range partOfLabelValue.Value {
+		if string(c) == partOfSplitChar {
+			// Tt's split index if it's just one "-"
+			isSplitIndex := (i != 0 && string(partOfLabelValue.Value[i-1]) != partOfSplitChar) &&
+				(i != l-1 && string(partOfLabelValue.Value[i+1]) != partOfSplitChar)
+
+			if isSplitIndex {
+				return types.NamespacedName{
+					// The ReplaceAll calls undoes the escaping done in the constructor
+					Namespace: strings.ReplaceAll(partOfLabelValue.Value[:i], partOfEscapedSplitChar, partOfSplitChar),
+					Name:      strings.ReplaceAll(partOfLabelValue.Value[i+1:], partOfEscapedSplitChar, partOfSplitChar),
+				}
+			}
+		}
+	}
+	return types.NamespacedName{}
+}
+
+func (partOfLabelValue *PartOfLabelValue) String() string {
+	return partOfLabelValue.Value
+}

--- a/controllers/datadogagent/labels_test.go
+++ b/controllers/datadogagent/labels_test.go
@@ -1,0 +1,46 @@
+package datadogagent
+
+import (
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+func Test_NamespacedName(t *testing.T) {
+	tests := []struct {
+		name                   string
+		agentName              string
+		agentNamespace         string
+		expectedNamespacedName types.NamespacedName
+	}{
+		{
+			name:                   "without the split char",
+			agentNamespace:         "foo",
+			agentName:              "bar",
+			expectedNamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"},
+		},
+		{
+			name:                   "with the split char",
+			agentNamespace:         "f-o-o",
+			agentName:              "bar",
+			expectedNamespacedName: types.NamespacedName{Namespace: "f-o-o", Name: "bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dda := datadoghqv1alpha1.DatadogAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.agentName,
+					Namespace: tt.agentNamespace,
+				},
+			}
+
+			value := NewPartOfLabelValue(&dda)
+
+			assert.Equal(t, tt.expectedNamespacedName, value.NamespacedName())
+		})
+	}
+}

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1907,7 +1907,7 @@ func getDefaultLabels(dda *datadoghqv1alpha1.DatadogAgent, instanceName, version
 	labels := make(map[string]string)
 	labels[kubernetes.AppKubernetesNameLabelKey] = "datadog-agent-deployment"
 	labels[kubernetes.AppKubernetesInstanceLabelKey] = instanceName
-	labels[kubernetes.AppKubernetesPartOfLabelKey] = dda.Namespace + "-" + dda.Name
+	labels[kubernetes.AppKubernetesPartOfLabelKey] = NewPartOfLabelValue(dda).String()
 	labels[kubernetes.AppKubernetesVersionLabelKey] = version
 	labels[kubernetes.AppKubernetesManageByLabelKey] = "datadog-operator"
 

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -8,6 +8,7 @@ package controllers
 import (
 	"context"
 
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -15,7 +16,10 @@ import (
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -159,10 +163,15 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.ServiceAccount{}).
-		Owns(&rbacv1.ClusterRole{}).
-		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&networkingv1.NetworkPolicy{})
+
+	// DatadogAgent is namespaced whereas ClusterRole and ClusterRoleBinding are
+	// cluster-scoped. That means that DatadogAgent cannot be their owner, and
+	// we cannot use .Owns().
+	handlerEnqueue := handler.EnqueueRequestsFromMapFunc(enqueueIfOwnedByDatadogAgent)
+	builder.Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, handlerEnqueue)
+	builder.Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, handlerEnqueue)
 
 	if r.Options.SupportExtendedDaemonset {
 		builder = builder.Owns(&edsdatadoghqv1alpha1.ExtendedDaemonSet{})
@@ -195,4 +204,17 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.internal = internal
 
 	return nil
+}
+
+func enqueueIfOwnedByDatadogAgent(obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+
+	if labels[kubernetes.AppKubernetesManageByLabelKey] != "datadog-operator" {
+		return nil
+	}
+
+	partOfLabelVal := datadogagent.PartOfLabelValue{Value: labels[kubernetes.AppKubernetesPartOfLabelKey]}
+	owner := partOfLabelVal.NamespacedName()
+
+	return []reconcile.Request{{NamespacedName: owner}}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the DatadogAgent controller setup so it watches ClusterRoles and ClusterRoleBindings. Those were not watched because we were using `.Owns()`. However, DatadogAgent is namespaced whereas ClusterRole and ClusterRoleBinding are cluster-scoped. That means that DatadogAgent cannot be their owner, and `.Owns()` does not work.

Instead of using owner references, we use a couple of labels to track the ownership. This PR also introduces a new `labels.go` file that includes some helpers to work with those labels.

### Describe your test plan

Deploy a DatadogAgent and edit or delete any of the ClusterRoles or ClusterRoleBindings it creates. Just after doing that, you should see that the operator will receive a reconcile event and will revert the changes you made.
