### PR TITLE
Do not create a pdb if agent has a single replica

### DIFF
--- a/controllers/datadogagent/poddisruptionbudget.go
+++ b/controllers/datadogagent/poddisruptionbudget.go
@@ -34,8 +34,11 @@ type (
 )
 
 func (r *Reconciler) manageClusterAgentPDB(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
-	cleanUpCondition := !isClusterAgentEnabled(dda.Spec.ClusterAgent)
-	return r.managePDB(logger, dda, getClusterAgentPDBName(dda), buildClusterAgentPDB, cleanUpCondition)
+  if *dda.Spec.ClusterAgent.Replicas > 1 {
+    cleanUpCondition := !isClusterAgentEnabled(dda.Spec.ClusterAgent)
+    return r.managePDB(logger, dda, getClusterAgentPDBName(dda), buildClusterAgentPDB, cleanUpCondition)
+  }
+  return reconcile.Result{}, nil
 }
 
 func (r *Reconciler) manageClusterChecksRunnerPDB(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {


### PR DESCRIPTION
This PR fixes #401 which is caused by a PDB being created even when their is only on replica of the agent.