### PR TITLE
[controllers/datadogagent] Register dogstatsd feature

### DIFF
--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -33,6 +33,7 @@ import (
 
 	// Use to register features
 	_ "github.com/DataDog/datadog-operator/controllers/datadogagent/feature/cspm"
+	_ "github.com/DataDog/datadog-operator/controllers/datadogagent/feature/dogstatsd"
 	_ "github.com/DataDog/datadog-operator/controllers/datadogagent/feature/dummy"
 	_ "github.com/DataDog/datadog-operator/controllers/datadogagent/feature/enabledefault"
 	_ "github.com/DataDog/datadog-operator/controllers/datadogagent/feature/eventcollection"


### PR DESCRIPTION
### What does this PR do?

Registers the dogstatsd feature.
We probably forgot to register it when it was implemented.
