### PR TITLE
Remove defaulting behavior of logs_config.open_files_limit

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -58,7 +58,6 @@ const (
 	defaultPodLogsPath                      string = "/var/log/pods"
 	defaultContainerSymlinksPath            string = "/var/log/containers"
 	defaultLogsTempStoragePath              string = "/var/lib/datadog-agent/logs"
-	defaultLogsOpenFilesLimit               int32  = 100
 	defaultProcessEnabled                   bool   = false
 	// `false` defaults to live container, agent activated but no process collection
 	defaultProcessCollectionEnabled                      bool   = false
@@ -762,11 +761,6 @@ func DefaultDatadogFeatureLogCollection(ft *DatadogFeatures) *LogCollectionConfi
 	if ft.LogCollection.TempStoragePath == nil {
 		ft.LogCollection.TempStoragePath = NewStringPointer(defaultLogsTempStoragePath)
 		logOverride.TempStoragePath = ft.LogCollection.TempStoragePath
-	}
-
-	if ft.LogCollection.OpenFilesLimit == nil {
-		ft.LogCollection.OpenFilesLimit = NewInt32Pointer(defaultLogsOpenFilesLimit)
-		logOverride.OpenFilesLimit = ft.LogCollection.OpenFilesLimit
 	}
 
 	return logOverride

--- a/apis/datadoghq/v1alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default_test.go
@@ -167,7 +167,6 @@ func TestDefaultFeatures(t *testing.T) {
 					PodLogsPath:                   NewStringPointer("/var/log/pods"),
 					ContainerSymlinksPath:         NewStringPointer("/var/log/containers"),
 					TempStoragePath:               NewStringPointer("/var/lib/datadog-agent/logs"),
-					OpenFilesLimit:                NewInt32Pointer(100),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
 					Enabled: NewBoolPointer(false),
@@ -187,7 +186,6 @@ func TestDefaultFeatures(t *testing.T) {
 					PodLogsPath:                   NewStringPointer("/var/log/pods"),
 					ContainerSymlinksPath:         NewStringPointer("/var/log/containers"),
 					TempStoragePath:               NewStringPointer("/var/lib/datadog-agent/logs"),
-					OpenFilesLimit:                NewInt32Pointer(100),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
 					Enabled: NewBoolPointer(false),
@@ -205,7 +203,6 @@ func TestDefaultFeatures(t *testing.T) {
 				LogCollection: &LogCollectionConfig{
 					LogsConfigContainerCollectAll: NewBoolPointer(false),
 					ContainerLogsPath:             NewStringPointer("/var/lib/docker/containers"),
-					OpenFilesLimit:                NewInt32Pointer(200),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
 					ServiceEndpoints: NewBoolPointer(true),
@@ -240,7 +237,6 @@ func TestDefaultFeatures(t *testing.T) {
 					Enabled:                       NewBoolPointer(false),
 					LogsConfigContainerCollectAll: NewBoolPointer(false),
 					ContainerLogsPath:             NewStringPointer("/var/lib/docker/containers"),
-					OpenFilesLimit:                NewInt32Pointer(200),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
 					Enabled:          NewBoolPointer(false),

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -2871,11 +2871,9 @@ func Test_newExtendedDaemonSetFromInstance_LogsEnabled(t *testing.T) {
 	logsEnabledPodSpec.Containers[0].VolumeMounts = append(logsEnabledPodSpec.Containers[0].VolumeMounts, logsVolumeMounts...)
 	logsEnabledPodSpec.Containers[0].Env = addEnvVar(logsEnabledPodSpec.Containers[0].Env, "DD_LOGS_ENABLED", "true")
 	logsEnabledPodSpec.Containers[0].Env = addEnvVar(logsEnabledPodSpec.Containers[0].Env, "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE", "true")
-	logsEnabledPodSpec.Containers[0].Env = addEnvVar(logsEnabledPodSpec.Containers[0].Env, "DD_LOGS_CONFIG_OPEN_FILES_LIMIT", "100")
 	logsEnabledPodSpec.InitContainers[1].VolumeMounts = append(logsEnabledPodSpec.InitContainers[1].VolumeMounts, logsVolumeMounts...)
 	logsEnabledPodSpec.InitContainers[1].Env = addEnvVar(logsEnabledPodSpec.InitContainers[1].Env, "DD_LOGS_ENABLED", "true")
 	logsEnabledPodSpec.InitContainers[1].Env = addEnvVar(logsEnabledPodSpec.Containers[0].Env, "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE", "true")
-	logsEnabledPodSpec.InitContainers[1].Env = addEnvVar(logsEnabledPodSpec.Containers[0].Env, "DD_LOGS_CONFIG_OPEN_FILES_LIMIT", "100")
 
 	test := extendedDaemonSetFromInstanceTest{
 		name:            "with logs enabled",


### PR DESCRIPTION
### What does this PR do?

Removes defaulting behavior of `logs_config.open_files_limit` in the operator so the value can be overridden using a custom agent `datadog.yaml` configuration file.

### Describe your test plan

Spin up an agent with a custom `datadog.yaml` file containing a custom `logs_config.open_files_limit` value:
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
(...)
  agent:
    image:
      name: "gcr.io/datadoghq/agent:latest"
    config:
      (...)
    log:
      enabled: true
      logsConfigContainerCollectAll: true
    customConfig:
      configData: |-
        logs_config:
          open_files_limit: 200
```
The `DD_LOGS_CONFIG_OPEN_FILES_LIMIT` env var should not be set in the agent daemonset and the `agent config` should show the custom value from the `datadog.yaml` file:
```
$ kubectl exec -it <datadog-agent-pod> -c agent -- agent config | grep open_files_limit
  open_files_limit: 200
```
Without setting a custom `logs_config.open_files_limit` value (e.g. spin up the above DatadogAgent with the `customConfig` section commented out), the open_files_limit value should be the default `100`:
```
$ kubectl exec -it <datadog-agent-pod> -c agent -- agent config | grep open_files_limit
  open_files_limit: 100
```