### PR TITLE
[controllers/datadogagent] Mount tmp volume in DCA and CLC

### DIFF
--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -132,6 +132,8 @@ const (
 
 	LogDatadogVolumeName                 = "logdatadog"
 	LogDatadogVolumePath                 = "/var/log/datadog"
+	TmpVolumeName                        = "tmp"
+	TmpVolumePath                        = "/tmp"
 	APMSocketVolumeName                  = "apmsocket"
 	APMSocketVolumePath                  = "/var/run/datadog/apm"
 	InstallInfoVolumeName                = "installinfo"

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -354,6 +354,15 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 			VolumeSource: confdVolumeSource,
 		},
 		getVolumeForLogs(),
+
+		// /tmp is needed because some versions of the DCA (at least until
+		// 1.19.0) write to it.
+		// In some code paths, the klog lib writes to /tmp instead of using the
+		// standard datadog logs path.
+		// In some envs like Openshift, when running as non-root, the pod will
+		// not have permissions to write on /tmp, that's why we need to mount
+		// it with write perms.
+		getVolumeForTmp(),
 	}
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -368,6 +377,7 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 			ReadOnly:  true,
 		},
 		getVolumeMountForLogs(),
+		getVolumeMountForTmp(),
 	}
 
 	if dda.Spec.ClusterAgent.CustomConfig != nil {

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -53,6 +53,7 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 					{Name: "confd", ReadOnly: true, MountPath: "/conf.d"},
 					{Name: "orchestrator-explorer-config", ReadOnly: true, MountPath: "/etc/datadog-agent/conf.d/orchestrator.d"},
 					{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
+					{Name: "tmp", ReadOnly: false, MountPath: "/tmp"},
 				},
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
@@ -89,6 +90,12 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 			},
 			{
 				Name: "logdatadog",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: "tmp",
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -476,6 +476,15 @@ func getVolumesForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 		getVolumeForChecksd(dda),
 		getVolumeForConfig(),
 		getVolumeForLogs(),
+
+		// /tmp is needed because some versions of the DCA (at least until
+		// 1.19.0) write to it.
+		// In some code paths, the klog lib writes to /tmp instead of using the
+		// standard datadog logs path.
+		// In some envs like Openshift, when running as non-root, the pod will
+		// not have permissions to write on /tmp, that's why we need to mount
+		// it with write perms.
+		getVolumeForTmp(),
 		{
 			Name: datadoghqv1alpha1.InstallInfoVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -506,6 +515,7 @@ func getVolumeMountsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) 
 	volumeMounts := []corev1.VolumeMount{
 		getVolumeMountForChecksd(),
 		getVolumeMountForLogs(),
+		getVolumeMountForTmp(),
 		{
 			Name:      datadoghqv1alpha1.InstallInfoVolumeName,
 			SubPath:   datadoghqv1alpha1.InstallInfoVolumeSubPath,

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -76,6 +76,11 @@ func clusterChecksRunnerDefaultVolumeMounts() []corev1.VolumeMount {
 			ReadOnly:  false,
 		},
 		{
+			Name:      datadoghqv1alpha1.TmpVolumeName,
+			MountPath: datadoghqv1alpha1.TmpVolumePath,
+			ReadOnly:  false,
+		},
+		{
 			Name:      "installinfo",
 			SubPath:   "install_info",
 			MountPath: "/etc/datadog-agent/install_info",
@@ -108,6 +113,12 @@ func clusterChecksRunnerDefaultVolumes() []corev1.Volume {
 		},
 		{
 			Name: datadoghqv1alpha1.LogDatadogVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: datadoghqv1alpha1.TmpVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1387,6 +1387,23 @@ func getVolumeMountForLogs() corev1.VolumeMount {
 	}
 }
 
+func getVolumeForTmp() corev1.Volume {
+	return corev1.Volume{
+		Name: datadoghqv1alpha1.TmpVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+func getVolumeMountForTmp() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      datadoghqv1alpha1.TmpVolumeName,
+		MountPath: datadoghqv1alpha1.TmpVolumePath,
+		ReadOnly:  false,
+	}
+}
+
 func getSecCompRootPath(spec *datadoghqv1alpha1.SystemProbeSpec) string {
 	return spec.SecCompRootPath
 }


### PR DESCRIPTION
### What does this PR do?

Mounts /tmp with write permissions as an "empty dir" volume.

This is needed because some versions of the DCA (at least until 1.19.0) write to /tmp.

In some code paths, the klog lib writes to /tmp instead of using the standard datadog logs path. This seems to be a bug in the code, because most of the calls to klog are wrapped and converted to the datadog log format, but not all of them.

In some envs like Openshift, when running as non-root, the pod will not have permissions to write on /tmp, that's why we need to mount it with write perms.

### Describe your test plan

Run on Openshift with DCA v1.19.0. Check that the DCA doesn't crash with an error like this one:
```
log: exiting because of error: log: cannot create log: open /tmp/datadog-cluster-agent.datadog-cluster-agent-67889c8974-g5vfs.dd-agent.log.WARNING.20220404-130646.1: read-only file system
```
