### PR TITLE
[defaulting/images] Update agent to 7.35.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,7 +16,7 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.34.0"
+	AgentLatestVersion = "7.35.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
 	ClusterAgentLatestVersion = "1.18.0"
 


### PR DESCRIPTION
### What does this PR do?

Updates default agent image to latest 7.35.0.

### Describe your test plan

7.35.0 should be deployed by default.
