### PR TITLE
[DatadogAgent] patch bundle to rm status defaultOverride

### DIFF
--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -13,3 +13,6 @@ $YQ m -i -a "$ROOT_DIR/bundle/manifests/datadog-operator.clusterserviceversion.y
 
 # Remove ServiceAccount bundled in SCC (but required for Kustomize installation to work)
 rm -f "$ROOT_DIR/bundle/manifests/datadog-operator-manager_v1_serviceaccount.yaml"
+
+# Remove defaultOverride section in DatadogAgent status due to the error: "datadoghq.com_datadogagents.yaml bigger than total allowed limit"
+$YQ d -i "$ROOT_DIR/bundle/manifests/datadoghq.com_datadogagents.yaml" 'spec.validation.openAPIV3Schema.properties.status.properties.defaultOverride'


### PR DESCRIPTION
### What does this PR do?

Remove status defaultOverride in bundled version due to the CRD being too long

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
