### PR TITLE
Fix error raised in the DCA when using external metrics

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1205,6 +1205,11 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 					datadoghqv1alpha1.GetVerb,
 				},
 			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+				Resources: []string{datadoghqv1alpha1.EventsResource},
+				Verbs:     []string{datadoghqv1alpha1.CreateVerb},
+			},
 		)
 
 		if dda.Spec.ClusterAgent.Config.ExternalMetrics.UseDatadogMetrics {


### PR DESCRIPTION
### What does this PR do?

Fixes an error that happens when the external metrics option is enabled in the DCA:

```
  clusterAgent:
    config:
      externalMetrics:
        enabled: true
```

When creating a datadog metric, and an HPA object that references it, the DCA shows an error like this one:

```
...events is forbidden: User "system:serviceaccount:datadog:datadog-cluster-agent" cannot create resource "events" in API group ""...
```

This PR fixes the issue by adding create perms for events in the cluster agent cluster role. We're already setting these perms in the helm chart: https://github.com/DataDog/helm-charts/blob/0316b0ec18de7eda72279c3b683770efa502ffc7/charts/datadog/templates/cluster-agent-rbac.yaml#L22

Also note that I haven't tested the external metrics extensively, in this PR I just wanted to solve the RBAC issue.

### Describe your test plan

Enable the external metrics option, create a datadog metric, then create an HPA object that references it, and make sure that the error above doesn't show in the cluster agent logs.
Docs about external metrics: https://docs.datadoghq.com/agent/cluster_agent/external_metrics/