### PR TITLE
[controllers/datadogagent/clusteragent] Fix "externalmetrics" cluster role binding

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -896,7 +896,7 @@ func (r *Reconciler) manageClusterAgentRBACs(logger logr.Logger, dda *datadoghqv
 		return result, err
 	}
 
-	if result, err := r.manageClusterRoleBinding(logger, dda, metricsReaderClusterRoleName, clusterAgentVersion, r.createExternalMetricsReaderClusterRoleBinding, r.updateIfNeededClusterAgentClusterRoleBinding, !metricsProviderEnabled); err != nil {
+	if result, err := r.manageClusterRoleBinding(logger, dda, metricsReaderClusterRoleName, clusterAgentVersion, r.createExternalMetricsReaderClusterRoleBinding, r.updateIfNeededExternalMetricsReaderClusterRoleBinding, !metricsProviderEnabled); err != nil {
 		return result, err
 	}
 
@@ -1002,16 +1002,6 @@ func (r *Reconciler) createClusterAgentRoleBinding(logger logr.Logger, dda *data
 	event := buildEventInfo(roleBinding.Name, roleBinding.Namespace, roleBindingKind, datadog.CreationEvent)
 	r.recordEvent(dda, event)
 	return reconcile.Result{}, r.client.Create(context.TODO(), roleBinding)
-}
-
-func (r *Reconciler) updateIfNeededClusterAgentClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (reconcile.Result, error) {
-	info := roleBindingInfo{
-		name:               name,
-		roleName:           getClusterAgentRbacResourcesName(dda),
-		serviceAccountName: getClusterAgentServiceAccount(dda),
-	}
-	newRoleBinding := buildClusterRoleBinding(dda, info, agentVersion)
-	return r.updateIfNeededClusterRoleBindingRaw(logger, dda, clusterRoleBinding, newRoleBinding)
 }
 
 // buildAgentClusterRole creates a ClusterRole object for the Agent based on its config

--- a/controllers/datadogagent/clusteragent_metricsserver.go
+++ b/controllers/datadogagent/clusteragent_metricsserver.go
@@ -87,6 +87,16 @@ func (r *Reconciler) createExternalMetricsReaderClusterRoleBinding(logger logr.L
 	return reconcile.Result{Requeue: true}, r.client.Create(context.TODO(), clusterRoleBinding)
 }
 
+func (r *Reconciler) updateIfNeededExternalMetricsReaderClusterRoleBinding(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string, clusterRoleBinding *rbacv1.ClusterRoleBinding) (reconcile.Result, error) {
+	newClusterRoleBinding := buildExternalMetricsReaderClusterRoleBinding(dda, name, agentVersion)
+
+	if newClusterRoleBinding == nil {
+		return reconcile.Result{}, nil
+	}
+
+	return r.updateIfNeededClusterRoleBindingRaw(logger, dda, clusterRoleBinding, newClusterRoleBinding)
+}
+
 func (r *Reconciler) createExternalMetricsReaderClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) (reconcile.Result, error) {
 	clusterRole := buildExternalMetricsReaderClusterRole(dda, name, agentVersion)
 	if clusterRole == nil {


### PR DESCRIPTION
### What does this PR do?

Fixes the cluster role binding that we create to give permissions to the HPA to read external metrics.

The problem was that when reconciling the cluster role binding we were providing a wrong "update if needed" function that was meant to be used to reconcile a different cluster role binding.

As a result, HPA objects reported errors related with not being able to read "external.metrics.k8s.io" objects. Like this one:
```
Warning  FailedGetExternalMetric       3m2s (x201 over 53m)  horizontal-pod-autoscaler  unable to get external metric ecommerce/datadogmetric@ecommerce:frontend-hits/nil: unable to fetch metrics from external metrics API: datadogmetric@ecommerce:frontend-hits.external.metrics.k8s.io is forbidden: User "system:serviceaccount:kube-system:horizontal-pod-autoscaler" cannot list resource "datadogmetric@ecommerce:frontend-hits" in API group "external.metrics.k8s.io" in the namespace "ecommerce"

```

### Describe your test plan

Deploy with external metrics enabled:
```  
clusterAgent:
    config:
      externalMetrics:
        enabled: true
        useDatadogMetrics: true
```

Create a datadogmetric object and an HPA that references it. Check that the HPA object does not report any errors like the one pasted above.
