### PR TITLE
[features] Fix OOM Kill and TCP Queue Length

### DIFF
--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -17,6 +17,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	test "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/orchestrator"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
@@ -1263,7 +1264,7 @@ func defaultSystemProbePodSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1.PodSp
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"},
+						Add: agent.DefaultCapabilitiesForSystemProbe(),
 					},
 					RunAsUser: apiutils.NewInt64Pointer(0),
 				},
@@ -1375,7 +1376,7 @@ func noSeccompInstallSystemProbeSpec(dda *datadoghqv1alpha1.DatadogAgent) corev1
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"},
+						Add: agent.DefaultCapabilitiesForSystemProbe(),
 					},
 					RunAsUser: apiutils.NewInt64Pointer(0),
 				},
@@ -1737,7 +1738,7 @@ func runtimeSecurityAgentPodSpec(extraEnv map[string]string, extraDir string) co
 				},
 				SecurityContext: &corev1.SecurityContext{
 					Capabilities: &corev1.Capabilities{
-						Add: []corev1.Capability{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"},
+						Add: agent.DefaultCapabilitiesForSystemProbe(),
 					},
 					RunAsUser: apiutils.NewInt64Pointer(0),
 				},

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -61,6 +61,21 @@ func NewDefaultAgentPodTemplateSpec(dda metav1.Object, requiredContainers []comm
 	}
 }
 
+// DefaultCapabilitiesForSystemProbe returns the default Security Context
+// Capabilities for the System Probe container
+func DefaultCapabilitiesForSystemProbe() []corev1.Capability {
+	return []corev1.Capability{
+		"SYS_ADMIN",
+		"SYS_RESOURCE",
+		"SYS_PTRACE",
+		"NET_ADMIN",
+		"NET_BROADCAST",
+		"NET_RAW",
+		"IPC_LOCK",
+		"CHOWN",
+	}
+}
+
 func getDefaultServiceAccountName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
 }

