### PR TITLE
Fix image registry setting

### DIFF
--- a/controllers/datadogagent/override/global.go
+++ b/controllers/datadogagent/override/global.go
@@ -66,11 +66,11 @@ func ApplyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 		}
 		fullImage := fmt.Sprintf("%s/%s:%s", *config.Registry, image, version)
 
-		for idx, _ := range manager.PodTemplateSpec().Spec.InitContainers {
+		for idx := range manager.PodTemplateSpec().Spec.InitContainers {
 			manager.PodTemplateSpec().Spec.InitContainers[idx].Image = fullImage
 		}
 
-		for idx, _ := range manager.PodTemplateSpec().Spec.Containers {
+		for idx := range manager.PodTemplateSpec().Spec.Containers {
 			manager.PodTemplateSpec().Spec.Containers[idx].Image = fullImage
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

The registry in global settings wasn't properly setting the image registry in the containers.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Change the image registry and ensure it's reflected in the resulting pods.

```yaml
spec:
  global:
    registry: public.ecr.aws/datadog
```

```
> kubectl get po -l app.kubernetes.io/managed-by=datadog-operator -o jsonpath='{range .items[*]}{"pod: "}{.metadata.name}{"\n"}{range .spec.initContainers[*]}{"     initcontainer: "}{.name}{"\n     image: "}{.image}{"\n"}{end}{range .spec.containers[*]}{"     container: "}{.name}{"\n     image: "}{.image}{"\n"}{end}{end}'

pod: datadog-agent-xxxxx
     initcontainer: init-volume
     image: public.ecr.aws/datadog/agent:7.38.0
     initcontainer: init-config
     image: public.ecr.aws/datadog/agent:7.38.0
     container: agent
     image: public.ecr.aws/datadog/agent:7.38.0
     container: process-agent
     image: public.ecr.aws/datadog/agent:7.38.0
pod: datadog-cluster-agent-xxxxxxxxxx-xxxxx
     container: cluster-agent
     image: public.ecr.aws/datadog/cluster-agent:1.22.0
pod: datadog-cluster-checks-runner-xxxxxxxxxx-xxxxx
     initcontainer: init-config
     image: public.ecr.aws/datadog/agent:7.38.0
     container: agent
     image: public.ecr.aws/datadog/agent:7.38.0
```
