### PR TITLE
fix config links and apiVersion of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ However, the Datadog Operator is still in beta, so it is not yet a recommended w
 
 ## Getting started
 
-See the [Getting Started][5] dedicated documentation to learn how to deploy the Datadog operator and your first Agent, and Configuration ([v1alpha1][12] or [v2alpha1][13]) to see examples and a list of all configuration keys.
+See the [Getting Started][5] dedicated documentation to learn how to deploy the Datadog operator and your first Agent, and [Configuration][12] to see examples and a list of all configuration keys.
 
 ## Functionalities
 
@@ -54,7 +54,6 @@ See the [How to Contribute page][9].
 [10]: https://catalog.redhat.com/software/operators/detail/5e9874986c5dcb34dfbb1a12
 [11]: https://operatorhub.io/operator/datadog-operator
 [12]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md
-[13]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ However, the Datadog Operator is still in beta, so it is not yet a recommended w
 
 ## Getting started
 
-See the [Getting Started][5] dedicated documentation to learn how to deploy the Datadog operator and your first Agent, and [Configuration][12] to see examples and a list of all configuration keys.
+See the [Getting Started][5] dedicated documentation to learn how to deploy the Datadog operator and your first Agent, and Configuration ([v1alpha1][12] or [v2alpha1][13]) to see examples and a list of all configuration keys.
 
 ## Functionalities
 
@@ -53,7 +53,8 @@ See the [How to Contribute page][9].
 [9]: https://github.com/DataDog/datadog-operator/tree/main/docs/how-to-contribute.md
 [10]: https://catalog.redhat.com/software/operators/detail/5e9874986c5dcb34dfbb1a12
 [11]: https://operatorhub.io/operator/datadog-operator
-[12]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md
+[12]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md
+[13]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
 
 ## Release
 

--- a/docs/configuration.v1alpha1.md
+++ b/docs/configuration.v1alpha1.md
@@ -12,7 +12,7 @@
 ## All configuration options
 
 The following table lists the configurable parameters for the `DatadogAgent`
-resource. For example, if you wanted to set a value for `agent.image.name`,
+resource. For example, if you wanted to set a value for `clusterName`,
 your `DatadogAgent` resource would look like the following:
 
 ```yaml
@@ -21,6 +21,7 @@ kind: DatadogAgent
 metadata:
   name: datadog
 spec:
+  clusterName: my-test-cluster
   credentials:
     apiSecret:
       secretName: datadog-secret

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -12,7 +12,7 @@
 ## All configuration options
 
 The following table lists the configurable parameters for the `DatadogAgent`
-resource. For example, if you wanted to set a value for `agent.image.name`,
+resource. For example, if you wanted to set a value for `global.clusterName`,
 your `DatadogAgent` resource would look like the following:
 
 ```yaml
@@ -22,6 +22,7 @@ metadata:
   name: datadog
 spec:
   global:
+    clusterName: my-test-cluster
     credentials:
       apiSecret:
         secretName: datadog-secret

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -16,7 +16,7 @@ resource. For example, if you wanted to set a value for `agent.image.name`,
 your `DatadogAgent` resource would look like the following:
 
 ```yaml
-apiVersion: datadoghq.com/v1alpha1
+apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
   name: datadog

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -21,13 +21,15 @@ kind: DatadogAgent
 metadata:
   name: datadog
 spec:
-  credentials:
-    apiSecret:
-      secretName: datadog-secret
-      keyName: api-key
-    appSecret:
-      secretName: datadog-secret
-      keyName: app-key
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+
 ```
 
 | Parameter | Description |

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -85,7 +85,7 @@ helm delete my-datadog-operator
 [2]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 [3]: https://artifacthub.io/packages/helm/datadog/datadog-operator
 [4]: https://app.datadoghq.com/account/settings#api
-[5]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.md
+[5]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v1alpha1.md
 [6]: ttps://gcr.io/datadoghq
 [7]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-registry.yaml
 [8]: https://gallery.ecr.aws/datadog/


### PR DESCRIPTION
### What does this PR do?

#435 renamed `docs/configuration.md` to `docs.configuration.v1alpha1.md`, but that broke links to that page. This fixes the links.

I also noticed that the example manifest in `configuration.v2alpha1.md` still referred to `v1alpha1`, which I assume is a copy-paste typo.

### Motivation

I clicked on the "Configuration" link in the README and it took me to a 404 page.

### Describe your test plan

n/a, doc change only