--- a/controllers/datadogagent/feature/cws/feature.go
+++ b/controllers/datadogagent/feature/cws/feature.go
@@ -8,6 +8,7 @@ package cws
 import (
 	"path/filepath"
 
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
@@ -109,17 +110,7 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	managers.Annotation().AddAnnotation(apicommon.SystemProbeAppArmorAnnotationKey, apicommon.SystemProbeAppArmorAnnotationValue)
 
 	// security context capabilities
-	capabilities := []corev1.Capability{
-		"SYS_ADMIN",
-		"SYS_RESOURCE",
-		"SYS_PTRACE",
-		"NET_ADMIN",
-		"NET_BROADCAST",
-		"NET_RAW",
-		"IPC_LOCK",
-		"CHOWN",
-	}
-	managers.SecurityContext().AddCapabilitiesToContainer(capabilities, apicommonv1.SystemProbeContainerName)
+	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommonv1.SystemProbeContainerName)
 
 	// envvars
 	enabledEnvVar := &corev1.EnvVar{

--- a/controllers/datadogagent/feature/cws/feature_test.go
+++ b/controllers/datadogagent/feature/cws/feature_test.go
@@ -8,6 +8,7 @@ package cws
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	corev1 "k8s.io/api/core/v1"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
@@ -80,18 +81,8 @@ func Test_cwsFeature_Configure(t *testing.T) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
 
 		// check security context capabilities
-		wantCapabilities := []corev1.Capability{
-			"SYS_ADMIN",
-			"SYS_RESOURCE",
-			"SYS_PTRACE",
-			"NET_ADMIN",
-			"NET_BROADCAST",
-			"NET_RAW",
-			"IPC_LOCK",
-			"CHOWN",
-		}
 		sysProbeCapabilities := mgr.SecurityContextMgr.CapabilitiesByC[apicommonv1.SystemProbeContainerName]
-		assert.True(t, apiutils.IsEqualStruct(sysProbeCapabilities, wantCapabilities), "System Probe security context capabilities \ndiff = %s", cmp.Diff(sysProbeCapabilities, wantCapabilities))
+		assert.True(t, apiutils.IsEqualStruct(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()), "System Probe security context capabilities \ndiff = %s", cmp.Diff(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()))
 
 		securityWant := []*corev1.EnvVar{
 			{

--- a/controllers/datadogagent/feature/npm/feature.go
+++ b/controllers/datadogagent/feature/npm/feature.go
@@ -6,6 +6,7 @@
 package npm
 
 import (
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
@@ -92,17 +93,7 @@ func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	managers.Annotation().AddAnnotation(apicommon.SystemProbeAppArmorAnnotationKey, apicommon.SystemProbeAppArmorAnnotationValue)
 
 	// security context capabilities
-	capabilities := []corev1.Capability{
-		"SYS_ADMIN",
-		"SYS_RESOURCE",
-		"SYS_PTRACE",
-		"NET_ADMIN",
-		"NET_BROADCAST",
-		"NET_RAW",
-		"IPC_LOCK",
-		"CHOWN",
-	}
-	managers.SecurityContext().AddCapabilitiesToContainer(capabilities, apicommonv1.SystemProbeContainerName)
+	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommonv1.SystemProbeContainerName)
 
 	// procdir volume mount
 	procdirVol, procdirVolMount := volume.GetVolumes(apicommon.ProcdirVolumeName, apicommon.ProcdirHostPath, apicommon.ProcdirMountPath, true)

--- a/controllers/datadogagent/feature/npm/feature_test.go
+++ b/controllers/datadogagent/feature/npm/feature_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
@@ -61,18 +62,8 @@ func Test_npmFeature_Configure(t *testing.T) {
 		assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
 
 		// check security context capabilities
-		wantCapabilities := []corev1.Capability{
-			"SYS_ADMIN",
-			"SYS_RESOURCE",
-			"SYS_PTRACE",
-			"NET_ADMIN",
-			"NET_BROADCAST",
-			"NET_RAW",
-			"IPC_LOCK",
-			"CHOWN",
-		}
 		sysProbeCapabilities := mgr.SecurityContextMgr.CapabilitiesByC[apicommonv1.SystemProbeContainerName]
-		assert.True(t, apiutils.IsEqualStruct(sysProbeCapabilities, wantCapabilities), "System Probe security context capabilities \ndiff = %s", cmp.Diff(sysProbeCapabilities, wantCapabilities))
+		assert.True(t, apiutils.IsEqualStruct(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()), "System Probe security context capabilities \ndiff = %s", cmp.Diff(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()))
 
 		// check volume mounts
 		wantVolumeMounts := []corev1.VolumeMount{

--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -86,6 +86,11 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers) e
 	managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommonv1.SystemProbeContainerName)
 	managers.Volume().AddVolume(&srcVol)
 
+	// debugfs volume mount
+	debugfsVol, debugfsVolMount := volume.GetVolumes(apicommon.DebugfsVolumeName, apicommon.DebugfsPath, apicommon.DebugfsPath, false)
+	managers.Volume().AddVolume(&debugfsVol)
+	managers.VolumeMount().AddVolumeMountToContainers(&debugfsVolMount, []apicommonv1.AgentContainerName{apicommonv1.ProcessAgentContainerName, apicommonv1.SystemProbeContainerName})
+
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDEnableOOMKillEnvVar,
 		Value: "true",

--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -6,6 +6,7 @@
 package oomkill
 
 import (
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
@@ -72,6 +73,9 @@ func (f *oomKillFeature) ManageClusterAgent(managers feature.PodTemplateManagers
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
+	// security context capabilities
+	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommonv1.SystemProbeContainerName)
+
 	// modules volume mount
 	modulesVol, modulesVolMount := volume.GetVolumes(apicommon.ModulesVolumeName, apicommon.ModulesVolumePath, apicommon.ModulesVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&modulesVolMount, apicommonv1.SystemProbeContainerName)

--- a/controllers/datadogagent/feature/oomkill/feature_test.go
+++ b/controllers/datadogagent/feature/oomkill/feature_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
@@ -54,6 +55,15 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 
 	oomKillAgentNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+		// check security context capabilities
+		sysProbeCapabilities := mgr.SecurityContextMgr.CapabilitiesByC[apicommonv1.SystemProbeContainerName]
+		assert.True(
+			t,
+			apiutils.IsEqualStruct(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()),
+			"System Probe security context capabilities \ndiff = %s",
+			cmp.Diff(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()),
+		)
 
 		// check volume mounts
 		wantVolumeMounts := []corev1.VolumeMount{

--- a/controllers/datadogagent/feature/oomkill/feature_test.go
+++ b/controllers/datadogagent/feature/oomkill/feature_test.go
@@ -77,6 +77,11 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 				MountPath: apicommon.SrcVolumePath,
 				ReadOnly:  true,
 			},
+			{
+				Name:      apicommon.DebugfsVolumeName,
+				MountPath: apicommon.DebugfsPath,
+				ReadOnly:  false,
+			},
 		}
 
 		systemProbeVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.SystemProbeContainerName]
@@ -97,6 +102,14 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: apicommon.SrcVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.DebugfsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.DebugfsPath,
 					},
 				},
 			},

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -89,6 +89,11 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 	managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommonv1.SystemProbeContainerName)
 	managers.Volume().AddVolume(&srcVol)
 
