### PR TITLE
Fix continuous create and delete of cluster roles and bindings

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -886,17 +886,17 @@ func (r *Reconciler) manageClusterAgentRBACs(logger logr.Logger, dda *datadoghqv
 	metricsProviderEnabled := isMetricsProviderEnabled(dda.Spec.ClusterAgent)
 	// Create or delete HPA ClusterRoleBinding
 	hpaClusterRoleBindingName := getHPAClusterRoleBindingName(dda)
-	if result, err := r.manageClusterRoleBinding(logger, dda, hpaClusterRoleBindingName, clusterAgentVersion, r.createHPAClusterRoleBinding, r.updateIfNeededHPAClusterRole, metricsProviderEnabled); err != nil {
+	if result, err := r.manageClusterRoleBinding(logger, dda, hpaClusterRoleBindingName, clusterAgentVersion, r.createHPAClusterRoleBinding, r.updateIfNeededHPAClusterRole, !metricsProviderEnabled); err != nil {
 		return result, err
 	}
 
 	// Create or delete external metrics reader ClusterRole and ClusterRoleBinding
 	metricsReaderClusterRoleName := getExternalMetricsReaderClusterRoleName(dda, r.versionInfo)
-	if result, err := r.manageClusterRole(logger, dda, metricsReaderClusterRoleName, clusterAgentVersion, r.createExternalMetricsReaderClusterRole, r.updateIfNeededExternalMetricsReaderClusterRole, metricsProviderEnabled); err != nil {
+	if result, err := r.manageClusterRole(logger, dda, metricsReaderClusterRoleName, clusterAgentVersion, r.createExternalMetricsReaderClusterRole, r.updateIfNeededExternalMetricsReaderClusterRole, !metricsProviderEnabled); err != nil {
 		return result, err
 	}
 
-	if result, err := r.manageClusterRoleBinding(logger, dda, metricsReaderClusterRoleName, clusterAgentVersion, r.createExternalMetricsReaderClusterRoleBinding, r.updateIfNeededClusterAgentClusterRoleBinding, metricsProviderEnabled); err != nil {
+	if result, err := r.manageClusterRoleBinding(logger, dda, metricsReaderClusterRoleName, clusterAgentVersion, r.createExternalMetricsReaderClusterRoleBinding, r.updateIfNeededClusterAgentClusterRoleBinding, !metricsProviderEnabled); err != nil {
 		return result, err
 	}
 

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -176,6 +176,10 @@ type (
 )
 
 func (r *Reconciler) manageClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, clusterRoleName, agentVersion string, createFunc createClusterRoleFunc, updateFunc updateIfNeedClusterRoleFunc, shouldCleanup bool) (reconcile.Result, error) {
+	if shouldCleanup {
+		return r.cleanupClusterRole(logger, dda, clusterRoleName)
+	}
+
 	clusterRole := &rbacv1.ClusterRole{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleName}, clusterRole); err != nil {
 		if errors.IsNotFound(err) {
@@ -184,9 +188,7 @@ func (r *Reconciler) manageClusterRole(logger logr.Logger, dda *datadoghqv1alpha
 			return reconcile.Result{}, err
 		}
 	}
-	if shouldCleanup {
-		return r.cleanupClusterRole(logger, dda, clusterRoleName)
-	}
+
 	return updateFunc(logger, dda, clusterRoleName, agentVersion, clusterRole)
 }
 
@@ -196,6 +198,10 @@ type (
 )
 
 func (r *Reconciler) manageClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, clusterRoleBindingName, agentVersion string, createFunc createClusterRoleBindingFunc, updateFunc updateIfNeedClusterRoleBindingFunc, shouldCleanup bool) (reconcile.Result, error) {
+	if shouldCleanup {
+		return r.cleanupClusterRoleBinding(logger, dda, clusterRoleBindingName)
+	}
+
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: clusterRoleBindingName}, clusterRoleBinding); err != nil {
 		if errors.IsNotFound(err) {
@@ -203,9 +209,6 @@ func (r *Reconciler) manageClusterRoleBinding(logger logr.Logger, dda *datadoghq
 		} else if err != nil {
 			return reconcile.Result{}, err
 		}
-	}
-	if shouldCleanup {
-		return r.cleanupClusterRoleBinding(logger, dda, clusterRoleBindingName)
 	}
 
 	return updateFunc(logger, dda, clusterRoleBindingName, agentVersion, clusterRoleBinding)


### PR DESCRIPTION
### What does this PR do?

When external metrics are enabled in the cluster agent, the `datadog-cluster-agent-metrics-reader` cluster role and the `datadog-cluster-agent-metrics-reader` and `datadog-cluster-agent-auth-delegator` cluster role bindings are being created and deleted continuously.

This PR fixes the bug. There were 2 issues, each solved in one commit:
1) The functions that manage cluster roles and cluster role bindings were not handling correctly the "cleanup" case. In that case, they were creating the resource, and then deleting it.
2) The controller was setting the cleanup attr incorrectly. The cluster roles and bindings mentioned above should be created when external metrics are enabled, but the controller was doing the opposite.

### Describe your test plan

Enable external metrics in the cluster agent:
```
  clusterAgent:
    config:
      externalMetrics:
        enabled: true
```

Check that the cluster roles and cluster role bindings mentioned above are not created and deleted continuously.
