### PR TITLE
[features/factory] Delete unnecessary err return in BuildFeatures funcs

### DIFF
--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -239,8 +239,7 @@ func (test clusterAgentDeploymentFromInstanceTest) Run(t *testing.T) {
 	t.Helper()
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	logger := logf.Log.WithName(t.Name())
-	features, _, err := feature.BuildFeaturesV1(test.agentdeployment, &feature.Options{Logger: logger})
-	assert.NoError(t, err, "BuildFeaturesV1 error")
+	features, _ := feature.BuildFeaturesV1(test.agentdeployment, &feature.Options{Logger: logger})
 	got, _, err := newClusterAgentDeploymentFromInstance(logger, features, test.agentdeployment, test.selector)
 	if test.wantErr {
 		assert.Error(t, err, "newClusterAgentDeploymentFromInstance() expected an error")

--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -7,7 +7,6 @@ package datadogagent
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -158,10 +157,7 @@ func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logg
 func (r *Reconciler) reconcileInstance(ctx context.Context, logger logr.Logger, instance *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
 	var result reconcile.Result
 
-	features, requiredComponents, err := feature.BuildFeaturesV1(instance, reconcilerOptionsToFeatureOptions(&r.options, logger))
-	if err != nil {
-		return result, fmt.Errorf("unable to build features, err: %w", err)
-	}
+	features, requiredComponents := feature.BuildFeaturesV1(instance, reconcilerOptionsToFeatureOptions(&r.options, logger))
 	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent, "cluster-agent", requiredComponents.ClusterAgent, "cluster-checks-runner", requiredComponents.ClusterChecksRunner)
 
 	// -----------------------
@@ -176,7 +172,7 @@ func (r *Reconciler) reconcileInstance(ctx context.Context, logger logr.Logger, 
 	resourcesManager := feature.NewResourceManagers(depsStore)
 	var errs []error
 	for _, feat := range features {
-		if featErr := feat.ManageDependencies(resourcesManager, requiredComponents); err != nil {
+		if featErr := feat.ManageDependencies(resourcesManager, requiredComponents); featErr != nil {
 			errs = append(errs, featErr)
 		}
 	}
@@ -194,6 +190,7 @@ func (r *Reconciler) reconcileInstance(ctx context.Context, logger logr.Logger, 
 		r.reconcileClusterChecksRunner,
 		r.reconcileAgent,
 	}
+	var err error
 	for _, reconcileFunc := range reconcileFuncs {
 		result, err = reconcileFunc(logger, features, instance, newStatus)
 		if utils.ShouldReturn(result, err) {

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -7,7 +7,6 @@ package datadogagent
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -87,10 +86,7 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, request reconcile.
 func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent) (reconcile.Result, error) {
 	var result reconcile.Result
 
-	features, requiredComponents, err := feature.BuildFeatures(instance, reconcilerOptionsToFeatureOptions(&r.options, logger))
-	if err != nil {
-		return result, fmt.Errorf("unable to build features, err: %w", err)
-	}
+	features, requiredComponents := feature.BuildFeatures(instance, reconcilerOptionsToFeatureOptions(&r.options, logger))
 	logger.Info("requiredComponents status:", "agent", requiredComponents.Agent.IsEnabled(), "cluster-agent", requiredComponents.ClusterAgent.IsEnabled(), "cluster-checks-runner", requiredComponents.ClusterChecksRunner.IsEnabled())
 
 	// -----------------------
@@ -109,7 +105,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	// Set up dependencies required by enabled features
 	for id, feat := range features {
 		logger.Info("Dependency ManageDependencies", "featureID", id)
-		if featErr := feat.ManageDependencies(resourceManagers, requiredComponents); err != nil {
+		if featErr := feat.ManageDependencies(resourceManagers, requiredComponents); featErr != nil {
 			errs = append(errs, featErr)
 		}
 	}
@@ -127,6 +123,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	// Start reconcile Components
 	// -----------------------------
 
+	var err error
 	newStatus := instance.Status.DeepCopy()
 
 	if requiredComponents.ClusterAgent.IsEnabled() {

--- a/controllers/datadogagent/feature/factory.go
+++ b/controllers/datadogagent/feature/factory.go
@@ -31,7 +31,7 @@ func Register(id IDType, buildFunc BuildFunc) error {
 }
 
 // BuildFeatures use to build a list features depending of the v1alpha1.DatadogAgent instance
-func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options) ([]Feature, RequiredComponents, error) {
+func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options) ([]Feature, RequiredComponents) {
 	builderMutex.RLock()
 	defer builderMutex.RUnlock()
 
@@ -57,11 +57,11 @@ func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options) ([]Feature, Req
 		requiredComponents.Merge(&config)
 	}
 
-	return output, requiredComponents, nil
+	return output, requiredComponents
 }
 
 // BuildFeaturesV1 use to build a list features depending of the v1alpha1.DatadogAgent instance
-func BuildFeaturesV1(dda *v1alpha1.DatadogAgent, options *Options) ([]Feature, RequiredComponents, error) {
+func BuildFeaturesV1(dda *v1alpha1.DatadogAgent, options *Options) ([]Feature, RequiredComponents) {
 	builderMutex.RLock()
 	defer builderMutex.RUnlock()
 
@@ -87,7 +87,7 @@ func BuildFeaturesV1(dda *v1alpha1.DatadogAgent, options *Options) ([]Feature, R
 		requiredComponents.Merge(&config)
 	}
 
-	return output, requiredComponents, nil
+	return output, requiredComponents
 }
 
 var (


### PR DESCRIPTION
### What does this PR do?

Deletes an unnecessary error return parameter from a couple of functions in `controllers/datadogagent/feature/factory.go`: `BuildFeatures` and `BuildFeaturesV1`.

### Describe your test plan

Skip.
