### PR TITLE
Fix panic that happens when using the minimal recommended DDA

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -793,7 +793,10 @@ func DefaultDatadogFeatureLogCollection(ft *DatadogFeatures) *LogCollectionConfi
 // return the defaulted ProcessSpec
 func DefaultDatadogAgentSpecAgentProcess(agent *DatadogAgentSpecAgentSpec) *ProcessSpec {
 	if agent.Process == nil {
-		agent.Process = &ProcessSpec{Enabled: apiutils.NewBoolPointer(defaultProcessEnabled)}
+		agent.Process = &ProcessSpec{
+			Enabled:                  apiutils.NewBoolPointer(defaultProcessEnabled),
+			ProcessCollectionEnabled: apiutils.NewBoolPointer(defaultProcessCollectionEnabled),
+		}
 		return agent.Process
 	}
 

--- a/apis/datadoghq/v1alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default_test.go
@@ -481,7 +481,7 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				},
 				Rbac:        &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Apm:         &APMSpec{Enabled: apiutils.NewBoolPointer(false)},
-				Process:     &ProcessSpec{Enabled: apiutils.NewBoolPointer(false)},
+				Process:     &ProcessSpec{Enabled: apiutils.NewBoolPointer(false), ProcessCollectionEnabled: apiutils.NewBoolPointer(false)},
 				SystemProbe: &SystemProbeSpec{Enabled: apiutils.NewBoolPointer(false)},
 				Security: &SecuritySpec{
 					Compliance: ComplianceSpec{Enabled: apiutils.NewBoolPointer(false)},
@@ -531,7 +531,7 @@ func TestDefaultDatadogAgentSpecAgent(t *testing.T) {
 				},
 				Rbac:        &RbacConfig{Create: apiutils.NewBoolPointer(true)},
 				Apm:         &APMSpec{Enabled: apiutils.NewBoolPointer(false)},
-				Process:     &ProcessSpec{Enabled: apiutils.NewBoolPointer(false)},
+				Process:     &ProcessSpec{Enabled: apiutils.NewBoolPointer(false), ProcessCollectionEnabled: apiutils.NewBoolPointer(false)},
 				SystemProbe: &SystemProbeSpec{Enabled: apiutils.NewBoolPointer(false)},
 				Security: &SecuritySpec{
 					Compliance: ComplianceSpec{Enabled: apiutils.NewBoolPointer(false)},


### PR DESCRIPTION
### What does this PR do?

This PR defaults `agent.Process.ProcessCollectionEnabled` in the DDA spec to avoid a panic in the operator when using the minimal DDA config recommended here:
https://github.com/DataDog/datadog-operator/blob/main/docs/getting_started.md#deploy-the-agent-with-the-operator

```
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  credentials:
    apiSecret:
      secretName: datadog-secret
      keyName: api-key
    appSecret:
      secretName: datadog-secret
      keyName: app-key
```

Here's the trace:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16237aa]

goroutine 424 [running]:
github.com/DataDog/datadog-operator/controllers/datadogagent.getVolumeMountsForProcessAgent(0xc00005f800,
0xc0009021e0, 0xc0009b9010, 0x1)
        /workspace/controllers/datadogagent/utils.go:1597 +0x20a
```

### Describe your test plan

Use the config pasted above and check that the operator doesn't panic.
