### PR TITLE
[defaulting/images] Update agent to 7.38.1

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,7 +16,7 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.38.0"
+	AgentLatestVersion = "7.38.1"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
 	ClusterAgentLatestVersion = "1.22.0"
 


### PR DESCRIPTION
### What does this PR do?

Updates the agent image to 7.38.1.

### Describe your test plan

agent 7.38.1 should be deployed by default.
