### PR TITLE
[defaulting/images] Update DCA to 1.22.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -18,7 +18,7 @@ const (
 	// AgentLatestVersion correspond to the latest stable agent release
 	AgentLatestVersion = "7.38.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "1.21.0"
+	ClusterAgentLatestVersion = "1.22.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

Updates the DCA image to 1.22.0.

### Describe your test plan

DCA 1.22.0 should be deployed by default.
