### PR TITLE
Update base image to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG GOARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o manager main.go
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o helpers cmd/helpers/main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL name="datadog/operator"
 LABEL vendor="Datadog Inc."


### PR DESCRIPTION
### What does this PR do?

Fix the CVEs blocking publishing in the google marketplace. Bumping to the new UBI seems to be sufficient.

```
➜  datadog-operator git:(char/fix-cve-080) ✗ docker scan charlyyfon/operator:v0.8.1
Testing charlyyfon/operator:v0.8.1...
Package manager:   linux
Project name:      docker-image|charlyyfon/operator
Docker image:      charlyyfon/operator:v0.8.1
Platform:          linux/amd64
✔ Tested charlyyfon/operator:v0.8.1 for known vulnerabilities, no vulnerable paths found.
```

### Motivation

Publish the latest version in the google marketplace.
