### PR TITLE
feat: Add Cluster Resources cleanup process

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -1403,6 +1403,8 @@ const (
 	DatadogAgentConditionTypeReconcileError DatadogAgentConditionType = "ReconcileError"
 	// DatadogAgentConditionTypeSecretError the required Secret doesn't exist.
 	DatadogAgentConditionTypeSecretError DatadogAgentConditionType = "SecretError"
+	// DatadogAgentConditionTypeResourcesCleaner the resource cleaner process has run
+	DatadogAgentConditionTypeResourcesCleaner DatadogAgentConditionType = "ResourcesCleaner"
 
 	// DatadogMetricsActive forwarding metrics and events to Datadog is active.
 	DatadogMetricsActive DatadogAgentConditionType = "ActiveDatadogMetrics"

--- a/controllers/datadogagent/cleaner.go
+++ b/controllers/datadogagent/cleaner.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilserrors "k8s.io/apimachinery/pkg/util/errors"
+	kversion "k8s.io/apimachinery/pkg/version"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/condition"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+// handleDeprecatedResources this function is used to cleanup old resources that was used by the DatadogAgent
+func (r *Reconciler) handleDeprecatedResources(reqLogger logr.Logger, now time.Time, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) error {
+	// get cleaner status condition
+	cleanerCondition, err := condition.GetDatadogAgentStatusCondition(newStatus, datadoghqv1alpha1.DatadogAgentConditionTypeResourcesCleaner, metav1.NewTime(now), true)
+	if err != nil {
+		return err
+	}
+	lastRun := cleanerCondition.LastUpdateTime.Time
+	if lastRun.Add(r.cleanUpPeriod).Sub(now) > 0 {
+		return nil
+	}
+
+	status := corev1.ConditionTrue
+	description := ""
+	if _, err = cleanupOldClusterRBACs(reqLogger, r.client, r.versionInfo, dda); err != nil {
+		status = corev1.ConditionFalse
+		description = fmt.Sprintf("err: %v", err)
+	}
+	condition.UpdateDatadogAgentStatusConditions(newStatus, metav1.NewTime(now), datadoghqv1alpha1.DatadogAgentConditionTypeResourcesCleaner, status, description, true)
+
+	return err
+}
+
+// cleanupOldClusterRBACs use to delete resources that should not exist anymore.
+// for example if the user update the name of the DCA deployment, the RBAC name is updated, new resources are created, but older wasn't cleanup
+func cleanupOldClusterRBACs(reqLogger logr.Logger, k8sClient client.Client, version *kversion.Info, dda *datadoghqv1alpha1.DatadogAgent) ([]client.Object, error) {
+	// Get All RBAC attached to the DDA
+	labelSet := labels.Set{
+		kubernetes.AppKubernetesPartOfLabelKey: NewPartOfLabelValue(dda).String(),
+	}
+	listOptions := &client.ListOptions{
+		LabelSelector: labelSet.AsSelector(),
+	}
+
+	// all ClusterRole attached to the DDA
+	allClusterRoles := &rbacv1.ClusterRoleList{}
+	if err := k8sClient.List(context.TODO(), allClusterRoles, listOptions); err != nil {
+		return nil, fmt.Errorf("unabled to list ClusterRole, err: %w", err)
+	}
+
+	// all ClusterRole attached to the DDA
+	allClusterRoleBindings := &rbacv1.ClusterRoleBindingList{}
+	if err := k8sClient.List(context.TODO(), allClusterRoleBindings, listOptions); err != nil {
+		return nil, fmt.Errorf("unabled to list ClusterRoleBinding, err: %w", err)
+	}
+
+	// Get the list of current RBAC
+	currentResourceNameMap := map[string]struct{}{}
+	for _, name := range rbacNamesForDda(dda, version) {
+		currentResourceNameMap[name] = struct{}{}
+	}
+
+	var resourcesToDeleted []client.Object
+	// Make the diff
+	for id, clusterRole := range allClusterRoles.Items {
+		if _, found := currentResourceNameMap[clusterRole.Name]; !found {
+			resourcesToDeleted = append(resourcesToDeleted, &allClusterRoles.Items[id])
+		}
+	}
+	for id, clusterRoleBinding := range allClusterRoleBindings.Items {
+		if _, found := currentResourceNameMap[clusterRoleBinding.Name]; !found {
+			resourcesToDeleted = append(resourcesToDeleted, &allClusterRoleBindings.Items[id])
+		}
+	}
+
+	// Cleanup (delete)
+	var errs []error
+	for _, obj := range resourcesToDeleted {
+		if err := k8sClient.Delete(context.TODO(), obj); err != nil {
+			errs = append(errs, err)
+			reqLogger.Error(err, "cleanupOldClusterRBAC: unable to delete object", getObjInfo(obj)...)
+		}
+		reqLogger.Info("cleanupOldClusterRBAC: object deleted", getObjInfo(obj)...)
+	}
+
+	return resourcesToDeleted, utilserrors.NewAggregate(errs)
+}
+
+func getObjInfo(obj client.Object) []interface{} {
+	return []interface{}{"kind", obj.GetObjectKind(), "namespace", obj.GetNamespace(), "name", obj.GetName()}
+}

--- a/controllers/datadogagent/cleaner_test.go
+++ b/controllers/datadogagent/cleaner_test.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagent
+
+import (
+	"reflect"
+	"testing"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	test "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
+	kversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func Test_cleanupOldClusterRBAC(t *testing.T) {
+	t.Helper()
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	logger := logf.Log.WithName(t.Name())
+
+	s := scheme.Scheme
+
+	ddaName := "foo"
+	ddaNamespace := "bar"
+	ddaDefaultOptions := &test.NewDatadogAgentOptions{
+		ClusterAgentEnabled:        true,
+		ClusterChecksEnabled:       true,
+		ClusterChecksRunnerEnabled: true,
+		KubeStateMetricsCore: &datadoghqv1alpha1.KubeStateMetricsCore{
+			Enabled:      datadoghqv1alpha1.NewBoolPointer(true),
+			ClusterCheck: datadoghqv1alpha1.NewBoolPointer(true),
+		},
+	}
+	defaultDDA := test.NewDefaultedDatadogAgent(ddaNamespace, ddaName, ddaDefaultOptions)
+	agentVersion := getAgentVersion(defaultDDA)
+	serviceAccountName := getClusterChecksRunnerServiceAccount(defaultDDA)
+	roleName := "cluster-agent"
+	rbacResourcesName := getClusterChecksRunnerRbacResourcesName(defaultDDA)
+	clusterRoleBindingInfo := roleBindingInfo{
+		name:               rbacResourcesName,
+		roleName:           roleName,
+		serviceAccountName: serviceAccountName,
+	}
+
+	defaultClusterRoleBinding := buildClusterRoleBinding(defaultDDA, clusterRoleBindingInfo, agentVersion)
+
+	defaultClusterAgentClusterRoleRBAC := buildClusterAgentClusterRole(defaultDDA, rbacResourcesName, agentVersion)
+
+	ksmClusterRoleRBAC := buildKubeStateMetricsCoreRBAC(defaultDDA, getKubeStateMetricsRBACResourceName(defaultDDA, checkRunnersSuffix), agentVersion)
+
+	oldClusterAgentClusterRoleRBAC := defaultClusterAgentClusterRoleRBAC.DeepCopy()
+	oldClusterAgentClusterRoleRBAC.Name = oldClusterAgentClusterRoleRBAC.Name + "-old"
+
+	type args struct {
+		k8sClient client.Client
+		version   *kversion.Info
+		dda       *datadoghqv1alpha1.DatadogAgent
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []client.Object
+		wantErr bool
+	}{
+		{
+			name: "nothing to clean",
+			args: args{
+				k8sClient: fake.NewClientBuilder().WithScheme(s).Build(),
+				version:   &kversion.Info{},
+				dda:       defaultDDA,
+			},
+			wantErr: false,
+			want:    nil,
+		},
+		{
+			name: "nothing to clean, existing RBAC",
+			args: args{
+				k8sClient: fake.NewClientBuilder().WithScheme(s).WithObjects(defaultClusterRoleBinding, defaultClusterAgentClusterRoleRBAC, ksmClusterRoleRBAC).Build(),
+				version:   &kversion.Info{},
+				dda:       defaultDDA,
+			},
+			wantErr: false,
+			want:    nil,
+		},
+		{
+			name: "delete 1 resources, existing RBAC",
+			args: args{
+				k8sClient: fake.NewClientBuilder().WithScheme(s).WithObjects(defaultClusterRoleBinding, defaultClusterAgentClusterRoleRBAC, ksmClusterRoleRBAC, oldClusterAgentClusterRoleRBAC).Build(),
+				version:   &kversion.Info{},
+				dda:       defaultDDA,
+			},
+			wantErr: false,
+			want:    []client.Object{oldClusterAgentClusterRoleRBAC},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cleanupOldClusterRBACs(logger.WithName(tt.name), tt.args.k8sClient, tt.args.version, tt.args.dda)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("cleanupOldClusterRBAC() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("cleanupOldClusterRBAC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/utils/condition/condition.go
+++ b/pkg/controller/utils/condition/condition.go
@@ -14,6 +14,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// GetDatadogAgentStatusCondition used to access a specific DatadogAgentCondition from a DatadogAgentStatus.
+// the option createIfNotExist allow the creation of the condition if it doesn't exist yet.
+func GetDatadogAgentStatusCondition(status *datadoghqv1alpha1.DatadogAgentStatus, conditionType datadoghqv1alpha1.DatadogAgentConditionType, now metav1.Time, createIfNotExist bool) (*datadoghqv1alpha1.DatadogAgentCondition, error) {
+	idCondition := getIndexForConditionType(status, conditionType)
+	if idCondition == -1 {
+		if createIfNotExist {
+			status.Conditions = append(status.Conditions, NewDatadogAgentStatusCondition(conditionType, corev1.ConditionUnknown, now, "", ""))
+			idCondition = len(status.Conditions) - 1
+		} else {
+			return nil, fmt.Errorf("condition not found")
+		}
+	}
+
+	return &status.Conditions[idCondition], nil
+}
+
 // UpdateDatadogAgentStatusConditionsFailure used to update the failure StatusConditions
 func UpdateDatadogAgentStatusConditionsFailure(status *datadoghqv1alpha1.DatadogAgentStatus, now metav1.Time, conditionType datadoghqv1alpha1.DatadogAgentConditionType, err error) {
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

the new `handleDeprecatedResources()` function will take care of removing
useless Cluster Resources (ClusterRoles, ClusterRoleBindings)

This process complete the logic introduced in the finalizer to not wait
to delete the DatadogAgent resource to cleanup deprecated resources.

### Motivation

in case of a Cluster Resource is not needed anymore, for example when:
* A configuration change renamed the resource.
* An disable option
the older resources are new cleanup.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
