### PR TITLE
Update agent and cluster-agent default images

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.30.0"
+	AgentLatestVersion = "7.31.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "1.14.0"
+	ClusterAgentLatestVersion = "1.15.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

* default `agent` image is now `7.31.0`
* default `cluster-agent` image is now `1.15.0`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

deploy the agent with the example `datadog-agent-with-credential-secret.yaml`
the cluster-agent and agent should be deploy with the new versions. 
