### PR TITLE
feat: add a status-check to be used for helm test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ image: registry.ddbuild.io/images/mirror/golang:1.17.6-bullseye
 variables:
   GO111MODULE: "on"
   PROJECTNAME: "datadog-operator"
+  PROJECTNAME_CHECK: "datadog-operator-check"
   GOPATH: "$CI_PROJECT_DIR/.cache"
   BUILD_DOCKER_REGISTRY: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci"
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
@@ -48,7 +49,7 @@ generate_code:
     - make generate manifests
     - git diff --exit-code
 
-build_image_amd64:
+build_operator_image_amd64:
   stage: image
   tags: ["runner:docker", "size:large"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
@@ -60,10 +61,10 @@ build_image_amd64:
     # DockerHub login for build to limit rate limit when pulling base images
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - IMG=$TARGET_IMAGE make docker-build-ci docker-push
+    - IMG=$TARGET_IMAGE make docker-build-ci docker-push-ci
     - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
 
-build_image_arm64:
+build_operator_image_arm64:
   stage: image
   tags: ["runner:docker-arm", "platform:arm64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718787-3888eda-18.09.6-arm64-py3
@@ -75,7 +76,37 @@ build_image_arm64:
     # DockerHub login for build to limit rate limit when pulling base images
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - IMG=$TARGET_IMAGE make docker-build-ci docker-push
+    - IMG=$TARGET_IMAGE make docker-build-ci docker-push-ci
+    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+
+build_operator_check_image_amd64:
+  stage: image
+  tags: ["runner:docker", "size:large"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
+  variables:
+    GOARCH: amd64
+    TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    RELEASE_IMAGE: $@DOCKER_REGISTRY/$PROJECTNAME_CHECK:$CI_COMMIT_TAG-amd64
+  script:
+    # DockerHub login for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - IMG_CHECK=$TARGET_IMAGE make docker-build-check-ci docker-push-check-ci
+    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+
+build_operator_check_image_arm64:
+  stage: image
+  tags: ["runner:docker-arm", "platform:arm64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718787-3888eda-18.09.6-arm64-py3
+  variables:
+    GOARCH: arm64
+    TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
+    RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:$CI_COMMIT_TAG-arm64
+  script:
+    # DockerHub login for build to limit rate limit when pulling base images
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - IMG_CHECK=$TARGET_IMAGE make docker-build-check-ci docker-push-check-ci
     - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
 
 build_bundle_image:
@@ -155,7 +186,7 @@ publish_redhat_bundle:
     IMG_DESTINATIONS: operator-bundle:$CI_COMMIT_TAG
     IMG_REGISTRIES: redhat-operator-bundle
 
-trigger_internal_image:
+trigger_internal_operator_image:
   stage: release
   rules:
     - if: $CI_COMMIT_TAG
@@ -167,6 +198,24 @@ trigger_internal_image:
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: datadog-operator
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"
+
+trigger_internal_operator_check_image:
+  stage: release
+  rules:
+    - if: $CI_COMMIT_TAG
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v1
+    IMAGE_NAME: $PROJECTNAME_CHECK
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
 IMG ?= gcr.io/datadoghq/operator:$(IMG_VERSION)
+IMG_CHECK ?= gcr.io/datadoghq/operator-check:latest
 
 CRD_OPTIONS ?= "crd:preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -150,16 +151,29 @@ generate: $(CONTROLLER_GEN) generate-openapi generate-docs ## Generate code
 generate-docs: manifests
 	go run ./hack/generate-docs.go
 
+# Build the docker images
 .PHONY: docker-build
-docker-build: generate docker-build-ci ## Build the docker image
+docker-build: generate docker-build-ci docker-build-check-ci
 
 .PHONY: docker-build-ci
 docker-build-ci:
 	docker build . -t ${IMG} --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}"
 
+.PHONY: docker-build-check-ci
+docker-build-check-ci:
+	docker build . -t ${IMG_CHECK} -f check-operator.Dockerfile --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}"
+
+# Push the docker images
 .PHONY: docker-push
-docker-push: ## Push the docker image
+docker-push: docker-push-ci docker-push-check-ci
+
+.PHONY: docker-push-ci
+docker-push-ci:
 	docker push ${IMG}
+
+.PHONY: docker-push-check-ci
+docker-push-check-ci:
+	docker push ${IMG_CHECK}
 
 ##@ Test
 
@@ -271,6 +285,10 @@ vendor: ## Run go vendor
 
 kubectl-datadog: lint
 	go build -ldflags '${LDFLAGS}' -o bin/kubectl-datadog ./cmd/kubectl-datadog/main.go
+
+.PHONY: check-operator
+check-operator: fmt vet lint
+	go build -ldflags '${LDFLAGS}' -o bin/check-operator ./cmd/check-operator/main.go
 
 bin/$(PLATFORM)/openapi-gen: vendor/k8s.io/kube-openapi/cmd/openapi-gen/openapi-gen.go
 	go build -o bin/$(PLATFORM)/openapi-gen k8s.io/kube-openapi/cmd/openapi-gen

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,0 +1,27 @@
+# Build the manager binary
+FROM golang:1.17 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/check-operator/ cmd/check-operator/
+COPY apis/ apis/
+COPY pkg/ pkg/
+
+# Build
+ARG LDFLAGS
+ARG GOARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o check-operator cmd/check-operator/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+WORKDIR /
+COPY --from=builder /workspace/check-operator .
+USER 1001
+
+ENTRYPOINT ["/check-operator"]

--- a/cmd/check-operator/README.md
+++ b/cmd/check-operator/README.md
@@ -1,4 +1,4 @@
 # check-operator
 
 `check-operator` is a CLI to run checks against the operator.
-The main use-case is to run it as a [Helm chart test](https://helm.sh/docs/topics/chart_tests/) to validate the rolling-update of the Agent based on the DatadogAgent custom resource status.
+The main use case is to run it as a [Helm chart test](https://helm.sh/docs/topics/chart_tests/) to validate the rolling update of the Agent, based on the DatadogAgent custom resource status.

--- a/cmd/check-operator/README.md
+++ b/cmd/check-operator/README.md
@@ -1,4 +1,4 @@
 # check-operator
 
-`check-operator` is a CLI to runs checks against the operator.
+`check-operator` is a CLI to run checks against the operator.
 The main use-case is to run it as a [Helm chart test](https://helm.sh/docs/topics/chart_tests/) to validate the rolling-update of the Agent based on the DatadogAgent custom resource status.

--- a/cmd/check-operator/README.md
+++ b/cmd/check-operator/README.md
@@ -1,0 +1,4 @@
+# check-operator
+
+`check-operator` is a CLI to runs checks against the operator.
+The main use-case is to run it as a [Helm chart test](https://helm.sh/docs/topics/chart_tests/) to validate the rolling-update of the Agent based on the DatadogAgent custom resource status.

--- a/cmd/check-operator/main.go
+++ b/cmd/check-operator/main.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/DataDog/datadog-operator/cmd/check-operator/root"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("check-operator", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	root := root.NewCmdRoot(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/check-operator/root/root.go
+++ b/cmd/check-operator/root/root.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package root
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/DataDog/datadog-operator/cmd/check-operator/upgrade"
+)
+
+// Options provides information required to manage Root.
+type Options struct {
+	configFlags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+}
+
+// NewRootOptions provides an instance of Options with default values.
+func NewRootOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		configFlags: genericclioptions.NewConfigFlags(false),
+		IOStreams:   streams,
+	}
+}
+
+// NewCmdRoot provides a cobra command wrapping Options.
+func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewRootOptions(streams)
+	cmd := &cobra.Command{
+		Use: "check-operator [subcommand] [flags]",
+	}
+
+	o.configFlags.AddFlags(cmd.Flags())
+	cmd.AddCommand(upgrade.NewCmdUpgrade(streams))
+
+	return cmd
+}
+
+// Complete sets all information required for processing the command.
+func (o *Options) Complete(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+// Validate ensures that all required arguments and flag values are provided.
+func (o *Options) Validate() error {
+	return nil
+}
+
+// Run runs the command.
+func (o *Options) Run() error {
+	return nil
+}

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -1,0 +1,209 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/plugin/common"
+)
+
+// Options provides information required to manage canary.
+type Options struct {
+	genericclioptions.IOStreams
+	common.Options
+	args               []string
+	datadogAgentName   string
+	checkPeriod        time.Duration
+	checkTimeout       time.Duration
+	agentCompletionPct float64
+	agentCompletionMin int32
+	dcaMinUpToDate     int32
+	clcMinUpToDate     int32
+}
+
+// NewOptions provides an instance of Options with default values.
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	opts := &Options{
+		IOStreams:          streams,
+		checkPeriod:        30 * time.Second,
+		checkTimeout:       2 * time.Hour,
+		agentCompletionPct: 0.95,
+		agentCompletionMin: 10,
+		dcaMinUpToDate:     1,
+		clcMinUpToDate:     2,
+	}
+
+	opts.SetConfigFlags()
+
+	if val, found := os.LookupEnv("AGENT_COMPLETION_PCT"); found {
+		if iVal, err := strconv.ParseFloat(val, 64); err == nil {
+			opts.agentCompletionPct = iVal / 100
+		}
+	}
+
+	if val, found := os.LookupEnv("AGENT_COMPLETION_MIN"); found {
+		if iVal, err := strconv.ParseInt(val, 10, 32); err == nil {
+			opts.agentCompletionMin = int32(iVal)
+		}
+	}
+
+	if val, found := os.LookupEnv("DCA_MIN_UP_TO_DATE"); found {
+		if iVal, err := strconv.ParseInt(val, 10, 32); err == nil {
+			opts.dcaMinUpToDate = int32(iVal)
+		}
+	}
+
+	if val, found := os.LookupEnv("CLC_MIN_UP_TO_DATE"); found {
+		if iVal, err := strconv.ParseInt(val, 10, 32); err == nil {
+			opts.clcMinUpToDate = int32(iVal)
+		}
+	}
+
+	if val, found := os.LookupEnv("CHECK_TIMEOUT_MINUTES"); found {
+		if iVal, err := strconv.ParseInt(val, 10, 32); err == nil {
+			opts.checkTimeout = time.Duration(iVal) * time.Minute
+		}
+	}
+
+	return opts
+}
+
+// NewCmdUpgrade provides a cobra command wrapping Options.
+func NewCmdUpgrade(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "upgrade [DatadogAgent name]",
+		Short:        "Wait until the rolling-update of all agent components is finished",
+		Example:      "./check-operator upgrade datadog-agent",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+
+			return o.Run()
+		},
+	}
+
+	o.ConfigFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// Complete sets all information required for processing the command.
+func (o *Options) Complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	if len(args) > 0 {
+		o.datadogAgentName = args[0]
+	}
+
+	return o.Init(cmd)
+}
+
+// Validate ensures that all required arguments and flag values are provided.
+func (o *Options) Validate() error {
+	if o.datadogAgentName == "" {
+		return fmt.Errorf("the DatadogAgent name is required")
+	}
+
+	return nil
+}
+
+// Run use to run the command.
+func (o *Options) Run() error {
+	o.printOutf("Start checking rolling-update status")
+	agentDone, dcaDone, clcDone := false, false, false
+	checkFunc := func() (bool, error) {
+		datadogAgent := &v1alpha1.DatadogAgent{}
+		err := o.Client.Get(context.TODO(), client.ObjectKey{Namespace: o.UserNamespace, Name: o.datadogAgentName}, datadogAgent)
+		if err != nil {
+			return false, fmt.Errorf("unable to get DatadogAgent, err: %w", err)
+		}
+
+		if !agentDone {
+			agentDone = o.isAgentDone(datadogAgent.Status.Agent)
+		}
+
+		if !dcaDone {
+			dcaDone = o.isDeploymentDone(datadogAgent.Status.ClusterAgent, o.dcaMinUpToDate, "Cluster Agent")
+		}
+
+		if !clcDone {
+			clcDone = o.isDeploymentDone(datadogAgent.Status.ClusterChecksRunner, o.clcMinUpToDate, "Cluster Check Runner")
+		}
+
+		if agentDone && dcaDone && clcDone {
+			return true, nil
+		}
+
+		o.printOutf("One or multiple components are still upgrading...")
+
+		if datadogAgent.Status.Agent != nil {
+			o.printOutf("[Agent] nb pods: %d, nb updated pods: %d", datadogAgent.Status.Agent.Current, datadogAgent.Status.Agent.UpToDate)
+		}
+
+		if datadogAgent.Status.ClusterAgent != nil {
+			o.printOutf("[Cluster Agent] nb pods: %d, nb updated pods: %d", datadogAgent.Status.ClusterAgent.Replicas, datadogAgent.Status.ClusterAgent.UpdatedReplicas)
+		}
+
+		if datadogAgent.Status.ClusterChecksRunner != nil {
+			o.printOutf("[Cluster Check Runner] nb pods: %d, nb updated pods: %d", datadogAgent.Status.ClusterChecksRunner.Replicas, datadogAgent.Status.ClusterChecksRunner.UpdatedReplicas)
+		}
+
+		return false, nil
+	}
+
+	return wait.Poll(o.checkPeriod, o.checkTimeout, checkFunc)
+}
+
+func (o *Options) isAgentDone(status *v1alpha1.DaemonSetStatus) bool {
+	if status == nil {
+		return true
+	}
+
+	if float64(status.UpToDate) > float64(status.Current)*o.agentCompletionPct || status.Current-status.UpToDate <= o.agentCompletionMin {
+		o.printOutf("[Agent] upgrade is now finished (reached threshold): %d, nb updated pods: %d, threshold pct: %f, min threshold: %d", status.Current, status.UpToDate, o.agentCompletionPct, o.agentCompletionMin)
+
+		return true
+	}
+
+	return false
+}
+
+func (o *Options) isDeploymentDone(status *v1alpha1.DeploymentStatus, minUpToDate int32, component string) bool {
+	if status == nil {
+		return true
+	}
+
+	if status.UpdatedReplicas >= minUpToDate {
+		o.printOutf("[%s] upgrade is now finished (reached threshold): %d, nb updated pods: %d, min up-to-date threshold: %d", component, status.Replicas, status.UpdatedReplicas, o.dcaMinUpToDate)
+
+		return true
+	}
+
+	return false
+}
+
+func (o *Options) printOutf(format string, a ...interface{}) {
+	args := []interface{}{time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), o.UserNamespace, o.datadogAgentName}
+	args = append(args, a...)
+	_, _ = fmt.Fprintf(o.Out, "[%s] DatadogAgent '%s/%s': "+format+"\n", args...)
+}


### PR DESCRIPTION
### What does this PR do?

Add a small check to be run as a helm test job for both operator and agent with operator deploys. It checks the rolling-updates status of the agent via the operator status.

### Motivation

Improve CI reliability

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

This will be tested closely in the internal infra
