### PR TITLE
fix: add vpa permissions to ksm core rbacs

### DIFF
--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -228,20 +228,21 @@ const (
 	// Consts used to setup Rbac config
 	// API Groups
 
-	CoreAPIGroup           = ""
-	ExtensionsAPIGroup     = "extensions"
-	OpenShiftQuotaAPIGroup = "quota.openshift.io"
-	RbacAPIGroup           = "rbac.authorization.k8s.io"
-	AutoscalingAPIGroup    = "autoscaling"
-	CertificatesAPIGroup   = "certificates.k8s.io"
-	StorageAPIGroup        = "storage.k8s.io"
-	CoordinationAPIGroup   = "coordination.k8s.io"
-	DatadogAPIGroup        = "datadoghq.com"
-	AdmissionAPIGroup      = "admissionregistration.k8s.io"
-	AppsAPIGroup           = "apps"
-	BatchAPIGroup          = "batch"
-	PolicyAPIGroup         = "policy"
-	NetworkingAPIGroup     = "networking.k8s.io"
+	CoreAPIGroup             = ""
+	ExtensionsAPIGroup       = "extensions"
+	OpenShiftQuotaAPIGroup   = "quota.openshift.io"
+	RbacAPIGroup             = "rbac.authorization.k8s.io"
+	AutoscalingAPIGroup      = "autoscaling"
+	CertificatesAPIGroup     = "certificates.k8s.io"
+	StorageAPIGroup          = "storage.k8s.io"
+	CoordinationAPIGroup     = "coordination.k8s.io"
+	DatadogAPIGroup          = "datadoghq.com"
+	AdmissionAPIGroup        = "admissionregistration.k8s.io"
+	AppsAPIGroup             = "apps"
+	BatchAPIGroup            = "batch"
+	PolicyAPIGroup           = "policy"
+	NetworkingAPIGroup       = "networking.k8s.io"
+	AutoscalingK8sIoAPIGroup = "autoscaling.k8s.io"
 
 	// Resources
 
@@ -288,6 +289,7 @@ const (
 	RoleBindingResource                 = "rolebindings"
 	NetworkPolicyResource               = "networkpolicies"
 	IngressesResource                   = "ingresses"
+	VPAResource                         = "verticalpodautoscalers"
 
 	// Resource names
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -331,6 +331,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - batch
   resources:
   - cronjobs

--- a/controllers/datadogagent/kubestatemetrics.go
+++ b/controllers/datadogagent/kubestatemetrics.go
@@ -255,6 +255,12 @@ func buildKubeStateMetricsCoreRBAC(dda *datadoghqv1alpha1.DatadogAgent, name, ve
 				datadoghqv1alpha1.LeasesResource,
 			},
 		},
+		{
+			APIGroups: []string{datadoghqv1alpha1.AutoscalingK8sIoAPIGroup},
+			Resources: []string{
+				datadoghqv1alpha1.VPAResource,
+			},
+		},
 	}
 
 	clusterRole.Rules = rbacRules

--- a/controllers/datadogagent/testdata/ksm_clusterrole.yaml
+++ b/controllers/datadogagent/testdata/ksm_clusterrole.yaml
@@ -118,3 +118,10 @@ rules:
     verbs:
       - list
       - watch
+  - apigroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - list
+      - watch

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -150,6 +150,7 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=list;watch
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses;volumeattachments,verbs=list;watch
+// +kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=list;watch
 
 // Reconcile loop for DatadogAgent.
 func (r *DatadogAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
### What does this PR do?

Add vpa permissions to ksm core rbacs

### Motivation

KSM Core in agent 7.33 supports VPA metrics

### Additional Notes

Same as https://github.com/DataDog/helm-charts/pull/453

### Describe your test plan

Deploy a CR with ksm core enabled, make sure the KSM clusterrole contains vpa list and watch RBACs