+	// debugfs volume mount
+	debugfsVol, debugfsVolMount := volume.GetVolumes(apicommon.DebugfsVolumeName, apicommon.DebugfsPath, apicommon.DebugfsPath, false)
+	managers.Volume().AddVolume(&debugfsVol)
+	managers.VolumeMount().AddVolumeMountToContainers(&debugfsVolMount, []apicommonv1.AgentContainerName{apicommonv1.ProcessAgentContainerName, apicommonv1.SystemProbeContainerName})
+
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDEnableTCPQueueLengthEnvVar,
 		Value: "true",

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -6,6 +6,7 @@
 package tcpqueuelength
 
 import (
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
@@ -75,6 +76,9 @@ func (f *tcpQueueLengthFeature) ManageClusterAgent(managers feature.PodTemplateM
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
+	// security context capabilities
+	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommonv1.SystemProbeContainerName)
+
 	// modules volume mount
 	modulesVol, modulesVolMount := volume.GetVolumes(apicommon.ModulesVolumeName, apicommon.ModulesVolumePath, apicommon.ModulesVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&modulesVolMount, apicommonv1.SystemProbeContainerName)

--- a/controllers/datadogagent/feature/tcpqueuelength/feature_test.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
@@ -54,6 +55,15 @@ func Test_tcpQueueLengthFeature_Configure(t *testing.T) {
 
 	tcpQueueLengthAgentNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+		// check security context capabilities
+		sysProbeCapabilities := mgr.SecurityContextMgr.CapabilitiesByC[apicommonv1.SystemProbeContainerName]
+		assert.True(
+			t,
+			apiutils.IsEqualStruct(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()),
+			"System Probe security context capabilities \ndiff = %s",
+			cmp.Diff(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()),
+		)
 
 		// check volume mounts
 		wantVolumeMounts := []corev1.VolumeMount{

--- a/controllers/datadogagent/feature/tcpqueuelength/feature_test.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature_test.go
@@ -77,6 +77,11 @@ func Test_tcpQueueLengthFeature_Configure(t *testing.T) {
 				MountPath: apicommon.SrcVolumePath,
 				ReadOnly:  true,
 			},
+			{
+				Name:      apicommon.DebugfsVolumeName,
+				MountPath: apicommon.DebugfsPath,
+				ReadOnly:  false,
+			},
 		}
 
 		systemProbeVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.SystemProbeContainerName]
@@ -97,6 +102,14 @@ func Test_tcpQueueLengthFeature_Configure(t *testing.T) {
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: apicommon.SrcVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.DebugfsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.DebugfsPath,
 					},
 				},
 			},

