### PR TITLE
update rbac to support secret backend multiple providers script

### DIFF
--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -45,6 +45,7 @@ const (
 const (
 	DatadogHost                                  = "DATADOG_HOST"
 	DDAPIKey                                     = "DD_API_KEY"
+	DDSecretBackendCommand                       = "DD_SECRET_BACKEND_COMMAND"
 	DDClusterName                                = "DD_CLUSTER_NAME"
 	DDSite                                       = "DD_SITE"
 	DDddURL                                      = "DD_DD_URL"

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -1070,6 +1070,18 @@ func buildClusterRole(dda *datadoghqv1alpha1.DatadogAgent, needClusterLevelRBAC 
 		},
 	}
 
+	// If the secret backend uses the provided `/readsecret_multiple_providers.sh` script, then we need to add secrets GET permissions
+	if *dda.Spec.Credentials.UseSecretBackend &&
+		(checkSecretBackendMultipleProvidersUsed(dda.Spec.Agent.Env) || checkSecretBackendMultipleProvidersUsed(dda.Spec.Agent.Config.Env) ||
+			checkSecretBackendMultipleProvidersUsed(dda.Spec.Agent.Apm.Env) || checkSecretBackendMultipleProvidersUsed(dda.Spec.Agent.Process.Env) ||
+			checkSecretBackendMultipleProvidersUsed(dda.Spec.Agent.SystemProbe.Env) || checkSecretBackendMultipleProvidersUsed(dda.Spec.Agent.Security.Env)) {
+		rbacRules = append(rbacRules, rbacv1.PolicyRule{
+			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+			Resources: []string{datadoghqv1alpha1.SecretsResource},
+			Verbs:     []string{datadoghqv1alpha1.GetVerb},
+		})
+	}
+
 	if needClusterLevelRBAC {
 		// Cluster Agent is disabled, the Agent needs extra permissions
 		// to collect cluster level metrics and events
@@ -1176,6 +1188,16 @@ func buildClusterAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, age
 
 	if apiutils.BoolValue(dda.Spec.ClusterAgent.Config.CollectEvents) {
 		rbacRules = append(rbacRules, getEventCollectionPolicyRule())
+	}
+
+	// If the secret backend uses the provided `/readsecret_multiple_providers.sh` script, then we need to add secrets GET permissions
+	if *dda.Spec.Credentials.UseSecretBackend &&
+		checkSecretBackendMultipleProvidersUsed(dda.Spec.ClusterAgent.Config.Env) {
+		rbacRules = append(rbacRules, rbacv1.PolicyRule{
+			APIGroups: []string{datadoghqv1alpha1.CoreAPIGroup},
+			Resources: []string{datadoghqv1alpha1.SecretsResource},
+			Verbs:     []string{datadoghqv1alpha1.GetVerb},
+		})
 	}
 
 	if isMetricsProviderEnabled(dda.Spec.ClusterAgent) {

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -20,6 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const secretBackendMultipleProvidersScript = "/readsecret_multiple_providers.sh"
+
 // roleBindingInfo contains the required information to build a Cluster Role Binding
 type roleBindingInfo struct {
 	name               string
@@ -307,4 +309,13 @@ func isClusterRolesBindingEqual(a, b *rbacv1.ClusterRoleBinding) bool {
 	// Even if a ClusterRoleBinding should not contain DatadogAgent ownerref, we need to check it is the case to be able to remove the ownerref that might have added
 	// by a previous Operator version.
 	return apiequality.Semantic.DeepEqual(a.RoleRef, b.RoleRef) && apiequality.Semantic.DeepEqual(a.Subjects, b.Subjects) && apiequality.Semantic.DeepEqual(a.ObjectMeta.OwnerReferences, b.ObjectMeta.OwnerReferences)
+}
+
+func checkSecretBackendMultipleProvidersUsed(envVarList []corev1.EnvVar) bool {
+	for _, envVar := range envVarList {
+		if envVar.Name == datadoghqv1alpha1.DDSecretBackendCommand && envVar.Value == secretBackendMultipleProvidersScript {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/datadogagent/common_rbac_test.go
+++ b/controllers/datadogagent/common_rbac_test.go
@@ -161,3 +161,75 @@ func newReconcilerForRbacTests(client client.Client) *Reconciler {
 		recorder: recorder,
 	}
 }
+
+func Test_checkSecretBackendMultipleProvidersUsed(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		envVarList []corev1.EnvVar
+		want       bool
+	}{
+		{
+			name: "Secret backend multiple providers script is found",
+			envVarList: []corev1.EnvVar{
+				{
+					Name:  "EnvVar1",
+					Value: "Value1",
+				},
+				{
+					Name:  "EnvVar2",
+					Value: "Value2",
+				},
+				{
+					Name:  "DD_SECRET_BACKEND_COMMAND",
+					Value: "/readsecret_multiple_providers.sh",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Script does not match",
+			envVarList: []corev1.EnvVar{
+				{
+					Name:  "EnvVar1",
+					Value: "Value1",
+				},
+				{
+					Name:  "EnvVar2",
+					Value: "Value2",
+				},
+				{
+					Name:  "DD_SECRET_BACKEND_COMMAND",
+					Value: "/readsecret.sh",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "EnvVar name does not match",
+			envVarList: []corev1.EnvVar{
+				{
+					Name:  "EnvVar1",
+					Value: "Value1",
+				},
+				{
+					Name:  "EnvVar2",
+					Value: "Value2",
+				},
+				{
+					Name:  "DD_SECRET_BACKEND_COMMANDD",
+					Value: "/readsecret_multiple_providers.sh",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkSecretBackendMultipleProvidersUsed(tt.envVarList)
+			if result != tt.want {
+				t.Errorf("checkEnvVarMatchesValue() result is %v but want %v", result, tt.want)
+			}
+		})
+	}
+}

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -219,7 +219,7 @@ spec:
           mountPath: /etc/secret-volume
 ```
 
-The Datadog Agent also includes a script that can be used to read secrets from files mounted from Kubernetes secrets, or directly from Kubernetes secrets. This script can be used by setting `DD_SECRET_BACKEND_COMMAND` to `/readsecret_multiple_providers.sh`. A simple example of how to configure the DatadogAgent spec is provided below. For more details, see the [documentation][2].
+The Datadog Agent also includes a script that can be used to read secrets from files mounted from Kubernetes secrets, or directly from Kubernetes secrets. This script can be used by setting `DD_SECRET_BACKEND_COMMAND` to `/readsecret_multiple_providers.sh`. An example of how to configure the DatadogAgent spec is provided below. For more details, see [Secrets Management][2].
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1

--- a/docs/secret_management.md
+++ b/docs/secret_management.md
@@ -219,6 +219,24 @@ spec:
           mountPath: /etc/secret-volume
 ```
 
+The Datadog Agent also includes a script that can be used to read secrets from files mounted from Kubernetes secrets, or directly from Kubernetes secrets. This script can be used by setting `DD_SECRET_BACKEND_COMMAND` to `/readsecret_multiple_providers.sh`. A simple example of how to configure the DatadogAgent spec is provided below. For more details, see the [documentation][2].
+
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: ENC[k8s_secret@default/test-secret/api_key]
+    appKey: ENC[k8s_secret@default/test-secret/app_key]
+    useSecretBackend: true
+  agent:
+    env:
+      - name: DD_SECRET_BACKEND_COMMAND
+        value: "/readsecret_multiple_providers.sh"
+```
+
 **Remarks:**
 
 * For the "Agent" and "Cluster Agent", others options exist to configure secret backend command:
@@ -228,3 +246,4 @@ spec:
   * **DD_SECRET_BACKEND_TIMEOUT**: secret backend execution timeout in second. The default value is 5 seconds.
 
 [1]: https://docs.datadoghq.com/agent/guide/secrets-management
+[2]: https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux#script-for-reading-from-multiple-secret-providers


### PR DESCRIPTION
### What does this PR do?

To support use of the secret backend multiple providers script in the agent when deployed with the Datadog Operator.

### Motivation

Feature parity 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Create a secret called `test-secret` (in the example below, it is in the `system` namespace)
- Modify the examples/datadogagent/datadog-agent-secret-backend.yaml file to include the following:

```
spec:
  credentials:
    apiKey: ENC[k8s_secret@system/test-secret/api_key]
    appKey: ENC[k8s_secret@system/test-secret/app_key]
    useSecretBackend: true
  agent:
    env:
      - name: DD_SECRET_BACKEND_COMMAND
        value: "/readsecret_multiple_providers.sh"
  clusterAgent:
    enabled: true
    config:
      env:
        - name: DD_SECRET_BACKEND_COMMAND
          value: "/readsecret_multiple_providers.sh"
```
- make sure that the agents and cluster agent start properly, and that the agent can connect to the cluster agent