### PR TITLE
Add EDS Support

### DIFF
--- a/controllers/datadogagent/component/new.go
+++ b/controllers/datadogagent/component/new.go
@@ -75,8 +75,11 @@ func NewExtendedDaemonset(owner metav1.Object, componentKind, componentName, ver
 
 func defaultEDSStrategy() edsv1alpha1.ExtendedDaemonSetSpecStrategy {
 	return edsv1alpha1.ExtendedDaemonSetSpecStrategy{
-		Canary:        edsv1alpha1.DefaultExtendedDaemonSetSpecStrategyCanary(nil, edsv1alpha1.ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto),
-		RollingUpdate: *edsv1alpha1.DefaultExtendedDaemonSetSpecStrategyRollingUpdate(nil),
+		Canary: edsv1alpha1.DefaultExtendedDaemonSetSpecStrategyCanary(
+			&edsv1alpha1.ExtendedDaemonSetSpecStrategyCanary{},
+			edsv1alpha1.ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto,
+		),
+		RollingUpdate: *edsv1alpha1.DefaultExtendedDaemonSetSpecStrategyRollingUpdate(&edsv1alpha1.ExtendedDaemonSetSpecStrategyRollingUpdate{}),
 		ReconcileFrequency: &metav1.Duration{
 			Duration: apicommon.DefaultReconcileFrequency,
 		},


### PR DESCRIPTION
### What does this PR do?

Adds EDS support to v2 reconciler

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Deploy EDS controller: https://github.com/DataDog/extendeddaemonset#deployment
* Start operator with `supportExtendedDaemonset`: [example in helm templates](https://github.com/DataDog/helm-charts/blob/1432627093df17f009d95de8695c6b8ee85c630c/charts/datadog-operator/templates/deployment.yaml#L91)
* Spin up a DatadogAgent using v2alpha1
* Label any nodes you want pods from the EDS to go on due to [this EDS bug](https://github.com/DataDog/extendeddaemonset/issues/100): `kubectl label node <node> agent.datadoghq.com/component=agent agent.datadoghq.com/name=datadog`
* Check that an EDS, ERS, and agent pods are spun up

```bash
> kubectl get pods
NAME                                             READY   STATUS    RESTARTS   AGE
datadog-agent-xxxxx-xxxxx                        2/2     Running   0          5m26s
datadog-cluster-agent-xxxxxxxxxx-xxxxx           1/1     Running   0          5m33s
datadog-cluster-checks-runner-xxxxxxxxxx-xxxxx   1/1     Running   0          5m34s
datadog-operator-manager-xxxxxxxxxx-xxxxx        1/1     Running   0          7m
eds-extendeddaemonset-xxxxxxxxx-xxxxx            1/1     Running   0          2d
> kubectl get ers
NAME                  STATUS   DESIRED   CURRENT   READY   AVAILABLE   IGNORED UNRESPONSIVE NODES   NODE SELECTOR                                                                                    AGE
datadog-agent-xxxxx   active   1         1         1       1           0                            {"matchLabels":{"agent.datadoghq.com/component":"agent","agent.datadoghq.com/name":"datadog"}}   5m40s
> kubectl get eds
NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   IGNORED UNRESPONSIVE NODES   STATUS    REASON   ACTIVE RS             CANARY RS   AGE
datadog-agent   1         1         1       1            1                                        Running            datadog-agent-xxxxx               5m44s
```