### PR TITLE
uniformly name clusterchecksrunner

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -459,8 +459,8 @@ func DefaultRbacConfig(rbac *RbacConfig) *RbacConfig {
 	return rbacOverride
 }
 
-// DefaultDatadogClusterCheckRunnerSpecRbacConfig used to default a RbacConfig of the Cluster Check Runner
-func DefaultDatadogClusterCheckRunnerSpecRbacConfig(clc *DatadogAgentSpecClusterChecksRunnerSpec) *RbacConfig {
+// DefaultDatadogClusterChecksRunnerSpecRbacConfig used to default a RbacConfig of the Cluster Check Runner
+func DefaultDatadogClusterChecksRunnerSpecRbacConfig(clc *DatadogAgentSpecClusterChecksRunnerSpec) *RbacConfig {
 	if clc.Rbac == nil {
 		// prevent passing an empty reference
 		clc.Rbac = &RbacConfig{}
@@ -1148,11 +1148,11 @@ func DefaultDatadogAgentSpecClusterChecksRunner(clusterChecksRunner *DatadogAgen
 		clcOverride.Config = cfg
 	}
 
-	if rbac := DefaultDatadogClusterCheckRunnerSpecRbacConfig(clusterChecksRunner); !apiutils.IsEqualStruct(rbac, RbacConfig{}) {
+	if rbac := DefaultDatadogClusterChecksRunnerSpecRbacConfig(clusterChecksRunner); !apiutils.IsEqualStruct(rbac, RbacConfig{}) {
 		clcOverride.Rbac = rbac
 	}
 
-	if net := DefaultClusterCheckRunnerNetworkPolicy(clusterChecksRunner); !apiutils.IsEqualStruct(net, NetworkPolicySpec{}) {
+	if net := DefaultClusterChecksRunnerNetworkPolicy(clusterChecksRunner); !apiutils.IsEqualStruct(net, NetworkPolicySpec{}) {
 		clcOverride.NetworkPolicy = net
 	}
 
@@ -1277,8 +1277,8 @@ func DefaultClusterAgentNetworkPolicy(dca *DatadogAgentSpecClusterAgentSpec) *Ne
 	return DefaultNetworkPolicy(dca.NetworkPolicy)
 }
 
-// DefaultClusterCheckRunnerNetworkPolicy defaults the Network Policy for the Cluster Check Runner
-func DefaultClusterCheckRunnerNetworkPolicy(clc *DatadogAgentSpecClusterChecksRunnerSpec) *NetworkPolicySpec {
+// DefaultClusterChecksRunnerNetworkPolicy defaults the Network Policy for the Cluster Check Runner
+func DefaultClusterChecksRunnerNetworkPolicy(clc *DatadogAgentSpecClusterChecksRunnerSpec) *NetworkPolicySpec {
 	if clc.NetworkPolicy == nil {
 		clc.NetworkPolicy = &NetworkPolicySpec{}
 	}

--- a/apis/datadoghq/v1alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default_test.go
@@ -899,7 +899,7 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 			},
 		},
 		{
-			name: "enabled orchestrator, enabled clustecheck",
+			name: "enabled orchestrator, enabled clustercheck",
 			orc: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
 					Enabled:      apiutils.NewBoolPointer(true),
@@ -923,7 +923,7 @@ func TestDefaultDatadogFeatureOrchestratorExplorer(t *testing.T) {
 			},
 		},
 		{
-			name: "enabled orchestrator, checkrunner enabled, clustecheck disable",
+			name: "enabled orchestrator, checksrunner enabled, clustercheck disabled",
 			orc: &DatadogFeatures{
 				OrchestratorExplorer: &OrchestratorExplorerConfig{
 					Enabled:      apiutils.NewBoolPointer(true),

--- a/apis/datadoghq/v2alpha1/const.go
+++ b/apis/datadoghq/v2alpha1/const.go
@@ -6,8 +6,8 @@ const (
 	ClusterAgentReconcileConditionType = "ClusterAgentReconcile"
 	// AgentReconcileConditionType ReconcileConditionType for Agent component
 	AgentReconcileConditionType = "AgentReconcile"
-	// ClusterCheckRunnerReconcileConditionType ReconcileConditionType for Cluster Check Runner component
-	ClusterCheckRunnerReconcileConditionType = "ClusterCheckRunnerReconcile"
+	// ClusterChecksRunnerReconcileConditionType ReconcileConditionType for Cluster Checks Runner component
+	ClusterChecksRunnerReconcileConditionType = "ClusterChecksRunnerReconcile"
 	// DatadogAgentReconcileErrorConditionType  ReconcileConditionType for DatadogAgent reconcile error
 	DatadogAgentReconcileErrorConditionType = "DatadogAgentReconcileError"
 )

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -829,8 +829,8 @@ func (r *Reconciler) createAgentClusterRole(logger logr.Logger, dda *datadoghqv1
 	return reconcile.Result{Requeue: true}, err
 }
 
-func (r *Reconciler) createClusterCheckRunnerClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) (reconcile.Result, error) {
-	clusterRole := buildClusterCheckRunnerClusterRole(dda, name, agentVersion)
+func (r *Reconciler) createClusterChecksRunnerClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string) (reconcile.Result, error) {
+	clusterRole := buildClusterChecksRunnerClusterRole(dda, name, agentVersion)
 	logger.V(1).Info("createAgentClusterRole", "clusterRole.name", clusterRole.Name)
 	event := buildEventInfo(clusterRole.Name, clusterRole.Namespace, clusterRoleKind, datadog.CreationEvent)
 	r.recordEvent(dda, event)
@@ -853,8 +853,8 @@ func (r *Reconciler) updateIfNeededAgentClusterRole(logger logr.Logger, dda *dat
 	return r.updateIfNeededClusterRole(logger, dda, clusterRole, newClusterRole)
 }
 
-func (r *Reconciler) updateIfNeededClusterCheckRunnerClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string, clusterRole *rbacv1.ClusterRole) (reconcile.Result, error) {
-	newClusterRole := buildClusterCheckRunnerClusterRole(dda, name, agentVersion)
+func (r *Reconciler) updateIfNeededClusterChecksRunnerClusterRole(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, name, agentVersion string, clusterRole *rbacv1.ClusterRole) (reconcile.Result, error) {
+	newClusterRole := buildClusterChecksRunnerClusterRole(dda, name, agentVersion)
 	return r.updateIfNeededClusterRole(logger, dda, clusterRole, newClusterRole)
 }
 
@@ -907,8 +907,8 @@ func buildAgentClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, version st
 	return buildClusterRole(dda, !isClusterAgentEnabled(dda.Spec.ClusterAgent), name, version)
 }
 
-// buildClusterCheckRunnerClusterRole creates a ClusterRole object for the ClusterCheckRunner based on its config
-func buildClusterCheckRunnerClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, version string) *rbacv1.ClusterRole {
+// buildClusterChecksRunnerClusterRole creates a ClusterRole object for the ClusterChecksRunner based on its config
+func buildClusterChecksRunnerClusterRole(dda *datadoghqv1alpha1.DatadogAgent, name, version string) *rbacv1.ClusterRole {
 	return buildClusterRole(dda, true, name, version)
 }
 

--- a/controllers/datadogagent/clusterchecksrunner_rbac.go
+++ b/controllers/datadogagent/clusterchecksrunner_rbac.go
@@ -37,11 +37,11 @@ func (r *Reconciler) manageClusterChecksRunnerRBACs(logger logr.Logger, dda *dat
 	clusterRole := &rbacv1.ClusterRole{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: rbacResourcesName}, clusterRole); err != nil {
 		if errors.IsNotFound(err) {
-			return r.createClusterCheckRunnerClusterRole(logger, dda, rbacResourcesName, agentVersion)
+			return r.createClusterChecksRunnerClusterRole(logger, dda, rbacResourcesName, agentVersion)
 		}
 		return reconcile.Result{}, err
 	}
-	if result, err := r.updateIfNeededClusterCheckRunnerClusterRole(logger, dda, rbacResourcesName, agentVersion, clusterRole); err != nil {
+	if result, err := r.updateIfNeededClusterChecksRunnerClusterRole(logger, dda, rbacResourcesName, agentVersion, clusterRole); err != nil {
 		return result, err
 	}
 
@@ -73,11 +73,11 @@ func (r *Reconciler) manageClusterChecksRunnerRBACs(logger logr.Logger, dda *dat
 	}
 
 	if isOrchestratorExplorerEnabled(dda) {
-		if result, err := r.createOrUpdateOrchestratorCoreRBAC(logger, dda, serviceAccountName, clusterChecksRunnerVersion, common.CheckRunnersSuffix); err != nil {
+		if result, err := r.createOrUpdateOrchestratorCoreRBAC(logger, dda, serviceAccountName, clusterChecksRunnerVersion, common.ChecksRunnerSuffix); err != nil {
 			return result, err
 		}
 	} else {
-		if result, err := r.cleanupOrchestratorCoreRBAC(logger, dda, common.CheckRunnersSuffix); err != nil {
+		if result, err := r.cleanupOrchestratorCoreRBAC(logger, dda, common.ChecksRunnerSuffix); err != nil {
 			return result, err
 		}
 	}

--- a/controllers/datadogagent/common/const.go
+++ b/controllers/datadogagent/common/const.go
@@ -14,6 +14,6 @@ const (
 	ExtensionAPIServerAuthResourceName = "extension-apiserver-authentication"
 	KubeSystemResourceName             = "kube-system"
 
-	CheckRunnersSuffix = "ccr"
+	ChecksRunnerSuffix = "ccr"
 	ClusterAgentSuffix = "dca"
 )

--- a/controllers/datadogagent/common_rbac.go
+++ b/controllers/datadogagent/common_rbac.go
@@ -292,10 +292,10 @@ func rbacNamesForDda(dda *datadoghqv1alpha1.DatadogAgent, versionInfo *version.I
 		getExternalMetricsReaderClusterRoleName(dda, versionInfo),
 		// kubestatemetrics_core can run on the DCA and the Runners
 		kubernetesstatecore.GetKubeStateMetricsRBACResourceName(dda, common.ClusterAgentSuffix),
-		kubernetesstatecore.GetKubeStateMetricsRBACResourceName(dda, common.CheckRunnersSuffix),
+		kubernetesstatecore.GetKubeStateMetricsRBACResourceName(dda, common.ChecksRunnerSuffix),
 		// Orchestrator can run on the DCA or the Runners
 		getOrchestratorRBACResourceName(dda, common.ClusterAgentSuffix),
-		getOrchestratorRBACResourceName(dda, common.CheckRunnersSuffix),
+		getOrchestratorRBACResourceName(dda, common.ChecksRunnerSuffix),
 	}
 }
 

--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package clustercheckrunner
+package clusterchecksrunner
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
@@ -15,11 +15,11 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 )
 
-// NewDefaultClusterCheckRunnerDeployment return a new default cluster-check-runner deployment
-func NewDefaultClusterCheckRunnerDeployment(dda metav1.Object) *appsv1.Deployment {
-	deployment := component.NewDeployment(dda, apicommon.DefaultClusterChecksRunnerResourceSuffix, component.GetClusterCheckRunnerName(dda), component.GetAgentVersion(dda), nil)
+// NewDefaultClusterChecksRunnerDeployment return a new default cluster-check-runner deployment
+func NewDefaultClusterChecksRunnerDeployment(dda metav1.Object) *appsv1.Deployment {
+	deployment := component.NewDeployment(dda, apicommon.DefaultClusterChecksRunnerResourceSuffix, component.GetClusterChecksRunnerName(dda), component.GetAgentVersion(dda), nil)
 
-	podTemplate := NewDefaultClusterCheckRunnerPodTemplateSpec(dda)
+	podTemplate := NewDefaultClusterChecksRunnerPodTemplateSpec(dda)
 	for key, val := range deployment.GetLabels() {
 		podTemplate.Labels[key] = val
 	}
@@ -34,9 +34,9 @@ func NewDefaultClusterCheckRunnerDeployment(dda metav1.Object) *appsv1.Deploymen
 	return deployment
 }
 
-// NewDefaultClusterCheckRunnerPodTemplateSpec return a default cluster-check-runner for the cluster-agent deployment
-func NewDefaultClusterCheckRunnerPodTemplateSpec(dda metav1.Object) *corev1.PodTemplateSpec {
-	// TODO(operator-ga): implement NewDefaultClusterCheckRunnerPodTemplateSpec function
+// NewDefaultClusterChecksRunnerPodTemplateSpec return a default cluster-check-runner for the cluster-agent deployment
+func NewDefaultClusterChecksRunnerPodTemplateSpec(dda metav1.Object) *corev1.PodTemplateSpec {
+	// TODO(operator-ga): implement NewDefaultClusterChecksRunnerPodTemplateSpec function
 	template := &corev1.PodTemplateSpec{}
 
 	return template

--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 )
 
-// NewDefaultClusterChecksRunnerDeployment return a new default cluster-check-runner deployment
+// NewDefaultClusterChecksRunnerDeployment return a new default cluster-checks-runner deployment
 func NewDefaultClusterChecksRunnerDeployment(dda metav1.Object) *appsv1.Deployment {
 	deployment := component.NewDeployment(dda, apicommon.DefaultClusterChecksRunnerResourceSuffix, component.GetClusterChecksRunnerName(dda), component.GetAgentVersion(dda), nil)
 
@@ -34,7 +34,7 @@ func NewDefaultClusterChecksRunnerDeployment(dda metav1.Object) *appsv1.Deployme
 	return deployment
 }
 
-// NewDefaultClusterChecksRunnerPodTemplateSpec return a default cluster-check-runner for the cluster-agent deployment
+// NewDefaultClusterChecksRunnerPodTemplateSpec return a default cluster-checks-runner for the cluster-agent deployment
 func NewDefaultClusterChecksRunnerPodTemplateSpec(dda metav1.Object) *corev1.PodTemplateSpec {
 	// TODO(operator-ga): implement NewDefaultClusterChecksRunnerPodTemplateSpec function
 	template := &corev1.PodTemplateSpec{}

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -166,7 +166,7 @@ func GetAgentVersion(dda metav1.Object) string {
 	return ""
 }
 
-// GetClusterChecksRunnerName return the Cluster-Check-Runner name based on the DatadogAgent name
+// GetClusterChecksRunnerName return the Cluster-Checks-Runner name based on the DatadogAgent name
 func GetClusterChecksRunnerName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultClusterChecksRunnerResourceSuffix)
 }

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -166,7 +166,7 @@ func GetAgentVersion(dda metav1.Object) string {
 	return ""
 }
 
-// GetClusterCheckRunnerName return the Cluster-Check-Runner name based on the DatadogAgent name
-func GetClusterCheckRunnerName(dda metav1.Object) string {
+// GetClusterChecksRunnerName return the Cluster-Check-Runner name based on the DatadogAgent name
+func GetClusterChecksRunnerName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultClusterChecksRunnerResourceSuffix)
 }

--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -157,7 +157,7 @@ func (r *Reconciler) reconcileInstance(ctx context.Context, logger logr.Logger, 
 	if err != nil {
 		return result, fmt.Errorf("unable to build features, err: %w", err)
 	}
-	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent, "cluster-agent", requiredComponents.ClusterAgent, "cluster-check-runner", requiredComponents.ClusterCheckRunner)
+	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent, "cluster-agent", requiredComponents.ClusterAgent, "cluster-check-runner", requiredComponents.ClusterChecksRunner)
 
 	// -----------------------
 	// Manage dependencies

--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -157,7 +157,7 @@ func (r *Reconciler) reconcileInstance(ctx context.Context, logger logr.Logger, 
 	if err != nil {
 		return result, fmt.Errorf("unable to build features, err: %w", err)
 	}
-	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent, "cluster-agent", requiredComponents.ClusterAgent, "cluster-check-runner", requiredComponents.ClusterChecksRunner)
+	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent, "cluster-agent", requiredComponents.ClusterAgent, "cluster-checks-runner", requiredComponents.ClusterChecksRunner)
 
 	// -----------------------
 	// Manage dependencies

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -36,7 +36,7 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, features []feature.Fea
 		}
 	}
 
-	// If Override is define for the cluster-check-runner component, apply the override on the PodTemplateSpec, it will cascade to container.
+	// If Override is define for the cluster-checks-runner component, apply the override on the PodTemplateSpec, it will cascade to container.
 	if _, ok := dda.Spec.Override[datadoghqv2alpha1.NodeAgentComponentName]; ok {
 		_, err = override.PodTemplateSpec(podManagers, dda.Spec.Override[datadoghqv2alpha1.NodeAgentComponentName])
 		if err != nil {

--- a/controllers/datadogagent/controller_reconcile_ccr.go
+++ b/controllers/datadogagent/controller_reconcile_ccr.go
@@ -7,7 +7,7 @@ package datadogagent
 
 import (
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	componentclc "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clustercheckrunner"
+	componentccr "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusterchecksrunner"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/override"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,12 +16,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *Reconciler) reconcileV2ClusterCheckRunner(logger logr.Logger, features []feature.Feature, dda *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+func (r *Reconciler) reconcileV2ClusterChecksRunner(logger logr.Logger, features []feature.Feature, dda *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus) (reconcile.Result, error) {
 	var result reconcile.Result
 	var err error
 
 	// Start by creating the Default Cluster-Agent deployment
-	deployment := componentclc.NewDefaultClusterCheckRunnerDeployment(dda)
+	deployment := componentccr.NewDefaultClusterChecksRunnerDeployment(dda)
 	podManagers := feature.NewPodTemplateManagers(&deployment.Spec.Template)
 
 	// Set Global setting on the default deployment
@@ -42,11 +42,11 @@ func (r *Reconciler) reconcileV2ClusterCheckRunner(logger logr.Logger, features 
 		}
 	}
 
-	deploymentLogger := logger.WithValues("component", datadoghqv2alpha1.ClusterCheckRunnerReconcileConditionType)
-	return r.createOrUpdateDeployment(deploymentLogger, dda, deployment, newStatus, updateStatusV2WithClusterCheckRunner)
+	deploymentLogger := logger.WithValues("component", datadoghqv2alpha1.ClusterChecksRunnerReconcileConditionType)
+	return r.createOrUpdateDeployment(deploymentLogger, dda, deployment, newStatus, updateStatusV2WithClusterChecksRunner)
 }
 
-func updateStatusV2WithClusterCheckRunner(newStatus *datadoghqv2alpha1.DatadogAgentStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string) {
+func updateStatusV2WithClusterChecksRunner(newStatus *datadoghqv2alpha1.DatadogAgentStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string) {
 	// TODO(operator-ga): update status with DCA deployment information
-	datadoghqv2alpha1.UpdateDatadogAgentStatusConditions(newStatus, updateTime, datadoghqv2alpha1.ClusterCheckRunnerReconcileConditionType, status, reason, message, true)
+	datadoghqv2alpha1.UpdateDatadogAgentStatusConditions(newStatus, updateTime, datadoghqv2alpha1.ClusterChecksRunnerReconcileConditionType, status, reason, message, true)
 }

--- a/controllers/datadogagent/controller_reconcile_ccr.go
+++ b/controllers/datadogagent/controller_reconcile_ccr.go
@@ -34,7 +34,7 @@ func (r *Reconciler) reconcileV2ClusterChecksRunner(logger logr.Logger, features
 		}
 	}
 
-	// If Override is define for the cluster-check-runner component, apply the override on the PodTemplateSpec, it will cascade to container.
+	// If Override is define for the cluster-checks-runner component, apply the override on the PodTemplateSpec, it will cascade to container.
 	if _, ok := dda.Spec.Override[datadoghqv2alpha1.ClusterChecksRunnerComponentName]; ok {
 		_, err = override.PodTemplateSpec(podManagers, dda.Spec.Override[datadoghqv2alpha1.ClusterChecksRunnerComponentName])
 		if err != nil {

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -86,7 +86,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	if err != nil {
 		return result, fmt.Errorf("unable to build features, err: %w", err)
 	}
-	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent.IsEnabled(), "cluster-agent", requiredComponents.ClusterAgent.IsEnabled(), "cluster-check-runner", requiredComponents.ClusterCheckRunner.IsEnabled())
+	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent.IsEnabled(), "cluster-agent", requiredComponents.ClusterAgent.IsEnabled(), "cluster-check-runner", requiredComponents.ClusterChecksRunner.IsEnabled())
 
 	// -----------------------
 	// Manage dependencies
@@ -131,8 +131,8 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 		}
 	}
 
-	if requiredComponents.ClusterCheckRunner.IsEnabled() {
-		result, err = r.reconcileV2ClusterCheckRunner(logger, features, instance, newStatus)
+	if requiredComponents.ClusterChecksRunner.IsEnabled() {
+		result, err = r.reconcileV2ClusterChecksRunner(logger, features, instance, newStatus)
 		if utils.ShouldReturn(result, err) {
 			return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err)
 		}

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -86,7 +86,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	if err != nil {
 		return result, fmt.Errorf("unable to build features, err: %w", err)
 	}
-	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent.IsEnabled(), "cluster-agent", requiredComponents.ClusterAgent.IsEnabled(), "cluster-check-runner", requiredComponents.ClusterChecksRunner.IsEnabled())
+	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent.IsEnabled(), "cluster-agent", requiredComponents.ClusterAgent.IsEnabled(), "cluster-checks-runner", requiredComponents.ClusterChecksRunner.IsEnabled())
 
 	// -----------------------
 	// Manage dependencies

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -2034,7 +2034,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 					resourceName := getClusterChecksRunnerRbacResourcesName(dda)
 					version := getAgentVersion(dda)
 
-					_ = c.Create(context.TODO(), buildClusterCheckRunnerClusterRole(dda, resourceName, version))
+					_ = c.Create(context.TODO(), buildClusterChecksRunnerClusterRole(dda, resourceName, version))
 					_ = c.Create(context.TODO(), buildServiceAccount(dda, getClusterChecksRunnerServiceAccount(dda), version))
 				},
 			},
