### PR TITLE
Fix RBAC resource name too long

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1360,7 +1360,7 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 func buildClusterAgentRole(dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) *rbacv1.Role {
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), agentVersion),
+			Labels:    getDefaultLabels(dda, dda.Name, agentVersion),
 			Name:      name,
 			Namespace: dda.Namespace,
 		},

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1012,7 +1012,7 @@ func buildClusterCheckRunnerClusterRole(dda *datadoghqv1alpha1.DatadogAgent, nam
 func buildClusterRole(dda *datadoghqv1alpha1.DatadogAgent, needClusterLevelRBAC bool, name, version string) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: getDefaultLabels(dda, name, version),
+			Labels: getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), version),
 			Name:   name,
 		},
 	}
@@ -1107,7 +1107,7 @@ func getDefaultClusterAgentPolicyRules() []rbacv1.PolicyRule {
 func buildClusterRoleBinding(dda *datadoghqv1alpha1.DatadogAgent, info roleBindingInfo, agentVersion string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: getDefaultLabels(dda, info.name, agentVersion),
+			Labels: getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), agentVersion),
 			Name:   info.name,
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -1129,7 +1129,7 @@ func buildClusterRoleBinding(dda *datadoghqv1alpha1.DatadogAgent, info roleBindi
 func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: getDefaultLabels(dda, name, agentVersion),
+			Labels: getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), agentVersion),
 			Name:   name,
 		},
 	}
@@ -1360,7 +1360,7 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 func buildClusterAgentRole(dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) *rbacv1.Role {
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    getDefaultLabels(dda, name, agentVersion),
+			Labels:    getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), agentVersion),
 			Name:      name,
 			Namespace: dda.Namespace,
 		},

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -31,7 +31,7 @@ type roleBindingInfo struct {
 func buildRoleBinding(dda *datadoghqv1alpha1.DatadogAgent, info roleBindingInfo, agentVersion string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    getDefaultLabels(dda, info.name, agentVersion),
+			Labels:    getDefaultLabels(dda, dda.Name, agentVersion),
 			Name:      info.name,
 			Namespace: dda.Namespace,
 		},
@@ -54,7 +54,7 @@ func buildRoleBinding(dda *datadoghqv1alpha1.DatadogAgent, info roleBindingInfo,
 func buildServiceAccount(dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    getDefaultLabels(dda, name, agentVersion),
+			Labels:    getDefaultLabels(dda, dda.Name, agentVersion),
 			Name:      name,
 			Namespace: dda.Namespace,
 		},

--- a/controllers/datadogagent/const.go
+++ b/controllers/datadogagent/const.go
@@ -34,8 +34,8 @@ const (
 	apiServiceKind          = "APIService"
 	networkPolicyKind       = "NetworkPolicy"
 
-	checkRunnersSuffix = "check-runners"
-	clusterAgentSuffix = "cluster-agent"
+	checkRunnersSuffix = "ccr"
+	clusterAgentSuffix = "dca"
 
 	// Datadog tags prefix
 	datadogTagPrefix = "tags.datadoghq.com"

--- a/controllers/datadogagent/kubestatemetrics.go
+++ b/controllers/datadogagent/kubestatemetrics.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	kubeStateMetricsRBACPrefix = "kube-state-metrics-core"
+	kubeStateMetricsRBACPrefix = "ksm-core"
 	ksmCoreCheckName           = "kubernetes_state_core.yaml.default"
 	ksmCoreCheckFolderName     = "kubernetes_state_core.d"
 )

--- a/controllers/datadogagent/kubestatemetrics.go
+++ b/controllers/datadogagent/kubestatemetrics.go
@@ -80,7 +80,7 @@ func buildKSMCoreConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.ConfigM
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        getKubeStateMetricsConfName(dda),
 			Namespace:   dda.Namespace,
-			Labels:      getDefaultLabels(dda, dda.Name, getAgentVersion(dda)),
+			Labels:      getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), getAgentVersion(dda)),
 			Annotations: getDefaultAnnotations(dda),
 		},
 		Data: map[string]string{
@@ -160,7 +160,7 @@ func (r *Reconciler) cleanupKubeStateMetricsCoreRBAC(logger logr.Logger, dda *da
 func buildKubeStateMetricsCoreRBAC(dda *datadoghqv1alpha1.DatadogAgent, name, version string) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      getDefaultLabels(dda, name, version),
+			Labels:      getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), version),
 			Annotations: getDefaultAnnotations(dda),
 			Name:        name,
 		},

--- a/controllers/datadogagent/orchestrator.go
+++ b/controllers/datadogagent/orchestrator.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	orchestratorExplorerRBACPrefix      = "orchestrator-explorer"
+	orchestratorExplorerRBACPrefix      = "orch-exp"
 	orchestratorExplorerCheckName       = "orchestrator.yaml"
 	orchestratorExplorerCheckFolderName = "orchestrator.d"
 )

--- a/controllers/datadogagent/orchestrator.go
+++ b/controllers/datadogagent/orchestrator.go
@@ -57,7 +57,7 @@ func buildOrchestratorExplorerConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*c
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        getOrchestratorExplorerConfName(dda),
 			Namespace:   dda.Namespace,
-			Labels:      getDefaultLabels(dda, dda.Name, getAgentVersion(dda)),
+			Labels:      getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), getAgentVersion(dda)),
 			Annotations: getDefaultAnnotations(dda),
 		},
 		Data: map[string]string{
@@ -137,7 +137,7 @@ func (r *Reconciler) cleanupOrchestratorCoreRBAC(logger logr.Logger, dda *datado
 func buildOrchestratorExplorerRBAC(dda *datadoghqv1alpha1.DatadogAgent, name, version string) *rbacv1.ClusterRole {
 	clusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      getDefaultLabels(dda, name, version),
+			Labels:      getDefaultLabels(dda, NewPartOfLabelValue(dda).String(), version),
 			Annotations: getDefaultAnnotations(dda),
 			Name:        name,
 		},


### PR DESCRIPTION
### What does this PR do?

We introduced the `namespace` as prefix of the clusterrole and
clusterrolebinding to allow multi DatadogAgent deployment in a cluster.
But if the DatadogAgent namespace/name is very long like:
datadog-agent/datadog-agent the final rbac name for `orchestrator-explorer`
RBAC was: `datadog-agent-datadog-agent-orchestrator-explorer-cluster-agent`
which is longer than the limit of 64 chars.

This PR reduce the size by renaming it to `datadog-agent-datadog-agent-orch-exp-dca`

This PR also update the value in `app.kubernetes.io/instances` for cluster scoped resources like:
* clusterrole
* clusterrolebinding

### Motivation

Fix agent deployment

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

try to deploy the datadogAgent named `datadog-agent` in the namespace: `datadog-agent`
the install should work.
