### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See the [How to Contribute page][9].
 
 [1]: https://github.com/DataDog/datadog-agent/
 [2]: https://github.com/DataDog/extendeddaemonset
-[3]: https://github.com/helm/charts/tree/main/stable/datadog
+[3]: https://github.com/DataDog/helm-charts
 [4]: https://github.com/DataDog/datadog-agent/tree/6.15.0/Dockerfiles/manifests
 [5]: https://github.com/DataDog/datadog-operator/blob/main/docs/getting_started.md
 [6]: https://github.com/DataDog/datadog-operator/blob/main/docs/custom_check.md

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See the [How to Contribute page][9].
 
 [1]: https://github.com/DataDog/datadog-agent/
 [2]: https://github.com/DataDog/extendeddaemonset
-[3]: https://github.com/DataDog/helm-charts
+[3]: https://github.com/DataDog/helm-charts/tree/main/charts/datadog
 [4]: https://github.com/DataDog/datadog-agent/tree/6.15.0/Dockerfiles/manifests
 [5]: https://github.com/DataDog/datadog-operator/blob/main/docs/getting_started.md
 [6]: https://github.com/DataDog/datadog-operator/blob/main/docs/custom_check.md

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See the [How to Contribute page][9].
 [7]: https://github.com/DataDog/datadog-operator/blob/main/docs/cluster_agent_setup.md
 [8]: https://github.com/DataDog/datadog-operator/blob/main/docs/secret_management.md
 [9]: https://github.com/DataDog/datadog-operator/tree/main/docs/how-to-contribute.md
-[10]: https://catalog.redhat.com/software/operators/detail/5e845a42ecb5246c09fe90b6
+[10]: https://catalog.redhat.com/software/operators/detail/5e9874986c5dcb34dfbb1a12
 [11]: https://operatorhub.io/operator/datadog-operator
 [12]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes links in README:
- the redhat certified one was pointing to a 404
- the helm chart one was pointing to a 404 as well, but because the branch name is `master`. I took the liberty to link directly to the official charts. Otherwise the correct link would be https://github.com/helm/charts/tree/master/stable/datadog

### Motivation

Keep README up-to-date.
