### PR TITLE
Fix DatadogAgent secret backend usage

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -118,7 +118,6 @@ type AgentCredentials struct {
 
 	// UseSecretBackend use the Agent secret backend feature for retreiving all credentials needed by
 	// the different components: Agent, Cluster, Cluster-Checks.
-	// If `useSecretBackend: true`, other credential parameters will be ignored.
 	// default value is false.
 	UseSecretBackend *bool `json:"useSecretBackend,omitempty"`
 }

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -317,7 +317,7 @@ func schema__apis_datadoghq_v1alpha1_AgentCredentials(ref common.ReferenceCallba
 					},
 					"useSecretBackend": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UseSecretBackend use the Agent secret backend feature for retreiving all credentials needed by the different components: Agent, Cluster, Cluster-Checks. If `useSecretBackend: true`, other credential parameters will be ignored. default value is false.",
+							Description: "UseSecretBackend use the Agent secret backend feature for retreiving all credentials needed by the different components: Agent, Cluster, Cluster-Checks. default value is false.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -11897,9 +11897,7 @@ spec:
                   useSecretBackend:
                     description: 'UseSecretBackend use the Agent secret backend feature
                       for retreiving all credentials needed by the different components:
-                      Agent, Cluster, Cluster-Checks. If `useSecretBackend: true`,
-                      other credential parameters will be ignored. default value is
-                      false.'
+                      Agent, Cluster, Cluster-Checks. default value is false.'
                     type: boolean
                 type: object
               features:

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -11484,8 +11484,7 @@ spec:
                 useSecretBackend:
                   description: 'UseSecretBackend use the Agent secret backend feature
                     for retreiving all credentials needed by the different components:
-                    Agent, Cluster, Cluster-Checks. If `useSecretBackend: true`, other
-                    credential parameters will be ignored. default value is false.'
+                    Agent, Cluster, Cluster-Checks. default value is false.'
                   type: boolean
               type: object
             features:

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -35,7 +35,7 @@ import (
 )
 
 func (r *Reconciler) reconcileAgent(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageAgentDependencies(logger, dda, newStatus)
+	result, err := r.manageAgentDependencies(logger, dda)
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}
@@ -270,8 +270,8 @@ func (r *Reconciler) updateDaemonSet(logger logr.Logger, dda *datadoghqv1alpha1.
 	return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
 }
 
-func (r *Reconciler) manageAgentDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageAgentSecret(logger, dda, newStatus)
+func (r *Reconciler) manageAgentDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
+	result, err := r.manageAgentSecret(logger, dda)
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -36,7 +36,7 @@ import (
 )
 
 func (r *Reconciler) reconcileClusterAgent(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageClusterAgentDependencies(logger, dda, newStatus)
+	result, err := r.manageClusterAgentDependencies(logger, dda)
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}
@@ -191,13 +191,13 @@ func newClusterAgentDeploymentFromInstance(logger logr.Logger, dda *datadoghqv1a
 	return dca, hash, err
 }
 
-func (r *Reconciler) manageClusterAgentDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageAgentSecret(logger, dda, newStatus)
+func (r *Reconciler) manageClusterAgentDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
+	result, err := r.manageAgentSecret(logger, dda)
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}
 
-	result, err = r.manageExternalMetricsSecret(logger, dda, newStatus)
+	result, err = r.manageExternalMetricsSecret(logger, dda)
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -31,7 +31,6 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
-	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
 func (r *Reconciler) reconcileClusterChecksRunner(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
@@ -411,33 +410,15 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 		},
 	}
 
-	// This triggers use of the secret backend.
-	// Otherwise, read from the default or configured secret
-	if secrets.IsEnc(dda.Spec.Credentials.DatadogCredentials.APIKey) {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  datadoghqv1alpha1.DDAPIKey,
-			Value: dda.Spec.Credentials.DatadogCredentials.APIKey,
-		})
-	} else {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:      datadoghqv1alpha1.DDAPIKey,
-			ValueFrom: getAPIKeyFromSecret(dda),
-		})
-	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name:      datadoghqv1alpha1.DDAPIKey,
+		ValueFrom: getAPIKeyFromSecret(dda),
+	})
 
