### PR TITLE
[examples] Fix "datadog-agent-secret-backend"

### DIFF
--- a/examples/datadogagent/datadog-agent-secret-backend.yaml
+++ b/examples/datadogagent/datadog-agent-secret-backend.yaml
@@ -21,6 +21,10 @@ spec:
       volumeMounts:
         - name: secret-volume
           mountPath: /etc/secret-volume
+    process:
+      volumeMounts:
+        - name: secret-volume
+          mountPath: /etc/secret-volume
     apm:
       enabled: true
       volumeMounts:


### PR DESCRIPTION
### What does this PR do?

Fixes the example manifest in `examples/datadogagent/datadog-agent-secret-backend.yaml`.

Currently it fails with this error:
`critical: unable to decrypt secret from datadog.yaml: an error occurred while decrypting 'api_key': secret does not exist`

It's because the process container is created by default, so we need to mount the volume with the credentials.


### Describe your test plan

Deploy the example and check that the agent pods start.
