### PR TITLE
Remove the frequent need to do `rm -rf bin` to “fix stuff”

### DIFF
--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -1,29 +1,16 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-RELEASE_VERSION=$1
-ROOT=$(pwd)
+PLATFORM="$(uname -s)-$(uname -m)"
+ROOT=$(git rev-parse --show-toplevel)
 
-if [ -z "$RELEASE_VERSION" ];
-then
+if [[ $# -ne 1 ]]; then
   echo "usage: bin/install-operator-sdk.sh <version>"
   exit 1
 fi
+RELEASE_VERSION=$1
 
 # copy binary in current repo
-mkdir -p $ROOT/bin
-
-WORK_DIR=`mktemp -d`
-
-# deletes the temp directory
-function cleanup {      
-  rm -rf "$WORK_DIR"
-  echo "Deleted temp working directory $WORK_DIR"
-}
-
-# register the cleanup function to be called on the EXIT signal
-trap cleanup EXIT
-
 uname_os() {
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   case "$os" in
@@ -31,21 +18,8 @@ uname_os() {
   esac
   echo "$os"
 }
-
 OS=$(uname_os)
 
-
-mkdir -p bin
-
-cd $WORK_DIR
-if [ "$OS" == "darwin" ]; then
-    echo "darwin"
-    curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_darwin_amd64
-    mv operator-sdk_darwin_amd64 $ROOT/bin/operator-sdk
-else
-    echo "linux"
-    curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_linux_amd64
-    mv operator-sdk_linux_amd64 $ROOT/bin/operator-sdk
-fi
-
-chmod +x $ROOT/bin/operator-sdk 
+mkdir -p "$ROOT/bin/$PLATFORM"
+curl -Lo "$ROOT/bin/$PLATFORM/operator-sdk" "https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk_${OS}_amd64"
+chmod +x "$ROOT/bin/$PLATFORM/operator-sdk"

--- a/hack/install-wwhrd.sh
+++ b/hack/install-wwhrd.sh
@@ -1,29 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
+PLATFORM="$(uname -s)-$(uname -m)"
 ROOT=$(git rev-parse --show-toplevel)
-WORK_DIR=`mktemp -d`
-cleanup() {
-  rm -rf "$WORK_DIR"
-}
-trap "cleanup" EXIT SIGINT
 
-VERSION=$1
-TARBALL="wwhrd_${VERSION}_$(uname)_amd64.tar.gz"
-
-if [ -z "$VERSION" ];
-then
+if [[ $# -ne 1 ]]; then
   echo "usage: bin/install-wwhrd.sh <version>"
   exit 1
 fi
+VERSION=$1
+TARBALL="wwhrd_${VERSION}_$(uname)_amd64.tar.gz"
 
-cd $WORK_DIR
-curl -Lo ${TARBALL} https://github.com/frapposelli/wwhrd/releases/download/v${VERSION}/${TARBALL} && tar -C . -xzf $TARBALL
-
-chmod +x wwhrd
-mkdir -p $ROOT/bin
-mv wwhrd $ROOT/bin/wwhrd
+mkdir -p "$ROOT/bin/$PLATFORM"
+curl -L "https://github.com/frapposelli/wwhrd/releases/download/v${VERSION}/${TARBALL}" | tar -xmz -C "$ROOT/bin/$PLATFORM" wwhrd

--- a/hack/install-yq.sh
+++ b/hack/install-yq.sh
@@ -1,28 +1,16 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
+PLATFORM="$(uname -s)-$(uname -m)"
 ROOT=$(git rev-parse --show-toplevel)
-WORK_DIR=`mktemp -d`
-cleanup() {
-  rm -rf "$WORK_DIR"
-}
-trap "cleanup" EXIT SIGINT
-
-VERSION=$1
 BINARY="yq_$(uname)_amd64"
 
-if [ -z "$VERSION" ];
-then
+if [[ $# -ne 1 ]]; then
   echo "usage: bin/install-yq.sh <version>"
   exit 1
 fi
+VERSION=$1
 
-cd $WORK_DIR
-curl -Lo ${BINARY} https://github.com/mikefarah/yq/releases/download/$VERSION/$BINARY
-
-chmod +x $BINARY
-mkdir -p $ROOT/bin
-mv $BINARY $ROOT/bin/yq
+mkdir -p "$ROOT/bin/$PLATFORM"
+curl -Lo "$ROOT/bin/$PLATFORM/yq" "https://github.com/mikefarah/yq/releases/download/$VERSION/$BINARY"
+chmod +x "$ROOT/bin/$PLATFORM/yq"

--- a/hack/license.sh
+++ b/hack/license.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -exo pipefail
-
+PLATFORM="$(uname -s)-$(uname -m)"
 export LC_ALL=C
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 ROOT=$(git rev-parse --show-toplevel)
 
-$ROOT/bin/wwhrd list
+"$ROOT/bin/$PLATFORM/wwhrd" list
 
 echo Component,Origin,License > LICENSE-3rdparty.csv
 echo 'core,"github.com/frapposelli/wwhrd",MIT' >> LICENSE-3rdparty.csv
 unset grep
-$ROOT/bin/wwhrd list --no-color |& grep "Found License" | awk '{print $6,$5}' | sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" | sed s/" license="/,/ | sed s/package=/core,/ | sort >> LICENSE-3rdparty.csv
+"$ROOT/bin/$PLATFORM/wwhrd" list --no-color |& grep "Found License" | awk '{print $6,$5}' | sed -E "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" | sed s/" license="/,/ | sed s/package=/core,/ | sort >> LICENSE-3rdparty.csv

--- a/hack/patch-crds.sh
+++ b/hack/patch-crds.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
+set -euo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
-YQ="$ROOT_DIR/bin/yq"
+YQ="$ROOT_DIR/bin/$(uname -s)-$(uname -m)/yq"
 
 v1beta1=config/crd/bases/v1beta1
 v1=config/crd/bases/v1
@@ -15,11 +12,11 @@ v1=config/crd/bases/v1
 #
 # Cannot use directly yq -d .. 'spec.validation.openAPIV3Schema.properties.**.x-kubernetes-*'
 # as for some reason, yq takes several minutes to execute this command
-for crd in $(ls "$ROOT_DIR/$v1beta1")
+for crd in "$ROOT_DIR/$v1beta1"/*.yaml
 do
-  for path in $($YQ r "$ROOT_DIR/$v1beta1/$crd" 'spec.validation.openAPIV3Schema.properties.**.x-kubernetes-*' --printMode p)
+  for path in $($YQ r "$crd" 'spec.validation.openAPIV3Schema.properties.**.x-kubernetes-*' --printMode p)
   do
-    $YQ d -i "$ROOT_DIR/$v1beta1/$crd" $path
+    $YQ d -i "$crd" $path
   done
 done
 

--- a/hack/verify-license.sh
+++ b/hack/verify-license.sh
@@ -1,12 +1,8 @@
-#!/bin/bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 ROOT=$(git rev-parse --show-toplevel)
-cd $ROOT
+cd "$ROOT"
 
 make license 2>&1
 
@@ -22,7 +18,7 @@ DIFF=$(git ls-files docs/ --exclude-standard --others)
 if [[ "${DIFF}x" != "x" ]]
 then
     echo "License removed:" >&2
-    echo ${DIFF} >&2
+    echo "${DIFF}" >&2
     exit 2
 fi
 exit 0


### PR DESCRIPTION
### What does this PR do?

* Put binaries in a platform specific directory so that sharing a work tree between MacOS and Linux isn’t an issue anymore.
* Add a dependency between tools and the Makefile so that, when the desired version of a tool is updated in the Makefile, the tool is properly upgraded accordingly automatically without needing to be deleted manually.

### Motivation

I frequently switch between compiling from MacOS and from a Linux environment (docker devenv) which is mounting the `datadog-operator` worktree from the Mac.
At each switch, we get a `cannot execute binary file: Exec format error` error.

Also, when the versions of the tools (`yq`, `wwhrd`, `operator-sdk`, `golangci-lint`, etc.) is updated in the `Makefile`, the old and deprecated versions were kept in `/bin` forever.

In both cases, the errors were resolved by deleting manually the `bin` directory.
This PR should remove the need to delete this directory manually.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Validate that the `make` targets are still working even when switching between MacOS and Linux.