-	// This triggers use of the secret backend.
-	// Otherwise, read from the default or configured secret
-	if secrets.IsEnc(dda.Spec.Credentials.Token) {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  datadoghqv1alpha1.DDClusterAgentAuthToken,
-			Value: dda.Spec.Credentials.Token,
-		})
-	} else {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
-			ValueFrom: getClusterAgentAuthToken(dda),
-		})
-	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
+		ValueFrom: getClusterAgentAuthToken(dda),
+	})
 
 	if spec.ClusterName != "" {
 		envVars = append(envVars, corev1.EnvVar{

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -35,7 +35,7 @@ import (
 )
 
 func (r *Reconciler) reconcileClusterChecksRunner(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageClusterChecksRunnerDependencies(logger, dda, newStatus)
+	result, err := r.manageClusterChecksRunnerDependencies(logger, dda)
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}
@@ -198,8 +198,8 @@ func newClusterChecksRunnerDeploymentFromInstance(
 	return dca, hash, err
 }
 
-func (r *Reconciler) manageClusterChecksRunnerDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	result, err := r.manageAgentSecret(logger, dda, newStatus)
+func (r *Reconciler) manageClusterChecksRunnerDependencies(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
+	result, err := r.manageAgentSecret(logger, dda)
 	if utils.ShouldReturn(result, err) {
 		return result, err
 	}

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
 func (r *Reconciler) reconcileClusterChecksRunner(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
@@ -341,10 +342,6 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 	spec := &dda.Spec
 	envVars := []corev1.EnvVar{
 		{
-			Name:      datadoghqv1alpha1.DDAPIKey,
-			ValueFrom: getAPIKeyFromSecret(dda),
-		},
-		{
 			Name:  datadoghqv1alpha1.DDClusterChecksEnabled,
 			Value: "true",
 		},
@@ -355,10 +352,6 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 		{
 			Name:  datadoghqv1alpha1.DDClusterAgentKubeServiceName,
 			Value: getClusterAgentServiceName(dda),
-		},
-		{
-			Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
-			ValueFrom: getClusterAgentAuthToken(dda),
 		},
 		{
 			Name:  datadoghqv1alpha1.DDExtraConfigProviders,
@@ -416,6 +409,34 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 				},
 			},
 		},
+	}
+
+	// This triggers use of the secret backend.
+	// Otherwise, read from the default or configured secret
+	if secrets.IsEnc(dda.Spec.Credentials.DatadogCredentials.APIKey) {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDAPIKey,
+			Value: dda.Spec.Credentials.DatadogCredentials.APIKey,
+		})
+	} else {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:      datadoghqv1alpha1.DDAPIKey,
+			ValueFrom: getAPIKeyFromSecret(dda),
+		})
+	}
+
+	// This triggers use of the secret backend.
+	// Otherwise, read from the default or configured secret
+	if secrets.IsEnc(dda.Spec.Credentials.Token) {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  datadoghqv1alpha1.DDClusterAgentAuthToken,
+			Value: dda.Spec.Credentials.Token,
+		})
+	} else {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
+			ValueFrom: getClusterAgentAuthToken(dda),
+		})
 	}
 
 	if spec.ClusterName != "" {

--- a/controllers/datadogagent/secret.go
+++ b/controllers/datadogagent/secret.go
@@ -124,16 +124,3 @@ func (r *Reconciler) cleanupSecret(namespace, name string, dda *datadoghqv1alpha
 
 	return reconcile.Result{}, err
 }
-
-func dataFromCredentials(credentials *datadoghqv1alpha1.DatadogCredentials) map[string][]byte {
-	data := make(map[string][]byte)
-	// Create secret using DatadogAgent credentials if it exists
-	if credentials.APIKey != "" {
-		data[datadoghqv1alpha1.DefaultAPIKeyKey] = []byte(credentials.APIKey)
-	}
-	if credentials.AppKey != "" {
-		data[datadoghqv1alpha1.DefaultAPPKeyKey] = []byte(credentials.AppKey)
-	}
-
-	return data
-}

--- a/controllers/datadogagent/secret_agent.go
+++ b/controllers/datadogagent/secret_agent.go
@@ -18,11 +18,11 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
-func (r *Reconciler) manageAgentSecret(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	return r.manageSecret(logger, managedSecret{name: utils.GetDefaultCredentialsSecretName(dda), requireFunc: needAgentSecret, createFunc: newAgentSecret}, dda, newStatus)
+func (r *Reconciler) manageAgentSecret(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
+	return r.manageSecret(logger, managedSecret{name: utils.GetDefaultCredentialsSecretName(dda), requireFunc: needAgentSecret, createFunc: newAgentSecret}, dda)
 }
 
-func newAgentSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Secret, error) {
+func newAgentSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) *corev1.Secret {
 	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
 	annotations := getDefaultAnnotations(dda)
 
@@ -48,12 +48,12 @@ func newAgentSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) (*corev1.S
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
 	}
-	return secret, nil
+	return secret
 }
 
 // needAgentSecret checks if a secret should be used or created.
 func needAgentSecret(dda *datadoghqv1alpha1.DatadogAgent) bool {
-	// If credentials are not specified, there is nothing to create a secret from.
+	// If credentials is nil, there is nothing to create a secret from.
 	if dda.Spec.Credentials == nil {
 		return false
 	}

--- a/controllers/datadogagent/secret_clusteragent.go
+++ b/controllers/datadogagent/secret_clusteragent.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
-	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 )
 
 func (r *Reconciler) manageExternalMetricsSecret(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
@@ -51,8 +50,8 @@ func needExternalMetricsSecret(dda *datadoghqv1alpha1.DatadogAgent) bool {
 	}
 
 	// If API key and app key don't need a new secret, then don't create one.
-	if checkAPIKeySufficiency(dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials, apiutils.BoolValue(dda.Spec.Credentials.UseSecretBackend), datadoghqv1alpha1.DDExternalMetricsProviderAPIKey) &&
-		checkAppKeySufficiency(dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials, apiutils.BoolValue(dda.Spec.Credentials.UseSecretBackend), datadoghqv1alpha1.DDExternalMetricsProviderAPIKey) {
+	if checkAPIKeySufficiency(dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials, datadoghqv1alpha1.DDExternalMetricsProviderAPIKey) &&
+		checkAppKeySufficiency(dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials, datadoghqv1alpha1.DDExternalMetricsProviderAPIKey) {
 		return false
 	}
 

--- a/controllers/datadogagent/secret_clusteragent.go
+++ b/controllers/datadogagent/secret_clusteragent.go
@@ -17,11 +17,11 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 )
 
-func (r *Reconciler) manageExternalMetricsSecret(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	return r.manageSecret(logger, managedSecret{name: getDefaultExternalMetricSecretName(dda), requireFunc: needExternalMetricsSecret, createFunc: newExternalMetricsSecret}, dda, newStatus)
+func (r *Reconciler) manageExternalMetricsSecret(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
+	return r.manageSecret(logger, managedSecret{name: getDefaultExternalMetricSecretName(dda), requireFunc: needExternalMetricsSecret, createFunc: newExternalMetricsSecret}, dda)
 }
 
-func newExternalMetricsSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) (*corev1.Secret, error) {
+func newExternalMetricsSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) *corev1.Secret {
 	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, getClusterAgentVersion(dda))
 	annotations := getDefaultAnnotations(dda)
 
@@ -36,7 +36,7 @@ func newExternalMetricsSecret(name string, dda *datadoghqv1alpha1.DatadogAgent) 
 		Data: getKeysFromCredentials(dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials),
 	}
 
