### PR TITLE
[controllers/datadogagent] Mount logs volume in DCA and CLC

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -353,6 +353,7 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 			Name:         datadoghqv1alpha1.ConfdVolumeName,
 			VolumeSource: confdVolumeSource,
 		},
+		getVolumeForLogs(),
 	}
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -366,6 +367,7 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 			MountPath: datadoghqv1alpha1.ConfdVolumePath,
 			ReadOnly:  true,
 		},
+		getVolumeMountForLogs(),
 	}
 
 	if dda.Spec.ClusterAgent.CustomConfig != nil {

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -52,6 +52,7 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 					{Name: "installinfo", ReadOnly: true, SubPath: "install_info", MountPath: "/etc/datadog-agent/install_info"},
 					{Name: "confd", ReadOnly: true, MountPath: "/conf.d"},
 					{Name: "orchestrator-explorer-config", ReadOnly: true, MountPath: "/etc/datadog-agent/conf.d/orchestrator.d"},
+					{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 				},
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
@@ -84,6 +85,12 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 							Name: "foo-orchestrator-explorer-config",
 						},
 					},
+				},
+			},
+			{
+				Name: "logdatadog",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 		},

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -473,6 +473,7 @@ func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 	volumes := []corev1.Volume{
 		getVolumeForChecksd(dda),
 		getVolumeForConfig(),
+		getVolumeForLogs(),
 		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -502,6 +503,7 @@ func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		getVolumeMountForChecksd(),
+		getVolumeMountForLogs(),
 		{
 			Name:      datadoghqv1alpha1.InstallInfoVolumeName,
 			SubPath:   datadoghqv1alpha1.InstallInfoVolumeSubPath,

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -71,6 +71,11 @@ func clusterChecksRunnerDefaultVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  true,
 		},
 		{
+			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
+			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
+			ReadOnly:  false,
+		},
+		{
 			Name:      "installinfo",
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
@@ -97,6 +102,12 @@ func clusterChecksRunnerDefaultVolumes() []corev1.Volume {
 		},
 		{
 			Name: datadoghqv1alpha1.ConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.LogDatadogVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -991,12 +991,7 @@ func getEnvVarsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.E
 // getVolumesForAgent defines volumes for the Agent
 func getVolumesForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Volume {
 	volumes := []corev1.Volume{
-		{
-			Name: datadoghqv1alpha1.LogDatadogVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
+		getVolumeForLogs(),
 		getVolumeForAuth(),
 		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
@@ -1374,6 +1369,23 @@ func getVolumeForAuth() corev1.Volume {
 	}
 }
 
+func getVolumeForLogs() corev1.Volume {
+	return corev1.Volume{
+		Name: datadoghqv1alpha1.LogDatadogVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+func getVolumeMountForLogs() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      datadoghqv1alpha1.LogDatadogVolumeName,
+		MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
+		ReadOnly:  false,
+	}
+}
+
 func getSecCompRootPath(spec *datadoghqv1alpha1.SystemProbeSpec) string {
 	return spec.SecCompRootPath
 }
@@ -1413,10 +1425,7 @@ func getVolumeMountFromCustomConfigSpec(cfcm *datadoghqv1alpha1.CustomConfigSpec
 func getVolumeMountsForAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
-			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
-		},
+		getVolumeMountForLogs(),
 		getVolumeMountForAuth(false),
 		{
 			Name:      datadoghqv1alpha1.InstallInfoVolumeName,
@@ -1575,10 +1584,7 @@ func getVolumeMountForRuntimeSockets(criSocket *datadoghqv1alpha1.CRISocketConfi
 func getVolumeMountsForProcessAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
-			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
-		},
+		getVolumeMountForLogs(),
 		// Add auth token volume mount
 		getVolumeMountForAuth(true),
 		getVolumeMountDogstatsdSocket(true),
@@ -1638,10 +1644,7 @@ func getVolumeMountsForProcessAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev
 func getVolumeMountsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
-			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
-		},
+		getVolumeMountForLogs(),
 		// Add auth token volume mount
 		getVolumeMountForAuth(true),
 	}
@@ -1673,10 +1676,7 @@ func getVolumeMountsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Vo
 func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	// Default mounted volumes
 	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
-			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
-		},
+		getVolumeMountForLogs(),
 		getVolumeMountForAuth(true),
 		{
 			Name:      datadoghqv1alpha1.SystemProbeDebugfsVolumeName,
@@ -1739,10 +1739,7 @@ func getVolumeMountsForSystemProbe(dda *datadoghqv1alpha1.DatadogAgent) []corev1
 // getVolumeMountsForSecurityAgent defines mounted volumes for the Security Agent
 func getVolumeMountsForSecurityAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:      datadoghqv1alpha1.LogDatadogVolumeName,
-			MountPath: datadoghqv1alpha1.LogDatadogVolumePath,
-		},
+		getVolumeMountForLogs(),
 		getVolumeMountForAuth(true),
 		getVolumeMountDogstatsdSocket(true),
 		{


### PR DESCRIPTION
### What does this PR do?

Mounts the log volume in the DCA and the CLC. This is the same that the operator already does for the daemonset agent.

### Motivation

Without this, from the latest changes that allow the DCA and CLC to run as non-root, there are permissions errors like this one:
`open /var/log/datadog/cluster-agent.log: read-only file system`

### Describe your test plan

Deploy on Openshift with DCA and CLC running as non-root users (this is the default since https://github.com/DataDog/datadog-operator/pull/448). Check that the error mentioned above is not in the DCA or CLC logs.
