### PR TITLE
Add a missing DCA RBAC permission for the orchestrator check

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1383,6 +1383,12 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 			Resources: []string{datadoghqv1alpha1.DeploymentsResource, datadoghqv1alpha1.ReplicasetsResource, datadoghqv1alpha1.DaemonsetsResource, datadoghqv1alpha1.StatefulsetsResource},
 			Verbs:     []string{datadoghqv1alpha1.GetVerb, datadoghqv1alpha1.ListVerb, datadoghqv1alpha1.WatchVerb},
 		})
+
+		rbacRules = append(rbacRules, rbacv1.PolicyRule{
+			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+			Resources: []string{datadoghqv1alpha1.RoleResource},
+			Verbs:     []string{datadoghqv1alpha1.GetVerb, datadoghqv1alpha1.ListVerb, datadoghqv1alpha1.WatchVerb},
+		})
 	}
 
 	clusterRole.Rules = rbacRules


### PR DESCRIPTION
### What does this PR do?

Add permissions to `List`, `Get` and `Watch` `Roles` to the cluster agent `ServiceAccount` for the `orchestrator` check.

### Motivation

Fix the following errors:
```
2022-03-16 14:20:11 UTC | CLUSTER | ERROR | (pkg/collector/corechecks/loader.go:72 in Load) | core.loader: could not configure check orchestrator: couldn't sync informer roles in 1m5.0007228s
2022-03-16 14:20:11 UTC | CLUSTER | ERROR | (pkg/collector/scheduler.go:201 in getChecks) | Unable to load a check from instance of config 'orchestrator': Core Check Loader: Could not configure check orchestrator: couldn't sync informer roles in 1m5.0007228s
2022-03-16 14:20:11 UTC | CLUSTER | ERROR | (pkg/collector/scheduler.go:248 in GetChecksFromConfigs) | Unable to load the check: unable to load any check from config 'orchestrator'
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Start the latest version of the agent and cluster-agent with the latest version of the operator and validate that the orchestrator explorer works.
