### PR TITLE
[v2alpha1] Fix issues so agent and DCA boot without errors

### DIFF
--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -24,8 +24,9 @@ import (
 
 // NewDefaultAgentDaemonset return a new default agent DaemonSet
 func NewDefaultAgentDaemonset(dda metav1.Object, requiredContainers []common.AgentContainerName) *appsv1.DaemonSet {
-	podTemplate := NewDefaultAgentPodTemplateSpec(dda, requiredContainers)
 	daemonset := component.NewDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
+	podTemplate := NewDefaultAgentPodTemplateSpec(dda, requiredContainers, daemonset.GetLabels())
+
 	daemonset.Spec.Template = *podTemplate
 	return daemonset
 }
@@ -33,15 +34,15 @@ func NewDefaultAgentDaemonset(dda metav1.Object, requiredContainers []common.Age
 // NewDefaultAgentExtendedDaemonset return a new default agent DaemonSet
 func NewDefaultAgentExtendedDaemonset(dda metav1.Object, requiredContainers []common.AgentContainerName) *edsv1alpha1.ExtendedDaemonSet {
 	edsDaemonset := component.NewExtendedDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
-	edsDaemonset.Spec.Template = *NewDefaultAgentPodTemplateSpec(dda, requiredContainers)
+	edsDaemonset.Spec.Template = *NewDefaultAgentPodTemplateSpec(dda, requiredContainers, edsDaemonset.GetLabels())
 	return edsDaemonset
 }
 
 // NewDefaultAgentPodTemplateSpec return a default node agent for the cluster-agent deployment
-func NewDefaultAgentPodTemplateSpec(dda metav1.Object, requiredContainers []common.AgentContainerName) *corev1.PodTemplateSpec {
+func NewDefaultAgentPodTemplateSpec(dda metav1.Object, requiredContainers []common.AgentContainerName, labels map[string]string) *corev1.PodTemplateSpec {
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      make(map[string]string),
+			Labels:      labels,
 			Annotations: make(map[string]string),
 		},
 		Spec: corev1.PodSpec{

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -66,7 +66,7 @@ func getDefaultServiceAccountName(dda metav1.Object) string {
 }
 
 func agentImage() string {
-	return fmt.Sprintf("%s:%s", apicommon.DefaultAgentImageName, defaulting.AgentLatestVersion)
+	return fmt.Sprintf("%s/%s:%s", apicommon.DefaultImageRegistry, apicommon.DefaultAgentImageName, defaulting.AgentLatestVersion)
 }
 
 func agentContainers(requiredContainers []common.AgentContainerName) []corev1.Container {

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -16,10 +16,7 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
-	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
-	rbacv1 "k8s.io/api/rbac/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -306,30 +303,4 @@ func volumeMountsForSystemProbe() []corev1.VolumeMount {
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForAuth(),
 	}
-}
-
-// GetDefaultAgentClusterRolePolicyRules returns the default policy rules for
-// the Agent
-func GetDefaultAgentClusterRolePolicyRules() []rbacv1.PolicyRule {
-	// TODO (operator-ga):: this only adds the policy for the Kubelet. Check if we need others.
-	return []rbacv1.PolicyRule{GetKubeletPolicyRule()}
-}
-
-// GetKubeletPolicyRule returns the policy rule for Kubelet
-func GetKubeletPolicyRule() rbacv1.PolicyRule {
-	return rbacv1.PolicyRule{
-		APIGroups: []string{rbac.CoreAPIGroup},
-		Resources: []string{
-			rbac.NodeMetricsResource,
-			rbac.NodeSpecResource,
-			rbac.NodeProxyResource,
-			rbac.NodeStats,
-		},
-		Verbs: []string{rbac.GetVerb},
-	}
-}
-
-// GetAgentRbacResourcesName return the Cluster-Agent RBAC resource name
-func GetAgentRbacResourcesName(dda metav1.Object) string {
-	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
 }

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -16,8 +16,9 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
-
+	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -210,6 +211,14 @@ func commonEnvVars(dda metav1.Object) []corev1.EnvVar {
 			Name:  apicommon.DDClusterAgentTokenName,
 			Value: v2alpha1.GetDefaultDCATokenSecretName(dda),
 		},
+		{
+			Name: apicommon.DDKubeletHost,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: apicommon.FieldPathStatusHostIP,
+				},
+			},
+		},
 	}
 }
 
@@ -297,4 +306,30 @@ func volumeMountsForSystemProbe() []corev1.VolumeMount {
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForAuth(),
 	}
