### PR TITLE
fix: cluster-agent auth token generation

### DIFF
--- a/apis/datadoghq/v1alpha1/utils.go
+++ b/apis/datadoghq/v1alpha1/utils.go
@@ -7,6 +7,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"math/rand"
 )
 
 // NewInt32Pointer returns pointer on a new int32 value instance
@@ -62,4 +63,14 @@ func IsEqualStruct(in interface{}, cmp interface{}) bool {
 		return false
 	}
 	return string(inJSON) == string(cmpJSON)
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func generateRandomString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -41,17 +41,6 @@ func (r *Reconciler) reconcileClusterAgent(logger logr.Logger, dda *datadoghqv1a
 		return result, err
 	}
 
-	// Generate a Token for clusterAgent-Agent communication if not provided
-	if dda.Spec.Credentials.Token == "" {
-		if newStatus.ClusterAgent == nil {
-			newStatus.ClusterAgent = &datadoghqv1alpha1.DeploymentStatus{}
-		}
-		if newStatus.ClusterAgent.GeneratedToken == "" {
-			newStatus.ClusterAgent.GeneratedToken = generateRandomString(32)
-			return reconcile.Result{}, nil
-		}
-	}
-
 	if newStatus.ClusterAgent != nil &&
 		newStatus.ClusterAgent.DeploymentName != "" &&
 		newStatus.ClusterAgent.DeploymentName != getClusterAgentName(dda) {

--- a/controllers/datadogagent/secret_agent.go
+++ b/controllers/datadogagent/secret_agent.go
@@ -33,6 +33,7 @@ func newAgentSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) (*corev1.S
 
 	creds := dda.Spec.Credentials
 	data := dataFromCredentials(&creds.DatadogCredentials)
+
 	// Agent credentials has two more fields
 	if creds.Token != "" {
 		data[datadoghqv1alpha1.DefaultTokenKey] = []byte(creds.Token)

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1974,16 +1974,6 @@ func mergeAnnotationsLabels(logger logr.Logger, previousVal map[string]string, n
 	return mergedMap
 }
 
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-func generateRandomString(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
-	}
-	return string(b)
-}
-
 func isKSMCoreEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	if dda.Spec.Features.KubeStateMetricsCore == nil {
 		return false


### PR DESCRIPTION
### What does this PR do?

This PR move the `token` generation logic in the DatadogAgent CR defaulting
logic. Like this, we are sure that the generated token is here before the
creation of the secret containing the `token`.

This PR also solve another issue, if the user create the DatadogAgent without
token, but later update CR with a token. Now the generatedToken will be removed
from the status.

### Motivation

In some case, a race-condition was trigger between the creation of
the agent-secret that contains the token and the generation of the
token if the user haven't set it in the spec.credentials.
Scenario:
* The secret is created with an empty `token`.
* Then the DCA start, and take as parameter the empty token.
* After a reconcile loop, the token is generated properly and the secret
  is updated.
* Agent Daemonset is created, and Agent Pods start properly with the
  correct token.
* Communications between the cluster-agent and Agents are broken due to
  the usage of different token

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

First, create the datadog-secret with the folling command:
```
kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY --from-literal app-key=$DD_APP_KEY
```

Then, deploy the agent with:

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog-agent
spec:
  clusterName: "foo"
  credentials:
    apiSecret:
      secretName: datadog-secret
      keyName: api-key
    appSecret:
      secretName: datadog-secret
      keyName: app-key
  features:
    kubeStateMetricsCore:
      enabled: true
  clusterAgent:
      clusterChecksEnabled: true
  clusterChecksRunner:
    enabled: true
```

The secret `datadog-agent` should have been created with a proper `token` inside. The token value should be the same than the token present in the `DatadogAgent.status.clusterAgent.generatedToken` field.

The communication between Agents and Cluster-Agent should be ok. (check agent status). Same between the cluster-check-runner and the Cluster-Agent.