### PR TITLE
[feature/eventcollection] Add missing nil check

### DIFF
--- a/controllers/datadogagent/feature/eventcollection/feature.go
+++ b/controllers/datadogagent/feature/eventcollection/feature.go
@@ -45,7 +45,7 @@ func (f *eventCollectionFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 
 	// v2alpha1 configures event collection using the cluster agent only
 	// leader election is enabled by default
-	if dda.Spec.Features.EventCollection != nil && apiutils.BoolValue(dda.Spec.Features.EventCollection.CollectKubernetesEvents) {
+	if dda.Spec.Features != nil && dda.Spec.Features.EventCollection != nil && apiutils.BoolValue(dda.Spec.Features.EventCollection.CollectKubernetesEvents) {
 		f.serviceAccountName = v2alpha1.GetClusterAgentServiceAccount(dda)
 		f.rbacSuffix = common.ClusterAgentSuffix
 


### PR DESCRIPTION
This PR adds a missing nil check in the event collection feature.

This fixes a panic in the operator when `v2alpha1` is enabled and using the example `datadogagent` in `examples/v2alpha1/min.yaml`. There are more errors, but they're unrelated to this one, so I'll address them on a different PR.

### Describe your test plan

Try with `v2alpha1` enabled (`KUSTOMIZE_CONFIG=config/test-v2 make deploy`) and check that the operator doesn't panic when configuring the event collection feature.
