### PR TITLE
update datadog api go client to 1.7.0

### DIFF
--- a/controllers/datadogmonitor/monitor_test.go
+++ b/controllers/datadogmonitor/monitor_test.go
@@ -35,6 +35,7 @@ func Test_buildMonitor(t *testing.T) {
 	timeoutH := int64(2)
 	critThreshold := "0.05"
 	warnThreshold := "0.02"
+	priority := int64(3)
 
 	dm := &datadoghqv1alpha1.DatadogMonitor{
 		Spec: datadoghqv1alpha1.DatadogMonitorSpec{
@@ -42,7 +43,7 @@ func Test_buildMonitor(t *testing.T) {
 			Type:     "metric alert",
 			Name:     "Test monitor",
 			Message:  "Something went wrong",
-			Priority: 3,
+			Priority: priority,
 			Tags: []string{
 				"env:staging",
 				"kube_namespace:test",
@@ -68,23 +69,23 @@ func Test_buildMonitor(t *testing.T) {
 
 	monitor, monitorUR := buildMonitor(testLogger, dm)
 
-	assert.Equal(t, dm.Spec.Query, *monitor.Query, "discrepancy found in parameter: Query")
-	assert.Equal(t, dm.Spec.Query, *monitorUR.Query, "discrepancy found in parameter: Query")
+	assert.Equal(t, dm.Spec.Query, monitor.GetQuery(), "discrepancy found in parameter: Query")
+	assert.Equal(t, dm.Spec.Query, monitorUR.GetQuery(), "discrepancy found in parameter: Query")
 
-	assert.Equal(t, string(dm.Spec.Type), string(*monitor.Type), "discrepancy found in parameter: Type")
-	assert.Equal(t, string(dm.Spec.Type), string(*monitorUR.Type), "discrepancy found in parameter: Type")
+	assert.Equal(t, string(dm.Spec.Type), string(monitor.GetType()), "discrepancy found in parameter: Type")
+	assert.Equal(t, string(dm.Spec.Type), string(monitorUR.GetType()), "discrepancy found in parameter: Type")
 
-	assert.Equal(t, dm.Spec.Name, *monitor.Name, "discrepancy found in parameter: Name")
-	assert.Equal(t, dm.Spec.Name, *monitorUR.Name, "discrepancy found in parameter: Name")
+	assert.Equal(t, dm.Spec.Name, monitor.GetName(), "discrepancy found in parameter: Name")
+	assert.Equal(t, dm.Spec.Name, monitorUR.GetName(), "discrepancy found in parameter: Name")
 
-	assert.Equal(t, dm.Spec.Message, *monitor.Message, "discrepancy found in parameter: Message")
-	assert.Equal(t, dm.Spec.Message, *monitorUR.Message, "discrepancy found in parameter: Message")
+	assert.Equal(t, dm.Spec.Message, monitor.GetMessage(), "discrepancy found in parameter: Message")
+	assert.Equal(t, dm.Spec.Message, monitorUR.GetMessage(), "discrepancy found in parameter: Message")
 
-	assert.Equal(t, dm.Spec.Priority, *monitor.Priority, "discrepancy found in parameter: Priority")
-	assert.Equal(t, dm.Spec.Priority, *monitorUR.Priority, "discrepancy found in parameter: Priority")
+	assert.Equal(t, dm.Spec.Priority, monitor.GetPriority(), "discrepancy found in parameter: Priority")
+	assert.Equal(t, dm.Spec.Priority, monitorUR.GetPriority(), "discrepancy found in parameter: Priority")
 
-	assert.Equal(t, dm.Spec.Tags, *monitor.Tags, "discrepancy found in parameter: Tags")
-	assert.Equal(t, dm.Spec.Tags, *monitorUR.Tags, "discrepancy found in parameter: Tags")
+	assert.Equal(t, dm.Spec.Tags, monitor.GetTags(), "discrepancy found in parameter: Tags")
+	assert.Equal(t, dm.Spec.Tags, monitorUR.GetTags(), "discrepancy found in parameter: Tags")
 
 	assert.Equal(t, *dm.Spec.Options.EvaluationDelay, monitor.Options.GetEvaluationDelay(), "discrepancy found in parameter: EvaluationDelay")
 	assert.Equal(t, *dm.Spec.Options.EvaluationDelay, monitorUR.Options.GetEvaluationDelay(), "discrepancy found in parameter: EvaluationDelay")
@@ -121,13 +122,13 @@ func Test_buildMonitor(t *testing.T) {
 	assert.Equal(t, critVal, (&apiMonitorURThresholds).GetCritical(), "discrepancy found in parameter: Threshold.Critical")
 
 	// Also make sure tags are sorted
-	assert.Equal(t, "env:staging", (*monitor.Tags)[0], "tags are not properly sorted")
-	assert.Equal(t, "kube_cluster:test.staging", (*monitor.Tags)[1], "tags are not properly sorted")
-	assert.Equal(t, "kube_namespace:test", (*monitor.Tags)[2], "tags are not properly sorted")
+	assert.Equal(t, "env:staging", (monitor.GetTags())[0], "tags are not properly sorted")
+	assert.Equal(t, "kube_cluster:test.staging", (monitor.GetTags())[1], "tags are not properly sorted")
+	assert.Equal(t, "kube_namespace:test", (monitor.GetTags())[2], "tags are not properly sorted")
 
-	assert.Equal(t, "env:staging", (*monitorUR.Tags)[0], "tags are not properly sorted")
-	assert.Equal(t, "kube_cluster:test.staging", (*monitorUR.Tags)[1], "tags are not properly sorted")
-	assert.Equal(t, "kube_namespace:test", (*monitorUR.Tags)[2], "tags are not properly sorted")
+	assert.Equal(t, "env:staging", (monitorUR.GetTags())[0], "tags are not properly sorted")
+	assert.Equal(t, "kube_cluster:test.staging", (monitorUR.GetTags())[1], "tags are not properly sorted")
+	assert.Equal(t, "kube_namespace:test", (monitorUR.GetTags())[2], "tags are not properly sorted")
 }
 
 func Test_getMonitor(t *testing.T) {
@@ -212,11 +213,11 @@ func Test_createMonitor(t *testing.T) {
 	monitor, err := createMonitor(testAuth, testLogger, client, dm)
 	assert.Nil(t, err)
 
-	assert.Equal(t, dm.Spec.Query, *monitor.Query, "discrepancy found in parameter: Query")
-	assert.Equal(t, string(dm.Spec.Type), string(*monitor.Type), "discrepancy found in parameter: Type")
-	assert.Equal(t, dm.Spec.Name, *monitor.Name, "discrepancy found in parameter: Name")
-	assert.Equal(t, dm.Spec.Message, *monitor.Message, "discrepancy found in parameter: Message")
-	assert.Equal(t, dm.Spec.Tags, *monitor.Tags, "discrepancy found in parameter: Tags")
+	assert.Equal(t, dm.Spec.Query, monitor.GetQuery(), "discrepancy found in parameter: Query")
+	assert.Equal(t, string(dm.Spec.Type), string(monitor.GetType()), "discrepancy found in parameter: Type")
+	assert.Equal(t, dm.Spec.Name, monitor.GetName(), "discrepancy found in parameter: Name")
+	assert.Equal(t, dm.Spec.Message, monitor.GetMessage(), "discrepancy found in parameter: Message")
+	assert.Equal(t, dm.Spec.Tags, monitor.GetTags(), "discrepancy found in parameter: Tags")
 }
 
 func Test_updateMonitor(t *testing.T) {
@@ -255,11 +256,11 @@ func Test_updateMonitor(t *testing.T) {
 	monitor, err := updateMonitor(testAuth, testLogger, client, dm)
 	assert.Nil(t, err)
 
-	assert.Equal(t, dm.Spec.Query, *monitor.Query, "discrepancy found in parameter: Query")
-	assert.Equal(t, string(dm.Spec.Type), string(*monitor.Type), "discrepancy found in parameter: Type")
-	assert.Equal(t, dm.Spec.Name, *monitor.Name, "discrepancy found in parameter: Name")
-	assert.Equal(t, dm.Spec.Message, *monitor.Message, "discrepancy found in parameter: Message")
-	assert.Equal(t, dm.Spec.Tags, *monitor.Tags, "discrepancy found in parameter: Tags")
+	assert.Equal(t, dm.Spec.Query, monitor.GetQuery(), "discrepancy found in parameter: Query")
+	assert.Equal(t, string(dm.Spec.Type), string(monitor.GetType()), "discrepancy found in parameter: Type")
+	assert.Equal(t, dm.Spec.Name, monitor.GetName(), "discrepancy found in parameter: Name")
+	assert.Equal(t, dm.Spec.Message, monitor.GetMessage(), "discrepancy found in parameter: Message")
+	assert.Equal(t, dm.Spec.Tags, monitor.GetTags(), "discrepancy found in parameter: Tags")
 
 }
 
@@ -303,9 +304,9 @@ func genericMonitor(mId int) datadogapiclientv1.Monitor {
 		Message:  &msg,
 		Modified: &now,
 		Name:     &name,
-		Query:    &query,
+		Query:    query,
 		Tags:     &tags,
-		Type:     &mType,
+		Type:     mType,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,19 +3,24 @@ module github.com/DataDog/datadog-operator
 go 1.16
 
 require (
-	github.com/DataDog/datadog-api-client-go v1.0.0-beta.18
+	github.com/DataDog/datadog-api-client-go v1.7.0
 	github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c
 	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/dnaeon/go-vcr v1.0.1 // indirect
+	github.com/go-bdd/gobdd v1.1.3-0.20210205100305-4910f932a786 // indirect
 	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/spec v0.20.3
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.5.5
 	github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026
+	github.com/mcuadros/go-lookup v0.0.0-20200831155250-80f87a4fa5ee // indirect
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
@@ -23,6 +28,8 @@ require (
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/zorkian/go-datadog-api v2.30.0+incompatible
 	go.uber.org/zap v1.17.0
+	gopkg.in/DataDog/dd-trace-go.v1 v1.29.0-rc.1.0.20210226170446-a8dc39ec3484 // indirect
+	gopkg.in/h2non/gock.v1 v1.0.15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.2
 	k8s.io/apiextensions-apiserver v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18 h1:4i51yRTWm8SEuc9iRxxFicm59jQcAo70v+3ddZhEq8Q=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=
+github.com/DataDog/datadog-api-client-go v1.7.0 h1:82Jkz5dFQGR+ygERKfd6JpvlVbeNLe6HaeWBypu7+2w=
+github.com/DataDog/datadog-api-client-go v1.7.0/go.mod h1:QzaQF1cDO1/BIQG1fz14VrY+6RECUGkiwzDCtVbfP5c=
 github.com/DataDog/datadog-go v4.4.0+incompatible h1:R7WqXWP4fIOAqWJtUKmSfuc7eDsBT58k9AY5WSHVosk=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
@@ -765,6 +767,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
### What does this PR do?

Update datadog api go client to 1.7.0

### Motivation

Have the most up to date client that supports more recent DD features
### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Make sure the DatadogMonitor controller works as expected (create monitor, update, monitor, delete monitor)