### PR TITLE
feat: update Agent to 7.34.0 and DCA to 1.18.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.33.0"
+	AgentLatestVersion = "7.34.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "1.17.0"
+	ClusterAgentLatestVersion = "1.18.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

* Update default Datadog Agent image to `7.34.0`
* Update default Datadog Cluster Agent image to `1.18.0`

### Motivation

The Operator should deploy the latest Agent and Cluster-Agent version.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy a DatadogAgent from the examples folder without setting the Agent
or the Cluster-Agent. 

#### expected result

Agent image `7.34.0` and Cluster-Agent `1.18.0` should be used.

