### PR TITLE
The Network Monitoring feature enables the process agent

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -154,8 +154,9 @@ func FeatureOverride(dda *DatadogAgentSpec, dso *DatadogAgentSpec) {
 			dso.Agent.SystemProbe.Enabled = NewBoolPointer(true)
 		}
 	}
-	if dda.Features.OrchestratorExplorer != nil && BoolValue(dda.Features.OrchestratorExplorer.Enabled) {
-		// If the Orchestrator Explorer Feature is enabled, enable the Process Agent.
+	if dda.Features.NetworkMonitoring != nil && BoolValue(dda.Features.NetworkMonitoring.Enabled) ||
+		dda.Features.OrchestratorExplorer != nil && BoolValue(dda.Features.OrchestratorExplorer.Enabled) {
+		// If the Network Monitoring or the Orchestrator Explorer Feature is enabled, enable the Process Agent.
 		if !BoolValue(dda.Agent.Enabled) {
 			if dda.Agent.Process == nil {
 				dda.Agent.Process = DefaultDatadogAgentSpecAgentProcess(&dda.Agent)


### PR DESCRIPTION
### What does this PR do?

Make the network monitoring feature enable the process agent.

### Motivation

```yaml
spec:
  features:
    networkMonitoring:
      enabled: true
```

should be enough to make the network monitoring product work, which requires the `process-agent`.

### Additional Notes

The orchestrator explorer feature also enables the `process-agent` and is enabled by default.

### Describe your test plan

Spawn an agent with:

```yaml
spec:
  features:
    orchestratorExplorer:
      enabled: false
    networkMonitoring:
      enabled: true
```

It should instantiate a `process-agent`.