### PR TITLE
[controllers/datadogagent/clusteragent] Add "subjectaccessreviews" to RBAC

### DIFF
--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -244,6 +244,7 @@ const (
 	PolicyAPIGroup           = "policy"
 	NetworkingAPIGroup       = "networking.k8s.io"
 	AutoscalingK8sIoAPIGroup = "autoscaling.k8s.io"
+	AuthorizationAPIGroup    = "authorization.k8s.io"
 
 	// Resources
 
@@ -291,6 +292,7 @@ const (
 	NetworkPolicyResource               = "networkpolicies"
 	IngressesResource                   = "ingresses"
 	VPAResource                         = "verticalpodautoscalers"
+	SubjectAccessReviewResource         = "subjectaccessreviews"
 
 	// Resource names
 

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1197,6 +1197,14 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 					datadoghqv1alpha1.WatchVerb,
 				},
 			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{datadoghqv1alpha1.AuthorizationAPIGroup},
+				Resources: []string{datadoghqv1alpha1.SubjectAccessReviewResource},
+				Verbs: []string{
+					datadoghqv1alpha1.CreateVerb,
+					datadoghqv1alpha1.GetVerb,
+				},
+			},
 		)
 
 		if dda.Spec.ClusterAgent.Config.ExternalMetrics.UseDatadogMetrics {


### PR DESCRIPTION
### What does this PR do?

Fixes this error `subjectaccessreviews.authorization.k8s.io is forbidden: User "system:serviceaccount:datadog:datadog-cluster-agent" cannot create resource "subjectaccessreviews" in API group "authorization.k8s.io" at the cluster scope` that appears in the cluster agent when setting:
```
  clusterAgent:
    config:
      externalMetrics:
        enabled: true
```


### Describe your test plan

Deploy with external metrics enabled and check that the error mentioned above does not appear in the cluster agent.
