### PR TITLE
move apis/v1alpha1 utils to apis/utils

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"testing"
 
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 
@@ -32,17 +33,17 @@ func TestDefaultConfigDogstatsd(t *testing.T) {
 			name: "empty conf",
 			dsd:  NodeAgentConfig{},
 			override: &DogstatsdConfig{
-				DogstatsdOriginDetection: NewBoolPointer(false), // defaultDogstatsdOriginDetection
+				DogstatsdOriginDetection: apiutils.NewBoolPointer(false), // defaultDogstatsdOriginDetection
 				UnixDomainSocket: &DSDUnixDomainSocketSpec{
-					Enabled:      NewBoolPointer(false),
+					Enabled:      apiutils.NewBoolPointer(false),
 					HostFilepath: &defaultPath,
 				},
 			},
 			internal: NodeAgentConfig{
 				Dogstatsd: &DogstatsdConfig{
-					DogstatsdOriginDetection: NewBoolPointer(false),
+					DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 					UnixDomainSocket: &DSDUnixDomainSocketSpec{
-						Enabled:      NewBoolPointer(false),
+						Enabled:      apiutils.NewBoolPointer(false),
 						HostFilepath: &defaultPath,
 					},
 				},
@@ -53,19 +54,19 @@ func TestDefaultConfigDogstatsd(t *testing.T) {
 			dsd: NodeAgentConfig{
 				Dogstatsd: &DogstatsdConfig{
 					UnixDomainSocket: &DSDUnixDomainSocketSpec{
-						Enabled:      NewBoolPointer(false),
+						Enabled:      apiutils.NewBoolPointer(false),
 						HostFilepath: &defaultPath,
 					},
 				},
 			},
 			override: &DogstatsdConfig{
-				DogstatsdOriginDetection: NewBoolPointer(false),
+				DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 			},
 			internal: NodeAgentConfig{
 				Dogstatsd: &DogstatsdConfig{
-					DogstatsdOriginDetection: NewBoolPointer(false),
+					DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 					UnixDomainSocket: &DSDUnixDomainSocketSpec{
-						Enabled:      NewBoolPointer(false),
+						Enabled:      apiutils.NewBoolPointer(false),
 						HostFilepath: &defaultPath,
 					},
 				},
@@ -75,20 +76,20 @@ func TestDefaultConfigDogstatsd(t *testing.T) {
 			name: "dogtatsd missing defaulting: UseDogStatsDSocketVolume",
 			dsd: NodeAgentConfig{
 				Dogstatsd: &DogstatsdConfig{
-					DogstatsdOriginDetection: NewBoolPointer(false),
+					DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 				},
 			},
 			override: &DogstatsdConfig{
 				UnixDomainSocket: &DSDUnixDomainSocketSpec{
-					Enabled:      NewBoolPointer(false),
+					Enabled:      apiutils.NewBoolPointer(false),
 					HostFilepath: &defaultPath,
 				},
 			},
 			internal: NodeAgentConfig{
 				Dogstatsd: &DogstatsdConfig{
-					DogstatsdOriginDetection: NewBoolPointer(false),
+					DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 					UnixDomainSocket: &DSDUnixDomainSocketSpec{
-						Enabled:      NewBoolPointer(false),
+						Enabled:      apiutils.NewBoolPointer(false),
 						HostFilepath: &defaultPath,
 					},
 				},
@@ -98,8 +99,8 @@ func TestDefaultConfigDogstatsd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultConfigDogstatsd(&tt.dsd)
-			assert.True(t, IsEqualStruct(got, tt.override), "TestDefaultFeatures override \ndiff = %s", cmp.Diff(got, tt.override))
-			assert.True(t, IsEqualStruct(tt.dsd, tt.internal), "TestDefaultFeatures internal \ndiff = %s", cmp.Diff(tt.dsd, tt.internal))
+			assert.True(t, apiutils.IsEqualStruct(got, tt.override), "TestDefaultFeatures override \ndiff = %s", cmp.Diff(got, tt.override))
+			assert.True(t, apiutils.IsEqualStruct(tt.dsd, tt.internal), "TestDefaultFeatures internal \ndiff = %s", cmp.Diff(tt.dsd, tt.internal))
 		})
 	}
 }
@@ -116,134 +117,134 @@ func TestDefaultFeatures(t *testing.T) {
 			ft:   DatadogFeatures{},
 			overrideExpected: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled:      NewBoolPointer(true),
-					ClusterCheck: NewBoolPointer(false),
-					Scrubbing:    &Scrubbing{Containers: NewBoolPointer(true)},
+					Enabled:      apiutils.NewBoolPointer(true),
+					ClusterCheck: apiutils.NewBoolPointer(false),
+					Scrubbing:    &Scrubbing{Containers: apiutils.NewBoolPointer(true)},
 				},
-				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(false), ClusterCheck: NewBoolPointer(false)},
+				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: apiutils.NewBoolPointer(false), ClusterCheck: apiutils.NewBoolPointer(false)},
 				PrometheusScrape: &PrometheusScrapeConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
 				LogCollection: &LogCollectionConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
-				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: NewBoolPointer(false)},
+				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: apiutils.NewBoolPointer(false)},
 			},
 			internalDefaulted: DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled:      NewBoolPointer(true),
-					ClusterCheck: NewBoolPointer(false),
-					Scrubbing:    &Scrubbing{Containers: NewBoolPointer(true)},
+					Enabled:      apiutils.NewBoolPointer(true),
+					ClusterCheck: apiutils.NewBoolPointer(false),
+					Scrubbing:    &Scrubbing{Containers: apiutils.NewBoolPointer(true)},
 				},
-				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(false), ClusterCheck: NewBoolPointer(false)},
+				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: apiutils.NewBoolPointer(false), ClusterCheck: apiutils.NewBoolPointer(false)},
 				PrometheusScrape: &PrometheusScrapeConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
 				LogCollection: &LogCollectionConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
-				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: NewBoolPointer(false)},
+				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: apiutils.NewBoolPointer(false)},
 			},
 		},
 		{
 			name: "sparse config",
 			ft: DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
 				LogCollection: &LogCollectionConfig{
-					Enabled: NewBoolPointer(true),
+					Enabled: apiutils.NewBoolPointer(true),
 				},
 			},
 			overrideExpected: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
-				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(false), ClusterCheck: NewBoolPointer(false)},
+				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: apiutils.NewBoolPointer(false), ClusterCheck: apiutils.NewBoolPointer(false)},
 				LogCollection: &LogCollectionConfig{
-					Enabled:                       NewBoolPointer(true),
-					LogsConfigContainerCollectAll: NewBoolPointer(false),
-					ContainerCollectUsingFiles:    NewBoolPointer(true),
-					ContainerLogsPath:             NewStringPointer("/var/lib/docker/containers"),
-					PodLogsPath:                   NewStringPointer("/var/log/pods"),
-					ContainerSymlinksPath:         NewStringPointer("/var/log/containers"),
-					TempStoragePath:               NewStringPointer("/var/lib/datadog-agent/logs"),
+					Enabled:                       apiutils.NewBoolPointer(true),
+					LogsConfigContainerCollectAll: apiutils.NewBoolPointer(false),
+					ContainerCollectUsingFiles:    apiutils.NewBoolPointer(true),
+					ContainerLogsPath:             apiutils.NewStringPointer("/var/lib/docker/containers"),
+					PodLogsPath:                   apiutils.NewStringPointer("/var/log/pods"),
+					ContainerSymlinksPath:         apiutils.NewStringPointer("/var/log/containers"),
+					TempStoragePath:               apiutils.NewStringPointer("/var/lib/datadog-agent/logs"),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
-				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: NewBoolPointer(false)},
+				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: apiutils.NewBoolPointer(false)},
 			},
 			internalDefaulted: DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
-				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(false), ClusterCheck: NewBoolPointer(false)},
+				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: apiutils.NewBoolPointer(false), ClusterCheck: apiutils.NewBoolPointer(false)},
 				LogCollection: &LogCollectionConfig{
-					Enabled:                       NewBoolPointer(true),
-					LogsConfigContainerCollectAll: NewBoolPointer(false),
-					ContainerCollectUsingFiles:    NewBoolPointer(true),
-					ContainerLogsPath:             NewStringPointer("/var/lib/docker/containers"),
-					PodLogsPath:                   NewStringPointer("/var/log/pods"),
-					ContainerSymlinksPath:         NewStringPointer("/var/log/containers"),
-					TempStoragePath:               NewStringPointer("/var/lib/datadog-agent/logs"),
+					Enabled:                       apiutils.NewBoolPointer(true),
+					LogsConfigContainerCollectAll: apiutils.NewBoolPointer(false),
+					ContainerCollectUsingFiles:    apiutils.NewBoolPointer(true),
+					ContainerLogsPath:             apiutils.NewStringPointer("/var/lib/docker/containers"),
+					PodLogsPath:                   apiutils.NewStringPointer("/var/log/pods"),
+					ContainerSymlinksPath:         apiutils.NewStringPointer("/var/log/containers"),
+					TempStoragePath:               apiutils.NewStringPointer("/var/lib/datadog-agent/logs"),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
-				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: NewBoolPointer(false)},
+				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: apiutils.NewBoolPointer(false)},
 			},
 		},
 		{
 			name: "some config",
 			ft: DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Scrubbing: &Scrubbing{Containers: NewBoolPointer(false)},
+					Scrubbing: &Scrubbing{Containers: apiutils.NewBoolPointer(false)},
 				},
-				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(true), ClusterCheck: NewBoolPointer(true)},
+				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: apiutils.NewBoolPointer(true), ClusterCheck: apiutils.NewBoolPointer(true)},
 				LogCollection: &LogCollectionConfig{
-					LogsConfigContainerCollectAll: NewBoolPointer(false),
-					ContainerLogsPath:             NewStringPointer("/var/lib/docker/containers"),
+					LogsConfigContainerCollectAll: apiutils.NewBoolPointer(false),
+					ContainerLogsPath:             apiutils.NewStringPointer("/var/lib/docker/containers"),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
-					ServiceEndpoints: NewBoolPointer(true),
+					ServiceEndpoints: apiutils.NewBoolPointer(true),
 				},
-				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: NewBoolPointer(true)},
+				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: apiutils.NewBoolPointer(true)},
 			},
 			overrideExpected: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled:      NewBoolPointer(true), // defaultOrchestratorExplorerEnabled
-					ClusterCheck: NewBoolPointer(false),
+					Enabled:      apiutils.NewBoolPointer(true), // defaultOrchestratorExplorerEnabled
+					ClusterCheck: apiutils.NewBoolPointer(false),
 				},
 				KubeStateMetricsCore: &KubeStateMetricsCore{
-					Enabled:      NewBoolPointer(true),
-					ClusterCheck: NewBoolPointer(true),
+					Enabled:      apiutils.NewBoolPointer(true),
+					ClusterCheck: apiutils.NewBoolPointer(true),
 				},
 				LogCollection: &LogCollectionConfig{
-					Enabled: NewBoolPointer(false), // defaultLogEnabled
+					Enabled: apiutils.NewBoolPointer(false), // defaultLogEnabled
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
-					Enabled: NewBoolPointer(false), // defaultPrometheusScrapeEnabled
+					Enabled: apiutils.NewBoolPointer(false), // defaultPrometheusScrapeEnabled
 				},
-				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: NewBoolPointer(true)},
+				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: apiutils.NewBoolPointer(true)},
 			},
 			internalDefaulted: DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled:      NewBoolPointer(true), // defaultOrchestratorExplorerEnabled
-					ClusterCheck: NewBoolPointer(false),
-					Scrubbing:    &Scrubbing{Containers: NewBoolPointer(false)},
+					Enabled:      apiutils.NewBoolPointer(true), // defaultOrchestratorExplorerEnabled
+					ClusterCheck: apiutils.NewBoolPointer(false),
+					Scrubbing:    &Scrubbing{Containers: apiutils.NewBoolPointer(false)},
 				},
-				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: NewBoolPointer(true), ClusterCheck: NewBoolPointer(true)},
+				KubeStateMetricsCore: &KubeStateMetricsCore{Enabled: apiutils.NewBoolPointer(true), ClusterCheck: apiutils.NewBoolPointer(true)},
 				LogCollection: &LogCollectionConfig{
-					Enabled:                       NewBoolPointer(false),
-					LogsConfigContainerCollectAll: NewBoolPointer(false),
-					ContainerLogsPath:             NewStringPointer("/var/lib/docker/containers"),
+					Enabled:                       apiutils.NewBoolPointer(false),
+					LogsConfigContainerCollectAll: apiutils.NewBoolPointer(false),
+					ContainerLogsPath:             apiutils.NewStringPointer("/var/lib/docker/containers"),
 				},
 				PrometheusScrape: &PrometheusScrapeConfig{
-					Enabled:          NewBoolPointer(false),
-					ServiceEndpoints: NewBoolPointer(true),
+					Enabled:          apiutils.NewBoolPointer(false),
+					ServiceEndpoints: apiutils.NewBoolPointer(true),
 				},
-				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: NewBoolPointer(true)},
+				NetworkMonitoring: &NetworkMonitoringConfig{Enabled: apiutils.NewBoolPointer(true)},
 			},
 		},
 	}
@@ -252,8 +253,8 @@ func TestDefaultFeatures(t *testing.T) {
 			dda := &DatadogAgent{}
 			dda.Spec.Features = tt.ft
 			got := DefaultFeatures(dda)
-			assert.True(t, IsEqualStruct(got, tt.overrideExpected), "TestDefaultFeatures override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
-			assert.True(t, IsEqualStruct(dda.Spec.Features, tt.internalDefaulted), "TestDefaultFeatures internal \ndiff = %s", cmp.Diff(dda.Spec.Features, tt.internalDefaulted))
+			assert.True(t, apiutils.IsEqualStruct(got, tt.overrideExpected), "TestDefaultFeatures override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
+			assert.True(t, apiutils.IsEqualStruct(dda.Spec.Features, tt.internalDefaulted), "TestDefaultFeatures internal \ndiff = %s", cmp.Diff(dda.Spec.Features, tt.internalDefaulted))
 		})
 	}
 }
@@ -268,11 +269,11 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 		{
 			name: "disable field",
 			dca: DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 			overrideExpected: &DatadogAgentSpecClusterAgentSpec{},
 			internalDefaulted: DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 		},
 		{
@@ -280,12 +281,12 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 			dca: DatadogAgentSpecClusterAgentSpec{
 				Config: &ClusterAgentConfig{
 					AdmissionController: &AdmissionControllerConfig{
-						Enabled: NewBoolPointer(true),
+						Enabled: apiutils.NewBoolPointer(true),
 					},
 				},
 			},
 			overrideExpected: &DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:       defaultClusterAgentImageName,
 					Tag:        defaulting.ClusterAgentLatestVersion,
@@ -293,23 +294,23 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
-						Enabled: NewBoolPointer(false),
+						Enabled: apiutils.NewBoolPointer(false),
 					},
 					AdmissionController: &AdmissionControllerConfig{
-						MutateUnlabelled: NewBoolPointer(false),
-						ServiceName:      NewStringPointer("datadog-admission-controller"),
+						MutateUnlabelled: apiutils.NewBoolPointer(false),
+						ServiceName:      apiutils.NewStringPointer("datadog-admission-controller"),
 					},
-					ClusterChecksEnabled: NewBoolPointer(false),
-					LogLevel:             NewStringPointer(defaultLogLevel),
-					CollectEvents:        NewBoolPointer(false),
-					HealthPort:           NewInt32Pointer(5555),
+					ClusterChecksEnabled: apiutils.NewBoolPointer(false),
+					LogLevel:             apiutils.NewStringPointer(defaultLogLevel),
+					CollectEvents:        apiutils.NewBoolPointer(false),
+					HealthPort:           apiutils.NewInt32Pointer(5555),
 				},
-				Rbac:          &RbacConfig{Create: NewBoolPointer(true)},
+				Rbac:          &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Replicas:      nil,
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 			internalDefaulted: DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        defaultClusterAgentImageName,
 					Tag:         defaulting.ClusterAgentLatestVersion,
