### PR TITLE
[feature/cws] Fix tagger auth error

### DIFF
--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -317,5 +317,6 @@ func volumeMountsForSystemProbe() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForConfig(),
 	}
 }

--- a/controllers/datadogagent/feature/cws/feature.go
+++ b/controllers/datadogagent/feature/cws/feature.go
@@ -147,12 +147,6 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	}
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, policiesDirEnvVar)
 
-	authTokenPathEnvVar := &corev1.EnvVar{
-		Name:  apicommon.DDAuthTokenFilePath,
-		Value: filepath.Join(apicommon.AuthVolumePath, "token"),
-	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, authTokenPathEnvVar)
-
 	hostRootEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDHostRootEnvVar,
 		Value: apicommon.HostRootMountPath,

--- a/controllers/datadogagent/feature/cws/feature_test.go
+++ b/controllers/datadogagent/feature/cws/feature_test.go
@@ -123,10 +123,6 @@ func Test_cwsFeature_Configure(t *testing.T) {
 				Name:  apicommon.DDRuntimeSecurityConfigPoliciesDir,
 				Value: apicommon.SecurityAgentRuntimePoliciesDirVolumePath,
 			},
-			{
-				Name:  apicommon.DDAuthTokenFilePath,
-				Value: "/etc/datadog-agent/auth/token",
-			},
 		}
 		securityAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.SecurityAgentContainerName]
 		assert.True(t, apiutils.IsEqualStruct(securityAgentEnvVars, securityWant), "Security agent envvars \ndiff = %s", cmp.Diff(securityAgentEnvVars, securityWant))


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the CWS. There was an error in the system-probe container because it couldn't fetch the token for the remote tagger connection.

I did these changes based on what we're already doing in the helm charts.

### Describe your test plan

Enable the CWS feature and check that there are no errors in the system-probe container.
