### PR TITLE
[ksm feature] configmap fix

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -214,14 +214,6 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 		}
 	}
 
-	if *ddaSpec.Features.KubeStateMetricsCore.Enabled {
-		if ddaSpec.Features.KubeStateMetricsCore.Conf == nil {
-			ddaSpec.Features.KubeStateMetricsCore.Conf = &CustomConfig{
-				ConfigData: apiutils.NewStringPointer(defaultKubeStateMetricsCoreConf),
-			}
-		}
-	}
-
 	// AdmissionController Feature
 	if ddaSpec.Features.AdmissionController != nil && *ddaSpec.Features.AdmissionController.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.AdmissionController.MutateUnlabelled, defaultAdmissionControllerMutateUnlabelled)


### PR DESCRIPTION
### What does this PR do?

Both the defaulting code and feature code were trying to set the default configmap for the ksmcore check. Removing it from the former for better separation of concerns, and so that the cluster agent can start properly.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