@@ -318,51 +319,51 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
-						Enabled: NewBoolPointer(false),
+						Enabled: apiutils.NewBoolPointer(false),
 					},
 					AdmissionController: &AdmissionControllerConfig{
-						Enabled:          NewBoolPointer(true),
-						MutateUnlabelled: NewBoolPointer(false),
-						ServiceName:      NewStringPointer("datadog-admission-controller"),
+						Enabled:          apiutils.NewBoolPointer(true),
+						MutateUnlabelled: apiutils.NewBoolPointer(false),
+						ServiceName:      apiutils.NewStringPointer("datadog-admission-controller"),
 					},
 					Resources:            &corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}},
-					LogLevel:             NewStringPointer(defaultLogLevel),
-					ClusterChecksEnabled: NewBoolPointer(false),
-					CollectEvents:        NewBoolPointer(false),
-					HealthPort:           NewInt32Pointer(5555),
+					LogLevel:             apiutils.NewStringPointer(defaultLogLevel),
+					ClusterChecksEnabled: apiutils.NewBoolPointer(false),
+					CollectEvents:        apiutils.NewBoolPointer(false),
+					HealthPort:           apiutils.NewInt32Pointer(5555),
 				},
-				Rbac:          &RbacConfig{Create: NewBoolPointer(true)},
+				Rbac:          &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Replicas:      nil,
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 		},
 		{
 			name: "almost full config",
 			dca: DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:       "foo",
-					PullPolicy: (*corev1.PullPolicy)(NewStringPointer("Always")),
+					PullPolicy: (*corev1.PullPolicy)(apiutils.NewStringPointer("Always")),
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
-						Enabled:           NewBoolPointer(true),
+						Enabled:           apiutils.NewBoolPointer(true),
 						WpaController:     true,
 						UseDatadogMetrics: true,
 					},
-					LogLevel: NewStringPointer("DEBUG"),
+					LogLevel: apiutils.NewStringPointer("DEBUG"),
 					AdmissionController: &AdmissionControllerConfig{
-						Enabled:          NewBoolPointer(true),
-						MutateUnlabelled: NewBoolPointer(false),
-						ServiceName:      NewStringPointer("foo"),
+						Enabled:          apiutils.NewBoolPointer(true),
+						MutateUnlabelled: apiutils.NewBoolPointer(false),
+						ServiceName:      apiutils.NewStringPointer("foo"),
 					},
-					ClusterChecksEnabled: NewBoolPointer(true),
-					CollectEvents:        NewBoolPointer(false),
-					HealthPort:           NewInt32Pointer(5555),
+					ClusterChecksEnabled: apiutils.NewBoolPointer(true),
+					CollectEvents:        apiutils.NewBoolPointer(false),
+					HealthPort:           apiutils.NewInt32Pointer(5555),
 				},
-				Rbac:          &RbacConfig{Create: NewBoolPointer(false)},
-				Replicas:      NewInt32Pointer(2),
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(true)},
+				Rbac:          &RbacConfig{Create: apiutils.NewBoolPointer(false)},
+				Replicas:      apiutils.NewInt32Pointer(2),
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(true)},
 			},
 			overrideExpected: &DatadogAgentSpecClusterAgentSpec{
 				Image: &ImageConfig{
@@ -370,41 +371,41 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
-						Port: NewInt32Pointer(8443),
+						Port: apiutils.NewInt32Pointer(8443),
 					},
 				},
 				NetworkPolicy: &NetworkPolicySpec{Flavor: NetworkPolicyFlavorKubernetes},
 			},
 			internalDefaulted: DatadogAgentSpecClusterAgentSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        "foo",
 					Tag:         defaulting.ClusterAgentLatestVersion,
-					PullPolicy:  (*corev1.PullPolicy)(NewStringPointer("Always")),
+					PullPolicy:  (*corev1.PullPolicy)(apiutils.NewStringPointer("Always")),
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
 				Config: &ClusterAgentConfig{
 					ExternalMetrics: &ExternalMetricsConfig{
-						Enabled:           NewBoolPointer(true),
+						Enabled:           apiutils.NewBoolPointer(true),
 						WpaController:     true,
 						UseDatadogMetrics: true,
-						Port:              NewInt32Pointer(8443),
+						Port:              apiutils.NewInt32Pointer(8443),
 					},
 					AdmissionController: &AdmissionControllerConfig{
-						Enabled:          NewBoolPointer(true),
-						MutateUnlabelled: NewBoolPointer(false),
-						ServiceName:      NewStringPointer("foo"),
+						Enabled:          apiutils.NewBoolPointer(true),
+						MutateUnlabelled: apiutils.NewBoolPointer(false),
+						ServiceName:      apiutils.NewStringPointer("foo"),
 					},
 					Resources:            &corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}},
-					ClusterChecksEnabled: NewBoolPointer(true),
-					CollectEvents:        NewBoolPointer(false),
-					LogLevel:             NewStringPointer("DEBUG"),
-					HealthPort:           NewInt32Pointer(5555),
+					ClusterChecksEnabled: apiutils.NewBoolPointer(true),
+					CollectEvents:        apiutils.NewBoolPointer(false),
+					LogLevel:             apiutils.NewStringPointer("DEBUG"),
+					HealthPort:           apiutils.NewInt32Pointer(5555),
 				},
-				Rbac:     &RbacConfig{Create: NewBoolPointer(false)},
-				Replicas: NewInt32Pointer(2),
+				Rbac:     &RbacConfig{Create: apiutils.NewBoolPointer(false)},
+				Replicas: apiutils.NewInt32Pointer(2),
 				NetworkPolicy: &NetworkPolicySpec{
-					Create: NewBoolPointer(true),
+					Create: apiutils.NewBoolPointer(true),
 					Flavor: NetworkPolicyFlavorKubernetes,
 				},
 			},
@@ -413,8 +414,8 @@ func TestDefaultDatadogAgentSpecClusterAgent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultDatadogAgentSpecClusterAgent(&tt.dca)
-			assert.True(t, IsEqualStruct(got, tt.overrideExpected), "TestDefaultDatadogAgentSpecClusterAgent override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
-			assert.True(t, IsEqualStruct(tt.dca, tt.internalDefaulted), "TestDefaultDatadogAgentSpecClusterAgent internal \ndiff = %s", cmp.Diff(tt.dca, tt.internalDefaulted))
+			assert.True(t, apiutils.IsEqualStruct(got, tt.overrideExpected), "TestDefaultDatadogAgentSpecClusterAgent override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
+			assert.True(t, apiutils.IsEqualStruct(tt.dca, tt.internalDefaulted), "TestDefaultDatadogAgentSpecClusterAgent internal \ndiff = %s", cmp.Diff(tt.dca, tt.internalDefaulted))
 		})
 	}
 }
@@ -430,11 +431,11 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 		{
 			name: "agent disabled field",
 			agent: DatadogAgentSpecAgentSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 			overrideExpected: &DatadogAgentSpecAgentSpec{},
 			internalDefaulted: DatadogAgentSpecAgentSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 		},
 		{
@@ -443,54 +444,54 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				Config: &NodeAgentConfig{},
 			},
 			overrideExpected: &DatadogAgentSpecAgentSpec{
-				Enabled:              NewBoolPointer(true),
-				UseExtendedDaemonset: NewBoolPointer(false),
+				Enabled:              apiutils.NewBoolPointer(true),
+				UseExtendedDaemonset: apiutils.NewBoolPointer(false),
 				Image: &ImageConfig{
 					Name:       defaultAgentImageName,
 					Tag:        defaulting.AgentLatestVersion,
 					PullPolicy: &defaultImagePullPolicy,
 				},
 				Config: &NodeAgentConfig{
-					LogLevel:       NewStringPointer(defaultLogLevel),
-					CollectEvents:  NewBoolPointer(false),
-					LeaderElection: NewBoolPointer(false),
+					LogLevel:       apiutils.NewStringPointer(defaultLogLevel),
+					CollectEvents:  apiutils.NewBoolPointer(false),
+					LeaderElection: apiutils.NewBoolPointer(false),
 					LivenessProbe:  GetDefaultLivenessProbe(),
 					ReadinessProbe: GetDefaultReadinessProbe(),
-					HealthPort:     NewInt32Pointer(5555),
+					HealthPort:     apiutils.NewInt32Pointer(5555),
 					// CriSocket unset as we use latest
 					Dogstatsd: &DogstatsdConfig{
-						DogstatsdOriginDetection: NewBoolPointer(false),
+						DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 						UnixDomainSocket: &DSDUnixDomainSocketSpec{
-							Enabled:      NewBoolPointer(false),
-							HostFilepath: NewStringPointer(path.Join(defaultHostDogstatsdSocketPath, defaultHostDogstatsdSocketName)),
+							Enabled:      apiutils.NewBoolPointer(false),
+							HostFilepath: apiutils.NewStringPointer(path.Join(defaultHostDogstatsdSocketPath, defaultHostDogstatsdSocketName)),
 						},
 					},
 				},
 				DeploymentStrategy: &DaemonSetDeploymentStrategy{
-					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(NewStringPointer("RollingUpdate")),
+					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(apiutils.NewStringPointer("RollingUpdate")),
 					RollingUpdate: DaemonSetRollingUpdateSpec{
 						MaxUnavailable:            &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxUnavailable},
 						MaxPodSchedulerFailure:    &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxPodSchedulerFailure},
-						MaxParallelPodCreation:    NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
+						MaxParallelPodCreation:    apiutils.NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
 						SlowStartIntervalDuration: &metav1.Duration{Duration: defaultRollingUpdateSlowStartIntervalDuration},
 						SlowStartAdditiveIncrease: &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateSlowStartAdditiveIncrease},
 					},
 					Canary:             edsdatadoghqv1alpha1.DefaultExtendedDaemonSetSpecStrategyCanary(testCanary),
 					ReconcileFrequency: &metav1.Duration{Duration: defaultReconcileFrequency},
 				},
-				Rbac:        &RbacConfig{Create: NewBoolPointer(true)},
-				Apm:         &APMSpec{Enabled: NewBoolPointer(false)},
-				Process:     &ProcessSpec{Enabled: NewBoolPointer(false)},
-				SystemProbe: &SystemProbeSpec{Enabled: NewBoolPointer(false)},
+				Rbac:        &RbacConfig{Create: apiutils.NewBoolPointer(true)},
+				Apm:         &APMSpec{Enabled: apiutils.NewBoolPointer(false)},
+				Process:     &ProcessSpec{Enabled: apiutils.NewBoolPointer(false)},
+				SystemProbe: &SystemProbeSpec{Enabled: apiutils.NewBoolPointer(false)},
 				Security: &SecuritySpec{
-					Compliance: ComplianceSpec{Enabled: NewBoolPointer(false)},
-					Runtime:    RuntimeSecuritySpec{Enabled: NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: NewBoolPointer(false)}},
+					Compliance: ComplianceSpec{Enabled: apiutils.NewBoolPointer(false)},
+					Runtime:    RuntimeSecuritySpec{Enabled: apiutils.NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: apiutils.NewBoolPointer(false)}},
 				},
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 			internalDefaulted: DatadogAgentSpecAgentSpec{
-				Enabled:              NewBoolPointer(true),
-				UseExtendedDaemonset: NewBoolPointer(false),
+				Enabled:              apiutils.NewBoolPointer(true),
+				UseExtendedDaemonset: apiutils.NewBoolPointer(false),
 				Image: &ImageConfig{
 					Name:        defaultAgentImageName,
 					Tag:         defaulting.AgentLatestVersion,
@@ -498,56 +499,56 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
 				Config: &NodeAgentConfig{
-					LogLevel:             NewStringPointer(defaultLogLevel),
+					LogLevel:             apiutils.NewStringPointer(defaultLogLevel),
 					PodLabelsAsTags:      map[string]string{},
 					PodAnnotationsAsTags: map[string]string{},
 					Tags:                 []string{},
-					CollectEvents:        NewBoolPointer(false),
-					LeaderElection:       NewBoolPointer(false),
+					CollectEvents:        apiutils.NewBoolPointer(false),
+					LeaderElection:       apiutils.NewBoolPointer(false),
 					LivenessProbe:        GetDefaultLivenessProbe(),
 					Resources:            &corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}},
 					ReadinessProbe:       GetDefaultReadinessProbe(),
-					HealthPort:           NewInt32Pointer(5555),
+					HealthPort:           apiutils.NewInt32Pointer(5555),
 					Dogstatsd: &DogstatsdConfig{
-						DogstatsdOriginDetection: NewBoolPointer(false),
+						DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 						UnixDomainSocket: &DSDUnixDomainSocketSpec{
-							Enabled:      NewBoolPointer(false),
-							HostFilepath: NewStringPointer(path.Join(defaultHostDogstatsdSocketPath, defaultHostDogstatsdSocketName)),
+							Enabled:      apiutils.NewBoolPointer(false),
+							HostFilepath: apiutils.NewStringPointer(path.Join(defaultHostDogstatsdSocketPath, defaultHostDogstatsdSocketName)),
 						},
 					},
 				},
 				DeploymentStrategy: &DaemonSetDeploymentStrategy{
-					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(NewStringPointer("RollingUpdate")),
+					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(apiutils.NewStringPointer("RollingUpdate")),
 					RollingUpdate: DaemonSetRollingUpdateSpec{
 						MaxUnavailable:            &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxUnavailable},
 						MaxPodSchedulerFailure:    &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxPodSchedulerFailure},
-						MaxParallelPodCreation:    NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
+						MaxParallelPodCreation:    apiutils.NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
 						SlowStartIntervalDuration: &metav1.Duration{Duration: defaultRollingUpdateSlowStartIntervalDuration},
 						SlowStartAdditiveIncrease: &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateSlowStartAdditiveIncrease},
 					},
 					Canary:             edsdatadoghqv1alpha1.DefaultExtendedDaemonSetSpecStrategyCanary(testCanary),
 					ReconcileFrequency: &metav1.Duration{Duration: defaultReconcileFrequency},
 				},
