### PR TITLE
Do not enforce `dd-agent` user (UID 101) for the CLC and DCA

### DIFF
--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -1267,6 +1267,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 					Capabilities: &corev1.Capabilities{
 						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"},
 					},
+					RunAsUser: apiutils.NewInt64Pointer(0),
 				},
 				Resources:    corev1.ResourceRequirements{},
 				Env:          defaultSystemProbeEnvVars(),
@@ -1274,6 +1275,9 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 			},
 		},
 		Volumes: defaultSystemProbeVolumes(),
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: apiutils.NewInt64Pointer(0),
+		},
 	}
 }
 
@@ -1375,6 +1379,7 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 					Capabilities: &corev1.Capabilities{
 						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"},
 					},
+					RunAsUser: apiutils.NewInt64Pointer(0),
 				},
 				Resources:    corev1.ResourceRequirements{},
 				Env:          defaultSystemProbeEnvVars(),
@@ -1382,6 +1387,9 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 			},
 		},
 		Volumes: volumes,
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: apiutils.NewInt64Pointer(0),
+		},
 	}
 }
 
@@ -1457,6 +1465,9 @@ func defaultPodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSpec {
 			},
 		},
 		Volumes: defaultProcessMount(),
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: apiutils.NewInt64Pointer(0),
+		},
 	}
 }
 
@@ -1730,6 +1741,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 					Capabilities: &corev1.Capabilities{
 						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"},
 					},
+					RunAsUser: apiutils.NewInt64Pointer(0),
 				},
 				Resources: corev1.ResourceRequirements{},
 				Env:       systemProbeEnv,
@@ -1755,6 +1767,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 					Capabilities: &corev1.Capabilities{
 						Add: []corev1.Capability{"AUDIT_CONTROL", "AUDIT_READ"},
 					},
+					RunAsUser: apiutils.NewInt64Pointer(0),
 				},
 				Resources:    corev1.ResourceRequirements{},
 				Env:          securityAgentEnvVars(false, true, true, extraEnv),
@@ -1762,6 +1775,9 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 			},
 		},
 		Volumes: volumesBuilder.Build(),
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: apiutils.NewInt64Pointer(0),
+		},
 	}
 }
 
@@ -1830,6 +1846,7 @@ func complianceSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 					Capabilities: &corev1.Capabilities{
 						Add: []corev1.Capability{"AUDIT_CONTROL", "AUDIT_READ"},
 					},
+					RunAsUser: apiutils.NewInt64Pointer(0),
 				},
 				Resources:    corev1.ResourceRequirements{},
 				Env:          securityAgentEnvVars(true, false, false, extraEnv),
@@ -1837,6 +1854,9 @@ func complianceSecurityAgentPodSpec(extraEnv map[string]string) corev1.PodSpec {
 			},
 		},
 		Volumes: complianceSecurityAgentVolumes(),
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: apiutils.NewInt64Pointer(0),
+		},
 	}
 }
 
@@ -1991,6 +2011,9 @@ func customKubeletConfigPodSpec(kubeletConfig *datadoghqv1alpha1.KubeletConfig) 
 			},
 		},
 		Volumes: VolumeBuilder.Build(),
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsUser: apiutils.NewInt64Pointer(0),
+		},
 	}
 }
 

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -470,11 +470,10 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 		Tolerations:       clusterAgentSpec.Tolerations,
 		PriorityClassName: dda.Spec.ClusterAgent.PriorityClassName,
 		Volumes:           volumes,
-		SecurityContext: &corev1.PodSecurityContext{
-			RunAsNonRoot: apiutils.NewBoolPointer(true),
-			// 101 is the UID of user `dd-agent` in the official datadog cluster agent image
-			RunAsUser: apiutils.NewInt64Pointer(101),
-		},
+		// To be uncommented when the cluster-agent Dockerfile will be updated to use a non-root user by default
+		// SecurityContext: &corev1.PodSecurityContext{
+		// 	RunAsNonRoot: apiutils.NewBoolPointer(true),
+		// },
 	}
 
 	newPodTemplate := corev1.PodTemplateSpec{

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -94,10 +94,10 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 				},
 			},
 		},
-		SecurityContext: &v1.PodSecurityContext{
-			RunAsNonRoot: apiutils.NewBoolPointer(true),
-			RunAsUser:    apiutils.NewInt64Pointer(101),
-		},
+		// To be uncommented when the cluster-agent Dockerfile will be updated to use a non-root user by default
+		// SecurityContext: &v1.PodSecurityContext{
+		// 	RunAsNonRoot: apiutils.NewBoolPointer(true),
+		// },
 	}
 }
 

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -302,11 +302,10 @@ func newClusterChecksRunnerPodTemplate(dda *datadoghqv1alpha1.DatadogAgent, labe
 			Affinity:          getPodAffinity(clusterChecksRunnerSpec.Affinity),
 			Tolerations:       clusterChecksRunnerSpec.Tolerations,
 			PriorityClassName: clusterChecksRunnerSpec.PriorityClassName,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: apiutils.NewBoolPointer(true),
-				// 101 is the UID of user `dd-agent` in the official datadog agent image
-				RunAsUser: apiutils.NewInt64Pointer(101),
-			},
+			// To be uncommented when the agent Dockerfile will be updated to use a non-root user by default
+			// SecurityContext: &corev1.PodSecurityContext{
+			// 	RunAsNonRoot: apiutils.NewBoolPointer(true),
+			// },
 		},
 	}
 

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -56,10 +56,10 @@ func clusterChecksRunnerDefaultPodSpec() corev1.PodSpec {
 			},
 		},
 		Volumes: clusterChecksRunnerDefaultVolumes(),
-		SecurityContext: &v1.PodSecurityContext{
-			RunAsNonRoot: apiutils.NewBoolPointer(true),
-			RunAsUser:    apiutils.NewInt64Pointer(101),
-		},
+		// To be uncommented when the agent Dockerfile will be updated to use a non-root user by default
+		// SecurityContext: &v1.PodSecurityContext{
+		// 	RunAsNonRoot: apiutils.NewBoolPointer(true),
+		// },
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Do not enforce a specific non-`root` user in the `SecurityContext` of the cluster agent and the cluster check runners.
Partial revert of #448.

### Motivation

The cluster agent and the cluster check runners don’t need to run as `root`.
But explicitly setting a user (`dd-agent` with UID `101`) breaks on OpenShift where the `restricted` SCC already forces those two components to run with a random OpenShift-chosen UID.

In order to not break on OpenShift and still not default to `root` user on non-OpenShift setups, here is what should be done instead:
* define a non-`root` default user in the agent and cluster-agent docker images.
  * https://github.com/DataDog/datadog-agent/blob/71552876f9be5ad67d525589489e91d98cd7839b/Dockerfiles/agent/amd64/Dockerfile#L162-L166
  * https://github.com/DataDog/datadog-agent/blob/71552876f9be5ad67d525589489e91d98cd7839b/Dockerfiles/cluster-agent/amd64/Dockerfile#L73
* Specify that node agent should run as `root` explicitly in its `SecurityContext`.

Like that, the DCA and CLC should run with `dd-agent` (specified in the `Dockerfile`) on non-OpenShift setups. On OpenShift, it will run with the random OpenShift-chosen UID because of the `restricted` SCC.
The node agent will keep on running as `root`.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Validate that the operator can successfully deploy the cluster agent and the cluster check runners on both OpenShift and non-OpenShift clusters.