### PR TITLE
Merge custom and bundled compliance benchmarks

### DIFF
--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -194,11 +194,12 @@ const (
 
 	HostCriSocketPathPrefix = "/host"
 
-	SecurityAgentRuntimeCustomPoliciesVolumeName = "customruntimepolicies"
-	SecurityAgentRuntimePoliciesDirVolumeName    = "runtimepoliciesdir"
-	SecurityAgentRuntimePoliciesDirVolumePath    = "/etc/datadog-agent/runtime-security.d"
-	SecurityAgentComplianceConfigDirVolumeName   = "compliancedir"
-	SecurityAgentComplianceConfigDirVolumePath   = "/etc/datadog-agent/compliance.d"
+	SecurityAgentRuntimeCustomPoliciesVolumeName     = "customruntimepolicies"
+	SecurityAgentRuntimePoliciesDirVolumeName        = "runtimepoliciesdir"
+	SecurityAgentRuntimePoliciesDirVolumePath        = "/etc/datadog-agent/runtime-security.d"
+	SecurityAgentComplianceCustomConfigDirVolumeName = "customcompliancebenchmarks"
+	SecurityAgentComplianceConfigDirVolumeName       = "compliancedir"
+	SecurityAgentComplianceConfigDirVolumePath       = "/etc/datadog-agent/compliance.d"
 
 	ClusterAgentCustomConfigVolumeName    = "custom-datadog-yaml"
 	ClusterAgentCustomConfigVolumePath    = "/etc/datadog-agent/datadog-cluster.yaml"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -365,6 +365,12 @@ func complianceSecurityAgentVolumes() []corev1.Volume {
 			},
 		},
 		{
+			Name: datadoghqv1alpha1.SecurityAgentComplianceConfigDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: datadoghqv1alpha1.ConfigVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},


### PR DESCRIPTION
### What does this PR do?

Instead of replacing the /etc/datadog-agent/compliance.d directory with the content
of a configmap, merge the benchmarks bundled with the agent and the one provided
with the configmap.

### Motivation

This behaviour is the same than the security policies and it allows to both add new benchmarks
and replace existing ones.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