-	return secret, nil
+	return secret
 }
 
 func needExternalMetricsSecret(dda *datadoghqv1alpha1.DatadogAgent) bool {

--- a/controllers/datadogagent/secret_common.go
+++ b/controllers/datadogagent/secret_common.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagent
+
+import (
+	"os"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/pkg/secrets"
+)
+
+// getKeysFromCredentials returns any key data that need to be stored in a new secret
+func getKeysFromCredentials(credentials *datadoghqv1alpha1.DatadogCredentials) map[string][]byte {
+	data := make(map[string][]byte)
+	// Create secret using DatadogAgent credentials if it exists
+	if credentials.APIKey != "" && !secrets.IsEnc(credentials.APIKey) {
+		data[datadoghqv1alpha1.DefaultAPIKeyKey] = []byte(credentials.APIKey)
+	}
+	if credentials.AppKey != "" && !secrets.IsEnc(credentials.AppKey) {
+		data[datadoghqv1alpha1.DefaultAPPKeyKey] = []byte(credentials.AppKey)
+	}
+
+	return data
+}
+
+// For each of the API key and app key, check if:
+// 1. an existing secret is defined, or
+// 2. the secret backend should be used (from the credentials key), or
+// 3. the corresponding env var is defined (whether in ENC format or not)
+// If any of these is true, the secret is not needed for that particular key.
+func checkAPIKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVar string) bool {
+	return ((creds.APISecret != nil && creds.APISecret.SecretName != "") ||
+		creds.APIKeyExistingSecret != "" ||
+		(secrets.IsEnc(creds.APIKey) && useSecretBackend) ||
+		os.Getenv(envVar) != "")
+}
+
+func checkAppKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVar string) bool {
+	return ((creds.APPSecret != nil && creds.APPSecret.SecretName != "") ||
+		creds.AppKeyExistingSecret != "" ||
+		(secrets.IsEnc(creds.AppKey) && useSecretBackend) ||
+		os.Getenv(envVar) != "")
+}
+
+// Check if the token should come from the secret backend.
+// If so, the secret is not needed for the token.
+func checkTokenSufficiency(creds *datadoghqv1alpha1.AgentCredentials) bool {
+	return secrets.IsEnc(creds.Token) && apiutils.BoolValue(creds.UseSecretBackend)
+}

--- a/controllers/datadogagent/secret_common.go
+++ b/controllers/datadogagent/secret_common.go
@@ -9,18 +9,16 @@ import (
 	"os"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
-	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
 // getKeysFromCredentials returns any key data that need to be stored in a new secret
 func getKeysFromCredentials(credentials *datadoghqv1alpha1.DatadogCredentials) map[string][]byte {
 	data := make(map[string][]byte)
 	// Create secret using DatadogAgent credentials if it exists
-	if credentials.APIKey != "" && !secrets.IsEnc(credentials.APIKey) {
+	if credentials.APIKey != "" {
 		data[datadoghqv1alpha1.DefaultAPIKeyKey] = []byte(credentials.APIKey)
 	}
-	if credentials.AppKey != "" && !secrets.IsEnc(credentials.AppKey) {
+	if credentials.AppKey != "" {
 		data[datadoghqv1alpha1.DefaultAPPKeyKey] = []byte(credentials.AppKey)
 	}
 
@@ -29,25 +27,16 @@ func getKeysFromCredentials(credentials *datadoghqv1alpha1.DatadogCredentials) m
 
 // For each of the API key and app key, check if:
 // 1. an existing secret is defined, or
-// 2. the secret backend should be used (from the credentials key), or
-// 3. the corresponding env var is defined (whether in ENC format or not)
-// If any of these is true, the secret is not needed for that particular key.
-func checkAPIKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVarName string) bool {
+// 2. the corresponding env var is defined (whether in ENC format or not)
+// If either of these is true, the secret is not needed for that particular key.
+func checkAPIKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, envVarName string) bool {
 	return ((creds.APISecret != nil && creds.APISecret.SecretName != "") ||
 		creds.APIKeyExistingSecret != "" ||
-		(secrets.IsEnc(creds.APIKey) && useSecretBackend) ||
 		os.Getenv(envVarName) != "")
 }
 
-func checkAppKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVarName string) bool {
+func checkAppKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, envVarName string) bool {
 	return ((creds.APPSecret != nil && creds.APPSecret.SecretName != "") ||
 		creds.AppKeyExistingSecret != "" ||
-		(secrets.IsEnc(creds.AppKey) && useSecretBackend) ||
 		os.Getenv(envVarName) != "")
-}
-
-// Check if the token should come from the secret backend.
-// If so, the secret is not needed for the token.
-func checkTokenSufficiency(creds *datadoghqv1alpha1.AgentCredentials) bool {
-	return secrets.IsEnc(creds.Token) && apiutils.BoolValue(creds.UseSecretBackend)
 }

--- a/controllers/datadogagent/secret_common.go
+++ b/controllers/datadogagent/secret_common.go
@@ -32,18 +32,18 @@ func getKeysFromCredentials(credentials *datadoghqv1alpha1.DatadogCredentials) m
 // 2. the secret backend should be used (from the credentials key), or
 // 3. the corresponding env var is defined (whether in ENC format or not)
 // If any of these is true, the secret is not needed for that particular key.
-func checkAPIKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVar string) bool {
+func checkAPIKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVarName string) bool {
 	return ((creds.APISecret != nil && creds.APISecret.SecretName != "") ||
 		creds.APIKeyExistingSecret != "" ||
 		(secrets.IsEnc(creds.APIKey) && useSecretBackend) ||
-		os.Getenv(envVar) != "")
+		os.Getenv(envVarName) != "")
 }
 
-func checkAppKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVar string) bool {
+func checkAppKeySufficiency(creds *datadoghqv1alpha1.DatadogCredentials, useSecretBackend bool, envVarName string) bool {
 	return ((creds.APPSecret != nil && creds.APPSecret.SecretName != "") ||
 		creds.AppKeyExistingSecret != "" ||
 		(secrets.IsEnc(creds.AppKey) && useSecretBackend) ||
-		os.Getenv(envVar) != "")
+		os.Getenv(envVarName) != "")
 }
 
 // Check if the token should come from the secret backend.

