### PR TITLE
fix: update golang version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
### What does this PR do?

Update to golang 1.17 the  operator `Dockerfile`.

### Motivation

the PR #462 missed to update the `Dockerfile`

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

the next operator release, check the golang version in the binary
