### PR TITLE
[controllers/datadogagent/component] Implement default agent containers

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -141,6 +141,9 @@ const (
 	// same path on host and container
 	SrcVolumePath = "/usr/src"
 
+	AgentCustomConfigVolumePath = "/etc/datadog-agent/datadog.yaml"
+	SystemProbeConfigVolumePath = "/etc/datadog-agent/system-probe.yaml"
+
 	LogDatadogVolumeName       = "logdatadog"
 	LogDatadogVolumePath       = "/var/log/datadog"
 	TmpVolumeName              = "tmp"
@@ -162,6 +165,8 @@ const (
 	ContainerLogVolumePath     = "/var/lib/docker/containers"
 	SymlinkContainerVolumeName = "symlinkcontainerpath"
 	SymlinkContainerVolumePath = "/var/log/containers"
+	DogstatsdSocketVolumeName  = "dsdsocket"
+	DogstatsdSocketVolumePath  = "/var/run/datadog/statsd"
 )
 
 const (

--- a/apis/datadoghq/v1alpha1/const.go
+++ b/apis/datadoghq/v1alpha1/const.go
@@ -98,8 +98,6 @@ const (
 	PasswdVolumePath                     = "/etc/passwd"
 	GroupVolumeName                      = "group"
 	GroupVolumePath                      = "/etc/group"
-	HostRootVolumeName                   = "hostroot"
-	HostRootVolumePath                   = "/host/root"
 	CgroupsVolumeName                    = "cgroups"
 	CgroupsVolumePath                    = "/host/sys/fs/cgroup"
 	CgroupsVolumeReadOnly                = true
@@ -107,8 +105,6 @@ const (
 	SystemProbeSocketVolumePath          = "/var/run/sysprobe"
 	CriSocketVolumeName                  = "runtimesocketdir"
 	CriSocketVolumeReadOnly              = true
-	DogstatsdSocketVolumeName            = "dsdsocket"
-	DogstatsdSocketVolumePath            = "/var/run/datadog/statsd"
 	PointerVolumeName                    = "pointerdir"
 	PointerVolumePath                    = "/opt/datadog-agent/run"
 	LogPodVolumeName                     = "logpodpath"
@@ -121,7 +117,6 @@ const (
 	SystemProbeDebugfsVolumeName         = "debugfs"
 	SystemProbeDebugfsVolumePath         = "/sys/kernel/debug"
 	SystemProbeConfigVolumeName          = "system-probe-config"
-	SystemProbeConfigVolumePath          = "/etc/datadog-agent/system-probe.yaml"
 	SystemProbeConfigVolumeSubPath       = "system-probe.yaml"
 	SystemProbeAgentSecurityVolumeName   = "datadog-agent-security"
 	SystemProbeAgentSecurityVolumePath   = "/etc/config"
@@ -132,7 +127,6 @@ const (
 	SystemProbeUsrSrcVolumeName          = "src"
 	SystemProbeUsrSrcVolumePath          = "/usr/src"
 	AgentCustomConfigVolumeName          = "custom-datadog-yaml"
-	AgentCustomConfigVolumePath          = "/etc/datadog-agent/datadog.yaml"
 	AgentCustomConfigVolumeSubPath       = "datadog.yaml"
 	KubeletCAVolumeName                  = "kubelet-ca"
 	DefaultKubeletAgentCAPath            = "/var/run/host-kubelet-ca.crt"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -138,7 +138,7 @@ func defaultVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.DogstatsdSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -302,7 +302,7 @@ func defaultSystemProbeVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.DogstatsdSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -340,7 +340,7 @@ func complianceSecurityAgentVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.DogstatsdSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -420,7 +420,7 @@ func complianceSecurityAgentVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.HostRootVolumeName,
+			Name: apicommon.HostRootVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/",
@@ -534,7 +534,7 @@ func runtimeSecurityAgentVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.DogstatsdSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -563,7 +563,7 @@ func runtimeSecurityAgentVolumes() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.HostRootVolumeName,
+			Name: apicommon.HostRootVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: "/",
@@ -1484,7 +1484,7 @@ func defaultProcessMount() []corev1.Volume {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.DogstatsdSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -2276,7 +2276,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomConfigMaps(t *testing.T) {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.DogstatsdSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -2407,7 +2407,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 			},
 		},
 		{
-			Name: datadoghqv1alpha1.DogstatsdSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -3433,7 +3433,7 @@ func Test_newExtendedDaemonSetFromInstance_SecurityAgent_Runtime(t *testing.T) {
 		},
 		{
 			Name:      datadoghqv1alpha1.SystemProbeConfigVolumeName,
-			MountPath: datadoghqv1alpha1.SystemProbeConfigVolumePath,
+			MountPath: apicommon.SystemProbeConfigVolumePath,
 			SubPath:   datadoghqv1alpha1.SystemProbeConfigVolumeSubPath,
 		},
 	}...)
@@ -3460,7 +3460,7 @@ func Test_newExtendedDaemonSetFromInstance_SecurityAgent_Runtime(t *testing.T) {
 		},
 		{
 			Name:      datadoghqv1alpha1.SystemProbeConfigVolumeName,
-			MountPath: datadoghqv1alpha1.SystemProbeConfigVolumePath,
+			MountPath: apicommon.SystemProbeConfigVolumePath,
 			SubPath:   datadoghqv1alpha1.SystemProbeConfigVolumeSubPath,
 		},
 	}...)

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -23,22 +23,22 @@ import (
 )
 
 // NewDefaultAgentDaemonset return a new default agent DaemonSet
-func NewDefaultAgentDaemonset(dda metav1.Object) *appsv1.DaemonSet {
-	podTemplate := NewDefaultAgentPodTemplateSpec(dda)
+func NewDefaultAgentDaemonset(dda metav1.Object, requiredContainers []common.AgentContainerName) *appsv1.DaemonSet {
+	podTemplate := NewDefaultAgentPodTemplateSpec(dda, requiredContainers)
 	daemonset := component.NewDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
 	daemonset.Spec.Template = *podTemplate
 	return daemonset
 }
 
 // NewDefaultAgentExtendedDaemonset return a new default agent DaemonSet
-func NewDefaultAgentExtendedDaemonset(dda metav1.Object) *edsv1alpha1.ExtendedDaemonSet {
+func NewDefaultAgentExtendedDaemonset(dda metav1.Object, requiredContainers []common.AgentContainerName) *edsv1alpha1.ExtendedDaemonSet {
 	edsDaemonset := component.NewExtendedDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
-	edsDaemonset.Spec.Template = *NewDefaultAgentPodTemplateSpec(dda)
+	edsDaemonset.Spec.Template = *NewDefaultAgentPodTemplateSpec(dda, requiredContainers)
 	return edsDaemonset
 }
 
 // NewDefaultAgentPodTemplateSpec return a default node agent for the cluster-agent deployment
-func NewDefaultAgentPodTemplateSpec(dda metav1.Object) *corev1.PodTemplateSpec {
+func NewDefaultAgentPodTemplateSpec(dda metav1.Object, requiredContainers []common.AgentContainerName) *corev1.PodTemplateSpec {
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      make(map[string]string),
@@ -54,7 +54,7 @@ func NewDefaultAgentPodTemplateSpec(dda metav1.Object) *corev1.PodTemplateSpec {
 				initVolumeContainer(),
 				initConfigContainer(),
 			},
-			Containers: []corev1.Container{agentContainer()},
+			Containers: agentContainers(requiredContainers),
 			Volumes:    volumesForAgent(dda),
 		},
 	}
@@ -68,13 +68,94 @@ func agentImage() string {
 	return fmt.Sprintf("%s:%s", apicommon.DefaultAgentImageName, defaulting.AgentLatestVersion)
 }
 
-func agentContainer() corev1.Container {
+func agentContainers(requiredContainers []common.AgentContainerName) []corev1.Container {
+	containers := []corev1.Container{coreAgentContainer()}
+
+	for _, containerName := range requiredContainers {
+		switch containerName {
+		case common.CoreAgentContainerName:
+			// Nothing to do. It's always required.
+		case common.TraceAgentContainerName:
+			containers = append(containers, traceAgentContainer())
+		case common.ProcessAgentContainerName:
+			containers = append(containers, processAgentContainer())
+		case common.SecurityAgentContainerName:
+			containers = append(containers, securityAgentContainer())
+		case common.SystemProbeContainerName:
+			containers = append(containers, systemProbeContainer())
+		}
+	}
+
+	return containers
+}
+
+func coreAgentContainer() corev1.Container {
 	return corev1.Container{
 		Name:           string(common.CoreAgentContainerName),
 		Image:          agentImage(),
 		Command:        []string{"agent", "run"},
-		Env:            defaultEnvVars(),
-		VolumeMounts:   volumeMountsForAgent(),
+		Env:            envVarsForCoreAgent(),
+		VolumeMounts:   volumeMountsForCoreAgent(),
+		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
+		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+	}
+}
+
+func traceAgentContainer() corev1.Container {
+	return corev1.Container{
+		Name:  string(common.TraceAgentContainerName),
+		Image: agentImage(),
+		Command: []string{
+			"trace-agent",
+			fmt.Sprintf("--config=%s", apicommon.AgentCustomConfigVolumePath),
+		},
+		Env:            commonEnvVars(),
+		VolumeMounts:   volumeMountsForTraceAgent(),
+		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
+		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+	}
+}
+
+func processAgentContainer() corev1.Container {
+	return corev1.Container{
+		Name:  string(common.ProcessAgentContainerName),
+		Image: agentImage(),
+		Command: []string{
+			"process-agent", fmt.Sprintf("--config=%s", apicommon.AgentCustomConfigVolumePath),
+			fmt.Sprintf("--sysprobe-config=%s", apicommon.SystemProbeConfigVolumePath),
+		},
+		Env:            commonEnvVars(),
+		VolumeMounts:   volumeMountsForProcessAgent(),
+		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
+		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+	}
+}
+
+func securityAgentContainer() corev1.Container {
+	return corev1.Container{
+		Name:  string(common.SecurityAgentContainerName),
+		Image: agentImage(),
+		Command: []string{
+			"security-agent",
+			"start", fmt.Sprintf("-c=%s", apicommon.AgentCustomConfigVolumePath),
+		},
+		Env:            envVarsForSecurityAgent(),
+		VolumeMounts:   volumeMountsForSecurityAgent(),
+		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
+		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+	}
+}
+
+func systemProbeContainer() corev1.Container {
+	return corev1.Container{
+		Name:  string(common.SystemProbeContainerName),
+		Image: agentImage(),
+		Command: []string{
+			"system-probe",
+			fmt.Sprintf("--config=%s", apicommon.SystemProbeConfigVolumePath),
+		},
+		Env:            commonEnvVars(),
+		VolumeMounts:   volumeMountsForSystemProbe(),
 		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
 		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
 	}
@@ -103,13 +184,22 @@ func initConfigContainer() corev1.Container {
 		Args: []string{
 			"for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done",
 		},
-		VolumeMounts: volumeMountsForAgent(),
-		Env:          defaultEnvVars(),
+		VolumeMounts: volumeMountsForCoreAgent(),
+		Env:          envVarsForCoreAgent(),
 	}
 }
 
-func defaultEnvVars() []corev1.EnvVar {
+func commonEnvVars() []corev1.EnvVar {
 	return []corev1.EnvVar{
+		{
+			Name:  apicommon.KubernetesEnvVar,
+			Value: "yes",
+		},
+	}
+}
+
+func envVarsForCoreAgent() []corev1.EnvVar {
+	envs := []corev1.EnvVar{
 		{
 			Name:  apicommon.DDHealthPort,
 			Value: strconv.Itoa(int(apicommon.DefaultAgentHealthPort)),
@@ -118,11 +208,20 @@ func defaultEnvVars() []corev1.EnvVar {
 			Name:  apicommon.DDLeaderElection,
 			Value: "true",
 		},
+	}
+
+	return append(envs, commonEnvVars()...)
+}
+
+func envVarsForSecurityAgent() []corev1.EnvVar {
+	envs := []corev1.EnvVar{
 		{
-			Name:  apicommon.KubernetesEnvVar,
-			Value: "yes",
+			Name:  "HOST_ROOT",
+			Value: apicommon.HostRootMountPath,
 		},
 	}
+
+	return append(envs, commonEnvVars()...)
 }
 
 func volumesForAgent(dda metav1.Object) []corev1.Volume {
@@ -134,10 +233,11 @@ func volumesForAgent(dda metav1.Object) []corev1.Volume {
 		component.GetVolumeForConfig(),
 		component.GetVolumeForProc(),
 		component.GetVolumeForCgroups(),
+		component.GetVolumeForDogstatsd(),
 	}
 }
 
-func volumeMountsForAgent() []corev1.VolumeMount {
+func volumeMountsForCoreAgent() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForAuth(),
@@ -146,5 +246,40 @@ func volumeMountsForAgent() []corev1.VolumeMount {
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForProc(),
 		component.GetVolumeMountForCgroups(),
+		component.GetVolumeMountForDogstatsdSocket(false),
+	}
+}
+
+func volumeMountsForTraceAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		component.GetVolumeMountForLogs(),
+		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForConfig(),
+		component.GetVolumeMountForDogstatsdSocket(true),
+	}
+}
+
+func volumeMountsForProcessAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		component.GetVolumeMountForLogs(),
+		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForConfig(),
+		component.GetVolumeMountForDogstatsdSocket(true),
+	}
+}
+
+func volumeMountsForSecurityAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		component.GetVolumeMountForLogs(),
+		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForConfig(),
+		component.GetVolumeMountForDogstatsdSocket(true),
+	}
+}
+
+func volumeMountsForSystemProbe() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		component.GetVolumeMountForLogs(),
+		component.GetVolumeMountForAuth(),
 	}
 }

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -102,6 +102,16 @@ func GetVolumeForCgroups() corev1.Volume {
 	}
 }
 
