### PR TITLE
fix(ksm-core): set CLC Runner enabled properly

### DIFF
--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -26,7 +26,7 @@ const (
 	DDLogsConfigContainerCollectAll       = "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL"
 	DDLogsContainerCollectUsingFiles      = "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE"
 	DDLogsConfigOpenFilesLimit            = "DD_LOGS_CONFIG_OPEN_FILES_LIMIT"
-  DDPrometheusScrapeEnabled             = "DD_PROMETHEUS_SCRAPE_ENABLED"
+	DDPrometheusScrapeEnabled             = "DD_PROMETHEUS_SCRAPE_ENABLED"
 	DDPrometheusScrapeServiceEndpoints    = "DD_PROMETHEUS_SCRAPE_SERVICE_ENDPOINTS"
 	DDPrometheusScrapeChecks              = "DD_PROMETHEUS_SCRAPE_CHECKS"
 )

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -73,11 +73,11 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 
 		if dda.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.Enabled) {
 			f.clusterChecksEnabled = true
-			output.ClusterCheckRunner.IsRequired = &f.clusterChecksEnabled
 
 			if apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners) {
 				f.rbacSuffix = common.CheckRunnersSuffix
 				f.serviceAccountName = v2alpha1.GetClusterChecksRunnerServiceAccount(dda)
+				output.ClusterCheckRunner.IsRequired = apiutils.NewBoolPointer(true)
 			} else {
 				f.serviceAccountName = v2alpha1.GetClusterAgentServiceAccount(dda)
 			}
@@ -96,12 +96,15 @@ func (f *ksmFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) feature.RequiredCom
 		f.enable = true
 		output.ClusterAgent.IsRequired = &f.enable
 
-		if dda.Spec.ClusterAgent.Config != nil && apiutils.BoolValue(dda.Spec.ClusterAgent.Config.ClusterChecksEnabled) {
+		if dda.Spec.ClusterAgent.Config != nil && apiutils.BoolValue(dda.Spec.ClusterAgent.Config.ClusterChecksEnabled) && apiutils.BoolValue(dda.Spec.Features.KubeStateMetricsCore.ClusterCheck) {
 			f.clusterChecksEnabled = true
-			f.rbacSuffix = common.CheckRunnersSuffix
-			f.serviceAccountName = v1alpha1.GetClusterChecksRunnerServiceAccount(dda)
 
-			output.ClusterCheckRunner.IsRequired = &f.clusterChecksEnabled
+			if apiutils.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
+				output.ClusterCheckRunner.IsRequired = apiutils.NewBoolPointer(true)
+
+				f.rbacSuffix = common.CheckRunnersSuffix
+				f.serviceAccountName = v1alpha1.GetClusterChecksRunnerServiceAccount(dda)
+			}
 		} else {
 			f.serviceAccountName = v1alpha1.GetClusterAgentServiceAccount(dda)
 		}


### PR DESCRIPTION
### What does this PR do?

Fix how we configure the `kubernetes_state_core` check feature:
* It should run in cluster-check-runner only if they are enabled.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Create an DatadogAgent with ksm-core enable, but without CLC runner enabled:
* the check should run in the DCA

Then update the DatadogAgent with CLC runner enabled:
* the check should now run in the clc-runner.
