### PR TITLE
fix: k8s version detection for agent service

### DIFF
--- a/controllers/datadogagent/service.go
+++ b/controllers/datadogagent/service.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/pkg/version"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -152,7 +151,10 @@ var testGitVersion string
 
 func (r *Reconciler) manageAgentService(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
 	// Service Internal Traffic Policy exists in Kube 1.21 but it is enabled by default since 1.22
-	gitVersion := version.Get().GitVersion
+	gitVersion := ""
+	if r.versionInfo != nil {
+		gitVersion = r.versionInfo.GitVersion
+	}
 	if testGitVersion != "" {
 		gitVersion = testGitVersion
 	}

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -57,6 +57,11 @@ func TestCompareVersion(t *testing.T) {
 			minVersion: "7.28.0",
 			expected:   false,
 		},
+		{
+			version:    "1.23.4",
+			minVersion: "1.22-0",
+			expected:   true,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.version, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fix how we detect the Kubernetes version.
the information was already present in the reconciler.

the `manageAgentService()` function now use the information
from the `Reconcile` struct. 

### Motivation

Fix how we detect the Kubernetes version to automaticaly
create the local agent service if it is supported by the
kubernetes version.


### Additional Notes


### Describe your test plan

deploy the operator and create the `DatadogAgent` with this manifest

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  agent:
    apm:
      enabled: true
  clusterName: foo
  credentials:
    apiSecret:
      keyName: api-key
      secretName: datadog-secret
    appSecret:
      keyName: app-key
      secretName: datadog-secret
```

the service `datadog-agent` should be created in the same namespace.