--- a/controllers/datadogagent/secret_test.go
+++ b/controllers/datadogagent/secret_test.go
@@ -7,94 +7,554 @@ package datadogagent
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/testutils"
-	"github.com/DataDog/datadog-operator/pkg/config"
 )
 
-// TestNewAgentSecret that the credentials are stored in the secret in an expected hierarchy
-func TestNewAgentSecret(t *testing.T) {
-	options := &testutils.NewDatadogAgentOptions{}
+// Test_newAgentSecret tests that the credentials are stored in the secret in an expected hierarchy
+func Test_newAgentSecret(t *testing.T) {
 
 	type fields struct {
-		DatadogAgentAPIKey string
-		DatadogAgentAppKey string
-		APIKeyEnvVar       string
-		AppKeyEnvVar       string
+		APIKey string
+		appKey string
+		token  string
 	}
 	tests := []struct {
-		name         string
-		apiKeyEnvVar string
-		appKeyEnvVar string
-		fields       fields
-		wantAPIKey   string
-		wantAppKey   string
-		wantErr      bool
+		name       string
+		fields     fields
+		wantAPIKey string
+		wantAppKey string
+		wantToken  string
 	}{
 		{
-			name: "API and App keys are set in the DatadogAgent",
+			name: "API key, App key, and token are set",
 			fields: fields{
-				DatadogAgentAPIKey: "adflkajdflkjalkcmlkdjacsf",
-				DatadogAgentAppKey: "sgfggtdhfghfghfghfgbdfdgs",
+				APIKey: "adflkajdflkjalkcmlkdjacsf",
+				appKey: "sgfggtdhfghfghfghfgbdfdgs",
+				token:  "iamamoderatelylongtoken",
 			},
 			wantAPIKey: "adflkajdflkjalkcmlkdjacsf",
 			wantAppKey: "sgfggtdhfghfghfghfgbdfdgs",
+			wantToken:  "iamamoderatelylongtoken",
 		},
 		{
-			name: "API and App keys are empty in the DatadogAgent, but present in EnvVar",
+			name: "API and App keys are empty, token is set",
 			fields: fields{
-				DatadogAgentAPIKey: "",
-				DatadogAgentAppKey: "",
-			},
-			apiKeyEnvVar: "adflkajdflkjalkcmlkdjacsf",
-			appKeyEnvVar: "sgfggtdhfghfghfghfgbdfdgs",
-			wantAPIKey:   "",
-			wantAppKey:   "",
-		},
-		{
-			name: "API and App keys are empty in the DatadogAgent, returns error",
-			fields: fields{
-				DatadogAgentAPIKey: "",
-				DatadogAgentAppKey: "",
+				APIKey: "",
+				appKey: "",
+				token:  "iamamoderatelylongtoken",
 			},
 			wantAPIKey: "",
 			wantAppKey: "",
-			wantErr:    true,
+			wantToken:  "iamamoderatelylongtoken",
+		},
+		{
+			name: "API and App keys are set, token is empty",
+			fields: fields{
+				APIKey: "adflkajdflkjalkcmlkdjacsf",
+				appKey: "sgfggtdhfghfghfghfgbdfdgs",
+				token:  "",
+			},
+			wantAPIKey: "adflkajdflkjalkcmlkdjacsf",
+			wantAppKey: "sgfggtdhfghfghfghfgbdfdgs",
+			wantToken:  "<GENERATED>", // indicates token is randomly generated
+		},
+		{
+			name: "API key, App key and token use secret backend",
+			fields: fields{
+				APIKey: "ENC[api_key]",
+				appKey: "ENC[app_key]",
+				token:  "ENC[token]",
+			},
+			wantAPIKey: "",
+			wantAppKey: "",
+			wantToken:  "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(config.DDAPIKeyEnvVar, tt.apiKeyEnvVar)
-			os.Setenv(config.DDAppKeyEnvVar, tt.appKeyEnvVar)
 
-			options.APIKey = tt.fields.DatadogAgentAPIKey
-			options.AppKey = tt.fields.DatadogAgentAppKey
+			options := &testutils.NewDatadogAgentOptions{
+				APIKey: tt.fields.APIKey,
+				AppKey: tt.fields.appKey,
+				Token:  tt.fields.token,
+			}
+
 			dda := testutils.NewDatadogAgent("default", "test", "datadog/agent:7.24.1", options)
+			// Generate token if needed
+			dso := datadoghqv1alpha1.DefaultDatadogAgent(dda)
+			dda.Status = *dso
 
-			result, err := newAgentSecret("foo", dda)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("newAgentSecret() should return have been returned an error")
+			result := newAgentSecret("foo", dda)
+
+			if val, ok := result.Data[datadoghqv1alpha1.DefaultAPIKeyKey]; ok {
+				if string(val) != tt.wantAPIKey {
+					t.Errorf("newAgentSecret() API key = %v, want %v", string(result.Data[datadoghqv1alpha1.DefaultAPIKeyKey]), tt.wantAPIKey)
 				}
 			} else {
-				if err != nil {
-					t.Errorf("newAgentSecret() unexpected error, failed with err: %v", err)
-				}
-
-				if len(result.Data) > 0 {
-					if string(result.Data[datadoghqv1alpha1.DefaultAPIKeyKey]) != tt.wantAPIKey {
-						t.Errorf("newAgentSecret() API key = %v, want %v", string(result.Data[datadoghqv1alpha1.DefaultAPIKeyKey]), tt.wantAPIKey)
-					}
-					if string(result.Data[datadoghqv1alpha1.DefaultAPPKeyKey]) != tt.wantAppKey {
-						t.Errorf("newAgentSecret() App key = %v, want %v", string(result.Data[datadoghqv1alpha1.DefaultAPPKeyKey]), tt.wantAppKey)
-					}
+				if tt.wantAPIKey != "" {
+					t.Errorf("newAgentSecret() API key is empty but want %v", tt.wantAPIKey)
 				}
 			}
 
-			os.Unsetenv(tt.fields.APIKeyEnvVar)
-			os.Unsetenv(tt.fields.AppKeyEnvVar)
+			if val, ok := result.Data[datadoghqv1alpha1.DefaultAPPKeyKey]; ok {
+				if string(val) != tt.wantAppKey {
+					t.Errorf("newAgentSecret() App key = %v, want %v", string(result.Data[datadoghqv1alpha1.DefaultAPPKeyKey]), tt.wantAPIKey)
+				}
+			} else {
+				if tt.wantAppKey != "" {
+					t.Errorf("newAgentSecret() App key is empty but want %v", tt.wantAppKey)
+				}
+			}
+
+			if val, ok := result.Data[datadoghqv1alpha1.DefaultTokenKey]; ok {
+				if string(val) != tt.wantToken && tt.wantToken != "<GENERATED>" {
+					t.Errorf("newAgentSecret() token key = %v, want %v", string(result.Data[datadoghqv1alpha1.DefaultTokenKey]), tt.wantAPIKey)
+				}
+			} else {
+				if tt.wantToken != "" {
+					t.Errorf("newAgentSecret() token key is empty but want %v", tt.wantToken)
+				}
+			}
+		})
+	}
+}
+
+func Test_needAgentSecret(t *testing.T) {
+
+	type fields struct {
+		APIKey           string
+		appKey           string
+		token            string
+		useSecretBackend bool
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		nilCredentials bool
+		want           bool
+	}{
+		{
+			name: "API key, App key, and token are set",
+			fields: fields{
+				APIKey: "adflkajdflkjalkcmlkdjacsf",
+				appKey: "sgfggtdhfghfghfghfgbdfdgs",
+				token:  "iamamoderatelylongtoken",
+			},
+			want: true,
+		},
+		{
+			name: "API key, App key, and token use secret backend",
+			fields: fields{
+				APIKey:           "ENC[api_key]",
+				appKey:           "ENC[app_key]",
+				token:            "ENC[token]",
+				useSecretBackend: true,
+			},
+			want: false,
+		},
+		{
+			name:           "Nil credentials",
+			nilCredentials: true,
+			fields: fields{
+				APIKey: "",
+				appKey: "",
+				token:  "",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			options := &testutils.NewDatadogAgentOptions{
+				APIKey:           tt.fields.APIKey,
+				AppKey:           tt.fields.appKey,
+				Token:            tt.fields.token,
+				UseSecretBackend: tt.fields.useSecretBackend,
+			}
+
+			dda := testutils.NewDatadogAgent("default", "test", "datadog/agent:7.24.1", options)
+
+			// Generate token if needed
+			dso := datadoghqv1alpha1.DefaultDatadogAgent(dda)
+			dda.Status = *dso
+
+			// For the case to check if Credetials are nil; need this because NewDatadogAgent always defines credentials
+			if tt.nilCredentials {
+				dda.Spec.Credentials = nil
+			}
+
+			result := needAgentSecret(dda)
+			if tt.want != result {
+				t.Errorf("needAgentSecret() result is %v but want %v", result, tt.want)
+			}
+		})
+	}
+
+}
+
+func Test_newExternalMetricsSecret(t *testing.T) {
+
+	name := "test-external-metrics"
+	ns := "default"
+	dda := testutils.NewDatadogAgent(ns, name, "datadog/agent:7.24.1", &testutils.NewDatadogAgentOptions{})
+	dda.Spec.ClusterAgent.Config.ExternalMetrics = &datadoghqv1alpha1.ExternalMetricsConfig{
+		Enabled: apiutils.NewBoolPointer(true),
+		Credentials: &datadoghqv1alpha1.DatadogCredentials{
+			APIKey: "adflkajdflkjalkcmlkdjacsf",
+			AppKey: "sgfggtdhfghfghfghfgbdfdgs",
+		},
+	}
+	result := newExternalMetricsSecret(name, dda)
+
+	labels := getDefaultLabels(dda, datadoghqv1alpha1.DefaultClusterAgentResourceSuffix, "")
+	wantSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Labels:      labels,
+			Annotations: map[string]string{},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: getKeysFromCredentials(dda.Spec.ClusterAgent.Config.ExternalMetrics.Credentials),
+	}
+
+	if !reflect.DeepEqual(result, wantSecret) {
+		t.Errorf("newExternalMetricsSecret() result is %v but want %v", result, wantSecret)
+	}
+}
+
+func Test_needExternalMetricsSecret(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		clusterAgentSpec datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec
+		want             bool
+	}{
+		{
+			name: "cluster agent is not enabled",
+			clusterAgentSpec: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: apiutils.NewBoolPointer(false),
+			},
+			want: false,
+		},
+		{
+			name: "cluster agent config is nil",
+			clusterAgentSpec: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: apiutils.NewBoolPointer(true),
+				Config:  nil,
+			},
+			want: false,
+		},
+		{
+			name: "external metrics config is nil",
+			clusterAgentSpec: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: apiutils.NewBoolPointer(true),
+				Config: &datadoghqv1alpha1.ClusterAgentConfig{
+					ExternalMetrics: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "external metrics config is not enabled",
+			clusterAgentSpec: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: apiutils.NewBoolPointer(true),
+				Config: &datadoghqv1alpha1.ClusterAgentConfig{
+					ExternalMetrics: &datadoghqv1alpha1.ExternalMetricsConfig{
+						Enabled: apiutils.NewBoolPointer(false),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "external metrics config credentials is nil",
+			clusterAgentSpec: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: apiutils.NewBoolPointer(true),
+				Config: &datadoghqv1alpha1.ClusterAgentConfig{
+					ExternalMetrics: &datadoghqv1alpha1.ExternalMetricsConfig{
+						Enabled:     apiutils.NewBoolPointer(true),
+						Credentials: nil,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "external metrics config credentials API and app keys are empty",
+			clusterAgentSpec: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: apiutils.NewBoolPointer(true),
+				Config: &datadoghqv1alpha1.ClusterAgentConfig{
+					ExternalMetrics: &datadoghqv1alpha1.ExternalMetricsConfig{
+						Enabled: apiutils.NewBoolPointer(true),
+						Credentials: &datadoghqv1alpha1.DatadogCredentials{
+							APIKey: "",
+							AppKey: "",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "external metrics config credentials API and app keys are set",
+			clusterAgentSpec: datadoghqv1alpha1.DatadogAgentSpecClusterAgentSpec{
+				Enabled: apiutils.NewBoolPointer(true),
+				Config: &datadoghqv1alpha1.ClusterAgentConfig{
+					ExternalMetrics: &datadoghqv1alpha1.ExternalMetricsConfig{
+						Enabled: apiutils.NewBoolPointer(true),
+						Credentials: &datadoghqv1alpha1.DatadogCredentials{
+							APIKey: "adflkajdflkjalkcmlkdjacsf",
+							AppKey: "sgfggtdhfghfghfghfgbdfdgs",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := "test-external-metrics"
+			ns := "default"
+			dda := testutils.NewDatadogAgent(ns, name, "datadog/agent:7.24.1", &testutils.NewDatadogAgentOptions{})
+			dda.Spec.ClusterAgent = tt.clusterAgentSpec
+			result := needExternalMetricsSecret(dda)
+			if result != tt.want {
+				t.Errorf("needExternalMetricsSecret() result is %v but want %v", result, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getKeysFromCredentials(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		APIKey   string
+		appKey   string
+		wantFunc func() map[string][]byte
+	}{
+		{
+			name:     "API and app keys are empty",
+			APIKey:   "",
+			appKey:   "",
+			wantFunc: func() map[string][]byte { return map[string][]byte{} },
+		},
+		{
+			name:     "API and app keys are formatted for the secret backend",
+			APIKey:   "ENC[api_key]",
+			appKey:   "ENC[app_key]",
+			wantFunc: func() map[string][]byte { return map[string][]byte{} },
+		},
+		{
+			name:   "API and app keys are set",
+			APIKey: "adflkajdflkjalkcmlkdjacsf",
+			appKey: "sgfggtdhfghfghfghfgbdfdgs",
+			wantFunc: func() map[string][]byte {
+				wantMap := make(map[string][]byte)
+				wantMap[datadoghqv1alpha1.DefaultAPIKeyKey] = []byte("adflkajdflkjalkcmlkdjacsf")
+				wantMap[datadoghqv1alpha1.DefaultAPPKeyKey] = []byte("sgfggtdhfghfghfghfgbdfdgs")
+				return wantMap
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds := &datadoghqv1alpha1.DatadogCredentials{
+				APIKey: tt.APIKey,
+				AppKey: tt.appKey,
+			}
+			result := getKeysFromCredentials(creds)
+			wantMap := tt.wantFunc()
+			if !reflect.DeepEqual(result, wantMap) {
+				t.Errorf("getKeysFromCredentials() result is %v but want %v", result, wantMap)
+			}
+		})
+	}
+}
+
+func Test_checkAPIKeySufficiency(t *testing.T) {
+	apiKeyValue := "adflkajdflkjalkcmlkdjacsf"
+
+	tests := []struct {
+		name             string
+		credentials      *datadoghqv1alpha1.DatadogCredentials
+		useSecretBackend bool
+		envVarName       string
+		want             bool
+	}{
+		{
+			name: "APISecret is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				APISecret: &datadoghqv1alpha1.Secret{
+					SecretName: "test-secret",
+					KeyName:    "api_key",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "APIKeyExistingSecret is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				APIKeyExistingSecret: "test-secret",
+			},
+			want: true,
+		},
+		{
+			name: "secret backend is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				APIKey: "ENC[api_key]",
+			},
+			useSecretBackend: true,
+			want:             true,
+		},
+		{
+			name:        "envvar is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{},
+			envVarName:  "DD_API_KEY",
+			want:        true,
+		},
+		{
+			name: "envvar is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				APIKey: apiKeyValue,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVarName != "" {
+				os.Setenv(tt.envVarName, apiKeyValue)
+			}
+			result := checkAPIKeySufficiency(tt.credentials, tt.useSecretBackend, tt.envVarName)
+			if result != tt.want {
+				t.Errorf("checkAPIKeySufficiency() result is %v but want %v", result, tt.want)
+			}
+			if tt.envVarName != "" {
+				os.Unsetenv(tt.envVarName)
+			}
+		})
+	}
+}
+
+func Test_checkAppKeySufficiency(t *testing.T) {
+	appKeyValue := "sgfggtdhfghfghfghfgbdfdgs"
+
+	tests := []struct {
+		name             string
+		credentials      *datadoghqv1alpha1.DatadogCredentials
+		useSecretBackend bool
+		envVarName       string
+		want             bool
+	}{
+		{
+			name: "APPSecret is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				APPSecret: &datadoghqv1alpha1.Secret{
+					SecretName: "test-secret",
+					KeyName:    "app_key",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "AppKeyExistingSecret is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				AppKeyExistingSecret: "test-secret",
+			},
+			want: true,
+		},
+		{
+			name: "secret backend is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				AppKey: "ENC[api_key]",
+			},
+			useSecretBackend: true,
+			want:             true,
+		},
+		{
+			name:        "envvar is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{},
+			envVarName:  "DD_APP_KEY",
+			want:        true,
+		},
+		{
+			name: "envvar is used",
+			credentials: &datadoghqv1alpha1.DatadogCredentials{
+				AppKey: appKeyValue,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVarName != "" {
+				os.Setenv(tt.envVarName, appKeyValue)
+			}
+			result := checkAppKeySufficiency(tt.credentials, tt.useSecretBackend, tt.envVarName)
+			if result != tt.want {
+				t.Errorf("checkAppKeySufficiency() result is %v but want %v", result, tt.want)
+			}
+			if tt.envVarName != "" {
+				os.Unsetenv(tt.envVarName)
+			}
+		})
+	}
+}
+
+func Test_checkTokenSufficiency(t *testing.T) {
+	tests := []struct {
+		name        string
+		credentials *datadoghqv1alpha1.AgentCredentials
+		want        bool
+	}{
+		{
+			name: "token uses secret backend",
+			credentials: &datadoghqv1alpha1.AgentCredentials{
+				Token:            "ENC[token]",
+				UseSecretBackend: apiutils.NewBoolPointer(true),
+			},
+			want: true,
+		},
+		{
+			name: "secret backend is not enabled",
+			credentials: &datadoghqv1alpha1.AgentCredentials{
+				Token:            "ENC[token]",
+				UseSecretBackend: apiutils.NewBoolPointer(false),
+			},
+			want: false,
+		},
+		{
+			name: "token is set",
+			credentials: &datadoghqv1alpha1.AgentCredentials{
+				Token: "iamamoderatelylongtoken",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkTokenSufficiency(tt.credentials)
+			if result != tt.want {
+				t.Errorf("checkTokenSufficiency() result is %v but want %v", result, tt.want)
+			}
 		})
 	}
 }

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
-	"github.com/DataDog/datadog-operator/pkg/secrets"
 
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	"github.com/go-logr/logr"
@@ -711,19 +710,10 @@ func getEnvVarsCommon(dda *datadoghqv1alpha1.DatadogAgent, needAPIKey bool) ([]c
 	}
 
 	if needAPIKey {
-		// This triggers use of the secret backend in the metrics forwarder
-		// Otherwise, read from the default or configured secret
-		if secrets.IsEnc(dda.Spec.Credentials.DatadogCredentials.APIKey) {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:  datadoghqv1alpha1.DDAPIKey,
-				Value: dda.Spec.Credentials.DatadogCredentials.APIKey,
-			})
-		} else {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:      datadoghqv1alpha1.DDAPIKey,
-				ValueFrom: getAPIKeyFromSecret(dda),
-			})
-		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:      datadoghqv1alpha1.DDAPIKey,
+			ValueFrom: getAPIKeyFromSecret(dda),
+		})
 	}
 
 	if len(dda.Spec.Agent.Config.Tags) > 0 {
@@ -986,19 +976,10 @@ func getEnvVarsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.E
 			},
 		}
 
-		// This triggers use of the secret backend.
-		// Otherwise, read from the default or configured secret
-		if secrets.IsEnc(dda.Spec.Credentials.Token) {
-			clusterEnv = append(clusterEnv, corev1.EnvVar{
-				Name:  datadoghqv1alpha1.DDClusterAgentAuthToken,
-				Value: dda.Spec.Credentials.Token,
-			})
-		} else {
-			clusterEnv = append(clusterEnv, corev1.EnvVar{
-				Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
-				ValueFrom: getClusterAgentAuthToken(dda),
-			})
-		}
+		clusterEnv = append(clusterEnv, corev1.EnvVar{
+			Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
+			ValueFrom: getClusterAgentAuthToken(dda),
+		})
 		envVars = append(envVars, clusterEnv...)
 	}
 	if spec.Agent.Config != nil {
@@ -2355,19 +2336,10 @@ func envForClusterAgentConnection(dda *datadoghqv1alpha1.DatadogAgent) []corev1.
 			},
 		}
 