+// GetVolumeForDogstatsd returns the volume with the Dogstatsd socket
+func GetVolumeForDogstatsd() corev1.Volume {
+	return corev1.Volume{
+		Name: apicommon.DogstatsdSocketVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
 // GetInstallInfoConfigMapName return the InstallInfo config map name base on the dda name
 func GetInstallInfoConfigMapName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-install-info", dda.GetName())
@@ -137,6 +147,7 @@ func GetVolumeMountForAuth() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      apicommon.AuthVolumeName,
 		MountPath: apicommon.AuthVolumePath,
+		ReadOnly:  true,
 	}
 }
 
@@ -212,6 +223,15 @@ func GetVolumeMountForCgroups() corev1.VolumeMount {
 		Name:      apicommon.CgroupsVolumeName,
 		MountPath: apicommon.CgroupsMountPath,
 		ReadOnly:  true,
+	}
+}
+
+// GetVolumeMountForDogstatsdSocket returns the VolumeMount with the Dogstatsd socket
+func GetVolumeMountForDogstatsdSocket(readOnly bool) corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      apicommon.DogstatsdSocketVolumeName,
+		MountPath: apicommon.DogstatsdSocketVolumePath,
+		ReadOnly:  readOnly,
 	}
 }
 

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -6,6 +6,7 @@
 package datadogagent
 
 import (
+	"github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	componentagent "github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
@@ -16,14 +17,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (r *Reconciler) reconcileV2Agent(logger logr.Logger, features []feature.Feature, dda *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus) (reconcile.Result, error) {
+func (r *Reconciler) reconcileV2Agent(logger logr.Logger, features []feature.Feature, dda *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus, requiredContainers []common.AgentContainerName) (reconcile.Result, error) {
 	var result reconcile.Result
 	var err error
 
 	// TODO for now only support Daemonset (not EDS)
 
 	// Start by creating the Default Cluster-Agent deployment
-	daemonset := componentagent.NewDefaultAgentDaemonset(dda)
+	daemonset := componentagent.NewDefaultAgentDaemonset(dda, requiredContainers)
 	podManagers := feature.NewPodTemplateManagers(&daemonset.Spec.Template)
 
 	// Set Global setting on the default deployment

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -125,7 +125,8 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	}
 
 	if requiredComponents.Agent.IsEnabled() {
-		result, err = r.reconcileV2Agent(logger, features, instance, newStatus)
+		requiredContainers := requiredComponents.Agent.Containers
+		result, err = r.reconcileV2Agent(logger, features, instance, newStatus, requiredContainers)
 		if utils.ShouldReturn(result, err) {
 			return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err)
 		}


### PR DESCRIPTION
### What does this PR do?

Continues the work started in #507 
This PR implements the default agent containers returned in the `NewDefaultAgentPodTemplateSpec` function


### Describe your test plan

Same as #507.
