### PR TITLE
Add port names to agent service

### DIFF
--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -39,6 +39,10 @@ const (
 	DefaultAdmissionControllerTargetPort = 8000
 	// DefaultDogstatsdPort default dogstatsd port
 	DefaultDogstatsdPort = 8125
+	// DefaultDogstatsdPortName default dogstatsd port name
+	DefaultDogstatsdPortName = "dogstatsd"
+	// DefaultApmPortName default apm port name
+	DefaultApmPortName = "apm"
 )
 
 // Datadog env var names

--- a/controllers/datadogagent/service.go
+++ b/controllers/datadogagent/service.go
@@ -462,6 +462,7 @@ func newAgentService(dda *datadoghqv1alpha1.DatadogAgent) *corev1.Service {
 					Protocol:   corev1.ProtocolUDP,
 					TargetPort: intstr.FromInt(datadoghqv1alpha1.DefaultDogstatsdPort),
 					Port:       datadoghqv1alpha1.DefaultDogstatsdPort,
+					Name:       datadoghqv1alpha1.DefaultDogstatsdPortName,
 				},
 			},
 			SessionAffinity:       corev1.ServiceAffinityNone,
@@ -475,6 +476,7 @@ func newAgentService(dda *datadoghqv1alpha1.DatadogAgent) *corev1.Service {
 				Protocol:   corev1.ProtocolTCP,
 				TargetPort: intstr.FromInt(int(*dda.Spec.Agent.Apm.HostPort)),
 				Port:       *dda.Spec.Agent.Apm.HostPort,
+				Name:       datadoghqv1alpha1.DefaultApmPortName,
 			})
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add port names to the agent service.

### Motivation

When enabling both dogstatsd and APM, the agent service tries to expose 2 unnamed ports, which is [not allowed by Kubernetes](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) as it is considered ambiguous. The operator logs give the following error:

```json
{"level":"ERROR","ts":"2022-04-11T02:23:42Z","logger":"controller-runtime.manager.controller.datadogagent","msg":"Reconciler error","reconciler group":"datadoghq.com","reconciler kind":"DatadogAgent","name":"datadog","namespace":"default","error":"Service \"datadog-agent\" is invalid: [spec.ports[0].name: Required value, spec.ports[1].name: Required value]"}
```

### Describe your test plan

Spin up a DatadogAgent with APM enabled in the agent spec (`agent.apm.enabled=true`) so that both dogstatsd and APM are enabled:

```yaml
spec:
  agent:
    apm:
      enabled: true
```

If needed, to force creation of the agent service in Kubernetes v1.21+, enable `agent.localService.forceLocalServiceEnable=true`:

```yaml
spec:
  agent:
    localService:
      forceLocalServiceEnable: true
```

There shouldn't be any error in the operator logs about creating the agent service. The service should be created exposing both dogstatsd and APM ports:

```
> kubectl describe svc 
NAME                                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
datadog-agent                          ClusterIP   <cluster-ip>   <none>        8125/UDP,8126/TCP   2d19h
```