### PR TITLE
[feature/{npm,usm}] Fix system-probe volume mount perms

### DIFF
--- a/controllers/datadogagent/feature/npm/feature_test.go
+++ b/controllers/datadogagent/feature/npm/feature_test.go
@@ -89,20 +89,27 @@ func Test_npmFeature_Configure(t *testing.T) {
 			{
 				Name:      apicommon.DebugfsVolumeName,
 				MountPath: apicommon.DebugfsPath,
-				ReadOnly:  true,
-			},
-			{
-				Name:      apicommon.SystemProbeSocketVolumeName,
-				MountPath: apicommon.SystemProbeSocketVolumePath,
-				ReadOnly:  true,
+				ReadOnly:  false,
 			},
 		}
 
+		wantProcessAgentVolMounts := append(wantVolumeMounts, corev1.VolumeMount{
+			Name:      apicommon.SystemProbeSocketVolumeName,
+			MountPath: apicommon.SystemProbeSocketVolumePath,
+			ReadOnly:  true,
+		})
+
+		wantSystemProbeAgentVolMounts := append(wantVolumeMounts, corev1.VolumeMount{
+			Name:      apicommon.SystemProbeSocketVolumeName,
+			MountPath: apicommon.SystemProbeSocketVolumePath,
+			ReadOnly:  false,
+		})
+
 		processAgentMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.ProcessAgentContainerName]
-		assert.True(t, apiutils.IsEqualStruct(processAgentMounts, wantVolumeMounts), "Process Agent volume mounts \ndiff = %s", cmp.Diff(processAgentMounts, wantVolumeMounts))
+		assert.True(t, apiutils.IsEqualStruct(processAgentMounts, wantProcessAgentVolMounts), "Process Agent volume mounts \ndiff = %s", cmp.Diff(processAgentMounts, wantVolumeMounts))
 
 		sysProbeAgentMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.SystemProbeContainerName]
-		assert.True(t, apiutils.IsEqualStruct(sysProbeAgentMounts, wantVolumeMounts), "System Probe volume mounts \ndiff = %s", cmp.Diff(sysProbeAgentMounts, wantVolumeMounts))
+		assert.True(t, apiutils.IsEqualStruct(sysProbeAgentMounts, wantSystemProbeAgentVolMounts), "System Probe volume mounts \ndiff = %s", cmp.Diff(sysProbeAgentMounts, wantVolumeMounts))
 
 		coreWantVolumeMounts := []corev1.VolumeMount{
 			{

--- a/controllers/datadogagent/feature/usm/feature_test.go
+++ b/controllers/datadogagent/feature/usm/feature_test.go
@@ -96,12 +96,12 @@ func Test_usmFeature_Configure(t *testing.T) {
 			{
 				Name:      apicommon.DebugfsVolumeName,
 				MountPath: apicommon.DebugfsPath,
-				ReadOnly:  true,
+				ReadOnly:  false,
 			},
 			{
 				Name:      apicommon.SystemProbeSocketVolumeName,
 				MountPath: apicommon.SystemProbeSocketVolumePath,
-				ReadOnly:  true,
+				ReadOnly:  false,
 			},
 		}
 

--- a/controllers/datadogagent/object/volume/volumes.go
+++ b/controllers/datadogagent/object/volume/volumes.go
@@ -37,7 +37,7 @@ func GetVolumes(volumeName, hostPath, mountPath string, readOnly bool) (corev1.V
 }
 
 // GetVolumesEmptyDir creates a corev1.Volume (with an empty dir) and corev1.VolumeMount.
-func GetVolumesEmptyDir(volumeName, mountPath string) (corev1.Volume, corev1.VolumeMount) {
+func GetVolumesEmptyDir(volumeName, mountPath string, readOnly bool) (corev1.Volume, corev1.VolumeMount) {
 	var volume corev1.Volume
 	var volumeMount corev1.VolumeMount
 
@@ -50,7 +50,7 @@ func GetVolumesEmptyDir(volumeName, mountPath string) (corev1.Volume, corev1.Vol
 	volumeMount = corev1.VolumeMount{
 		Name:      volumeName,
 		MountPath: mountPath,
-		ReadOnly:  true,
+		ReadOnly:  readOnly,
 	}
 
 	return volume, volumeMount


### PR DESCRIPTION
### What does this PR do?

Fixes the volume mount permissions for system-probe when the NPM or the USM features are enabled.

### Describe your test plan

Enable the features and verify that the system-probe container is not in `CrashLoopBackOff` state because some volume is read-only.
