### PR TITLE
Fix CCR CrashLoopBackOff

### DIFF
--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -108,7 +108,7 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				VolumeMounts: volumeMounts,
 				Command:      []string{"bash", "-c"},
 				Args: []string{
-					"rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run",
+					"agent run",
 				},
 				LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
 				ReadinessProbe: apicommon.GetDefaultReadinessProbe(),


### PR DESCRIPTION
### What does this PR do?

Fixes a CrashLoopBackOff in the cluster check runner from trying to delete a mounted directory. Currently the CCR crashes with this error log:

```
rm: cannot remove '/etc/datadog-agent/conf.d': Device or resource busy
```

With this, the core checks are still removed from `conf.d/` and the `datadog.yaml` file exists and is empty:

```
> ls -la /etc/datadog-agent/
total 20
drwxrwxrwx  3 root     root 4096 Jul 11 19:55 .
drwxrwxr-x 38 root     root 4096 Jun 28 09:02 ..
-rw-------  1 dd-agent root   64 Jul 11 19:55 auth_token
drwxrwxrwx  2 root     root 4096 Jul 11 19:55 conf.d
-rw-r--r--  1 root     root    0 Jul 11 19:55 datadog.yaml
-rw-r--r--  1 root     root  119 Jul 11 19:55 install_info
> ls -la /etc/datadog-agent/conf.d/
total 8
drwxrwxrwx 2 root root 4096 Jul 11 19:55 .
drwxrwxrwx 3 root root 4096 Jul 11 19:55 ..
> cat /etc/datadog-agent/datadog.yaml
> 
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
