### PR TITLE
Add missing FQDNs to Cilium network policy

### DIFF
--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -444,7 +444,13 @@ func (b agentNetworkPolicyBuilder) ddFQDNs() []cilium.FQDNSelector {
 			MatchPattern: fmt.Sprintf("*-app.agent.%s", site),
 		},
 		{
+			MatchName: fmt.Sprintf("api.%s", site),
+		},
+		{
 			MatchName: fmt.Sprintf("agent-intake.logs.%s", site),
+		},
+		{
+			MatchName: fmt.Sprintf("agent-http-intake.logs.%s", site),
 		},
 		{
 			MatchName: fmt.Sprintf("process.%s", site),


### PR DESCRIPTION
### What does this PR do?

Adds missing FQDN rules to the agent Cilium network policy.

### Motivation

This was reported as a bug in the helm chart, but it is also present in the operator: https://github.com/DataDog/helm-charts/issues/456

### Describe your test plan

Same as https://github.com/DataDog/helm-charts/issues/456