@@ -2102,7 +2102,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					version := getClusterChecksRunnerVersion(dda)
 					resourceName := getClusterChecksRunnerRbacResourcesName(dda)
-					_ = c.Create(context.TODO(), buildClusterCheckRunnerClusterRole(dda, resourceName, version))
+					_ = c.Create(context.TODO(), buildClusterChecksRunnerClusterRole(dda, resourceName, version))
 
 					_ = c.Create(context.TODO(), buildClusterRoleBinding(dda, roleBindingInfo{
 						name:               rbacResourcesNameClusterChecksRunner,
@@ -2867,7 +2867,7 @@ func createClusterChecksRunnerRBAC(c client.Client, dda *datadoghqv1alpha1.Datad
 	resourceName := getClusterChecksRunnerRbacResourcesName(dda)
 	version := getAgentVersion(dda)
 
-	_ = c.Create(context.TODO(), buildClusterCheckRunnerClusterRole(dda, resourceName, version))
+	_ = c.Create(context.TODO(), buildClusterChecksRunnerClusterRole(dda, resourceName, version))
 	_ = c.Create(context.TODO(), buildClusterRoleBinding(dda, roleBindingInfo{
 		name:               resourceName,
 		roleName:           resourceName,

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -2106,7 +2106,7 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 
 					_ = c.Create(context.TODO(), buildClusterRoleBinding(dda, roleBindingInfo{
 						name:               rbacResourcesNameClusterChecksRunner,
-						roleName:           "foo-cluster-check-runner",
+						roleName:           "foo-cluster-checks-runner",
 						serviceAccountName: rbacResourcesNameClusterChecksRunner,
 					}, version))
 				},

--- a/controllers/datadogagent/feature/dummy/feature.go
+++ b/controllers/datadogagent/feature/dummy/feature.go
@@ -58,7 +58,7 @@ func (f *dummyFeature) ManageClusterAgent(managers feature.PodTemplateManagers) 
 // It should do nothing if the feature doesn't need to configure it.
 func (f *dummyFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error { return nil }
 
-// ManageClusterChecksRunner allows a feature to configure the ClusterCheckRunnerAgent's corev1.PodTemplateSpec
+// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunnerAgent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *dummyFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
 	return nil

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -64,7 +64,7 @@ func (f *defaultFeature) ManageClusterAgent(managers feature.PodTemplateManagers
 // It should do nothing if the feature doesn't need to configure it.
 func (f *defaultFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error { return nil }
 
-// ManageClusterChecksRunner allows a feature to configure the ClusterCheckRunnerAgent's corev1.PodTemplateSpec
+// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunnerAgent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *defaultFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
 	return nil

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -75,9 +75,9 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 			f.clusterChecksEnabled = true
 
 			if apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners) {
-				f.rbacSuffix = common.CheckRunnersSuffix
+				f.rbacSuffix = common.ChecksRunnerSuffix
 				f.serviceAccountName = v2alpha1.GetClusterChecksRunnerServiceAccount(dda)
-				output.ClusterCheckRunner.IsRequired = apiutils.NewBoolPointer(true)
+				output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 			} else {
 				f.serviceAccountName = v2alpha1.GetClusterAgentServiceAccount(dda)
 			}
@@ -100,9 +100,9 @@ func (f *ksmFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) feature.RequiredCom
 			f.clusterChecksEnabled = true
 
 			if apiutils.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
-				output.ClusterCheckRunner.IsRequired = apiutils.NewBoolPointer(true)
+				output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 
-				f.rbacSuffix = common.CheckRunnersSuffix
+				f.rbacSuffix = common.ChecksRunnerSuffix
 				f.serviceAccountName = v1alpha1.GetClusterChecksRunnerServiceAccount(dda)
 			}
 		} else {
@@ -175,7 +175,7 @@ func (f *ksmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	return managers.EnvVar().AddEnvVarToContainerWithMergeFunc(apicommonv1.CoreAgentContainerName, ignoreAutoConf, merger.AppendToValueEnvVarMergeFunction)
 }
 
-// ManageClusterChecksRunner allows a feature to configure the ClusterCheckRunnerAgent's corev1.PodTemplateSpec
+// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunnerAgent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *ksmFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
 	return nil

--- a/controllers/datadogagent/feature/logcollection/feature.go
+++ b/controllers/datadogagent/feature/logcollection/feature.go
@@ -161,7 +161,7 @@ func (f *logCollectionFeature) ManageNodeAgent(managers feature.PodTemplateManag
 	return nil
 }
 
-// ManageClusterChecksRunner allows a feature to configure the ClusterCheckRunnerAgent's corev1.PodTemplateSpec
+// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunnerAgent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *logCollectionFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
 	return nil

--- a/controllers/datadogagent/feature/test/testsuite.go
+++ b/controllers/datadogagent/feature/test/testsuite.go
@@ -31,9 +31,9 @@ type FeatureTest struct {
 	StoreOption   *dependencies.StoreOptions
 	StoreInitFunc func(store dependencies.StoreClient)
 	// Test configuration
-	Agent              *ComponentTest
-	ClusterAgent       *ComponentTest
-	ClusterCheckRunner *ComponentTest
+	Agent               *ComponentTest
+	ClusterAgent        *ComponentTest
+	ClusterChecksRunner *ComponentTest
 	// Want
 	WantConfigure             bool
 	WantManageDependenciesErr bool
@@ -43,7 +43,7 @@ type FeatureTest struct {
 // Options use to provide some option to the test.
 type Options struct{}
 
-// ComponentTest use to configure how to test a component (Cluster-Agent, Agent, ClusterCheckRunner)
+// ComponentTest use to configure how to test a component (Cluster-Agent, Agent, ClusterChecksRunner)
 type ComponentTest struct {
 	CreateFunc func(testing.TB) feature.PodTemplateManagers
 	WantFunc   func(testing.TB, feature.PodTemplateManagers)
@@ -112,9 +112,9 @@ func runTest(t *testing.T, tt FeatureTest, buildFunc feature.BuildFunc) {
 		tt.Agent.WantFunc(t, tplManager)
 	}
 
-	if tt.ClusterCheckRunner != nil {
-		tplManager := tt.ClusterCheckRunner.CreateFunc(t)
+	if tt.ClusterChecksRunner != nil {
+		tplManager := tt.ClusterChecksRunner.CreateFunc(t)
 		_ = f.ManageClusterChecksRunner(tplManager)
-		tt.ClusterCheckRunner.WantFunc(t, tplManager)
+		tt.ClusterChecksRunner.WantFunc(t, tplManager)
 	}
 }

--- a/controllers/datadogagent/feature/types.go
+++ b/controllers/datadogagent/feature/types.go
@@ -20,14 +20,14 @@ import (
 
 // RequiredComponents use to know which component need to be enabled for the feature
 type RequiredComponents struct {
-	ClusterAgent       RequiredComponent
-	Agent              RequiredComponent
-	ClusterCheckRunner RequiredComponent
+	ClusterAgent        RequiredComponent
+	Agent               RequiredComponent
+	ClusterChecksRunner RequiredComponent
 }
 
 // IsEnabled return true if the Feature need to be enabled
 func (rc *RequiredComponents) IsEnabled() bool {
-	return rc.ClusterAgent.IsEnabled() || rc.Agent.IsEnabled() || rc.ClusterCheckRunner.IsEnabled()
+	return rc.ClusterAgent.IsEnabled() || rc.Agent.IsEnabled() || rc.ClusterChecksRunner.IsEnabled()
 }
 
 // Merge use to merge 2 RequiredComponents
@@ -36,7 +36,7 @@ func (rc *RequiredComponents) IsEnabled() bool {
 func (rc *RequiredComponents) Merge(in *RequiredComponents) *RequiredComponents {
 	rc.ClusterAgent.Merge(&in.ClusterAgent)
 	rc.Agent.Merge(&in.Agent)
-	rc.ClusterCheckRunner.Merge(&in.ClusterCheckRunner)
+	rc.ClusterChecksRunner.Merge(&in.ClusterChecksRunner)
 	return rc
 }
 
@@ -114,7 +114,7 @@ type Feature interface {
 	// ManageNodeAget allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 	// It should do nothing if the feature doesn't need to configure it.
 	ManageNodeAgent(managers PodTemplateManagers) error
-	// ManageClusterChecksRunner allows a feature to configure the ClusterCheckRunnerAgent's corev1.PodTemplateSpec
+	// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunnerAgent's corev1.PodTemplateSpec
 	// It should do nothing if the feature doesn't need to configure it.
 	ManageClusterChecksRunner(managers PodTemplateManagers) error
 }

--- a/docs/data_collected.md
+++ b/docs/data_collected.md
@@ -8,7 +8,7 @@ The Datadog Operator sends metrics and events to Datadog to monitor the Datadog 
 | -------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `datadog.operator.agent.deployment.success`              | gauge       | `1` if the desired number of Agent replicas equals the number of available Agent pods, `0` otherwise.                               |
 | `datadog.operator.clusteragent.deployment.success`       | gauge       | `1` if the desired number of Cluster Agent replicas equals the number of available Cluster Agent pods, `0` otherwise.               |
-| `datadog.operator.clustercheckrunner.deployment.success` | gauge       | `1` if the desired number of Cluster Check Runner replicas equals the number of available Cluster Check Runner pods, `0` otherwise. |
+| `datadog.operator.clusterchecksrunner.deployment.success` | gauge       | `1` if the desired number of Cluster Check Runner replicas equals the number of available Cluster Check Runner pods, `0` otherwise. |
 | `datadog.operator.reconcile.success`                     | gauge       | `1` if the last recorded reconcile error is null, `0` otherwise. The `reconcile_err` tag describes the last recorded error.         |
 
 **Note:** The [Datadog API and app keys][1] are required to forward metrics to Datadog. They must be provided in the `credentials` field in the Custom Resource definition.

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -45,7 +45,7 @@ const (
 	crNameTagFormat             = "cr_name:%s"
 	agentName                   = "agent"
 	clusteragentName            = "clusteragent"
-	clustercheckrunnerName      = "clustercheckrunner"
+	clusterchecksrunnerName     = "clusterchecksrunner"
 	reconcileSuccessValue       = 1.0
 	reconcileFailureValue       = 0.0
 	reconcileMetricFormat       = "%s.reconcile.success"
@@ -413,7 +413,7 @@ func (mf *metricsForwarder) sendStatusMetrics(status *datadoghqv1alpha1.DatadogA
 			metricValue = deploymentFailureValue
 		}
 		tags := mf.tagsWithExtraTag(stateTagFormat, status.ClusterChecksRunner.State)
-		if err := mf.sendDeploymentMetric(metricValue, clustercheckrunnerName, tags); err != nil {
+		if err := mf.sendDeploymentMetric(metricValue, clusterchecksrunnerName, tags); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -191,7 +191,7 @@ func TestMetricsForwarder_sendStatusMetrics(t *testing.T) {
 				f := &fakeMetricsForwarder{}
 				f.On("delegatedSendDeploymentMetric", 1.0, "agent", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
 				f.On("delegatedSendDeploymentMetric", 1.0, "clusteragent", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
-				f.On("delegatedSendDeploymentMetric", 1.0, "clustercheckrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
+				f.On("delegatedSendDeploymentMetric", 1.0, "clusterchecksrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
 				mf.delegator = f
 				return mf, f
 			},
@@ -220,7 +220,7 @@ func TestMetricsForwarder_sendStatusMetrics(t *testing.T) {
 				if !f.AssertCalled(t, "delegatedSendDeploymentMetric", 1.0, "clusteragent", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"}) {
 					return errors.New("Function not called")
 				}
-				if !f.AssertCalled(t, "delegatedSendDeploymentMetric", 1.0, "clustercheckrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"}) {
+				if !f.AssertCalled(t, "delegatedSendDeploymentMetric", 1.0, "clusterchecksrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"}) {
 					return errors.New("Function not called")
 				}
 				if !f.AssertNumberOfCalls(t, "delegatedSendDeploymentMetric", 3) {
@@ -265,12 +265,12 @@ func TestMetricsForwarder_sendStatusMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "all components, clustercheckrunner not available",
+			name: "all components, clusterchecksrunner not available",
 			loadFunc: func() (*metricsForwarder, *fakeMetricsForwarder) {
 				f := &fakeMetricsForwarder{}
 				f.On("delegatedSendDeploymentMetric", 1.0, "agent", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
 				f.On("delegatedSendDeploymentMetric", 1.0, "clusteragent", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
-				f.On("delegatedSendDeploymentMetric", 0.0, "clustercheckrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
+				f.On("delegatedSendDeploymentMetric", 0.0, "clusterchecksrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"})
 				mf.delegator = f
 				return mf, f
 			},
@@ -299,7 +299,7 @@ func TestMetricsForwarder_sendStatusMetrics(t *testing.T) {
 				if !f.AssertCalled(t, "delegatedSendDeploymentMetric", 1.0, "clusteragent", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"}) {
 					return errors.New("Function not called")
 				}
-				if !f.AssertCalled(t, "delegatedSendDeploymentMetric", 0.0, "clustercheckrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"}) {
+				if !f.AssertCalled(t, "delegatedSendDeploymentMetric", 0.0, "clusterchecksrunner", []string{"cr_namespace:foo", "cr_name:bar", "state:Running"}) {
 					return errors.New("Function not called")
 				}
 				if !f.AssertNumberOfCalls(t, "delegatedSendDeploymentMetric", 3) {


### PR DESCRIPTION
### What does this PR do?

This is a cosmetic PR to unify the naming of ClusterChecksRunner (i.e. not ClusterCheckRunner) to match our docs.

Note, this will also rename the metric `datadog.operator.clustercheckrunner.deployment.success` -> `datadog.operator.clusterchecksrunner.deployment.success`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
