### PR TITLE
[component/ccr] Fix default service account name

### DIFF
--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -79,7 +79,7 @@ func NewDefaultClusterChecksRunnerPodTemplateSpec(dda metav1.Object) *corev1.Pod
 
 // GetDefaultServiceAccountName return the default Cluster-Agent ServiceAccountName
 func GetDefaultServiceAccountName(dda metav1.Object) string {
-	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultClusterAgentResourceSuffix)
+	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultClusterChecksRunnerResourceSuffix)
 }
 
 func clusterChecksRunnerImage() string {

--- a/controllers/datadogagent/component/clusterchecksrunner/default_test.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package clusterchecksrunner
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetDefaultServiceAccountName(t *testing.T) {
+	dda := v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-datadog-agent",
+			Namespace: "some-namespace",
+		},
+	}
+
+	assert.Equal(t, "my-datadog-agent-cluster-checks-runner", GetDefaultServiceAccountName(&dda))
+}


### PR DESCRIPTION
### What does this PR do?

Fixes the default service account name used by the cluster checks runner.

The KSM core was not working when running on the runners because they were using the wrong service account.

### Describe your test plan

KSM core check should work properly when running on a cluster check runner.
