### PR TITLE
[controllers/datadogagent] Add "datadogmetrics" RBACs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -419,6 +419,21 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - datadogmetrics
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogmetrics/status
+  verbs:
+  - update
+- apiGroups:
+  - datadoghq.com
+  resources:
   - datadogmonitors
   verbs:
   - create

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -80,6 +80,8 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=*
 // +kubebuilder:rbac:groups=datadoghq.com,resources=watermarkpodautoscalers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=external.metrics.k8s.io,resources=*,verbs=get;list;watch
+// +kubebuilder:rbac:groups=datadoghq.com,resources=datadogmetrics,verbs=list;watch;create;delete
+// +kubebuilder:rbac:groups=datadoghq.com,resources=datadogmetrics/status,verbs=update
 
 // Use ExtendedDaemonSet
 // +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsets,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
### What does this PR do?

Adds datadogmetrics RBACs.

These are needed when `useDatadogMetrics` is set to true in the cluster agent config.

```
  clusterAgent:
    config:
      externalMetrics:
        enabled: true
        useDatadogMetrics: true
```

The operator now shows errors like this one because of the missing RBACs:
```
{"level":"ERROR","ts":"2022-01-18T11:57:38Z","logger":"controller-runtime.manager.controller.datadogagent","msg":"Reconciler error","reconciler group":"datadoghq.com","reconciler kind":"DatadogAgent","name":"datadog","namespace":"datadog","error":"clusterroles.rbac.authorization.k8s.io \"datadog-cluster-agent\" is forbidden: user \"system:serviceaccount:datadog:datadog-operator-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:datadog\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"datadoghq.com\"], Resources:[\"datadogmetrics\"], Verbs:[\"list\" \"watch\" \"create\" \"delete\"]}\n{APIGroups:[\"datadoghq.com\"], Resources:[\"datadogmetrics/status\"], Verbs:[\"update\"]}"}

```

### Describe your test plan

Deploy a DDA with `useDatadogMetrics` set to true like in the config shown above and check that there are no RBAC-related errors.
