### PR TITLE
feat(ksmcore): enable ingress metrics

### DIFF
--- a/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
@@ -68,6 +68,7 @@ instances:
     - namespaces
     - persistentvolumeclaims
     - persistentvolumes
+    - ingresses
     telemetry: true
     skip_leader_election: %s
 `, stringVal, stringVal)


### PR DESCRIPTION
### What does this PR do?

Enable the ingress collector in the default ksm core configuration

### Motivation

### Additional Notes

Related to https://github.com/DataDog/datadog-agent/pull/12344

### Describe your test plan

Enable the KSM core check and make sure it sends ingress metrics (assuming there are ingress objects in the cluster + agent 7.38)
