### PR TITLE
Default Agent version to 7.35.2

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,7 +16,7 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.35.0"
+	AgentLatestVersion = "7.35.2"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
 	ClusterAgentLatestVersion = "1.19.0"
 


### PR DESCRIPTION
### What does this PR do?
Update default agent image to 7.35.2.

### Describe your test plan
Deploy the agent without specifying an image tag. It should spin up agent version 7.35.2.