### PR TITLE
[component/agent] Implement default Agent ClusterRole

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -942,36 +943,7 @@ func buildClusterRole(dda *datadoghqv1alpha1.DatadogAgent, needClusterLevelRBAC 
 		},
 	}
 
-	rbacRules := []rbacv1.PolicyRule{
-		{
-			// Get /metrics permissions
-			NonResourceURLs: []string{rbac.MetricsURL},
-			Verbs:           []string{rbac.GetVerb},
-		},
-		{
-			// Kubelet connectivity
-			APIGroups: []string{rbac.CoreAPIGroup},
-			Resources: []string{
-				rbac.NodeMetricsResource,
-				rbac.NodeSpecResource,
-				rbac.NodeProxyResource,
-				rbac.NodeStats,
-			},
-			Verbs: []string{rbac.GetVerb},
-		},
-		{
-			// Leader election check
-			APIGroups: []string{rbac.CoreAPIGroup},
-			Resources: []string{rbac.EndpointsResource},
-			Verbs:     []string{rbac.GetVerb},
-		},
-		{
-			// Leader election check
-			APIGroups: []string{rbac.CoordinationAPIGroup},
-			Resources: []string{rbac.LeasesResource},
-			Verbs:     []string{rbac.GetVerb},
-		},
-	}
+	rbacRules := agent.GetDefaultAgentClusterRolePolicyRules()
 
 	// If the secret backend uses the provided `/readsecret_multiple_providers.sh` script, then we need to add secrets GET permissions
 	if *dda.Spec.Credentials.UseSecretBackend &&

--- a/controllers/datadogagent/component/agent/rbac.go
+++ b/controllers/datadogagent/component/agent/rbac.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package enabledefault
+package agent
 
 import (
 	"fmt"
@@ -14,11 +14,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func getAgentRoleName(dda metav1.Object) string {
+// GetAgentRoleName returns the name of the role for the Agent
+func GetAgentRoleName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
 }
 
-func getDefaultAgentClusterRolePolicyRules() []rbacv1.PolicyRule {
+// GetDefaultAgentClusterRolePolicyRules returns the default policy rules for the Agent cluster role
+func GetDefaultAgentClusterRolePolicyRules() []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		getMetricsEndpointPolicyRule(),
 		getKubeletPolicyRule(),

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
@@ -259,7 +260,7 @@ func (f *defaultFeature) agentDependencies(managers feature.ResourceManagers, co
 	}
 
 	// ClusterRole creation
-	if err := managers.RBACManager().AddClusterPolicyRules(f.owner.GetNamespace(), getAgentRoleName(f.owner), f.agent.serviceAccountName, getDefaultAgentClusterRolePolicyRules()); err != nil {
+	if err := managers.RBACManager().AddClusterPolicyRules(f.owner.GetNamespace(), agent.GetAgentRoleName(f.owner), f.agent.serviceAccountName, agent.GetDefaultAgentClusterRolePolicyRules()); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/controllers/datadogagent/feature/enabledefault/rbac.go
+++ b/controllers/datadogagent/feature/enabledefault/rbac.go
@@ -19,8 +19,19 @@ func getAgentRoleName(dda metav1.Object) string {
 }
 
 func getDefaultAgentClusterRolePolicyRules() []rbacv1.PolicyRule {
-	// TODO (operator-ga):: this only adds the policy for the Kubelet. Check if we need others.
-	return []rbacv1.PolicyRule{getKubeletPolicyRule()}
+	return []rbacv1.PolicyRule{
+		getMetricsEndpointPolicyRule(),
+		getKubeletPolicyRule(),
+		getEndpointsPolicyRule(),
+		getLeaderElectionPolicyRule(),
+	}
+}
+
+func getMetricsEndpointPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		NonResourceURLs: []string{rbac.MetricsURL},
+		Verbs:           []string{rbac.GetVerb},
+	}
 }
 
 func getKubeletPolicyRule() rbacv1.PolicyRule {
@@ -33,5 +44,21 @@ func getKubeletPolicyRule() rbacv1.PolicyRule {
 			rbac.NodeStats,
 		},
 		Verbs: []string{rbac.GetVerb},
+	}
+}
+
+func getEndpointsPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups: []string{rbac.CoreAPIGroup},
+		Resources: []string{rbac.EndpointsResource},
+		Verbs:     []string{rbac.GetVerb},
+	}
+}
+
+func getLeaderElectionPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups: []string{rbac.CoordinationAPIGroup},
+		Resources: []string{rbac.LeasesResource},
+		Verbs:     []string{rbac.GetVerb},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Addresses the `TODO` in the code that consisted of implementing the default ClusterRole for the Agent.

Notice that I've also moved the code from the `enabledefault` package to `component/agent`. I think this makes more sense given that now it's called from other places in the code.

### Describe your test plan

When using a default config, the clusterRole for the agent should be the same when using reconciler V1 and V2.
