### PR TITLE
Update default DCA image to 1.19.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -18,7 +18,7 @@ const (
 	// AgentLatestVersion correspond to the latest stable agent release
 	AgentLatestVersion = "7.35.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "1.18.0"
+	ClusterAgentLatestVersion = "1.19.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

Update default cluster agent image to `1.19.0`.

### Describe your test plan

Deploy the cluster agent without specifying an image tag. It should spin up cluster agent version `1.19.0`.