+}
+
+// GetDefaultAgentClusterRolePolicyRules returns the default policy rules for
+// the Agent
+func GetDefaultAgentClusterRolePolicyRules() []rbacv1.PolicyRule {
+	// TODO (operator-ga):: this only adds the policy for the Kubelet. Check if we need others.
+	return []rbacv1.PolicyRule{GetKubeletPolicyRule()}
+}
+
+// GetKubeletPolicyRule returns the policy rule for Kubelet
+func GetKubeletPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups: []string{rbac.CoreAPIGroup},
+		Resources: []string{
+			rbac.NodeMetricsResource,
+			rbac.NodeSpecResource,
+			rbac.NodeProxyResource,
+			rbac.NodeStats,
+		},
+		Verbs: []string{rbac.GetVerb},
+	}
+}
+
+// GetAgentRbacResourcesName return the Cluster-Agent RBAC resource name
+func GetAgentRbacResourcesName(dda metav1.Object) string {
+	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
 }

--- a/controllers/datadogagent/component/clusteragent/utils.go
+++ b/controllers/datadogagent/component/clusteragent/utils.go
@@ -9,7 +9,11 @@ import (
 	"fmt"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // GetClusterAgentServiceName return the Cluster-Agent service name based on the DatadogAgent name
@@ -31,4 +35,37 @@ func GetClusterAgentVersion(dda metav1.Object) string {
 // GetClusterAgentRbacResourcesName return the Cluster-Agent RBAC resource name
 func GetClusterAgentRbacResourcesName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultClusterAgentResourceSuffix)
+}
+
+// GetClusterAgentService returns the Cluster-Agent service
+func GetClusterAgentService(dda metav1.Object) *corev1.Service {
+	labels := object.GetDefaultLabels(dda, apicommon.DefaultClusterAgentResourceSuffix, GetClusterAgentVersion(dda))
+	annotations := object.GetDefaultAnnotations(dda)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        GetClusterAgentServiceName(dda),
+			Namespace:   dda.GetNamespace(),
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				apicommon.AgentDeploymentNameLabelKey:      dda.GetName(),
+				apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultClusterAgentResourceSuffix,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(apicommon.DefaultClusterAgentServicePort),
+					Port:       apicommon.DefaultClusterAgentServicePort,
+				},
+			},
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+	}
+	_, _ = comparison.SetMD5DatadogAgentGenerationAnnotation(&service.ObjectMeta, &service.Spec)
+
+	return service
 }

--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -82,13 +82,17 @@ func GetDefaultServiceAccountName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultClusterAgentResourceSuffix)
 }
 
