### PR TITLE
fix permissions for extendeddaemonsetreplicasets

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -432,6 +432,12 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - extendeddaemonsetreplicasets
+  verbs:
+  - get
+- apiGroups:
+  - datadoghq.com
+  resources:
   - extendeddaemonsets
   verbs:
   - create

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -81,6 +81,7 @@ type DatadogAgentReconciler struct {
 
 // Use ExtendedDaemonSet
 // +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsetreplicasets,verbs=get
 
 // OpenShift
 // +kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=get;list


### PR DESCRIPTION
### What does this PR do?

Fix RBAC issue; this is required for the cluster agent/admission controller.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

The issue was observed when the operator was installed with OLM; ensure the DatadogAgent controller can run without issue.