### PR TITLE
[defaulting/images] Update agent to 7.38.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,7 +16,7 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.37.1"
+	AgentLatestVersion = "7.38.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
 	ClusterAgentLatestVersion = "1.21.0"
 


### PR DESCRIPTION
### What does this PR do?

Updates the default agent image to 7.38.0


### Describe your test plan

Check that 7.38.0 is the version deployed by default.
