### PR TITLE
[controllers/datadogagent/component] Implement default agent

### DIFF
--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -6,8 +6,14 @@
 package agent
 
 import (
+	"fmt"
+	"strconv"
+
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+	"github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 
@@ -33,8 +39,112 @@ func NewDefaultAgentExtendedDaemonset(dda metav1.Object) *edsv1alpha1.ExtendedDa
 
 // NewDefaultAgentPodTemplateSpec return a default node agent for the cluster-agent deployment
 func NewDefaultAgentPodTemplateSpec(dda metav1.Object) *corev1.PodTemplateSpec {
-	// TODO(operator-ga): implement NewDefaultAgentPodTemplateSpec function
-	template := &corev1.PodTemplateSpec{}
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: corev1.PodSpec{
+			// Force root user for when the agent Dockerfile will be updated to use a non-root user by default
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: apiutils.NewInt64Pointer(0),
+			},
+			ServiceAccountName: getDefaultServiceAccountName(dda),
+			InitContainers: []corev1.Container{
+				initVolumeContainer(),
+				initConfigContainer(),
+			},
+			Containers: []corev1.Container{agentContainer()},
+			Volumes:    volumesForAgent(dda),
+		},
+	}
+}
 
-	return template
+func getDefaultServiceAccountName(dda metav1.Object) string {
+	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
+}
+
+func agentImage() string {
+	return fmt.Sprintf("%s:%s", apicommon.DefaultAgentImageName, defaulting.AgentLatestVersion)
+}
+
+func agentContainer() corev1.Container {
+	return corev1.Container{
+		Name:           string(common.CoreAgentContainerName),
+		Image:          agentImage(),
+		Command:        []string{"agent", "run"},
+		Env:            defaultEnvVars(),
+		VolumeMounts:   volumeMountsForAgent(),
+		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
+		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+	}
+}
+
+func initVolumeContainer() corev1.Container {
+	return corev1.Container{
+		Name:    "init-volume",
+		Image:   agentImage(),
+		Command: []string{"bash", "-c"},
+		Args:    []string{"cp -vnr /etc/datadog-agent /opt"},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      apicommon.ConfigVolumeName,
+				MountPath: "/opt/datadog-agent",
+			},
+		},
+	}
+}
+
+func initConfigContainer() corev1.Container {
+	return corev1.Container{
+		Name:    "init-config",
+		Image:   agentImage(),
+		Command: []string{"bash", "-c"},
+		Args: []string{
+			"for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done",
+		},
+		VolumeMounts: volumeMountsForAgent(),
+		Env:          defaultEnvVars(),
+	}
+}
+
+func defaultEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  apicommon.DDHealthPort,
+			Value: strconv.Itoa(int(apicommon.DefaultAgentHealthPort)),
+		},
+		{
+			Name:  apicommon.DDLeaderElection,
+			Value: "true",
+		},
+		{
+			Name:  apicommon.KubernetesEnvVar,
+			Value: "yes",
+		},
+	}
+}
+
+func volumesForAgent(dda metav1.Object) []corev1.Volume {
+	return []corev1.Volume{
+		component.GetVolumeForLogs(),
+		component.GetVolumeForAuth(),
+		component.GetVolumeInstallInfo(dda),
+		component.GetVolumeForConfd(),
+		component.GetVolumeForConfig(),
+		component.GetVolumeForProc(),
+		component.GetVolumeForCgroups(),
+	}
+}
+
+func volumeMountsForAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		component.GetVolumeMountForLogs(),
+		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForInstallInfo(),
+		component.GetVolumeMountForConfd(),
+		component.GetVolumeMountForConfig(),
+		component.GetVolumeMountForProc(),
+		component.GetVolumeMountForCgroups(),
+	}
 }

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -78,6 +78,30 @@ func GetVolumeInstallInfo(owner metav1.Object) corev1.Volume {
 	}
 }
 
+// GetVolumeForProc returns the volume with /proc
+func GetVolumeForProc() corev1.Volume {
+	return corev1.Volume{
+		Name: apicommon.ProcdirVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: apicommon.ProcdirHostPath,
+			},
+		},
+	}
+}
+
+// GetVolumeForCgroups returns the volume that contains the cgroup directory
+func GetVolumeForCgroups() corev1.Volume {
+	return corev1.Volume{
+		Name: apicommon.CgroupsVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/sys/fs/cgroup",
+			},
+		},
+	}
+}
+
 // GetInstallInfoConfigMapName return the InstallInfo config map name base on the dda name
 func GetInstallInfoConfigMapName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-install-info", dda.GetName())
@@ -105,6 +129,14 @@ func GetVolumeMountForRmCorechecks() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      "remove-corechecks",
 		MountPath: fmt.Sprintf("%s/%s", apicommon.ConfigVolumePath, "conf.d"),
+	}
+}
+
+// GetVolumeMountForAuth returns the VolumeMount that contains the authentication information
+func GetVolumeMountForAuth() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      apicommon.AuthVolumeName,
+		MountPath: apicommon.AuthVolumePath,
 	}
 }
 
@@ -162,6 +194,24 @@ func GetVolumeMountForInstallInfo() corev1.VolumeMount {
 		MountPath: apicommon.InstallInfoVolumePath,
 		SubPath:   apicommon.InstallInfoVolumeSubPath,
 		ReadOnly:  apicommon.InstallInfoVolumeReadOnly,
+	}
+}
+
+// GetVolumeMountForProc returns the VolumeMount that contains /proc
+func GetVolumeMountForProc() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      apicommon.ProcdirVolumeName,
+		MountPath: apicommon.ProcdirMountPath,
+		ReadOnly:  true,
+	}
+}
+
+// GetVolumeMountForCgroups returns the VolumeMount that contains the cgroups info
+func GetVolumeMountForCgroups() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      apicommon.CgroupsVolumeName,
+		MountPath: apicommon.CgroupsMountPath,
+		ReadOnly:  true,
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Implements the default agent component. Similar to what #506 did for cluster check runners.


### Describe your test plan

I think it should be tested together with [#506](https://github.com/DataDog/datadog-operator/pull/506) and https://github.com/DataDog/datadog-operator/pull/491
