### PR TITLE
[backport] fix: k8s version detection for agent service (#472)

### DIFF
--- a/controllers/datadogagent/service.go
+++ b/controllers/datadogagent/service.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/pkg/version"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -152,7 +151,10 @@ var testGitVersion string
 
 func (r *Reconciler) manageAgentService(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
 	// Service Internal Traffic Policy exists in Kube 1.21 but it is enabled by default since 1.22
-	gitVersion := version.Get().GitVersion
+	gitVersion := ""
+	if r.versionInfo != nil {
+		gitVersion = r.versionInfo.GitVersion
+	}
 	if testGitVersion != "" {
 		gitVersion = testGitVersion
 	}

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -57,6 +57,11 @@ func TestCompareVersion(t *testing.T) {
 			minVersion: "7.28.0",
 			expected:   false,
 		},
+		{
+			version:    "1.23.4",
+			minVersion: "1.22-0",
+			expected:   true,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.version, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

backport #472: fix k8s version detection for agent service

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