-				Rbac:        &RbacConfig{Create: NewBoolPointer(true)},
-				Apm:         &APMSpec{Enabled: NewBoolPointer(false)},
-				Process:     &ProcessSpec{Enabled: NewBoolPointer(false)},
-				SystemProbe: &SystemProbeSpec{Enabled: NewBoolPointer(false)},
+				Rbac:        &RbacConfig{Create: apiutils.NewBoolPointer(true)},
+				Apm:         &APMSpec{Enabled: apiutils.NewBoolPointer(false)},
+				Process:     &ProcessSpec{Enabled: apiutils.NewBoolPointer(false)},
+				SystemProbe: &SystemProbeSpec{Enabled: apiutils.NewBoolPointer(false)},
 				Security: &SecuritySpec{
-					Compliance: ComplianceSpec{Enabled: NewBoolPointer(false)},
-					Runtime:    RuntimeSecuritySpec{Enabled: NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: NewBoolPointer(false)}},
+					Compliance: ComplianceSpec{Enabled: apiutils.NewBoolPointer(false)},
+					Runtime:    RuntimeSecuritySpec{Enabled: apiutils.NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: apiutils.NewBoolPointer(false)}},
 				},
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 		},
 		{
 			name: "some config",
 			agent: DatadogAgentSpecAgentSpec{
 				Config: &NodeAgentConfig{
-					DDUrl:          NewStringPointer("www.datadog.com"),
-					LeaderElection: NewBoolPointer(true),
+					DDUrl:          apiutils.NewStringPointer("www.datadog.com"),
+					LeaderElection: apiutils.NewBoolPointer(true),
 					Dogstatsd: &DogstatsdConfig{
-						DogstatsdOriginDetection: NewBoolPointer(false),
-						UnixDomainSocket:         &DSDUnixDomainSocketSpec{Enabled: NewBoolPointer(true)},
+						DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
+						UnixDomainSocket:         &DSDUnixDomainSocketSpec{Enabled: apiutils.NewBoolPointer(true)},
 					},
 				},
 				Image: &ImageConfig{
@@ -557,103 +558,103 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 					Canary: edsdatadoghqv1alpha1.DefaultExtendedDaemonSetSpecStrategyCanary(testCanary),
 				},
 				Apm: &APMSpec{
-					HostPort: NewInt32Pointer(1664),
+					HostPort: apiutils.NewInt32Pointer(1664),
 				},
 				Process: &ProcessSpec{
-					Enabled: NewBoolPointer(true),
+					Enabled: apiutils.NewBoolPointer(true),
 				},
 				SystemProbe: &SystemProbeSpec{
-					Enabled:         NewBoolPointer(true),
-					BPFDebugEnabled: NewBoolPointer(true),
+					Enabled:         apiutils.NewBoolPointer(true),
+					BPFDebugEnabled: apiutils.NewBoolPointer(true),
 				},
 			},
 			overrideExpected: &DatadogAgentSpecAgentSpec{
-				Enabled:              NewBoolPointer(true),
-				UseExtendedDaemonset: NewBoolPointer(false),
+				Enabled:              apiutils.NewBoolPointer(true),
+				UseExtendedDaemonset: apiutils.NewBoolPointer(false),
 				Image: &ImageConfig{
 					PullPolicy: &defaultImagePullPolicy,
 				},
 				Config: &NodeAgentConfig{
-					LogLevel:       NewStringPointer(defaultLogLevel),
-					CollectEvents:  NewBoolPointer(false),
+					LogLevel:       apiutils.NewStringPointer(defaultLogLevel),
+					CollectEvents:  apiutils.NewBoolPointer(false),
 					LivenessProbe:  GetDefaultLivenessProbe(),
 					ReadinessProbe: GetDefaultReadinessProbe(),
-					HealthPort:     NewInt32Pointer(5555),
+					HealthPort:     apiutils.NewInt32Pointer(5555),
 					// CRI Socket specified as we use an older image
 					CriSocket: &CRISocketConfig{
-						DockerSocketPath: NewStringPointer(defaultDockerSocketPath),
+						DockerSocketPath: apiutils.NewStringPointer(defaultDockerSocketPath),
 					},
 					Dogstatsd: &DogstatsdConfig{
-						UnixDomainSocket: &DSDUnixDomainSocketSpec{HostFilepath: NewStringPointer("/var/run/datadog/statsd.sock")},
+						UnixDomainSocket: &DSDUnixDomainSocketSpec{HostFilepath: apiutils.NewStringPointer("/var/run/datadog/statsd.sock")},
 					},
 				},
 				DeploymentStrategy: &DaemonSetDeploymentStrategy{
-					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(NewStringPointer("RollingUpdate")),
+					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(apiutils.NewStringPointer("RollingUpdate")),
 					RollingUpdate: DaemonSetRollingUpdateSpec{
 						MaxUnavailable:            &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxUnavailable},
 						MaxPodSchedulerFailure:    &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxPodSchedulerFailure},
-						MaxParallelPodCreation:    NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
+						MaxParallelPodCreation:    apiutils.NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
 						SlowStartIntervalDuration: &metav1.Duration{Duration: defaultRollingUpdateSlowStartIntervalDuration},
 						SlowStartAdditiveIncrease: &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateSlowStartAdditiveIncrease},
 					},
 					ReconcileFrequency: &metav1.Duration{Duration: defaultReconcileFrequency},
 				},
-				Rbac:    &RbacConfig{Create: NewBoolPointer(true)},
-				Apm:     &APMSpec{Enabled: NewBoolPointer(false)},
-				Process: &ProcessSpec{ProcessCollectionEnabled: NewBoolPointer(false)},
+				Rbac:    &RbacConfig{Create: apiutils.NewBoolPointer(true)},
+				Apm:     &APMSpec{Enabled: apiutils.NewBoolPointer(false)},
+				Process: &ProcessSpec{ProcessCollectionEnabled: apiutils.NewBoolPointer(false)},
 				SystemProbe: &SystemProbeSpec{
 					SecCompRootPath:      "/var/lib/kubelet/seccomp",
 					SecCompProfileName:   "localhost/system-probe",
 					AppArmorProfileName:  "unconfined",
-					ConntrackEnabled:     NewBoolPointer(false),
-					EnableTCPQueueLength: NewBoolPointer(false),
-					EnableOOMKill:        NewBoolPointer(false),
-					CollectDNSStats:      NewBoolPointer(false),
+					ConntrackEnabled:     apiutils.NewBoolPointer(false),
+					EnableTCPQueueLength: apiutils.NewBoolPointer(false),
+					EnableOOMKill:        apiutils.NewBoolPointer(false),
+					CollectDNSStats:      apiutils.NewBoolPointer(false),
 				},
 				Security: &SecuritySpec{
-					Compliance: ComplianceSpec{Enabled: NewBoolPointer(false)},
-					Runtime:    RuntimeSecuritySpec{Enabled: NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: NewBoolPointer(false)}},
+					Compliance: ComplianceSpec{Enabled: apiutils.NewBoolPointer(false)},
+					Runtime:    RuntimeSecuritySpec{Enabled: apiutils.NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: apiutils.NewBoolPointer(false)}},
 				},
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 			internalDefaulted: DatadogAgentSpecAgentSpec{
-				Enabled:              NewBoolPointer(true),
-				UseExtendedDaemonset: NewBoolPointer(false),
+				Enabled:              apiutils.NewBoolPointer(true),
+				UseExtendedDaemonset: apiutils.NewBoolPointer(false),
 				Image: &ImageConfig{
 					Name:        "gcr.io/datadog/agent:6.26.0",
 					PullPolicy:  &defaultImagePullPolicy,
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
 				Config: &NodeAgentConfig{
-					DDUrl:                NewStringPointer("www.datadog.com"),
-					LeaderElection:       NewBoolPointer(true),
-					LogLevel:             NewStringPointer(defaultLogLevel),
+					DDUrl:                apiutils.NewStringPointer("www.datadog.com"),
+					LeaderElection:       apiutils.NewBoolPointer(true),
+					LogLevel:             apiutils.NewStringPointer(defaultLogLevel),
 					PodLabelsAsTags:      map[string]string{},
 					PodAnnotationsAsTags: map[string]string{},
 					Tags:                 []string{},
 					Resources:            &corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}},
-					CollectEvents:        NewBoolPointer(false),
+					CollectEvents:        apiutils.NewBoolPointer(false),
 					LivenessProbe:        GetDefaultLivenessProbe(),
 					ReadinessProbe:       GetDefaultReadinessProbe(),
-					HealthPort:           NewInt32Pointer(5555),
+					HealthPort:           apiutils.NewInt32Pointer(5555),
 					CriSocket: &CRISocketConfig{
-						DockerSocketPath: NewStringPointer(defaultDockerSocketPath),
+						DockerSocketPath: apiutils.NewStringPointer(defaultDockerSocketPath),
 					},
 					Dogstatsd: &DogstatsdConfig{
-						DogstatsdOriginDetection: NewBoolPointer(false),
+						DogstatsdOriginDetection: apiutils.NewBoolPointer(false),
 						UnixDomainSocket: &DSDUnixDomainSocketSpec{
-							Enabled:      NewBoolPointer(true),
-							HostFilepath: NewStringPointer("/var/run/datadog/statsd.sock"),
+							Enabled:      apiutils.NewBoolPointer(true),
+							HostFilepath: apiutils.NewStringPointer("/var/run/datadog/statsd.sock"),
 						},
 					},
 				},
-				Rbac: &RbacConfig{Create: NewBoolPointer(true)},
+				Rbac: &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				DeploymentStrategy: &DaemonSetDeploymentStrategy{
-					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(NewStringPointer("RollingUpdate")),
+					UpdateStrategyType: (*appsv1.DaemonSetUpdateStrategyType)(apiutils.NewStringPointer("RollingUpdate")),
 					RollingUpdate: DaemonSetRollingUpdateSpec{
 						MaxUnavailable:            &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxUnavailable},
 						MaxPodSchedulerFailure:    &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateMaxPodSchedulerFailure},
-						MaxParallelPodCreation:    NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
+						MaxParallelPodCreation:    apiutils.NewInt32Pointer(defaultRollingUpdateMaxParallelPodCreation),
 						SlowStartIntervalDuration: &metav1.Duration{Duration: defaultRollingUpdateSlowStartIntervalDuration},
 						SlowStartAdditiveIncrease: &intstr.IntOrString{Type: intstr.String, StrVal: defaultRollingUpdateSlowStartAdditiveIncrease},
 					},
@@ -661,37 +662,37 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 					ReconcileFrequency: &metav1.Duration{Duration: defaultReconcileFrequency},
 				},
 				Apm: &APMSpec{
-					Enabled:  NewBoolPointer(false),
-					HostPort: NewInt32Pointer(1664),
+					Enabled:  apiutils.NewBoolPointer(false),
+					HostPort: apiutils.NewInt32Pointer(1664),
 				},
 				Process: &ProcessSpec{
-					Enabled:                  NewBoolPointer(true),
-					ProcessCollectionEnabled: NewBoolPointer(false),
+					Enabled:                  apiutils.NewBoolPointer(true),
+					ProcessCollectionEnabled: apiutils.NewBoolPointer(false),
 				},
 				SystemProbe: &SystemProbeSpec{
-					Enabled:              NewBoolPointer(true),
-					BPFDebugEnabled:      NewBoolPointer(true),
+					Enabled:              apiutils.NewBoolPointer(true),
+					BPFDebugEnabled:      apiutils.NewBoolPointer(true),
 					SecCompRootPath:      "/var/lib/kubelet/seccomp",
 					SecCompProfileName:   "localhost/system-probe",
 					AppArmorProfileName:  "unconfined",
-					ConntrackEnabled:     NewBoolPointer(false),
-					EnableTCPQueueLength: NewBoolPointer(false),
-					EnableOOMKill:        NewBoolPointer(false),
-					CollectDNSStats:      NewBoolPointer(false),
+					ConntrackEnabled:     apiutils.NewBoolPointer(false),
+					EnableTCPQueueLength: apiutils.NewBoolPointer(false),
+					EnableOOMKill:        apiutils.NewBoolPointer(false),
+					CollectDNSStats:      apiutils.NewBoolPointer(false),
 				},
 				Security: &SecuritySpec{
-					Compliance: ComplianceSpec{Enabled: NewBoolPointer(false)},
-					Runtime:    RuntimeSecuritySpec{Enabled: NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: NewBoolPointer(false)}},
+					Compliance: ComplianceSpec{Enabled: apiutils.NewBoolPointer(false)},
+					Runtime:    RuntimeSecuritySpec{Enabled: apiutils.NewBoolPointer(false), SyscallMonitor: &SyscallMonitorSpec{Enabled: apiutils.NewBoolPointer(false)}},
 				},
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultDatadogAgentSpecAgent(&tt.agent)
-			assert.True(t, IsEqualStruct(got, tt.overrideExpected), "TestDefaultDatadogAgentSpecAgent override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
-			assert.True(t, IsEqualStruct(tt.agent, tt.internalDefaulted), "TestDefaultDatadogAgentSpecAgent internal \ndiff = %s", cmp.Diff(tt.agent, tt.internalDefaulted))
+			assert.True(t, apiutils.IsEqualStruct(got, tt.overrideExpected), "TestDefaultDatadogAgentSpecAgent override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
+			assert.True(t, apiutils.IsEqualStruct(tt.agent, tt.internalDefaulted), "TestDefaultDatadogAgentSpecAgent internal \ndiff = %s", cmp.Diff(tt.agent, tt.internalDefaulted))
 		})
 	}
 }
@@ -707,16 +708,16 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 			name: "empty conf",
 			clc:  DatadogAgentSpecClusterChecksRunnerSpec{},
 			overrideExpected: &DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 			internalDefaulted: DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 		},
 		{
 			name: "sparse conf",
 			clc: DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Config:  &ClusterChecksRunnerConfig{},
 				Image: &ImageConfig{
 					Name: "gcr.io/datadog/agent:latest",
@@ -728,17 +729,17 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 					PullPolicy: &defaultImagePullPolicy,
 				},
 				Config: &ClusterChecksRunnerConfig{
-					LogLevel:       NewStringPointer(defaultLogLevel),
+					LogLevel:       apiutils.NewStringPointer(defaultLogLevel),
 					LivenessProbe:  GetDefaultLivenessProbe(),
 					ReadinessProbe: GetDefaultReadinessProbe(),
-					HealthPort:     NewInt32Pointer(5555),
+					HealthPort:     apiutils.NewInt32Pointer(5555),
 				},
-				Rbac:          &RbacConfig{Create: NewBoolPointer(true)},
+				Rbac:          &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Replicas:      nil,
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 			internalDefaulted: DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        "gcr.io/datadog/agent:latest",
 					Tag:         defaulting.AgentLatestVersion,
@@ -746,24 +747,24 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
 				Config: &ClusterChecksRunnerConfig{
-					LogLevel:       NewStringPointer(defaultLogLevel),
+					LogLevel:       apiutils.NewStringPointer(defaultLogLevel),
 					LivenessProbe:  GetDefaultLivenessProbe(),
 					ReadinessProbe: GetDefaultReadinessProbe(),
-					HealthPort:     NewInt32Pointer(5555),
+					HealthPort:     apiutils.NewInt32Pointer(5555),
 					Resources:      &corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}},
 				},
-				Rbac:          &RbacConfig{Create: NewBoolPointer(true)},
+				Rbac:          &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Replicas:      nil,
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 		},
 		{
 			name: "some conf",
 			clc: DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Config: &ClusterChecksRunnerConfig{
-					LogLevel:   NewStringPointer("DEBUG"),
-					HealthPort: NewInt32Pointer(1664),
+					LogLevel:   apiutils.NewStringPointer("DEBUG"),
+					HealthPort: apiutils.NewInt32Pointer(1664),
 				},
 				Image: &ImageConfig{
 					Name: "agent",
@@ -778,12 +779,12 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 					LivenessProbe:  GetDefaultLivenessProbe(),
 					ReadinessProbe: GetDefaultReadinessProbe(),
 				},
-				Rbac:          &RbacConfig{Create: NewBoolPointer(true)},
+				Rbac:          &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Replicas:      nil,
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 			internalDefaulted: DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Image: &ImageConfig{
 					Name:        "agent",
 					Tag:         defaulting.AgentLatestVersion,
@@ -791,23 +792,23 @@ func TestDefaultDatadogAgentSpecClusterChecksRunner(t *testing.T) {
 					PullSecrets: &[]corev1.LocalObjectReference{},
 				},
 				Config: &ClusterChecksRunnerConfig{
-					LogLevel:       NewStringPointer("DEBUG"),
+					LogLevel:       apiutils.NewStringPointer("DEBUG"),
 					LivenessProbe:  GetDefaultLivenessProbe(),
 					ReadinessProbe: GetDefaultReadinessProbe(),
-					HealthPort:     NewInt32Pointer(1664),
+					HealthPort:     apiutils.NewInt32Pointer(1664),
 					Resources:      &corev1.ResourceRequirements{Limits: corev1.ResourceList{}, Requests: corev1.ResourceList{}},
 				},
-				Rbac:          &RbacConfig{Create: NewBoolPointer(true)},
+				Rbac:          &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Replicas:      nil,
-				NetworkPolicy: &NetworkPolicySpec{Create: NewBoolPointer(false)},
+				NetworkPolicy: &NetworkPolicySpec{Create: apiutils.NewBoolPointer(false)},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultDatadogAgentSpecClusterChecksRunner(&tt.clc)
-			assert.True(t, IsEqualStruct(got, tt.overrideExpected), "TestDefaultDatadogAgentSpecClusterChecksRunner override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
-			assert.True(t, IsEqualStruct(tt.clc, tt.internalDefaulted), "TestDefaultDatadogAgentSpecClusterChecksRunner internal \ndiff = %s", cmp.Diff(tt.clc, tt.internalDefaulted))
+			assert.True(t, apiutils.IsEqualStruct(got, tt.overrideExpected), "TestDefaultDatadogAgentSpecClusterChecksRunner override \ndiff = %s", cmp.Diff(got, tt.overrideExpected))
+			assert.True(t, apiutils.IsEqualStruct(tt.clc, tt.internalDefaulted), "TestDefaultDatadogAgentSpecClusterChecksRunner internal \ndiff = %s", cmp.Diff(tt.clc, tt.internalDefaulted))
 		})
 	}
 }