-		// This triggers use of the secret backend.
-		// Otherwise, read from the default or configured secret
-		if secrets.IsEnc(dda.Spec.Credentials.Token) {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:  datadoghqv1alpha1.DDClusterAgentAuthToken,
-				Value: dda.Spec.Credentials.Token,
-			})
-		} else {
-			envVars = append(envVars, corev1.EnvVar{
-				Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
-				ValueFrom: getClusterAgentAuthToken(dda),
-			})
-		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:      datadoghqv1alpha1.DDClusterAgentAuthToken,
+			ValueFrom: getClusterAgentAuthToken(dda),
+		})
 		return envVars
 	}
 	return []corev1.EnvVar{}

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -25,7 +25,6 @@ type NewDatadogAgentOptions struct {
 	APIKey                       string
 	AppKey                       string
 	Token                        string
-	UseSecretBackend             bool
 	CustomConfig                 *datadoghqv1alpha1.CustomConfigSpec
 	SecuritySpec                 *datadoghqv1alpha1.SecuritySpec
 	VolumeMounts                 []v1.VolumeMount
@@ -96,10 +95,6 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 
 		if options.Token != "" {
 			ad.Spec.Credentials.Token = options.Token
-		}
-
-		if options.UseSecretBackend {
-			ad.Spec.Credentials.UseSecretBackend = apiutils.NewBoolPointer(true)
 		}
 
 		if options.AgentDisabled {

--- a/controllers/testutils/new.go
+++ b/controllers/testutils/new.go
@@ -24,6 +24,8 @@ type NewDatadogAgentOptions struct {
 	UseEDS                       bool
 	APIKey                       string
 	AppKey                       string
+	Token                        string
+	UseSecretBackend             bool
 	CustomConfig                 *datadoghqv1alpha1.CustomConfigSpec
 	SecuritySpec                 *datadoghqv1alpha1.SecuritySpec
 	VolumeMounts                 []v1.VolumeMount
@@ -90,6 +92,14 @@ func NewDatadogAgent(ns, name, image string, options *NewDatadogAgentOptions) *d
 
 		if options.AppKey != "" {
 			ad.Spec.Credentials.AppKey = options.AppKey
+		}
+
+		if options.Token != "" {
+			ad.Spec.Credentials.Token = options.Token
+		}
+
+		if options.UseSecretBackend {
+			ad.Spec.Credentials.UseSecretBackend = apiutils.NewBoolPointer(true)
 		}
 
 		if options.AgentDisabled {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -430,7 +430,7 @@ spec:
 | credentials.appSecret.keyName | KeyName is the key of the secret to use. |
 | credentials.appSecret.secretName | SecretName is the name of the secret. |
 | credentials.token | This needs to be at least 32 characters a-zA-z. It is a preshared key between the node agents and the cluster agent. |
-| credentials.useSecretBackend | UseSecretBackend use the Agent secret backend feature for retreiving all credentials needed by the different components: Agent, Cluster, Cluster-Checks. If `useSecretBackend: true`, other credential parameters will be ignored. default value is false. |
+| credentials.useSecretBackend | UseSecretBackend use the Agent secret backend feature for retreiving all credentials needed by the different components: Agent, Cluster, Cluster-Checks. default value is false. |
 | features.kubeStateMetricsCore.clusterCheck | ClusterCheck configures the Kubernetes State Metrics Core check as a cluster check. |
 | features.kubeStateMetricsCore.conf.configData | ConfigData corresponds to the configuration file content. |
 | features.kubeStateMetricsCore.conf.configMap.fileKey | FileKey corresponds to the key used in the ConfigMap.Data to store the configuration file content. |

--- a/examples/datadogagent/datadog-agent-secret-backend.yaml
+++ b/examples/datadogagent/datadog-agent-secret-backend.yaml
@@ -1,0 +1,43 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: ENC[api_key]
+    appKey: ENC[app_key]
+    useSecretBackend: true
+  agent:
+    env:
+      - name: DD_SECRET_BACKEND_COMMAND
+        value: "/readsecret.sh"
+      - name: DD_SECRET_BACKEND_ARGUMENTS
+        value: "/etc/secret-volume"
+    config:
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: test-secret
+      volumeMounts:
+        - name: secret-volume
+          mountPath: /etc/secret-volume
+    apm:
+      enabled: true
+      volumeMounts:
+        - name: secret-volume
+          mountPath: /etc/secret-volume
+  clusterAgent:
+    enabled: true
+    config:
+      env:
+        - name: DD_SECRET_BACKEND_COMMAND
+          value: "/readsecret.sh"
+        - name: DD_SECRET_BACKEND_ARGUMENTS
+          value: "/etc/secret-volume"
+      volumes:
+        - name: secret-volume
+          secret:
+            secretName: test-secret
+      volumeMounts:
+        - name: secret-volume
+          mountPath: /etc/secret-volume

--- a/pkg/controller/utils/shared_utils.go
+++ b/pkg/controller/utils/shared_utils.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
-	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
 // GetDefaultCredentialsSecretName returns the default name for credentials secret
@@ -32,7 +31,7 @@ func GetAPIKeySecret(credentials *datadoghqv1alpha1.DatadogCredentials, defaultN
 		return true, credentials.APIKeyExistingSecret, datadoghqv1alpha1.DefaultAPIKeyKey
 	}
 
-	if credentials.APIKey != "" && !secrets.IsEnc(credentials.APIKey) {
+	if credentials.APIKey != "" {
 		return true, defaultName, datadoghqv1alpha1.DefaultAPIKeyKey
 	}
 
@@ -54,7 +53,7 @@ func GetAppKeySecret(credentials *datadoghqv1alpha1.DatadogCredentials, defaultN
 		return true, credentials.AppKeyExistingSecret, datadoghqv1alpha1.DefaultAPPKeyKey
 	}
 
-	if credentials.AppKey != "" && !secrets.IsEnc(credentials.AppKey) {
+	if credentials.AppKey != "" {
 		return true, defaultName, datadoghqv1alpha1.DefaultAPPKeyKey
 	}
 

--- a/pkg/controller/utils/shared_utils.go
+++ b/pkg/controller/utils/shared_utils.go
@@ -6,8 +6,10 @@
 package utils
 
 import (
-	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
 // GetDefaultCredentialsSecretName returns the default name for credentials secret
@@ -30,7 +32,7 @@ func GetAPIKeySecret(credentials *datadoghqv1alpha1.DatadogCredentials, defaultN
 		return true, credentials.APIKeyExistingSecret, datadoghqv1alpha1.DefaultAPIKeyKey
 	}
 
-	if credentials.APIKey != "" {
+	if credentials.APIKey != "" && !secrets.IsEnc(credentials.APIKey) {
 		return true, defaultName, datadoghqv1alpha1.DefaultAPIKeyKey
 	}
 
@@ -52,7 +54,7 @@ func GetAppKeySecret(credentials *datadoghqv1alpha1.DatadogCredentials, defaultN
 		return true, credentials.AppKeyExistingSecret, datadoghqv1alpha1.DefaultAPPKeyKey
 	}
 
-	if credentials.AppKey != "" {
+	if credentials.AppKey != "" && !secrets.IsEnc(credentials.AppKey) {
 		return true, defaultName, datadoghqv1alpha1.DefaultAPPKeyKey
 	}
 

--- a/pkg/secrets/utils.go
+++ b/pkg/secrets/utils.go
@@ -37,7 +37,7 @@ func extractHandle(str string) (string, error) {
 		return str[4 : len(str)-1], nil
 	}
 
-	return "", fmt.Errorf("wrong format, want ENC[<hanlde>], got: %s", str)
+	return "", fmt.Errorf("wrong format, want ENC[<handle>], got: %s", str)
 }
 
 // encFormat puts a given secret handle in a ENC[<handle>] format


### PR DESCRIPTION
### What does this PR do?

The secret backend feature for DatadogAgent was not working properly. This fixes the feature so that any credentials can use it. In addition, the Operator no longer creates a secret if it's not needed (i.e. it will not create an empty secret).

Other changes:
- create secret_common.go to hold common functions
- add new examples/datadogagent/datadog-agent-secret-backend.yaml
- update secret backed documentation

### Motivation

Fix

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Use the new `datadog-agent-secret-backend.yaml` example file to test the secret backend feature.

For completeness, can test the following cases (make sure the keys are read properly and the Agent can connect to the Cluster Agent):

(Create a secret containing credentials with `kubectl create secret generic test-secret --from-literal=api_key='<token>' --from-literal=app_key='<token>' --from-literal=token='<token>' `)

1. secret backend not used (check that Operator creates a secret based on provided credentials)
2. only API key uses secret backend
3. only App key uses secret backend
4. only token uses secret backend
5. all three (API key, App key, token) use secret backend
6. set API key using APISecret
7. set App key using APPSecret
9. enable ExternalMetrics with keys configured in ExternalMetricsCredentials, no secret backend
10. enable ExternalMetrics with keys configured in ExternalMetricsCredentials, with secret backend