### PR TITLE
Set the TriggerWindow correctly when an anomaly monitor is set up

### DIFF
--- a/controllers/datadogmonitor/monitor.go
+++ b/controllers/datadogmonitor/monitor.go
@@ -84,7 +84,7 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 			thresholdWindows.SetRecoveryWindow(*options.ThresholdWindows.RecoveryWindow)
 		}
 		if options.ThresholdWindows.TriggerWindow != nil {
-			thresholdWindows.SetRecoveryWindow(*options.ThresholdWindows.TriggerWindow)
+			thresholdWindows.SetTriggerWindow(*options.ThresholdWindows.TriggerWindow)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

The TriggerWindow is not set when defining a DatadogMonitor with anomaly detection.
The Datadog Operator reconciles the Monitor with the error `error validating monitor: 400 Bad Request: {\"errors\": [\"alert window query arg must match trigger window monitor option\"]}"}` because the TriggerWindow is never set as the code sets 2x the RecoveryWindow.

### Motivation

Anomaly Monitor did not work with Datadog Operator - so digged into the code to understand the reason as the Datadog Operator logs are not so useful finding the issue (a trace of the request send to DD would be nice on debug level)

### Additional Notes

Nope

### Describe your test plan

I am a complete Newbie in Go and i have no Idea how to test it, but this seems for me just like a bug. I validated the method name by looking into the sources for the Option (https://github.com/DataDog/datadog-api-client-go/blob/master/api/v1/datadog/model_monitor_threshold_window_options.go#L114)