@@ -824,17 +825,17 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 			name: "empty",
 			orc:  &DatadogFeatures{},
 			orcOverride: &OrchestratorExplorerConfig{
-				Enabled:      NewBoolPointer(true),
-				ClusterCheck: NewBoolPointer(false),
+				Enabled:      apiutils.NewBoolPointer(true),
+				ClusterCheck: apiutils.NewBoolPointer(false),
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 			internal: &OrchestratorExplorerConfig{
-				Enabled:      NewBoolPointer(true),
-				ClusterCheck: NewBoolPointer(false),
+				Enabled:      apiutils.NewBoolPointer(true),
+				ClusterCheck: apiutils.NewBoolPointer(false),
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 		},
@@ -842,20 +843,20 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 			name: "enabled orchestrator explorer, no scrubbing specified",
 			orc: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled: NewBoolPointer(true),
+					Enabled: apiutils.NewBoolPointer(true),
 				},
 			},
 			orcOverride: &OrchestratorExplorerConfig{
-				ClusterCheck: NewBoolPointer(false),
+				ClusterCheck: apiutils.NewBoolPointer(false),
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 			internal: &OrchestratorExplorerConfig{
-				Enabled:      NewBoolPointer(true),
-				ClusterCheck: NewBoolPointer(false),
+				Enabled:      apiutils.NewBoolPointer(true),
+				ClusterCheck: apiutils.NewBoolPointer(false),
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 		},
@@ -863,35 +864,35 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 			name: "disabled orchestrator",
 			orc: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
 			},
 			orcOverride: &OrchestratorExplorerConfig{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 			internal: &OrchestratorExplorerConfig{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 		},
 		{
 			name: "enabled orchestrator, filled scrubbing",
 			orc: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled: NewBoolPointer(true),
+					Enabled: apiutils.NewBoolPointer(true),
 					Scrubbing: &Scrubbing{
-						Containers: NewBoolPointer(true),
+						Containers: apiutils.NewBoolPointer(true),
 					},
 				},
 			},
 			orcOverride: &OrchestratorExplorerConfig{
 				Enabled:      nil,
-				ClusterCheck: NewBoolPointer(false),
+				ClusterCheck: apiutils.NewBoolPointer(false),
 			},
 			internal: &OrchestratorExplorerConfig{
-				Enabled:      NewBoolPointer(true),
-				ClusterCheck: NewBoolPointer(false),
+				Enabled:      apiutils.NewBoolPointer(true),
+				ClusterCheck: apiutils.NewBoolPointer(false),
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 		},
@@ -899,8 +900,8 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 			name: "enabled orchestrator, enabled clustecheck",
 			orc: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled:      NewBoolPointer(true),
-					ClusterCheck: NewBoolPointer(true),
+					Enabled:      apiutils.NewBoolPointer(true),
+					ClusterCheck: apiutils.NewBoolPointer(true),
 				},
 			},
 			clustercheck: true,
@@ -908,14 +909,14 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 				Enabled:      nil,
 				ClusterCheck: nil,
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 			internal: &OrchestratorExplorerConfig{
-				Enabled:      NewBoolPointer(true),
-				ClusterCheck: NewBoolPointer(true),
+				Enabled:      apiutils.NewBoolPointer(true),
+				ClusterCheck: apiutils.NewBoolPointer(true),
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 		},
@@ -923,22 +924,22 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 			name: "enabled orchestrator, checkrunner enabled, clustecheck disable",
 			orc: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
-					Enabled:      NewBoolPointer(true),
-					ClusterCheck: NewBoolPointer(false),
+					Enabled:      apiutils.NewBoolPointer(true),
+					ClusterCheck: apiutils.NewBoolPointer(false),
 				},
 			},
 			clustercheck: true,
 			orcOverride: &OrchestratorExplorerConfig{
 				Enabled: nil,
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 			internal: &OrchestratorExplorerConfig{
-				Enabled:      NewBoolPointer(true),
-				ClusterCheck: NewBoolPointer(false),
+				Enabled:      apiutils.NewBoolPointer(true),
+				ClusterCheck: apiutils.NewBoolPointer(false),
 				Scrubbing: &Scrubbing{
-					Containers: NewBoolPointer(true),
+					Containers: apiutils.NewBoolPointer(true),
 				},
 			},
 		},
@@ -947,8 +948,8 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultDatadogFeatureOrchestratorExplorer(tt.orc, tt.clustercheck)
-			assert.True(t, IsEqualStruct(got, tt.orcOverride), "TestDefaultDatadogFeatureOrchestratorExplorer override \ndiff = %s", cmp.Diff(got, tt.orcOverride))
-			assert.True(t, IsEqualStruct(tt.orc.OrchestratorExplorer, tt.internal), "TestDefaultDatadogFeatureOrchestratorExplorer internal \ndiff = %s", cmp.Diff(tt.orc.OrchestratorExplorer, tt.internal))
+			assert.True(t, apiutils.IsEqualStruct(got, tt.orcOverride), "TestDefaultDatadogFeatureOrchestratorExplorer override \ndiff = %s", cmp.Diff(got, tt.orcOverride))
+			assert.True(t, apiutils.IsEqualStruct(tt.orc.OrchestratorExplorer, tt.internal), "TestDefaultDatadogFeatureOrchestratorExplorer internal \ndiff = %s", cmp.Diff(tt.orc.OrchestratorExplorer, tt.internal))
 		})
 	}
 }
@@ -962,17 +963,17 @@ func TestDefaultDatadogAgentSpecAgentApm(t *testing.T) {
 		{
 			name: "APM not set",
 			input: &DatadogAgentSpecAgentSpec{
-				Enabled: NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 			},
 			want: &APMSpec{
-				Enabled: NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			},
 		},
 		{
 			name: "APM not enabled",
 			input: &DatadogAgentSpecAgentSpec{
 				Apm: &APMSpec{
-					Enabled: NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
 			},
 			want: &APMSpec{},
@@ -981,12 +982,12 @@ func TestDefaultDatadogAgentSpecAgentApm(t *testing.T) {
 			name: "APM enabled",
 			input: &DatadogAgentSpecAgentSpec{
 				Apm: &APMSpec{
-					Enabled: NewBoolPointer(true),
+					Enabled: apiutils.NewBoolPointer(true),
 				},
 			},
 			want: &APMSpec{
-				HostPort:         NewInt32Pointer(8126),
-				UnixDomainSocket: &APMUnixDomainSocketSpec{Enabled: NewBoolPointer(false)},
+				HostPort:         apiutils.NewInt32Pointer(8126),
+				UnixDomainSocket: &APMUnixDomainSocketSpec{Enabled: apiutils.NewBoolPointer(false)},
 				LivenessProbe:    getDefaultAPMAgentLivenessProbe(),
 			},
 		},
@@ -994,7 +995,7 @@ func TestDefaultDatadogAgentSpecAgentApm(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DefaultDatadogAgentSpecAgentApm(tt.input)
-			assert.True(t, IsEqualStruct(got, tt.want), "TestDefaultDatadogAgentSpecAgentApm defaulting \ndiff = %s", cmp.Diff(got, tt.want))
+			assert.True(t, apiutils.IsEqualStruct(got, tt.want), "TestDefaultDatadogAgentSpecAgentApm defaulting \ndiff = %s", cmp.Diff(got, tt.want))
 		})
 	}
 }