+func clusterChecksRunnerImage() string {
+	return fmt.Sprintf("%s/%s:%s", apicommon.DefaultImageRegistry, apicommon.DefaultAgentImageName, defaulting.AgentLatestVersion)
+}
+
 func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar) corev1.PodSpec {
 	podSpec := corev1.PodSpec{
 		ServiceAccountName: GetDefaultServiceAccountName(dda),
 		InitContainers: []corev1.Container{
 			{
 				Name:    "init-config",
-				Image:   fmt.Sprintf("%s:%s", apicommon.DefaultAgentImageName, defaulting.AgentLatestVersion),
+				Image:   clusterChecksRunnerImage(),
 				Command: []string{"bash", "-c"},
 				Args: []string{
 					"for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done",
@@ -99,7 +103,7 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 		Containers: []corev1.Container{
 			{
 				Name:         string(apicommonv1.ClusterChecksRunnersContainerName),
-				Image:        fmt.Sprintf("%s:%s", apicommon.DefaultAgentImageName, defaulting.AgentLatestVersion),
+				Image:        clusterChecksRunnerImage(),
 				Env:          envVars,
 				VolumeMounts: volumeMounts,
 				Command:      []string{"bash", "-c"},

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -12,11 +12,11 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/version"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -260,6 +260,12 @@ func (f *defaultFeature) agentDependencies(managers feature.ResourceManagers, co
 			errs = append(errs, err)
 		}
 	}
+
+	// ClusterRole creation
+	if err := managers.RBACManager().AddClusterPolicyRules(f.namespace, f.clusterAgent.serviceAccountName, agent.GetAgentRbacResourcesName(f.owner), agent.GetDefaultAgentClusterRolePolicyRules()); err != nil {
+		errs = append(errs, err)
+	}
+
 	return errors.NewAggregate(errs)
 }
 

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -290,6 +290,11 @@ func (f *defaultFeature) clusterAgentDependencies(managers feature.ResourceManag
 		}
 	}
 
+	dcaService := componentdca.GetClusterAgentService(f.owner)
+	if err := managers.Store().AddOrUpdate(kubernetes.ServicesKind, dcaService); err != nil {
+		return err
+	}
+
 	return errors.NewAggregate(errs)
 }
 

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -309,7 +309,25 @@ func (f *defaultFeature) clusterChecksRunnerDependencies(managers feature.Resour
 // ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *defaultFeature) ManageClusterAgent(managers feature.PodTemplateManagers) error {
-	// Add API/APP and Token secret envvar
+	f.addDefaultCommonEnvs(managers)
+	return nil
+}
+
+// ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
+// It should do nothing if the feature doesn't need to configure it.
+func (f *defaultFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
+	f.addDefaultCommonEnvs(managers)
+	return nil
+}
+
+// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunnerAgent's corev1.PodTemplateSpec
+// It should do nothing if the feature doesn't need to configure it.
+func (f *defaultFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
+	f.addDefaultCommonEnvs(managers)
+	return nil
+}
+
+func (f *defaultFeature) addDefaultCommonEnvs(managers feature.PodTemplateManagers) {
 	if f.dcaTokenInfo.token.SecretName != "" {
 		tokenEnvVar := component.BuildEnvVarFromSource(apicommon.DDClusterAgentAuthToken, component.BuildEnvVarFromSecret(f.dcaTokenInfo.token.SecretName, f.dcaTokenInfo.token.SecretKey))
 		managers.EnvVar().AddEnvVar(tokenEnvVar)
@@ -319,22 +337,11 @@ func (f *defaultFeature) ManageClusterAgent(managers feature.PodTemplateManagers
 		apiKeyEnvVar := component.BuildEnvVarFromSource(apicommon.DDAPIKey, component.BuildEnvVarFromSecret(f.credentialsInfo.apiKey.SecretName, f.credentialsInfo.apiKey.SecretKey))
 		managers.EnvVar().AddEnvVar(apiKeyEnvVar)
 	}
+
 	if f.credentialsInfo.appKey.SecretName != "" {
 		appKeyEnvVar := component.BuildEnvVarFromSource(apicommon.DDAppKey, component.BuildEnvVarFromSecret(f.credentialsInfo.appKey.SecretName, f.credentialsInfo.appKey.SecretKey))
 		managers.EnvVar().AddEnvVar(appKeyEnvVar)
 	}
-
-	return nil
-}
-
-// ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
-// It should do nothing if the feature doesn't need to configure it.
-func (f *defaultFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error { return nil }
-
-// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunnerAgent's corev1.PodTemplateSpec
-// It should do nothing if the feature doesn't need to configure it.
-func (f *defaultFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
-	return nil
 }
 
 func buildInstallInfoConfigMap(dda metav1.Object) *corev1.ConfigMap {

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -12,7 +12,6 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
@@ -262,7 +261,7 @@ func (f *defaultFeature) agentDependencies(managers feature.ResourceManagers, co
 	}
 
 	// ClusterRole creation
-	if err := managers.RBACManager().AddClusterPolicyRules(f.namespace, agent.GetAgentRbacResourcesName(f.owner), f.agent.serviceAccountName, agent.GetDefaultAgentClusterRolePolicyRules()); err != nil {
+	if err := managers.RBACManager().AddClusterPolicyRules(f.namespace, getAgentRoleName(f.owner), f.agent.serviceAccountName, getDefaultAgentClusterRolePolicyRules()); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -262,7 +262,7 @@ func (f *defaultFeature) agentDependencies(managers feature.ResourceManagers, co
 	}
 
 	// ClusterRole creation
-	if err := managers.RBACManager().AddClusterPolicyRules(f.namespace, f.clusterAgent.serviceAccountName, agent.GetAgentRbacResourcesName(f.owner), agent.GetDefaultAgentClusterRolePolicyRules()); err != nil {
+	if err := managers.RBACManager().AddClusterPolicyRules(f.namespace, agent.GetAgentRbacResourcesName(f.owner), f.agent.serviceAccountName, agent.GetDefaultAgentClusterRolePolicyRules()); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -280,12 +280,12 @@ func (f *defaultFeature) clusterAgentDependencies(managers feature.ResourceManag
 		}
 
 		// Role Creation
-		if err := managers.RBACManager().AddPolicyRules(f.namespace, f.clusterAgent.serviceAccountName, componentdca.GetClusterAgentRbacResourcesName(f.owner), componentdca.GetDefaultClusterAgentRolePolicyRules(f.owner)); err != nil {
+		if err := managers.RBACManager().AddPolicyRules(f.namespace, componentdca.GetClusterAgentRbacResourcesName(f.owner), f.clusterAgent.serviceAccountName, componentdca.GetDefaultClusterAgentRolePolicyRules(f.owner)); err != nil {
 			errs = append(errs, err)
 		}
 
 		// ClusterRole creation
-		if err := managers.RBACManager().AddClusterPolicyRules(f.namespace, f.clusterAgent.serviceAccountName, componentdca.GetClusterAgentRbacResourcesName(f.owner), componentdca.GetDefaultClusterAgentClusterRolePolicyRules(f.owner)); err != nil {
+		if err := managers.RBACManager().AddClusterPolicyRules(f.namespace, componentdca.GetClusterAgentRbacResourcesName(f.owner), f.clusterAgent.serviceAccountName, componentdca.GetDefaultClusterAgentClusterRolePolicyRules(f.owner)); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/controllers/datadogagent/feature/enabledefault/rbac.go
+++ b/controllers/datadogagent/feature/enabledefault/rbac.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package enabledefault
+
+import (
+	"fmt"
+
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getAgentRoleName(dda metav1.Object) string {
+	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
+}
+
+func getDefaultAgentClusterRolePolicyRules() []rbacv1.PolicyRule {
+	// TODO (operator-ga):: this only adds the policy for the Kubelet. Check if we need others.
+	return []rbacv1.PolicyRule{getKubeletPolicyRule()}
+}
+
+func getKubeletPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups: []string{rbac.CoreAPIGroup},
+		Resources: []string{
+			rbac.NodeMetricsResource,
+			rbac.NodeSpecResource,
+			rbac.NodeProxyResource,
+			rbac.NodeStats,
+		},
+		Verbs: []string{rbac.GetVerb},
+	}
+}

--- a/controllers/datadogagent/feature/eventcollection/feature.go
+++ b/controllers/datadogagent/feature/eventcollection/feature.go
@@ -109,7 +109,7 @@ func (f *eventCollectionFeature) ManageDependencies(managers feature.ResourceMan
 	}
 
 	// event collection RBAC
-	tokenResourceName := utils.GetDatadogTokenResourceName(f.owner)
+	tokenResourceName := v2alpha1.GetDefaultDCATokenSecretName(f.owner)
 	return managers.RBACManager().AddClusterPolicyRules("", rbacName, f.serviceAccountName, getRBACPolicyRules(tokenResourceName))
 }
 
@@ -133,7 +133,7 @@ func (f *eventCollectionFeature) ManageClusterAgent(managers feature.PodTemplate
 
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.ClusterAgentContainerName, &corev1.EnvVar{
 		Name:  apicommon.DDClusterAgentTokenName,
-		Value: utils.GetDatadogTokenResourceName(f.owner),
+		Value: v2alpha1.GetDefaultDCATokenSecretName(f.owner),
 	})
 
 	return nil
@@ -159,7 +159,7 @@ func (f *eventCollectionFeature) ManageNodeAgent(managers feature.PodTemplateMan
 
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, &corev1.EnvVar{
 		Name:  apicommon.DDClusterAgentTokenName,
-		Value: utils.GetDatadogTokenResourceName(f.owner),
+		Value: v2alpha1.GetDefaultDCATokenSecretName(f.owner),
 	})
 
 	return nil

--- a/controllers/datadogagent/feature/eventcollection/feature_test.go
+++ b/controllers/datadogagent/feature/eventcollection/feature_test.go
@@ -113,7 +113,7 @@ func Test_eventCollectionFeature_Configure(t *testing.T) {
 			},
 			{
 				Name:  apicommon.DDClusterAgentTokenName,
-				Value: "ddaDCAtoken",
+				Value: "ddaDCA-token",
 			},
 		}
 		assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, want), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, want))
@@ -138,7 +138,7 @@ func Test_eventCollectionFeature_Configure(t *testing.T) {
 			},
 			{
 				Name:  apicommon.DDClusterAgentTokenName,
-				Value: "ddaNodetoken",
+				Value: "ddaNode-token",
 			},
 		}
 		coreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]

--- a/controllers/datadogagent/override/global.go
+++ b/controllers/datadogagent/override/global.go
@@ -6,7 +6,10 @@
 package override
 
 import (
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -14,6 +17,13 @@ import (
 // ApplyGlobalSettings use to apply global setting to a PodTemplateSpec
 func ApplyGlobalSettings(manager feature.PodTemplateManagers, config *v2alpha1.GlobalConfig) *corev1.PodTemplateSpec {
 	// TODO(operator-ga): implement ApplyGlobalSettings
+
+	if config != nil && config.Kubelet != nil && config.Kubelet.TLSVerify != nil {
+		manager.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, &corev1.EnvVar{
+			Name:  apicommon.DDKubeletTLSVerify,
+			Value: apiutils.BoolToString(config.Kubelet.TLSVerify),
+		})
+	}
 
 	// set image registry
 


### PR DESCRIPTION
### What does this PR do?

Fixes the issues that were preventing the agent and the DCA to boot when using v2 (`KUSTOMIZE_CONFIG=config/test-v2`).

Notice that there might be other issues when enabling certain features. The goal of this PR is just to make the agent and the DCA start correctly when using the default config.

### Describe your test plan

Deploy with v2 (`KUSTOMIZE_CONFIG=config/test-v2 make deploy`) and check that the daemonset agent and the DCA start correctly.
