### PR TITLE
[feature/ksm] Don't schedule on the DaemonSet Agent

### DIFF
--- a/controllers/datadogagent/feature/kubernetesstatecore/configmap_test.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/configmap_test.go
@@ -27,13 +27,13 @@ instances:
       - pods
 `
 	type fields struct {
-		enable               bool
-		clusterChecksEnabled bool
-		rbacSuffix           string
-		serviceAccountName   string
-		owner                metav1.Object
-		customConfig         *apicommonv1.CustomConfig
-		configConfigMapName  string
+		enable                   bool
+		runInClusterChecksRunner bool
+		rbacSuffix               string
+		serviceAccountName       string
+		owner                    metav1.Object
+		customConfig             *apicommonv1.CustomConfig
+		configConfigMapName      string
 	}
 	tests := []struct {
 		name    string
@@ -44,36 +44,46 @@ instances:
 		{
 			name: "default",
 			fields: fields{
-				owner:                owner,
-				enable:               true,
-				clusterChecksEnabled: true,
-				configConfigMapName:  apicommon.DefaultKubeStateMetricsCoreConf,
+				owner:                    owner,
+				enable:                   true,
+				runInClusterChecksRunner: true,
+				configConfigMapName:      apicommon.DefaultKubeStateMetricsCoreConf,
 			},
 			want: buildDefaultConfigMap(owner, apicommon.DefaultKubeStateMetricsCoreConf, ksmCheckConfig(true)),
 		},
 		{
 			name: "override",
 			fields: fields{
-				owner:                owner,
-				enable:               true,
-				clusterChecksEnabled: true,
-				configConfigMapName:  apicommon.DefaultKubeStateMetricsCoreConf,
+				owner:                    owner,
+				enable:                   true,
+				runInClusterChecksRunner: true,
+				configConfigMapName:      apicommon.DefaultKubeStateMetricsCoreConf,
 				customConfig: &apicommonv1.CustomConfig{
 					ConfigData: &overrideConf,
 				},
 			},
 			want: buildDefaultConfigMap(owner, apicommon.DefaultKubeStateMetricsCoreConf, overrideConf),
 		},
+		{
+			name: "no cluster check runners",
+			fields: fields{
+				owner:                    owner,
+				enable:                   true,
+				runInClusterChecksRunner: false,
+				configConfigMapName:      apicommon.DefaultKubeStateMetricsCoreConf,
+			},
+			want: buildDefaultConfigMap(owner, apicommon.DefaultKubeStateMetricsCoreConf, ksmCheckConfig(false)),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &ksmFeature{
-				clusterChecksEnabled: tt.fields.clusterChecksEnabled,
-				rbacSuffix:           tt.fields.rbacSuffix,
-				serviceAccountName:   tt.fields.serviceAccountName,
-				owner:                tt.fields.owner,
-				customConfig:         tt.fields.customConfig,
-				configConfigMapName:  tt.fields.configConfigMapName,
+				runInClusterChecksRunner: tt.fields.runInClusterChecksRunner,
+				rbacSuffix:               tt.fields.rbacSuffix,
+				serviceAccountName:       tt.fields.serviceAccountName,
+				owner:                    tt.fields.owner,
+				customConfig:             tt.fields.customConfig,
+				configConfigMapName:      tt.fields.configConfigMapName,
 			}
 			got, err := f.buildKSMCoreConfigMap()
 			if (err != nil) != tt.wantErr {

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -43,7 +43,7 @@ func buildKSMFeature(options *feature.Options) feature.Feature {
 }
 
 type ksmFeature struct {
-	clusterChecksEnabled bool
+	runInClusterChecksRunner bool
 
 	rbacSuffix         string
 	serviceAccountName string
@@ -76,9 +76,8 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 		f.configConfigMapName = apicommonv1.GetConfName(dda, f.customConfig, apicommon.DefaultKubeStateMetricsCoreConf)
 
 		if dda.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.Enabled) {
-			f.clusterChecksEnabled = true
-
 			if apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners) {
+				f.runInClusterChecksRunner = true
 				f.rbacSuffix = common.ChecksRunnerSuffix
 				f.serviceAccountName = v2alpha1.GetClusterChecksRunnerServiceAccount(dda)
 				output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
@@ -98,9 +97,8 @@ func (f *ksmFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) feature.RequiredCom
 		output.ClusterAgent.IsRequired = apiutils.NewBoolPointer(true)
 
 		if dda.Spec.ClusterAgent.Config != nil && apiutils.BoolValue(dda.Spec.ClusterAgent.Config.ClusterChecksEnabled) && apiutils.BoolValue(dda.Spec.Features.KubeStateMetricsCore.ClusterCheck) {
-			f.clusterChecksEnabled = true
-
 			if apiutils.BoolValue(dda.Spec.ClusterChecksRunner.Enabled) {
+				f.runInClusterChecksRunner = true
 				output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 
 				f.rbacSuffix = common.ChecksRunnerSuffix


### PR DESCRIPTION
### What does this PR do?

Changes the KSM feature so that it runs on the DCA instead of a daemonset agent when cluster checks are enabled but with no runners deployed.

This is because the KSM check is not designed to run on the daemonset agents.

### Describe your test plan

Configure the cluster checks feature with:
```
    clusterChecks:
      enabled: true
      useClusterChecksRunners: false
```
and verify that the check runs on the DCA.
