### PR TITLE
Created a Datadog Agent file that allows the Datadog Agent as an Operator to work behind a proxy server

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ Here are the steps:
          keyName: app-key
    ```
 
-1. Refer to the ['Datadog Agent examples subfolder'](https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent)] and select an appropriate Datadog Agent configuration file.
+1. Refer to the [`Datadog Agent examples subfolder`](https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent)] and select an appropriate Datadog Agent configuration file.
 
 1. Deploy the Datadog agent with the above configuration file:
    ```shell

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,6 +47,10 @@ Here are the steps:
          keyName: app-key
    ```
 
+1. Refer to the ['Datadog Agent examples subfolder'](https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent)] and select an appropriate Datadog Agent configuration file.
+
+NOTE: If the Kubernetes cluster that you are deploying the Datadog Agent (as an Operator) to is behind a proxy server, the recommended Datadog Agent configuration file to use will be `datadog-agent-all-with-prox.yaml`
+
 1. Deploy the Datadog agent with the above configuration file:
    ```shell
    kubectl apply -f /path/to/your/datadog-agent.yaml

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,12 +49,12 @@ Here are the steps:
 
 1. Refer to the ['Datadog Agent examples subfolder'](https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent)] and select an appropriate Datadog Agent configuration file.
 
-NOTE: If the Kubernetes cluster that you are deploying the Datadog Agent (as an Operator) to is behind a proxy server, the recommended Datadog Agent configuration file to use will be `datadog-agent-all-with-prox.yaml`
-
 1. Deploy the Datadog agent with the above configuration file:
    ```shell
    kubectl apply -f /path/to/your/datadog-agent.yaml
    ```
+
+NOTE: If the Kubernetes cluster that you are deploying the Datadog Agent (as an Operator) to is behind a proxy server, the recommended Datadog Agent configuration file to use will be `datadog-agent-all-with-prox.yaml`
 
 ### Installation option
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -54,7 +54,7 @@ Here are the steps:
    kubectl apply -f /path/to/your/datadog-agent.yaml
    ```
 
-NOTE: If the Kubernetes cluster that you are deploying the Datadog Agent (as an Operator) to is behind a proxy server, the recommended Datadog Agent configuration file to use will be `datadog-agent-all-with-prox.yaml`
+NOTE: If the Kubernetes cluster that you are deploying the Datadog Agent (as an Operator) to is behind a proxy server, the recommended Datadog Agent configuration file to use will be `datadog-agent-all-with-proxy.yaml`.
 
 ### Installation option
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ Here are the steps:
          keyName: app-key
    ```
 
-1. Refer to the [`Datadog Agent examples subfolder`](https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent)] and select an appropriate Datadog Agent configuration file.
+1. Refer to the [`Datadog Agent examples subfolder`](https://github.com/DataDog/datadog-operator/tree/main/examples/datadogagent) and select an appropriate Datadog Agent configuration file.
 
 1. Deploy the Datadog agent with the above configuration file:
    ```shell

--- a/examples/datadogagent/datadog-agent-all-with-proxy.yaml
+++ b/examples/datadogagent/datadog-agent-all-with-proxy.yaml
@@ -1,0 +1,34 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  credentials:
+    apiKey: <DATADOG_API_KEY>
+    appKey: <DATADOG_APP_KEY>
+  agent:
+    apm:
+      enabled: true
+    process:
+      enabled: true
+      processCollectionEnabled: true
+    log:
+      enabled: true
+    systemProbe:
+      bpfDebugEnabled: true
+    security:
+      compliance:
+        enabled: true
+      runtime:
+        enabled: false
+  clusterAgent:
+    config:
+      externalMetrics:
+        enabled: true
+      admissionController:
+        enabled: true
+      env:
+        - name: DD_PROXY_HTTP
+          value: "http://<insert_proxy_address>"
+        - name: DD_PROXY_HTTPS
+          value: "https://<insert_proxy_address>"


### PR DESCRIPTION
### What does this PR do?

I have created a Datadog Agent file that allows the Datadog Agent as an Operator to work behind a proxy server

### Motivation

IHAC that requires Datadog Agent as an Operator to work behind a proxy server

### Additional Notes

I also included instructions in the Getting Started guide that helps in the setup of the Operator in order for it to work behind a proxy server

### Describe your test plan

Tests can be conducted on any Kubernetes cluster
