### PR TITLE
[defaulting/images] Update agent to 7.36.1 and DCA to 1.20.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.35.2"
+	AgentLatestVersion = "7.36.1"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "1.19.0"
+	ClusterAgentLatestVersion = "1.20.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

Updates the agent image to 7.36.1 and DCA to 1.20.0.

### Describe your test plan

Check that the operator deploys those versions by default.