--- a/apis/datadoghq/v1alpha1/datadogagent_validation.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_validation.go
@@ -8,6 +8,7 @@ package v1alpha1
 import (
 	"fmt"
 
+	"github.com/DataDog/datadog-operator/apis/utils"
 	utilserrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -15,7 +16,7 @@ import (
 func IsValidDatadogAgent(spec *DatadogAgentSpec) error {
 	var errs []error
 	var err error
-	if BoolValue(spec.Agent.Enabled) {
+	if utils.BoolValue(spec.Agent.Enabled) {
 		if spec.Agent.CustomConfig != nil {
 			if err = IsValidCustomConfigSpec(spec.Agent.CustomConfig); err != nil {
 				errs = append(errs, fmt.Errorf("invalid spec.agent.customConfig, err: %w", err))
@@ -29,7 +30,7 @@ func IsValidDatadogAgent(spec *DatadogAgentSpec) error {
 		}
 	}
 
-	if BoolValue(spec.ClusterAgent.Enabled) {
+	if utils.BoolValue(spec.ClusterAgent.Enabled) {
 		if spec.ClusterAgent.CustomConfig != nil {
 			if err = IsValidCustomConfigSpec(spec.ClusterAgent.CustomConfig); err != nil {
 				errs = append(errs, fmt.Errorf("invalid spec.clusterAgent.customConfig, err: %w", err))
@@ -37,7 +38,7 @@ func IsValidDatadogAgent(spec *DatadogAgentSpec) error {
 		}
 	}
 
-	if BoolValue(spec.ClusterChecksRunner.Enabled) {
+	if utils.BoolValue(spec.ClusterChecksRunner.Enabled) {
 		if spec.ClusterChecksRunner.CustomConfig != nil {
 			if err = IsValidCustomConfigSpec(spec.ClusterChecksRunner.CustomConfig); err != nil {
 				errs = append(errs, fmt.Errorf("invalid spec.clusterChecksRunner.customConfig, err: %w", err))

--- a/apis/datadoghq/v1alpha1/patch/datadogagent.go
+++ b/apis/datadoghq/v1alpha1/patch/datadogagent.go
@@ -5,7 +5,10 @@
 
 package patch
 
-import "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+import (
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+)
 
 // CopyAndPatchDatadogAgent used to patch the current DatadogAgent instance to use the new fields (not deprecated).
 // This function is here to ease the migration to a new DatadogAgent CRD version.
@@ -28,7 +31,7 @@ func patchFeatures(oldDA, newDA *v1alpha1.DatadogAgent) bool {
 
 func patchLogFeatures(oldDA, newDA *v1alpha1.DatadogAgent) bool {
 	var patched bool
-	if v1alpha1.IsEqualStruct(oldDA.Spec.Agent, v1alpha1.DatadogAgentSpecAgentSpec{}) {
+	if apiutils.IsEqualStruct(oldDA.Spec.Agent, v1alpha1.DatadogAgentSpecAgentSpec{}) {
 		return patched
 	}
 	// patch only if a value is not already set

--- a/apis/datadoghq/v1alpha1/patch/datadogagent_test.go
+++ b/apis/datadoghq/v1alpha1/patch/datadogagent_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -32,7 +34,7 @@ func TestDatadogAgent(t *testing.T) {
 				Spec: v1alpha1.DatadogAgentSpec{
 					Agent: v1alpha1.DatadogAgentSpecAgentSpec{
 						Log: &v1alpha1.LogCollectionConfig{
-							Enabled: v1alpha1.NewBoolPointer(true),
+							Enabled: apiutils.NewBoolPointer(true),
 						},
 					},
 				},
@@ -41,12 +43,12 @@ func TestDatadogAgent(t *testing.T) {
 				Spec: v1alpha1.DatadogAgentSpec{
 					Features: v1alpha1.DatadogFeatures{
 						LogCollection: &v1alpha1.LogCollectionConfig{
-							Enabled: v1alpha1.NewBoolPointer(true),
+							Enabled: apiutils.NewBoolPointer(true),
 						},
 					},
 					Agent: v1alpha1.DatadogAgentSpecAgentSpec{
 						Log: &v1alpha1.LogCollectionConfig{
-							Enabled: v1alpha1.NewBoolPointer(true),
+							Enabled: apiutils.NewBoolPointer(true),
 						},
 					},
 				},
@@ -59,12 +61,12 @@ func TestDatadogAgent(t *testing.T) {
 				Spec: v1alpha1.DatadogAgentSpec{
 					Features: v1alpha1.DatadogFeatures{
 						LogCollection: &v1alpha1.LogCollectionConfig{
-							Enabled: v1alpha1.NewBoolPointer(false),
+							Enabled: apiutils.NewBoolPointer(false),
 						},
 					},
 					Agent: v1alpha1.DatadogAgentSpecAgentSpec{
 						Log: &v1alpha1.LogCollectionConfig{
-							Enabled: v1alpha1.NewBoolPointer(true),
+							Enabled: apiutils.NewBoolPointer(true),
 						},
 					},
 				},
@@ -73,12 +75,12 @@ func TestDatadogAgent(t *testing.T) {
 				Spec: v1alpha1.DatadogAgentSpec{
 					Features: v1alpha1.DatadogFeatures{
 						LogCollection: &v1alpha1.LogCollectionConfig{
-							Enabled: v1alpha1.NewBoolPointer(false),
+							Enabled: apiutils.NewBoolPointer(false),
 						},
 					},
 					Agent: v1alpha1.DatadogAgentSpecAgentSpec{
 						Log: &v1alpha1.LogCollectionConfig{
-							Enabled: v1alpha1.NewBoolPointer(true),
+							Enabled: apiutils.NewBoolPointer(true),
 						},
 					},
 				},

--- a/apis/datadoghq/v1alpha1/test/new.go
+++ b/apis/datadoghq/v1alpha1/test/new.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
@@ -121,8 +122,8 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			Security:           &datadoghqv1alpha1.SecuritySpec{},
 			SystemProbe:        &datadoghqv1alpha1.SystemProbeSpec{},
 			Process: &datadoghqv1alpha1.ProcessSpec{
-				Enabled:                  datadoghqv1alpha1.NewBoolPointer(false),
-				ProcessCollectionEnabled: datadoghqv1alpha1.NewBoolPointer(false),
+				Enabled:                  apiutils.NewBoolPointer(false),
+				ProcessCollectionEnabled: apiutils.NewBoolPointer(false),
 			},
 		},
 	}
@@ -133,9 +134,9 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		}
 
 		if options.OrchestratorExplorerDisabled {
-			ad.Spec.Features.OrchestratorExplorer = &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(false)}
+			ad.Spec.Features.OrchestratorExplorer = &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: apiutils.NewBoolPointer(false)}
 		} else {
-			ad.Spec.Features.OrchestratorExplorer = &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true)}
+			ad.Spec.Features.OrchestratorExplorer = &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: apiutils.NewBoolPointer(true)}
 		}
 
 		if options.UseEDS {
@@ -191,10 +192,10 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 				config = options.ClusterAgentConfd
 			}
 			ad.Spec.ClusterAgent = datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
-				Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Config:  config,
 				Rbac: &datadoghqv1alpha1.RbacConfig{
-					Create: datadoghqv1alpha1.NewBoolPointer(true),
+					Create: apiutils.NewBoolPointer(true),
 				},
 				DeploymentName: options.ClusterAgentDeploymentName,
 				NetworkPolicy: &datadoghqv1alpha1.NetworkPolicySpec{
@@ -209,13 +210,13 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 
 			if options.MetricsServerEnabled {
 				externalMetricsConfig := datadoghqv1alpha1.ExternalMetricsConfig{
-					Enabled:           datadoghqv1alpha1.NewBoolPointer(true),
+					Enabled:           apiutils.NewBoolPointer(true),
 					UseDatadogMetrics: options.MetricsServerUseDatadogMetric,
 					WpaController:     options.MetricsServerWPAController,
 				}
 
 				if options.MetricsServerPort != 0 {
-					externalMetricsConfig.Port = datadoghqv1alpha1.NewInt32Pointer(options.MetricsServerPort)
+					externalMetricsConfig.Port = apiutils.NewInt32Pointer(options.MetricsServerPort)
 				}
 
 				if options.MetricsServerEndpoint != "" {
@@ -231,7 +232,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 
 			if options.AdmissionControllerEnabled {
 				ad.Spec.ClusterAgent.Config.AdmissionController = &datadoghqv1alpha1.AdmissionControllerConfig{
-					Enabled:          datadoghqv1alpha1.NewBoolPointer(true),
+					Enabled:          apiutils.NewBoolPointer(true),
 					MutateUnlabelled: &options.AdmissionMutateUnlabelled,
 				}
 				if options.AdmissionServiceName != "" {
@@ -240,7 +241,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			}
 
 			if options.ClusterChecksEnabled {
-				ad.Spec.ClusterAgent.Config.ClusterChecksEnabled = datadoghqv1alpha1.NewBoolPointer(true)
+				ad.Spec.ClusterAgent.Config.ClusterChecksEnabled = apiutils.NewBoolPointer(true)
 			}
 
 			if options.KubeStateMetricsCore != nil {
@@ -258,16 +259,16 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			}
 		} else {
 			ad.Spec.ClusterAgent = datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
-				Enabled: datadoghqv1alpha1.NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			}
 		}
 
 		if options.ClusterChecksRunnerEnabled {
 			ad.Spec.ClusterChecksRunner = datadoghqv1alpha1.DatadogAgentSpecClusterChecksRunnerSpec{
-				Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 				Config:  &datadoghqv1alpha1.ClusterChecksRunnerConfig{},
 				Rbac: &datadoghqv1alpha1.RbacConfig{
-					Create: datadoghqv1alpha1.NewBoolPointer(true),
+					Create: apiutils.NewBoolPointer(true),
 				},
 				NetworkPolicy: &datadoghqv1alpha1.NetworkPolicySpec{
 					Create: &options.CreateNetworkPolicy,
@@ -297,16 +298,16 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		}
 
 		if options.APMEnabled {
-			ad.Spec.Agent.Apm.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+			ad.Spec.Agent.Apm.Enabled = apiutils.NewBoolPointer(true)
 		}
 
 		if options.ProcessEnabled {
-			ad.Spec.Agent.Process.Enabled = datadoghqv1alpha1.NewBoolPointer(options.ProcessEnabled)
+			ad.Spec.Agent.Process.Enabled = apiutils.NewBoolPointer(options.ProcessEnabled)
 		}
 
 		if options.ProcessCollectionEnabled {
-			ad.Spec.Agent.Process.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
-			ad.Spec.Agent.Process.ProcessCollectionEnabled = datadoghqv1alpha1.NewBoolPointer(true)
+			ad.Spec.Agent.Process.Enabled = apiutils.NewBoolPointer(true)
+			ad.Spec.Agent.Process.ProcessCollectionEnabled = apiutils.NewBoolPointer(true)
 		}
 
 		if options.HostNetwork {
@@ -314,7 +315,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 		}
 
 		if options.SystemProbeEnabled {
-			ad.Spec.Agent.SystemProbe.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+			ad.Spec.Agent.SystemProbe.Enabled = apiutils.NewBoolPointer(true)
 			if options.SystemProbeAppArmorProfileName != "" {
 				ad.Spec.Agent.SystemProbe.AppArmorProfileName = options.SystemProbeAppArmorProfileName
 			}
@@ -323,11 +324,11 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			}
 
 			if options.SystemProbeTCPQueueLengthEnabled {
-				ad.Spec.Agent.SystemProbe.EnableTCPQueueLength = datadoghqv1alpha1.NewBoolPointer(true)
+				ad.Spec.Agent.SystemProbe.EnableTCPQueueLength = apiutils.NewBoolPointer(true)
 			}
 
 			if options.SystemProbeOOMKillEnabled {
-				ad.Spec.Agent.SystemProbe.EnableOOMKill = datadoghqv1alpha1.NewBoolPointer(true)
+				ad.Spec.Agent.SystemProbe.EnableOOMKill = apiutils.NewBoolPointer(true)
 			}
 
 			if options.SystemProbeCustomConfigMapName != "" {
@@ -369,11 +370,11 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			if ad.Spec.Agent.Security == nil {
 				ad.Spec.Agent.Security = &datadoghqv1alpha1.SecuritySpec{
 					Compliance: datadoghqv1alpha1.ComplianceSpec{
-						Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+						Enabled: apiutils.NewBoolPointer(true),
 					},
 				}
 			} else {
-				ad.Spec.Agent.Security.Compliance.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+				ad.Spec.Agent.Security.Compliance.Enabled = apiutils.NewBoolPointer(true)
 			}
 
 			if options.ComplianceCheckInterval.Duration != 0 {
@@ -388,11 +389,11 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			if ad.Spec.Agent.Security == nil {
 				ad.Spec.Agent.Security = &datadoghqv1alpha1.SecuritySpec{
 					Runtime: datadoghqv1alpha1.RuntimeSecuritySpec{
-						Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+						Enabled: apiutils.NewBoolPointer(true),
 					},
 				}
 			} else {
-				ad.Spec.Agent.Security.Runtime.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+				ad.Spec.Agent.Security.Runtime.Enabled = apiutils.NewBoolPointer(true)
 			}
 
 			if options.RuntimePoliciesDir != nil {
@@ -401,7 +402,7 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 
 			if options.RuntimeSyscallMonitorEnabled {
 				ad.Spec.Agent.Security.Runtime.SyscallMonitor = &datadoghqv1alpha1.SyscallMonitorSpec{
-					Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+					Enabled: apiutils.NewBoolPointer(true),
 				}
 			}
 		}

--- a/apis/utils/utils.go
+++ b/apis/utils/utils.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package v1alpha1
+package utils
 
 import (
 	"encoding/json"
@@ -67,7 +67,8 @@ func IsEqualStruct(in interface{}, cmp interface{}) bool {
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-func generateRandomString(n int) string {
+// GenerateRandomString use to generate random string with a define size
+func GenerateRandomString(n int) string {
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]

--- a/cmd/kubectl-datadog/agent/upgrade/upgrade.go
+++ b/cmd/kubectl-datadog/agent/upgrade/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/plugin/common"
 
@@ -129,7 +130,7 @@ func (o *options) run(cmd *cobra.Command) error {
 // upgrade updates the agent version in the DatadogAgent object
 func (o *options) upgrade(dd v1alpha1.DatadogAgent, image string) error {
 	// Not relying on the runtime object (which has Agent.Enabled) as this uses the one from the APIServer
-	if v1alpha1.IsEqualStruct(dd.Spec.Agent, v1alpha1.DatadogAgentSpecAgentSpec{}) {
+	if apiutils.IsEqualStruct(dd.Spec.Agent, v1alpha1.DatadogAgentSpecAgentSpec{}) {
 		return errors.New("agent is not enabled")
 	}
 

--- a/cmd/kubectl-datadog/clusteragent/upgrade/upgrade.go
+++ b/cmd/kubectl-datadog/clusteragent/upgrade/upgrade.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/plugin/common"
 
@@ -131,7 +132,7 @@ func (o *options) run(cmd *cobra.Command) error {
 
 // upgrade updates the cluster agent version in the DatadogAgent object.
 func (o *options) upgrade(dd v1alpha1.DatadogAgent, image string) error {
-	if v1alpha1.IsEqualStruct(dd.Spec.ClusterAgent, v1alpha1.DatadogAgentSpecAgentSpec{}) {
+	if apiutils.IsEqualStruct(dd.Spec.ClusterAgent, v1alpha1.DatadogAgentSpecAgentSpec{}) {
 		return errors.New("cluster agent is not enabled")
 	}
 

--- a/cmd/kubectl-datadog/clusteragent/upgrade/upgrade_test.go
+++ b/cmd/kubectl-datadog/clusteragent/upgrade/upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,7 +100,7 @@ func Test_options_upgrade(t *testing.T) {
 			name: "no image in the spec",
 			loadFunc: func(c client.Client) *datadoghqv1alpha1.DatadogAgent {
 				dd := buildDatadogAgent("")
-				dd.Spec.ClusterAgent.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+				dd.Spec.ClusterAgent.Enabled = apiutils.NewBoolPointer(true)
 				dd.Spec.ClusterAgent.Image = nil
 				_ = c.Create(context.TODO(), dd)
 				return dd

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
@@ -68,7 +69,7 @@ func (r *Reconciler) reconcileAgent(logger logr.Logger, dda *datadoghqv1alpha1.D
 		ds = nil
 	}
 
-	if !datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) {
+	if !apiutils.BoolValue(dda.Spec.Agent.Enabled) {
 		if ds != nil {
 			if err = r.deleteDaemonSet(logger, dda, ds); err != nil {
 				return result, err
@@ -83,7 +84,7 @@ func (r *Reconciler) reconcileAgent(logger logr.Logger, dda *datadoghqv1alpha1.D
 		return result, err
 	}
 
-	if r.options.SupportExtendedDaemonset && datadoghqv1alpha1.BoolValue(dda.Spec.Agent.UseExtendedDaemonset) {
+	if r.options.SupportExtendedDaemonset && apiutils.BoolValue(dda.Spec.Agent.UseExtendedDaemonset) {
 		if ds != nil {
 			// TODO manage properly the migration from DS to EDS
 			err = r.deleteDaemonSet(logger, dda, ds)
@@ -311,7 +312,7 @@ func (r *Reconciler) manageAgentDependencies(logger logr.Logger, dda *datadoghqv
 func (r *Reconciler) manageAgentNetworkPolicy(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
 	spec := dda.Spec.Agent
 	builder := agentNetworkPolicyBuilder{dda, spec.NetworkPolicy}
-	if !datadoghqv1alpha1.BoolValue(spec.Enabled) || spec.NetworkPolicy == nil || !datadoghqv1alpha1.BoolValue(spec.NetworkPolicy.Create) {
+	if !apiutils.BoolValue(spec.Enabled) || spec.NetworkPolicy == nil || !apiutils.BoolValue(spec.NetworkPolicy.Create) {
 		return r.cleanupNetworkPolicy(logger, dda, builder.Name())
 	}
 
@@ -698,7 +699,7 @@ func newDaemonSetFromInstance(logger logr.Logger, dda *datadoghqv1alpha1.Datadog
 }
 
 func daemonsetName(dda *datadoghqv1alpha1.DatadogAgent) string {
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) && dda.Spec.Agent.DaemonsetName != "" {
+	if apiutils.BoolValue(dda.Spec.Agent.Enabled) && dda.Spec.Agent.DaemonsetName != "" {
 		return dda.Spec.Agent.DaemonsetName
 	}
 	return fmt.Sprintf("%s-%s", dda.Name, "agent")
@@ -724,7 +725,7 @@ func getAgentCustomConfigConfigMapName(dda *datadoghqv1alpha1.DatadogAgent) stri
 }
 
 func buildAgentConfigurationConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*corev1.ConfigMap, error) {
-	if !datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) {
+	if !apiutils.BoolValue(dda.Spec.Agent.Enabled) {
 		return nil, nil
 	}
 	return buildConfigurationConfigMap(dda, dda.Spec.Agent.CustomConfig, getAgentCustomConfigConfigMapName(dda), datadoghqv1alpha1.AgentCustomConfigVolumeSubPath)

--- a/controllers/datadogagent/agent_rbac.go
+++ b/controllers/datadogagent/agent_rbac.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -19,7 +20,7 @@ import (
 
 // manageAgentRBACs creates deletes and updates the RBACs for the Agent
 func (r *Reconciler) manageAgentRBACs(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
-	if !datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) {
+	if !apiutils.BoolValue(dda.Spec.Agent.Enabled) {
 		return r.cleanupAgentRbacResources(logger, dda)
 	}
 

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -14,6 +14,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	test "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/orchestrator"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
@@ -1543,8 +1544,8 @@ func defaultOrchestratorEnvVars(dda *datadoghqv1alpha1.DatadogAgent) []corev1.En
 	}
 
 	explorerConfig := datadoghqv1alpha1.OrchestratorExplorerConfig{
-		Enabled:   datadoghqv1alpha1.NewBoolPointer(true),
-		Scrubbing: &datadoghqv1alpha1.Scrubbing{Containers: datadoghqv1alpha1.NewBoolPointer(true)},
+		Enabled:   apiutils.NewBoolPointer(true),
+		Scrubbing: &datadoghqv1alpha1.Scrubbing{Containers: apiutils.NewBoolPointer(true)},
 	}
 
 	vars := []corev1.EnvVar{
@@ -1914,7 +1915,7 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 		},
 		{
 			Name:  "DD_KUBELET_TLS_VERIFY",
-			Value: datadoghqv1alpha1.BoolToString(kubeletConfig.TLSVerify),
+			Value: apiutils.BoolToString(kubeletConfig.TLSVerify),
 		},
 		{
 			Name:  "DD_KUBELET_CLIENT_CA",
@@ -2812,7 +2813,7 @@ func Test_newExtendedDaemonSetFromInstance_LogsEnabled(t *testing.T) {
 		ClusterAgentEnabled: true,
 		Features: &datadoghqv1alpha1.DatadogFeatures{
 			LogCollection: &datadoghqv1alpha1.LogCollectionConfig{
-				Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+				Enabled: apiutils.NewBoolPointer(true),
 			},
 		},
 	})
@@ -2937,7 +2938,7 @@ func Test_newExtendedDaemonSetFromInstance_clusterChecksConfig(t *testing.T) {
 	clusterChecksPodSpec.Containers[0].Env = addEnvVar(clusterChecksPodSpec.Containers[0].Env, "DD_EXTRA_CONFIG_PROVIDERS", "clusterchecks endpointschecks")
 	clusterChecksPodSpec.InitContainers[1].Env = addEnvVar(clusterChecksPodSpec.InitContainers[1].Env, "DD_EXTRA_CONFIG_PROVIDERS", "clusterchecks endpointschecks")
 
-	datadoghqv1alpha1.BoolValue(dda.Spec.ClusterChecksRunner.Enabled)
+	apiutils.BoolValue(dda.Spec.ClusterChecksRunner.Enabled)
 
 	test := extendedDaemonSetFromInstanceTest{
 		name:            "with cluster checks / clc runners",
@@ -3290,10 +3291,10 @@ func Test_newExtendedDaemonSetFromInstance_PrometheusScrape(t *testing.T) {
 		UseEDS:              true,
 		ClusterAgentEnabled: true,
 		Features: &datadoghqv1alpha1.DatadogFeatures{
-			OrchestratorExplorer: &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true)},
+			OrchestratorExplorer: &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: apiutils.NewBoolPointer(true)},
 			PrometheusScrape: &datadoghqv1alpha1.PrometheusScrapeConfig{
-				Enabled:          datadoghqv1alpha1.NewBoolPointer(true),
-				ServiceEndpoints: datadoghqv1alpha1.NewBoolPointer(true),
+				Enabled:          apiutils.NewBoolPointer(true),
+				ServiceEndpoints: apiutils.NewBoolPointer(true),
 			},
 		},
 	})
@@ -3313,10 +3314,10 @@ func Test_newExtendedDaemonSetFromInstance_PrometheusScrape(t *testing.T) {
 		UseEDS:              true,
 		ClusterAgentEnabled: true,
 		Features: &datadoghqv1alpha1.DatadogFeatures{
-			OrchestratorExplorer: &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true)},
+			OrchestratorExplorer: &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: apiutils.NewBoolPointer(true)},
 			PrometheusScrape: &datadoghqv1alpha1.PrometheusScrapeConfig{
-				Enabled:           datadoghqv1alpha1.NewBoolPointer(true),
-				ServiceEndpoints:  datadoghqv1alpha1.NewBoolPointer(false),
+				Enabled:           apiutils.NewBoolPointer(true),
+				ServiceEndpoints:  apiutils.NewBoolPointer(false),
 				AdditionalConfigs: &additionalConfig,
 			},
 		},
@@ -3519,7 +3520,7 @@ func Test_newExtendedDaemonSetFromInstance_KubeletConfiguration(t *testing.T) {
 				FieldPath: FieldPathSpecNodeName,
 			},
 		},
-		TLSVerify:   datadoghqv1alpha1.NewBoolPointer(false),
+		TLSVerify:   apiutils.NewBoolPointer(false),
 		HostCAPath:  "/foo/bar/kubeletca.crt",
 		AgentCAPath: "/agent/foo/bar/ca.crt",
 	}

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -8,6 +8,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/orchestrator"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
@@ -163,7 +164,7 @@ func clusterAgentWithAdmissionControllerDefaultEnvVars(serviceName string, unlab
 	})
 	builder.Add(&v1.EnvVar{
 		Name:  "DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED",
-		Value: datadoghqv1alpha1.BoolToString(&unlabelled),
+		Value: apiutils.BoolToString(&unlabelled),
 	})
 	builder.Add(&v1.EnvVar{
 		Name:  "DD_ADMISSION_CONTROLLER_SERVICE_NAME",
@@ -543,8 +544,8 @@ func Test_newClusterAgentPrometheusScrapeEnabled(t *testing.T) {
 		&test.NewDatadogAgentOptions{
 			ClusterAgentEnabled: true,
 			Features: &datadoghqv1alpha1.DatadogFeatures{
-				OrchestratorExplorer: &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true)},
-				PrometheusScrape:     &datadoghqv1alpha1.PrometheusScrapeConfig{Enabled: datadoghqv1alpha1.NewBoolPointer(true), ServiceEndpoints: datadoghqv1alpha1.NewBoolPointer(true)},
+				OrchestratorExplorer: &datadoghqv1alpha1.OrchestratorExplorerConfig{Enabled: apiutils.NewBoolPointer(true)},
+				PrometheusScrape:     &datadoghqv1alpha1.PrometheusScrapeConfig{Enabled: apiutils.NewBoolPointer(true), ServiceEndpoints: apiutils.NewBoolPointer(true)},
 			},
 		},
 	)

--- a/controllers/datadogagent/clusterchecksrunner_rbac.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -19,7 +20,7 @@ import (
 
 // manageClusterChecksRunnerRBACs creates deletes and updates the RBACs for the Cluster Checks runner
 func (r *Reconciler) manageClusterChecksRunnerRBACs(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
-	if !datadoghqv1alpha1.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
+	if !apiutils.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
 		return r.cleanupClusterChecksRunnerRbacResources(logger, dda)
 	}
 

--- a/controllers/datadogagent/clusterchecksrunner_rbac_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac_test.go
@@ -12,6 +12,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	test "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 
 	"github.com/go-logr/logr"
@@ -51,8 +52,8 @@ func TestReconciler_manageClusterChecksRunnerRBACs(t *testing.T) {
 		ClusterChecksEnabled:       true,
 		ClusterChecksRunnerEnabled: true,
 		KubeStateMetricsCore: &datadoghqv1alpha1.KubeStateMetricsCore{
-			Enabled:      datadoghqv1alpha1.NewBoolPointer(true),
-			ClusterCheck: datadoghqv1alpha1.NewBoolPointer(true),
+			Enabled:      apiutils.NewBoolPointer(true),
+			ClusterCheck: apiutils.NewBoolPointer(true),
 		},
 	}
 	ddaDefault := test.NewDefaultedDatadogAgent(ddaNamespace, ddaName, ddaDefaultOptions)

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -18,6 +18,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	test "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
@@ -515,8 +516,8 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 						OrchestratorExplorerDisabled: true,
 						Labels:                       map[string]string{"label-foo-key": "label-bar-value"},
 						NodeAgentConfig: &datadoghqv1alpha1.NodeAgentConfig{
-							DDUrl:    datadoghqv1alpha1.NewStringPointer("https://test.url.com"),
-							LogLevel: datadoghqv1alpha1.NewStringPointer("TRACE"),
+							DDUrl:    apiutils.NewStringPointer("https://test.url.com"),
+							LogLevel: apiutils.NewStringPointer("TRACE"),
 							Tags:     []string{"tag:test"},
 							Env: []corev1.EnvVar{
 								{
@@ -536,8 +537,8 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 							PodAnnotationsAsTags: map[string]string{
 								"annotation": "test",
 							},
-							CollectEvents:  datadoghqv1alpha1.NewBoolPointer(true),
-							LeaderElection: datadoghqv1alpha1.NewBoolPointer(true),
+							CollectEvents:  apiutils.NewBoolPointer(true),
+							LeaderElection: apiutils.NewBoolPointer(true),
 						},
 					})
 					_ = c.Create(context.TODO(), dda)
@@ -632,7 +633,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					agentConfig := &datadoghqv1alpha1.DatadogAgentSpecAgentSpec{
 						Config: &datadoghqv1alpha1.NodeAgentConfig{
 							SecurityContext: &corev1.PodSecurityContext{
-								RunAsUser: datadoghqv1alpha1.NewInt64Pointer(100),
+								RunAsUser: apiutils.NewInt64Pointer(100),
 							},
 						},
 					}
@@ -1673,7 +1674,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 map[string]string{"label-foo-key": "label-bar-value"},
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -1735,7 +1736,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 map[string]string{"label-foo-key": "label-bar-value"},
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -1829,7 +1830,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 map[string]string{"label-foo-key": "label-bar-value"},
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(0),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(0),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -1889,7 +1890,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 dcaLabels,
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -1950,7 +1951,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 dcaLabels,
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -2013,7 +2014,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 dcaLabels,
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -2082,7 +2083,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 dcaLabels,
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -2156,7 +2157,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 dcaLabels,
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 
@@ -2402,7 +2403,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dcaOptions := &test.NewDeploymentOptions{
 						Labels:                 map[string]string{"label-foo-key": "label-bar-value"},
-						ForceAvailableReplicas: datadoghqv1alpha1.NewInt32Pointer(1),
+						ForceAvailableReplicas: apiutils.NewInt32Pointer(1),
 					}
 					dca := test.NewClusterAgentDeployment(resourcesNamespace, resourcesName, dcaOptions)
 					_ = c.Create(context.TODO(), dca)
@@ -2581,7 +2582,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					dda := test.NewDefaultedDatadogAgent(resourcesNamespace, resourcesName, dadOptions)
 					dda.Spec.Agent.LocalService = &datadoghqv1alpha1.LocalService{
-						ForceLocalServiceEnable: datadoghqv1alpha1.NewBoolPointer(true),
+						ForceLocalServiceEnable: apiutils.NewBoolPointer(true),
 					}
 					_ = c.Create(context.TODO(), dda)
 

--- a/controllers/datadogagent/orchestrator.go
+++ b/controllers/datadogagent/orchestrator.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/go-logr/logr"
@@ -219,12 +220,12 @@ func getOrchestratorExplorerConfName(dda *datadoghqv1alpha1.DatadogAgent) string
 }
 
 func isOrchestratorExplorerClusterCheck(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	return isOrchestratorExplorerEnabled(dda) && datadoghqv1alpha1.BoolValue(dda.Spec.Features.OrchestratorExplorer.ClusterCheck)
+	return isOrchestratorExplorerEnabled(dda) && apiutils.BoolValue(dda.Spec.Features.OrchestratorExplorer.ClusterCheck)
 }
 
 func isOrchestratorExplorerEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	if dda.Spec.Features.OrchestratorExplorer == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Features.OrchestratorExplorer.Enabled)
+	return apiutils.BoolValue(dda.Spec.Features.OrchestratorExplorer.Enabled)
 }

--- a/controllers/datadogagent/orchestrator/envs.go
+++ b/controllers/datadogagent/orchestrator/envs.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 )
 
 // Datadog orchestrator related env var names
@@ -24,12 +25,12 @@ func EnvVars(orc *datadoghqv1alpha1.OrchestratorExplorerConfig) ([]corev1.EnvVar
 	var envVars []corev1.EnvVar
 	envVars = append(envVars, corev1.EnvVar{
 		Name:  DDOrchestratorExplorerEnabled,
-		Value: strconv.FormatBool(datadoghqv1alpha1.BoolValue(orc.Enabled)),
+		Value: strconv.FormatBool(apiutils.BoolValue(orc.Enabled)),
 	})
 	// Scrubbing is defaulted to true beforehand in case it is nil
 	envVars = append(envVars, corev1.EnvVar{
 		Name:  DDOrchestratorExplorerContainerScrubbingEnabled,
-		Value: strconv.FormatBool(datadoghqv1alpha1.BoolValue(orc.Scrubbing.Containers)),
+		Value: strconv.FormatBool(apiutils.BoolValue(orc.Scrubbing.Containers)),
 	})
 
 	if orc.DDUrl != nil {

--- a/controllers/datadogagent/orchestrator_test.go
+++ b/controllers/datadogagent/orchestrator_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -61,7 +62,7 @@ instances:
 	}
 
 	// cluster check enabled
-	dda.Spec.Features.OrchestratorExplorer.ClusterCheck = datadoghqv1alpha1.NewBoolPointer(true)
+	dda.Spec.Features.OrchestratorExplorer.ClusterCheck = apiutils.NewBoolPointer(true)
 	cm, err := buildOrchestratorExplorerConfigMap(dda)
 	require.NoError(t, err)
 	require.NotNil(t, cm)

--- a/controllers/datadogagent/secret_agent.go
+++ b/controllers/datadogagent/secret_agent.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/go-logr/logr"
@@ -62,7 +63,7 @@ func needAgentSecret(dda *datadoghqv1alpha1.DatadogAgent) bool {
 		return false
 	}
 	return (isClusterAgentEnabled(dda.Spec.ClusterAgent) || (dda.Spec.Credentials.APIKey != "" || os.Getenv(config.DDAPIKeyEnvVar) != "") || (dda.Spec.Credentials.AppKey != "" || os.Getenv(config.DDAppKeyEnvVar) != "")) &&
-		!datadoghqv1alpha1.BoolValue(dda.Spec.Credentials.UseSecretBackend)
+		!apiutils.BoolValue(dda.Spec.Credentials.UseSecretBackend)
 }
 
 func checkCredentials(dda *datadoghqv1alpha1.DatadogAgent) error {

--- a/controllers/datadogagent/secret_clusteragent.go
+++ b/controllers/datadogagent/secret_clusteragent.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/go-logr/logr"
 )
 
@@ -51,7 +52,7 @@ func needExternalMetricsSecret(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	}
 	return isClusterAgentEnabled(dda.Spec.ClusterAgent) &&
 		(dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials.APIKey != "" || dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials.AppKey != "") &&
-		!datadoghqv1alpha1.BoolValue(dda.Spec.Credentials.UseSecretBackend)
+		!apiutils.BoolValue(dda.Spec.Credentials.UseSecretBackend)
 }
 
 func getDefaultExternalMetricSecretName(dda *datadoghqv1alpha1.DatadogAgent) string {

--- a/controllers/datadogagent/systemprobe.go
+++ b/controllers/datadogagent/systemprobe.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -29,7 +30,7 @@ func (r *Reconciler) manageSystemProbeDependencies(logger logr.Logger, dda *data
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) && getSeccompProfileName(dda.Spec.Agent.SystemProbe) == datadoghqv1alpha1.DefaultSeccompProfileName && dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap == "" {
+	if apiutils.BoolValue(dda.Spec.Agent.Enabled) && getSeccompProfileName(dda.Spec.Agent.SystemProbe) == datadoghqv1alpha1.DefaultSeccompProfileName && dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap == "" {
 		result, err = r.manageConfigMap(logger, dda, getSecCompConfigMapName(dda), buildSystemProbeSecCompConfigMap)
 		if utils.ShouldReturn(result, err) {
 			return result, err
@@ -76,7 +77,7 @@ func buildSystemProbeConfigConfigMap(dda *datadoghqv1alpha1.DatadogAgent) (*core
 	customConfig := dda.Spec.Agent.SystemProbe.CustomConfig
 	if customConfig == nil || customConfig.ConfigData == nil || *customConfig.ConfigData == "" {
 		customConfig = &datadoghqv1alpha1.CustomConfigSpec{
-			ConfigData: datadoghqv1alpha1.NewStringPointer(" "),
+			ConfigData: apiutils.NewStringPointer(" "),
 		}
 	}
 
@@ -293,14 +294,14 @@ func shouldInstallSeccompProfileFromConfigMap(dda *datadoghqv1alpha1.DatadogAgen
 }
 
 func shouldCreateSeccompConfigMap(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) &&
+	return apiutils.BoolValue(dda.Spec.Agent.Enabled) &&
 		isSystemProbeEnabled(&dda.Spec) &&
 		getSeccompProfileName(dda.Spec.Agent.SystemProbe) == datadoghqv1alpha1.DefaultSeccompProfileName &&
 		dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap == ""
 }
 
 func getSecCompConfigMapName(dda *datadoghqv1alpha1.DatadogAgent) string {
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) && dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap != "" {
+	if apiutils.BoolValue(dda.Spec.Agent.Enabled) && dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap != "" {
 		return dda.Spec.Agent.SystemProbe.SecCompCustomProfileConfigMap
 	}
 	return fmt.Sprintf("%s-%s", dda.Name, SystemProbeAgentSecurityConfigMapSuffixName)

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/orchestrator"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
@@ -159,56 +160,56 @@ func isClusterChecksEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.ClusterAgent.Config == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled)
+	return apiutils.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled)
 }
 
 func isAPMEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.Agent.Apm == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.Apm.Enabled)
+	return apiutils.BoolValue(spec.Agent.Apm.Enabled)
 }
 
 func isAPMUDSEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if !isAPMEnabled(spec) || spec.Agent.Apm.UnixDomainSocket == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.Apm.UnixDomainSocket.Enabled)
+	return apiutils.BoolValue(spec.Agent.Apm.UnixDomainSocket.Enabled)
 }
 
 func isSystemProbeEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.Agent.SystemProbe == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.SystemProbe.Enabled)
+	return apiutils.BoolValue(spec.Agent.SystemProbe.Enabled)
 }
 
 func isNetworkMonitoringEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.Features.NetworkMonitoring == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Features.NetworkMonitoring.Enabled)
+	return apiutils.BoolValue(spec.Features.NetworkMonitoring.Enabled)
 }
 
 func isComplianceEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.Agent.Security == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.Security.Compliance.Enabled)
+	return apiutils.BoolValue(spec.Agent.Security.Compliance.Enabled)
 }
 
 func isRuntimeSecurityEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.Agent.Security == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.Security.Runtime.Enabled)
+	return apiutils.BoolValue(spec.Agent.Security.Runtime.Enabled)
 }
 
 func isSecurityAgentEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.Agent.Security == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.Security.Compliance.Enabled) || datadoghqv1alpha1.BoolValue(spec.Agent.Security.Runtime.Enabled)
+	return apiutils.BoolValue(spec.Agent.Security.Compliance.Enabled) || apiutils.BoolValue(spec.Agent.Security.Runtime.Enabled)
 }
 
 func isSyscallMonitorEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
@@ -218,7 +219,7 @@ func isSyscallMonitorEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if spec.Agent.Security.Runtime.SyscallMonitor == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.Security.Runtime.SyscallMonitor.Enabled)
+	return apiutils.BoolValue(spec.Agent.Security.Runtime.SyscallMonitor.Enabled)
 }
 
 func isDogstatsdConfigured(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
@@ -232,7 +233,7 @@ func isDogstatsdUDSEnabled(spec *datadoghqv1alpha1.DatadogAgentSpec) bool {
 	if !isDogstatsdConfigured(spec) || spec.Agent.Config.Dogstatsd.UnixDomainSocket == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Agent.Config.Dogstatsd.UnixDomainSocket.Enabled)
+	return apiutils.BoolValue(spec.Agent.Config.Dogstatsd.UnixDomainSocket.Enabled)
 }
 
 // shouldAddProcessContainer returns whether the process container should be added.
@@ -243,7 +244,7 @@ func shouldAddProcessContainer(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	if dda.Spec.Agent.Process == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Process.Enabled) || isOrchestratorExplorerEnabled(dda)
+	return apiutils.BoolValue(dda.Spec.Agent.Process.Enabled) || isOrchestratorExplorerEnabled(dda)
 }
 
 func shouldMountPasswdVolume(dda *datadoghqv1alpha1.DatadogAgent) bool {
@@ -264,8 +265,8 @@ func processCollectionEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	if dda.Spec.Agent.Process == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Process.ProcessCollectionEnabled) &&
-		datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Process.Enabled)
+	return apiutils.BoolValue(dda.Spec.Agent.Process.ProcessCollectionEnabled) &&
+		apiutils.BoolValue(dda.Spec.Agent.Process.Enabled)
 }
 
 func getAgentDeploymentStrategy(dda *datadoghqv1alpha1.DatadogAgent) (*datadoghqv1alpha1.DaemonSetDeploymentStrategy, error) {
@@ -571,7 +572,7 @@ func getEnvVarsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar
 	}
 
 	// APM Unix Domain Socket configuration
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Apm.UnixDomainSocket.Enabled) {
+	if apiutils.BoolValue(dda.Spec.Agent.Apm.UnixDomainSocket.Enabled) {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDPPMReceiverSocket,
 			Value: getLocalFilepath(*dda.Spec.Agent.Apm.UnixDomainSocket.HostFilepath, localAPMSocketPath),
@@ -767,15 +768,15 @@ func getEnvVarsForLogCollection(logSpec *datadoghqv1alpha1.LogCollectionConfig) 
 	envVars := []corev1.EnvVar{
 		{
 			Name:  datadoghqv1alpha1.DDLogsEnabled,
-			Value: strconv.FormatBool(datadoghqv1alpha1.BoolValue(logSpec.Enabled)),
+			Value: strconv.FormatBool(apiutils.BoolValue(logSpec.Enabled)),
 		},
 		{
 			Name:  datadoghqv1alpha1.DDLogsConfigContainerCollectAll,
-			Value: strconv.FormatBool(datadoghqv1alpha1.BoolValue(logSpec.LogsConfigContainerCollectAll)),
+			Value: strconv.FormatBool(apiutils.BoolValue(logSpec.LogsConfigContainerCollectAll)),
 		},
 		{
 			Name:  datadoghqv1alpha1.DDLogsContainerCollectUsingFiles,
-			Value: strconv.FormatBool(datadoghqv1alpha1.BoolValue(logSpec.ContainerCollectUsingFiles)),
+			Value: strconv.FormatBool(apiutils.BoolValue(logSpec.ContainerCollectUsingFiles)),
 		},
 	}
 	if logSpec.OpenFilesLimit != nil {
@@ -861,8 +862,8 @@ func getEnvVarsForAgent(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent)
 
 	if isClusterAgentEnabled(dda.Spec.ClusterAgent) {
 		clusterEnv := envForClusterAgentConnection(dda)
-		if spec.ClusterAgent.Config != nil && datadoghqv1alpha1.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled) {
-			if !datadoghqv1alpha1.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
+		if spec.ClusterAgent.Config != nil && apiutils.BoolValue(spec.ClusterAgent.Config.ClusterChecksEnabled) {
+			if !apiutils.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
 				clusterEnv = append(clusterEnv, corev1.EnvVar{
 					Name:  datadoghqv1alpha1.DDExtraConfigProviders,
 					Value: datadoghqv1alpha1.ClusterAndEndpointsConfigPoviders,
@@ -1169,8 +1170,8 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 
 		volumes = append(volumes, systemProbeVolumes...)
 
-		if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.SystemProbe.EnableTCPQueueLength) ||
-			datadoghqv1alpha1.BoolValue(dda.Spec.Agent.SystemProbe.EnableOOMKill) {
+		if apiutils.BoolValue(dda.Spec.Agent.SystemProbe.EnableTCPQueueLength) ||
+			apiutils.BoolValue(dda.Spec.Agent.SystemProbe.EnableOOMKill) {
 			volumes = append(volumes, []corev1.Volume{
 				{
 					Name: datadoghqv1alpha1.SystemProbeLibModulesVolumeName,
@@ -1193,7 +1194,7 @@ func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 	}
 
 	logConfig := dda.Spec.Features.LogCollection
-	if logConfig != nil && datadoghqv1alpha1.BoolValue(logConfig.Enabled) {
+	if logConfig != nil && apiutils.BoolValue(logConfig.Enabled) {
 		if logConfig.TempStoragePath != nil {
 			volumes = append(volumes, corev1.Volume{
 				Name: datadoghqv1alpha1.PointerVolumeName,
@@ -1449,7 +1450,7 @@ func getVolumeMountsForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volum
 	volumeMounts = append(volumeMounts, getVolumeMountDogstatsdSocket(false))
 
 	// Log volumes
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Features.LogCollection.Enabled) {
+	if apiutils.BoolValue(dda.Spec.Features.LogCollection.Enabled) {
 		volumeMounts = append(volumeMounts, []corev1.VolumeMount{
 			{
 				Name:      datadoghqv1alpha1.PointerVolumeName,
@@ -1648,7 +1649,7 @@ func getVolumeMountsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Vo
 	volumeMounts = append(volumeMounts, getVolumeMountDogstatsdSocket(true))
 
 	// APM UDS
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Apm.UnixDomainSocket.Enabled) {
+	if apiutils.BoolValue(dda.Spec.Agent.Apm.UnixDomainSocket.Enabled) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      datadoghqv1alpha1.APMSocketVolumeName,
 			MountPath: datadoghqv1alpha1.APMSocketVolumePath,
@@ -1704,8 +1705,8 @@ func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1
 		})
 	}
 
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.SystemProbe.EnableTCPQueueLength) ||
-		datadoghqv1alpha1.BoolValue(dda.Spec.Agent.SystemProbe.EnableOOMKill) {
+	if apiutils.BoolValue(dda.Spec.Agent.SystemProbe.EnableTCPQueueLength) ||
+		apiutils.BoolValue(dda.Spec.Agent.SystemProbe.EnableOOMKill) {
 		volumeMounts = append(volumeMounts, []corev1.VolumeMount{
 			{
 				Name:      datadoghqv1alpha1.SystemProbeLibModulesVolumeName,
@@ -1838,7 +1839,7 @@ func getAgentVersion(dda *datadoghqv1alpha1.DatadogAgent) string {
 
 func getAgentServiceAccount(dda *datadoghqv1alpha1.DatadogAgent) string {
 	saDefault := fmt.Sprintf("%s-agent", dda.Name)
-	if !datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) {
+	if !apiutils.BoolValue(dda.Spec.Agent.Enabled) {
 		return saDefault
 	}
 	if dda.Spec.Agent.Rbac != nil && dda.Spec.Agent.Rbac.ServiceAccountName != nil {
@@ -1945,7 +1946,7 @@ func getExternalMetricsReaderClusterRoleName(dda *datadoghqv1alpha1.DatadogAgent
 func getClusterChecksRunnerServiceAccount(dda *datadoghqv1alpha1.DatadogAgent) string {
 	saDefault := fmt.Sprintf("%s-%s", dda.Name, datadoghqv1alpha1.DefaultClusterChecksRunnerResourceSuffix)
 
-	if !datadoghqv1alpha1.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
+	if !apiutils.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
 		return saDefault
 	}
 	if dda.Spec.ClusterChecksRunner.Rbac.ServiceAccountName != nil {
@@ -2008,11 +2009,11 @@ func isKSMCoreEnabled(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	if dda.Spec.Features.KubeStateMetricsCore == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(dda.Spec.Features.KubeStateMetricsCore.Enabled)
+	return apiutils.BoolValue(dda.Spec.Features.KubeStateMetricsCore.Enabled)
 }
 
 func isKSMCoreClusterCheck(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	return isKSMCoreEnabled(dda) && datadoghqv1alpha1.BoolValue(dda.Spec.Features.KubeStateMetricsCore.ClusterCheck)
+	return isKSMCoreEnabled(dda) && apiutils.BoolValue(dda.Spec.Features.KubeStateMetricsCore.ClusterCheck)
 }
 
 // GetConfName get the name of the Configmap for a CustomConfigSpec
@@ -2028,15 +2029,15 @@ func GetConfName(dca *datadoghqv1alpha1.DatadogAgent, conf *datadoghqv1alpha1.Cu
 func prometheusScrapeEnvVars(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{}
 
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Features.PrometheusScrape.Enabled) {
+	if apiutils.BoolValue(dda.Spec.Features.PrometheusScrape.Enabled) {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDPrometheusScrapeEnabled,
-			Value: datadoghqv1alpha1.BoolToString(dda.Spec.Features.PrometheusScrape.Enabled),
+			Value: apiutils.BoolToString(dda.Spec.Features.PrometheusScrape.Enabled),
 		})
 
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDPrometheusScrapeServiceEndpoints,
-			Value: datadoghqv1alpha1.BoolToString(dda.Spec.Features.PrometheusScrape.ServiceEndpoints),
+			Value: apiutils.BoolToString(dda.Spec.Features.PrometheusScrape.ServiceEndpoints),
 		})
 
 		if dda.Spec.Features.PrometheusScrape.AdditionalConfigs != nil {
@@ -2085,7 +2086,7 @@ func dsdMapperProfilesEnvVar(logger logr.Logger, dda *datadoghqv1alpha1.DatadogA
 }
 
 func isClusterAgentEnabled(spec datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec) bool {
-	return datadoghqv1alpha1.BoolValue(spec.Enabled)
+	return apiutils.BoolValue(spec.Enabled)
 }
 
 func isMetricsProviderEnabled(spec datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec) bool {
@@ -2095,7 +2096,7 @@ func isMetricsProviderEnabled(spec datadoghqv1alpha1.DatadogAgentSpecClusterAgen
 	if spec.Config == nil || spec.Config.ExternalMetrics == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Config.ExternalMetrics.Enabled)
+	return apiutils.BoolValue(spec.Config.ExternalMetrics.Enabled)
 }
 
 func hasMetricsProviderCustomCredentials(spec datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec) bool {
@@ -2106,14 +2107,14 @@ func isAdmissionControllerEnabled(spec datadoghqv1alpha1.DatadogAgentSpecCluster
 	if spec.Config == nil || spec.Config.AdmissionController == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(spec.Config.AdmissionController.Enabled)
+	return apiutils.BoolValue(spec.Config.AdmissionController.Enabled)
 }
 
 func isCreateRBACEnabled(config *datadoghqv1alpha1.RbacConfig) bool {
 	if config == nil {
 		return false
 	}
-	return datadoghqv1alpha1.BoolValue(config.Create)
+	return apiutils.BoolValue(config.Create)
 }
 
 func updateDaemonSetStatus(ds *appsv1.DaemonSet, dsStatus *datadoghqv1alpha1.DaemonSetStatus, updateTime *metav1.Time) *datadoghqv1alpha1.DaemonSetStatus {
@@ -2356,7 +2357,7 @@ func addBoolPointerEnVar(b *bool, varName string, varList []corev1.EnvVar) []cor
 	if b != nil {
 		varList = append(varList, corev1.EnvVar{
 			Name:  varName,
-			Value: datadoghqv1alpha1.BoolToString(b),
+			Value: apiutils.BoolToString(b),
 		})
 	}
 
@@ -2386,12 +2387,12 @@ func getReplicas(currentReplicas, newReplicas *int32) *int32 {
 		if currentReplicas != nil {
 			// Do not overwrite the current value
 			// It's most likely managed by an autoscaler
-			return datadoghqv1alpha1.NewInt32Pointer(*currentReplicas)
+			return apiutils.NewInt32Pointer(*currentReplicas)
 		}
 
 		// Both new and current are nil
 		return nil
 	}
 
-	return datadoghqv1alpha1.NewInt32Pointer(*newReplicas)
+	return apiutils.NewInt32Pointer(*newReplicas)
 }

--- a/controllers/datadogagent/utils_kubelet.go
+++ b/controllers/datadogagent/utils_kubelet.go
@@ -7,6 +7,7 @@ package datadogagent
 
 import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -35,7 +36,7 @@ func getKubeletEnvVars(dda *datadoghqv1alpha1.DatadogAgent) []corev1.EnvVar {
 	if dda.Spec.Agent.Config.Kubelet != nil && dda.Spec.Agent.Config.Kubelet.TLSVerify != nil {
 		kubeletVars = append(kubeletVars, corev1.EnvVar{
 			Name:  datadoghqv1alpha1.DDKubeletTLSVerify,
-			Value: datadoghqv1alpha1.BoolToString(dda.Spec.Agent.Config.Kubelet.TLSVerify),
+			Value: apiutils.BoolToString(dda.Spec.Agent.Config.Kubelet.TLSVerify),
 		})
 	}
 

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/testutils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
@@ -119,7 +120,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 
 	securityCompliance := &datadoghqv1alpha1.SecuritySpec{
 		Compliance: datadoghqv1alpha1.ComplianceSpec{
-			Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+			Enabled: apiutils.NewBoolPointer(true),
 			ConfigDir: &datadoghqv1alpha1.ConfigDirSpec{
 				ConfigMapName: "compliance-cm",
 			},
@@ -127,7 +128,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 	}
 	securityRuntime := &datadoghqv1alpha1.SecuritySpec{
 		Runtime: datadoghqv1alpha1.RuntimeSecuritySpec{
-			Enabled: datadoghqv1alpha1.NewBoolPointer(true),
+			Enabled: apiutils.NewBoolPointer(true),
 			PoliciesDir: &datadoghqv1alpha1.ConfigDirSpec{
 				ConfigMapName: "runtime-cm",
 			},
@@ -230,8 +231,8 @@ func Test_prometheusScrapeEnvVars(t *testing.T) {
 		{
 			name: "Enabled + Service endpoints disabled",
 			promConfig: &datadoghqv1alpha1.PrometheusScrapeConfig{
-				Enabled:          datadoghqv1alpha1.NewBoolPointer(true),
-				ServiceEndpoints: datadoghqv1alpha1.NewBoolPointer(false),
+				Enabled:          apiutils.NewBoolPointer(true),
+				ServiceEndpoints: apiutils.NewBoolPointer(false),
 			},
 			want: []v1.EnvVar{
 				{Name: "DD_PROMETHEUS_SCRAPE_ENABLED", Value: "true"},
@@ -241,8 +242,8 @@ func Test_prometheusScrapeEnvVars(t *testing.T) {
 		{
 			name: "Enabled + Service endpoints enabled",
 			promConfig: &datadoghqv1alpha1.PrometheusScrapeConfig{
-				Enabled:          datadoghqv1alpha1.NewBoolPointer(true),
-				ServiceEndpoints: datadoghqv1alpha1.NewBoolPointer(true),
+				Enabled:          apiutils.NewBoolPointer(true),
+				ServiceEndpoints: apiutils.NewBoolPointer(true),
 			},
 			want: []v1.EnvVar{
 				{Name: "DD_PROMETHEUS_SCRAPE_ENABLED", Value: "true"},
@@ -252,16 +253,16 @@ func Test_prometheusScrapeEnvVars(t *testing.T) {
 		{
 			name: "Disabled + Service endpoints enabled",
 			promConfig: &datadoghqv1alpha1.PrometheusScrapeConfig{
-				Enabled:          datadoghqv1alpha1.NewBoolPointer(false),
-				ServiceEndpoints: datadoghqv1alpha1.NewBoolPointer(true),
+				Enabled:          apiutils.NewBoolPointer(false),
+				ServiceEndpoints: apiutils.NewBoolPointer(true),
 			},
 			want: []v1.EnvVar{},
 		},
 		{
 			name: "Additional config",
 			promConfig: &datadoghqv1alpha1.PrometheusScrapeConfig{
-				Enabled: datadoghqv1alpha1.NewBoolPointer(true),
-				AdditionalConfigs: datadoghqv1alpha1.NewStringPointer(`- configurations:
+				Enabled: apiutils.NewBoolPointer(true),
+				AdditionalConfigs: apiutils.NewStringPointer(`- configurations:
   - timeout: 5
     send_distribution_buckets: true
   autodiscovery:
@@ -281,8 +282,8 @@ func Test_prometheusScrapeEnvVars(t *testing.T) {
 		{
 			name: "Invalid additional config",
 			promConfig: &datadoghqv1alpha1.PrometheusScrapeConfig{
-				Enabled:           datadoghqv1alpha1.NewBoolPointer(true),
-				AdditionalConfigs: datadoghqv1alpha1.NewStringPointer(","),
+				Enabled:           apiutils.NewBoolPointer(true),
+				AdditionalConfigs: apiutils.NewStringPointer(","),
 			},
 			want: []v1.EnvVar{
 				{Name: "DD_PROMETHEUS_SCRAPE_ENABLED", Value: "true"},
@@ -317,7 +318,7 @@ func Test_dsdMapperProfilesEnvVar(t *testing.T) {
 		{
 			name: "YAML conf data",
 			dsdMapperProfilesConf: &datadoghqv1alpha1.CustomConfigSpec{
-				ConfigData: datadoghqv1alpha1.NewStringPointer(`- name: my_custom_metric_profile
+				ConfigData: apiutils.NewStringPointer(`- name: my_custom_metric_profile
   prefix: custom_metric.
   mappings:
     - match: 'custom_metric.process.*.*'
@@ -335,7 +336,7 @@ func Test_dsdMapperProfilesEnvVar(t *testing.T) {
 		{
 			name: "JSON conf data",
 			dsdMapperProfilesConf: &datadoghqv1alpha1.CustomConfigSpec{
-				ConfigData: datadoghqv1alpha1.NewStringPointer(`[{"mappings":[{"match":"custom_metric.process.*.*","match_type":"wildcard","name":"custom_metric.process.prod.$1.live","tags":{"tag_key_2":"$2"}}],"name":"my_custom_metric_profile","prefix":"custom_metric."}]`),
+				ConfigData: apiutils.NewStringPointer(`[{"mappings":[{"match":"custom_metric.process.*.*","match_type":"wildcard","name":"custom_metric.process.prod.$1.live","tags":{"tag_key_2":"$2"}}],"name":"my_custom_metric_profile","prefix":"custom_metric."}]`),
 			},
 			want: &v1.EnvVar{
 				Name:  "DD_DOGSTATSD_MAPPER_PROFILES",
@@ -358,7 +359,7 @@ func Test_dsdMapperProfilesEnvVar(t *testing.T) {
 		{
 			name: "conf data + config map",
 			dsdMapperProfilesConf: &datadoghqv1alpha1.CustomConfigSpec{
-				ConfigData: datadoghqv1alpha1.NewStringPointer("foo: bar"),
+				ConfigData: apiutils.NewStringPointer("foo: bar"),
 				ConfigMap: &datadoghqv1alpha1.ConfigFileConfigMapSpec{
 					Name:    "dsd-config",
 					FileKey: "config",
@@ -372,7 +373,7 @@ func Test_dsdMapperProfilesEnvVar(t *testing.T) {
 		{
 			name: "invalid conf data",
 			dsdMapperProfilesConf: &datadoghqv1alpha1.CustomConfigSpec{
-				ConfigData: datadoghqv1alpha1.NewStringPointer(","),
+				ConfigData: apiutils.NewStringPointer(","),
 			},
 			want: nil,
 		},
@@ -471,7 +472,7 @@ func Test_getImage(t *testing.T) {
 				Name: "agent",
 				Tag:  "7",
 			},
-			registry: datadoghqv1alpha1.NewStringPointer("public.ecr.aws/datadog"),
+			registry: apiutils.NewStringPointer("public.ecr.aws/datadog"),
 			want:     "public.ecr.aws/datadog/agent:7",
 		},
 		{
@@ -480,7 +481,7 @@ func Test_getImage(t *testing.T) {
 				Name: "docker.io/datadog/agent:7.28.1-rc.3",
 				Tag:  "latest",
 			},
-			registry: datadoghqv1alpha1.NewStringPointer("gcr.io/datadoghq"),
+			registry: apiutils.NewStringPointer("gcr.io/datadoghq"),
 			want:     "docker.io/datadog/agent:7.28.1-rc.3",
 		},
 		{
@@ -549,21 +550,21 @@ func Test_getReplicas(t *testing.T) {
 	}{
 		{
 			name:    "both not nil",
-			current: datadoghqv1alpha1.NewInt32Pointer(2),
-			new:     datadoghqv1alpha1.NewInt32Pointer(3),
-			want:    datadoghqv1alpha1.NewInt32Pointer(3),
+			current: apiutils.NewInt32Pointer(2),
+			new:     apiutils.NewInt32Pointer(3),
+			want:    apiutils.NewInt32Pointer(3),
 		},
 		{
 			name:    "new is nil",
-			current: datadoghqv1alpha1.NewInt32Pointer(2),
+			current: apiutils.NewInt32Pointer(2),
 			new:     nil,
-			want:    datadoghqv1alpha1.NewInt32Pointer(2),
+			want:    apiutils.NewInt32Pointer(2),
 		},
 		{
 			name:    "current is nil",
 			current: nil,
-			new:     datadoghqv1alpha1.NewInt32Pointer(3),
-			want:    datadoghqv1alpha1.NewInt32Pointer(3),
+			new:     apiutils.NewInt32Pointer(3),
+			want:    apiutils.NewInt32Pointer(3),
 		},
 		{
 			name:    "both nil",

--- a/controllers/datadogagent_controller_test.go
+++ b/controllers/datadogagent_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/testutils"
 	// +kubebuilder:scaffold:imports
 )
@@ -167,21 +168,21 @@ var _ = Describe("DatadogAgent Controller", func() {
 
 			By("Activating APM", func() {
 				checkAgentUpdateOnDaemonSet(key, dsKey, func(agent *datadoghqv1alpha1.DatadogAgent) {
-					agent.Spec.Agent.Apm.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+					agent.Spec.Agent.Apm.Enabled = apiutils.NewBoolPointer(true)
 				}, nil)
 			})
 
 			By("Disabling OrchestratorExplorer", func() {
 				checkAgentUpdateOnDaemonSet(key, dsKey, func(agent *datadoghqv1alpha1.DatadogAgent) {
 					agent.Spec.Features.OrchestratorExplorer = &datadoghqv1alpha1.OrchestratorExplorerConfig{
-						Enabled: datadoghqv1alpha1.NewBoolPointer(false),
+						Enabled: apiutils.NewBoolPointer(false),
 					}
 				}, nil)
 			})
 
 			By("Activating System Probe", func() {
 				checkAgentUpdateOnDaemonSet(key, dsKey, func(agent *datadoghqv1alpha1.DatadogAgent) {
-					agent.Spec.Agent.SystemProbe.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+					agent.Spec.Agent.SystemProbe.Enabled = apiutils.NewBoolPointer(true)
 				}, nil)
 			})
 
@@ -198,7 +199,7 @@ var _ = Describe("DatadogAgent Controller", func() {
 
 			By("Enabled Process", func() {
 				checkAgentUpdateOnDaemonSet(key, dsKey, func(agent *datadoghqv1alpha1.DatadogAgent) {
-					agent.Spec.Agent.Process.Enabled = datadoghqv1alpha1.NewBoolPointer(true)
+					agent.Spec.Agent.Process.Enabled = apiutils.NewBoolPointer(true)
 				}, nil)
 			})
 		})
@@ -245,7 +246,7 @@ var _ = Describe("DatadogAgent Controller", func() {
 		It("Should update ClusterAgent", func() {
 			checkAgentUpdateOnClusterAgent(key, dcaKey, func(agent *datadoghqv1alpha1.DatadogAgent) {
 				agent.Spec.ClusterAgent.Image.Name = "datadog/cluster-agent:1.0.0"
-				agent.Spec.ClusterAgent.Config.ClusterChecksEnabled = datadoghqv1alpha1.NewBoolPointer(true)
+				agent.Spec.ClusterAgent.Config.ClusterChecksEnabled = apiutils.NewBoolPointer(true)
 				agent.Spec.ClusterChecksRunner = datadoghqv1alpha1.DatadogAgentSpecClusterChecksRunnerSpec{
 					Image: &datadoghqv1alpha1.ImageConfig{
 						Name: "datadog/agent:7.22.0",

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -7,6 +7,7 @@ package testutils
 
 import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -56,7 +57,7 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 					},
 				},
 				CriSocket: &datadoghqv1alpha1.CRISocketConfig{
-					CriSocketPath: datadoghqv1alpha1.NewStringPointer("/var/run/containerd/containerd.sock"),
+					CriSocketPath: apiutils.NewStringPointer("/var/run/containerd/containerd.sock"),
 				},
 				Env: []v1.EnvVar{
 					{
@@ -64,13 +65,13 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 						Value: "false",
 					},
 				},
-				LeaderElection: datadoghqv1alpha1.NewBoolPointer(true),
+				LeaderElection: apiutils.NewBoolPointer(true),
 			},
 			DeploymentStrategy: &datadoghqv1alpha1.DaemonSetDeploymentStrategy{},
 			Apm:                &datadoghqv1alpha1.APMSpec{},
 			Process: &datadoghqv1alpha1.ProcessSpec{
-				Enabled:                  datadoghqv1alpha1.NewBoolPointer(false),
-				ProcessCollectionEnabled: datadoghqv1alpha1.NewBoolPointer(false),
+				Enabled:                  apiutils.NewBoolPointer(false),
+				ProcessCollectionEnabled: apiutils.NewBoolPointer(false),
 			},
 		},
 	}
@@ -80,7 +81,7 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 		PullPolicy:  &pullPolicy,
 		PullSecrets: &[]v1.LocalObjectReference{},
 	}
-	ad.Spec.Agent.Rbac.Create = datadoghqv1alpha1.NewBoolPointer(true)
+	ad.Spec.Agent.Rbac.Create = apiutils.NewBoolPointer(true)
 
 	if options != nil {
 		if options.APIKey != "" {
@@ -92,10 +93,10 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 		}
 
 		if options.AgentDisabled {
-			ad.Spec.Agent.Enabled = datadoghqv1alpha1.NewBoolPointer(false)
+			ad.Spec.Agent.Enabled = apiutils.NewBoolPointer(false)
 		}
 
-		if options.UseEDS && datadoghqv1alpha1.BoolValue(ad.Spec.Agent.Enabled) {
+		if options.UseEDS && apiutils.BoolValue(ad.Spec.Agent.Enabled) {
 			ad.Spec.Agent.UseExtendedDaemonset = &options.UseEDS
 		}
 
@@ -128,7 +129,7 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 			}
 		} else {
 			ad.Spec.ClusterAgent = datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
-				Enabled: datadoghqv1alpha1.NewBoolPointer(false),
+				Enabled: apiutils.NewBoolPointer(false),
 			}
 		}
 
@@ -151,7 +152,7 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 				ad.Spec.Features.OrchestratorExplorer = &datadoghqv1alpha1.OrchestratorExplorerConfig{}
 			}
 
-			ad.Spec.Features.OrchestratorExplorer.Enabled = datadoghqv1alpha1.NewBoolPointer(false)
+			ad.Spec.Features.OrchestratorExplorer.Enabled = apiutils.NewBoolPointer(false)
 		}
 		// options can have an impact on the defaulting
 		_ = datadoghqv1alpha1.DefaultDatadogAgent(ad)

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/condition"
@@ -686,7 +687,7 @@ func (mf *metricsForwarder) isEventChanFull() bool {
 }
 
 func getbaseURL(dda *datadoghqv1alpha1.DatadogAgent) string {
-	if datadoghqv1alpha1.BoolValue(dda.Spec.Agent.Enabled) && dda.Spec.Agent.Config != nil && dda.Spec.Agent.Config.DDUrl != nil {
+	if apiutils.BoolValue(dda.Spec.Agent.Enabled) && dda.Spec.Agent.Config != nil && dda.Spec.Agent.Config.DDUrl != nil {
 		return *dda.Spec.Agent.Config.DDUrl
 	} else if dda.Spec.Site != "" {
 		return fmt.Sprintf("https://api.%s", dda.Spec.Site)

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -16,6 +16,7 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	test "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 
 	"github.com/stretchr/testify/mock"
@@ -464,7 +465,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 								APIKey: "foundApiKey",
 								AppKey: "foundAppKey",
 							},
-						}}),
+						},
+					}),
 			},
 			wantAPIKey: "foundApiKey",
 			wantAPPKey: "foundAppKey",
@@ -484,7 +486,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
 								APIKey: "foundApiKey",
 							},
-						}}),
+						},
+					}),
 			},
 			wantAPIKey: "",
 			wantAPPKey: "",
@@ -509,7 +512,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 									KeyName:    "application_key",
 								},
 							},
-						}}),
+						},
+					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					secret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -551,7 +555,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 								APIKeyExistingSecret: "datadog-creds",
 								AppKeyExistingSecret: "datadog-creds",
 							},
-						}}),
+						},
+					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					secret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -585,7 +590,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 									SecretName: "datadog-creds",
 								},
 							},
-						}}),
+						},
+					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					secret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -616,7 +622,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 								APIKey:               "foundApiKey",
 								AppKeyExistingSecret: "datadog-creds",
 							},
-						}}),
+						},
+					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					secret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -647,7 +654,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 								APIKey: "ENC[ApiKey]",
 								AppKey: "ENC[AppKey]",
 							},
-						}}),
+						},
+					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					m.cleanSecretsCache()
 					m.creds.Store("ENC[ApiKey]", "cachedApiKey")
@@ -678,7 +686,8 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 								APIKey: "ENC[ApiKey]",
 								AppKey: "ENC[AppKey]",
 							},
-						}}),
+						},
+					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					m.cleanSecretsCache()
 					d.On("Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"}).Once()
@@ -767,7 +776,7 @@ func TestMetricsForwarder_setTags(t *testing.T) {
 			name: "with clustername",
 			dda: test.NewDefaultedDatadogAgent("foo", "bar",
 				&test.NewDatadogAgentOptions{
-					ClusterName: datadoghqv1alpha1.NewStringPointer("testcluster"),
+					ClusterName: apiutils.NewStringPointer("testcluster"),
 				}),
 			want: []string{
 				"cluster_name:testcluster",
@@ -777,7 +786,7 @@ func TestMetricsForwarder_setTags(t *testing.T) {
 			name: "with clustername and labels",
 			dda: test.NewDefaultedDatadogAgent("foo", "bar",
 				&test.NewDatadogAgentOptions{
-					ClusterName: datadoghqv1alpha1.NewStringPointer("testcluster"),
+					ClusterName: apiutils.NewStringPointer("testcluster"),
 					Labels: map[string]string{
 						"firstKey":  "firstValue",
 						"secondKey": "secondValue",
@@ -1141,8 +1150,9 @@ func Test_getbaseURL(t *testing.T) {
 			args: args{
 				dda: test.NewDefaultedDatadogAgent("foo", "bar", &test.NewDatadogAgentOptions{
 					NodeAgentConfig: &datadoghqv1alpha1.NodeAgentConfig{
-						DDUrl: datadoghqv1alpha1.NewStringPointer("https://test.url.com"),
-					}}),
+						DDUrl: apiutils.NewStringPointer("https://test.url.com"),
+					},
+				}),
 			},
 			want: "https://test.url.com",
 		},
@@ -1152,8 +1162,9 @@ func Test_getbaseURL(t *testing.T) {
 				dda: test.NewDefaultedDatadogAgent("foo", "bar", &test.NewDatadogAgentOptions{
 					Site: "datadoghq.eu",
 					NodeAgentConfig: &datadoghqv1alpha1.NodeAgentConfig{
-						DDUrl: datadoghqv1alpha1.NewStringPointer("https://test.url.com"),
-					}}),
+						DDUrl: apiutils.NewStringPointer("https://test.url.com"),
+					},
+				}),
 			},
 			want: "https://test.url.com",
 		},


### PR DESCRIPTION
### What does this PR do?

move utilis like `NewBool()` to a dedicated package so it can be used by api v1 and v2.

### Motivation

I needed this modification for #412, it will be cleaner to have a dedicated PR, and other work can benefit from it at the meantime.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

only refactoring, if the compilation is ok, it should be fine.
