### PR TITLE
[docs/openshift] Fix example config

### DIFF
--- a/docs/install-openshift.md
+++ b/docs/install-openshift.md
@@ -49,22 +49,22 @@ The following contains the simplest configuration:
        appSecret:
          secretName: datadog-secret
          keyName: app-key
-      agent:
-        rbac:
-          serviceAccountName: datadog-agent-scc
-        config:
-          securityContext:
-            runAsUser: 0
-            seLinuxOptions:
-              level: s0
-              role: system_r
-              type: spc_t
-              user: system_u
-          criSocket:
-            criSocketPath: /var/run/crio/crio.sock
-          env:
-          - name: DD_KUBELET_TLS_VERIFY
-            value: "false"
+     agent:
+       rbac:
+         serviceAccountName: datadog-agent-scc
+       config:
+         securityContext:
+           runAsUser: 0
+           seLinuxOptions:
+             level: s0
+             role: system_r
+             type: spc_t
+             user: system_u
+         criSocket:
+           criSocketPath: /var/run/crio/crio.sock
+         env:
+         - name: DD_KUBELET_TLS_VERIFY
+           value: "false"
    ```
 
 3. Deploy the Datadog Agent with the configuration file above:


### PR DESCRIPTION
### What does this PR do?

The example config shown in `docs/install-openshift.md` has bad indentation and gives an error when deploying it. This PR fixes the issue.

### Describe your test plan

Run `kubectl apply -f` with the new config and check that there are no errors.
