### PR TITLE
[component/clusteragent] Change anti-affinity to "preferred"

### DIFF
--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -1540,14 +1540,17 @@ func Test_PodAntiAffinity(t *testing.T) {
 			affinity: nil,
 			want: &v1.Affinity{
 				PodAntiAffinity: &v1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 						{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"agent.datadoghq.com/component": "cluster-agent",
+							Weight: 50,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultClusterAgentResourceSuffix,
+									},
 								},
+								TopologyKey: "kubernetes.io/hostname",
 							},
-							TopologyKey: "kubernetes.io/hostname",
 						},
 					},
 				},

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -143,14 +143,17 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 func DefaultAffinity() *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 				{
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultClusterAgentResourceSuffix,
+					Weight: 50,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultClusterAgentResourceSuffix,
+							},
 						},
+						TopologyKey: "kubernetes.io/hostname",
 					},
-					TopologyKey: "kubernetes.io/hostname",
 				},
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

Changes the DCA anti-affinity from "required" to "preferred".
This is because when using "required" agent updates can't work on clusters with 1 node.
We're already using "preferred" in the cluster check runners.

### Describe your test plan

Deploy in a cluster with one node. Make an update that affects the DCA, for example, enable/disable the orchestrator explorer feature. Check that the new DCA pod is deployed correctly.
