### PR TITLE
[controllers/datadogagent] Mount certificates volume in DCA

### DIFF
--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -135,6 +135,8 @@ const (
 	LogDatadogVolumePath                 = "/var/log/datadog"
 	TmpVolumeName                        = "tmp"
 	TmpVolumePath                        = "/tmp"
+	CertificatesVolumeName               = "certificates"
+	CertificatesVolumePath               = "/etc/datadog-agent/certificates"
 	APMSocketVolumeName                  = "apmsocket"
 	APMSocketVolumePath                  = "/var/run/datadog/apm"
 	InstallInfoVolumeName                = "installinfo"

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -354,6 +354,7 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 			VolumeSource: confdVolumeSource,
 		},
 		getVolumeForLogs(),
+		getVolumeForCertificates(),
 
 		// /tmp is needed because some versions of the DCA (at least until
 		// 1.19.0) write to it.
@@ -377,6 +378,7 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 			ReadOnly:  true,
 		},
 		getVolumeMountForLogs(),
+		getVolumeMountForCertificates(),
 		getVolumeMountForTmp(),
 	}
 

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -54,6 +54,7 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 					{Name: "orchestrator-explorer-config", ReadOnly: true, MountPath: "/etc/datadog-agent/conf.d/orchestrator.d"},
 					{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 					{Name: "tmp", ReadOnly: false, MountPath: "/tmp"},
+					{Name: "certificates", ReadOnly: false, MountPath: "/etc/datadog-agent/certificates"},
 				},
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
@@ -96,6 +97,12 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 			},
 			{
 				Name: "tmp",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+			{
+				Name: "certificates",
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -1417,6 +1417,23 @@ func getVolumeMountForTmp() corev1.VolumeMount {
 	}
 }
 
+func getVolumeForCertificates() corev1.Volume {
+	return corev1.Volume{
+		Name: datadoghqv1alpha1.CertificatesVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+func getVolumeMountForCertificates() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      datadoghqv1alpha1.CertificatesVolumeName,
+		MountPath: datadoghqv1alpha1.CertificatesVolumePath,
+		ReadOnly:  false,
+	}
+}
+
 func getSecCompRootPath(spec *datadoghqv1alpha1.SystemProbeSpec) string {
 	return spec.SecCompRootPath
 }


### PR DESCRIPTION
### What does this PR do?

Mounts the certificates volume in the DCA.

This is needed when enabling external metrics and running on Openshift as non-root (which is the default now).

### Describe your test plan

Run on Openshift with:
```
...
  clusterAgent:
    config:
      externalMetrics:
        enabled: true
        useDatadogMetrics: true
...
```
Check that there are no errors in the DCA like this one:
`Error in the External Metrics API Server: error creating self-signed certificates: mkdir /etc/datadog-agent/certificates: read-only file system`.