--- a/controllers/datadogagent/feature/usm/feature.go
+++ b/controllers/datadogagent/feature/usm/feature.go
@@ -6,6 +6,7 @@
 package usm
 
 import (
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
@@ -99,17 +100,7 @@ func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	managers.Annotation().AddAnnotation(apicommon.SystemProbeAppArmorAnnotationKey, apicommon.SystemProbeAppArmorAnnotationValue)
 
 	// security context capabilities
-	capabilities := []corev1.Capability{
-		"SYS_ADMIN",
-		"SYS_RESOURCE",
-		"SYS_PTRACE",
-		"NET_ADMIN",
-		"NET_BROADCAST",
-		"NET_RAW",
-		"IPC_LOCK",
-		"CHOWN",
-	}
-	managers.SecurityContext().AddCapabilitiesToContainer(capabilities, apicommonv1.SystemProbeContainerName)
+	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommonv1.SystemProbeContainerName)
 
 	// volume mounts
 	procdirVol, procdirMount := volume.GetVolumes(apicommon.ProcdirVolumeName, apicommon.ProcdirHostPath, apicommon.ProcdirMountPath, true)

--- a/controllers/datadogagent/feature/usm/feature_test.go
+++ b/controllers/datadogagent/feature/usm/feature_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
@@ -68,18 +69,8 @@ func Test_usmFeature_Configure(t *testing.T) {
 		assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
 
 		// check security context capabilities
-		wantCapabilities := []corev1.Capability{
-			"SYS_ADMIN",
-			"SYS_RESOURCE",
-			"SYS_PTRACE",
-			"NET_ADMIN",
-			"NET_BROADCAST",
-			"NET_RAW",
-			"IPC_LOCK",
-			"CHOWN",
-		}
 		sysProbeCapabilities := mgr.SecurityContextMgr.CapabilitiesByC[apicommonv1.SystemProbeContainerName]
-		assert.True(t, apiutils.IsEqualStruct(sysProbeCapabilities, wantCapabilities), "System Probe security context capabilities \ndiff = %s", cmp.Diff(sysProbeCapabilities, wantCapabilities))
+		assert.True(t, apiutils.IsEqualStruct(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()), "System Probe security context capabilities \ndiff = %s", cmp.Diff(sysProbeCapabilities, agent.DefaultCapabilitiesForSystemProbe()))
 
 		// check volume mounts
 		wantVolumeMounts := []corev1.VolumeMount{

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -20,6 +20,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 	objectvolume "github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"
@@ -412,16 +413,7 @@ func getSystemProbeContainers(dda *datadoghqv1alpha1.DatadogAgent, image string)
 		Args:            getDefaultIfEmpty(dda.Spec.Agent.SystemProbe.Args, nil),
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{
-					"SYS_ADMIN",
-					"SYS_RESOURCE",
-					"SYS_PTRACE",
-					"NET_ADMIN",
-					"NET_BROADCAST",
-					"NET_RAW",
-					"IPC_LOCK",
-					"CHOWN",
-				},
+				Add: agent.DefaultCapabilitiesForSystemProbe(),
 			},
 			// Force root user for when the agent Dockerfile will be updated to use a non-root user by default
 			RunAsUser: apiutils.NewInt64Pointer(0),


### PR DESCRIPTION
### What does this PR do?

Fixes the OOM Kill and TCP Queue Length features when reconciler V2 is enabled.
Both of them were failing for the same reasons:
- The required security context capabilities were not being added to the system-probe container.
- The debugfs volume was missing.

The first commit is a refactor to define the capabilities needed for system-probe in a single place.

### Describe your test plan

Check that both features work correctly. Keep in mind that they don't work in all hosts. On my GKE cluster, they work on the ubuntu nodes, but not the COS ones. It's the same when I deploy with the Helm chart, so the problem is not in the operator.
