### PR TITLE
[WIP] Add OTLP ingest feature

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -198,6 +198,8 @@ const (
 	APMHostPortHostPort                          = 8126
 	APMSocketVolumeName                          = "apmsocket"
 	APMSocketVolumePath                          = "/var/run/datadog/apm"
+	OTLPGRPCPortName                             = "otlpgrpcport"
+	OTLPHTTPPortName                             = "otlphttpport"
 
 	AppArmorAnnotationKey = "container.apparmor.security.beta.kubernetes.io"
 )

--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -110,6 +110,9 @@ const (
 	DDTags                                          = "DD_TAGS"
 	DockerHost                                      = "DOCKER_HOST"
 
+	DDOTLPgRPCEndpoint = "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT"
+	DDOTLPHTTPEndpoint = "DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT"
+
 	// KubernetesEnvvarName Env var used by the Datadog Agent container entrypoint
 	// to add kubelet config provider and listener
 	KubernetesEnvVar = "KUBERNETES"

--- a/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -76,6 +76,10 @@ const (
 	defaultMutateUnlabelled                                     = false
 	DefaultAdmissionServiceName                                 = "datadog-admission-controller"
 	defaultAdmissionControllerEnabled                           = false
+	defaultOTLPGRPCEnabled                               bool   = false
+	defaultOTLPGRPCEndpoint                              string = "0.0.0.0:4317"
+	defaultOTLPHTTPEnabled                               bool   = false
+	defaultOTLPHTTPEndpoint                              string = "0.0.0.0:4318"
 )
 
 var defaultImagePullPolicy = corev1.PullIfNotPresent
@@ -239,6 +243,10 @@ func DefaultDatadogAgentSpecAgent(agent *DatadogAgentSpecAgentSpec) *DatadogAgen
 
 	if sec := DefaultDatadogAgentSpecAgentSecurity(agent); !apiutils.IsEqualStruct(*sec, SecuritySpec{}) {
 		agentOverride.Security = sec
+	}
+
+	if otlp := DefaultDatadogAgentSpecAgentOTLP(agent); !apiutils.IsEqualStruct(*otlp, OTLPSpec{}) {
+		agentOverride.OTLP = otlp
 	}
 
 	if proc := DefaultDatadogAgentSpecAgentProcess(agent); !apiutils.IsEqualStruct(*proc, ProcessSpec{}) {
@@ -690,6 +698,59 @@ func DefaultDatadogAgentSpecAgentSecurity(agent *DatadogAgentSpecAgentSpec) *Sec
 	}
 
 	return secOverride
+}
+
+// DefaultDatadogAgentSpecAgentOTLP defaults the OTLP Ingest in the DatadogAgentSpec
+func DefaultDatadogAgentSpecAgentOTLP(agent *DatadogAgentSpecAgentSpec) *OTLPSpec {
+	defaultOTLP := &OTLPSpec{OTLPReceiverSpec{OTLPProtocolsSpec{
+		GRPC: &OTLPGRPCSpec{
+			Enabled:  apiutils.NewBoolPointer(defaultOTLPGRPCEnabled),
+			Endpoint: apiutils.NewStringPointer(defaultOTLPGRPCEndpoint),
+		},
+		HTTP: &OTLPHTTPSpec{
+			Enabled:  apiutils.NewBoolPointer(defaultOTLPHTTPEnabled),
+			Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
+		},
+	}}}
+
+	if agent.OTLP == nil {
+		agent.OTLP = defaultOTLP
+		return agent.OTLP
+	}
+
+	otlpOverride := &OTLPSpec{}
+
+	// OTLP/gRPC section
+	if agent.OTLP.Receiver.Protocols.GRPC == nil {
+		agent.OTLP.Receiver.Protocols.GRPC = defaultOTLP.Receiver.Protocols.GRPC
+		otlpOverride.Receiver.Protocols.GRPC = agent.OTLP.Receiver.Protocols.GRPC
+	} else {
+		if agent.OTLP.Receiver.Protocols.GRPC.Enabled == nil {
+			agent.OTLP.Receiver.Protocols.GRPC.Enabled = defaultOTLP.Receiver.Protocols.GRPC.Enabled
+			otlpOverride.Receiver.Protocols.GRPC.Enabled = agent.OTLP.Receiver.Protocols.GRPC.Enabled
+		}
+		if agent.OTLP.Receiver.Protocols.GRPC.Endpoint == nil {
+			agent.OTLP.Receiver.Protocols.GRPC.Endpoint = defaultOTLP.Receiver.Protocols.GRPC.Endpoint
+			otlpOverride.Receiver.Protocols.GRPC.Endpoint = agent.OTLP.Receiver.Protocols.GRPC.Endpoint
+		}
+	}
+
+	// OTLP/HTTP section
+	if agent.OTLP.Receiver.Protocols.HTTP == nil {
+		agent.OTLP.Receiver.Protocols.HTTP = defaultOTLP.Receiver.Protocols.HTTP
+		otlpOverride.Receiver.Protocols.HTTP = agent.OTLP.Receiver.Protocols.HTTP
+	} else {
+		if agent.OTLP.Receiver.Protocols.HTTP.Enabled == nil {
+			agent.OTLP.Receiver.Protocols.HTTP.Enabled = defaultOTLP.Receiver.Protocols.HTTP.Enabled
+			otlpOverride.Receiver.Protocols.HTTP.Enabled = agent.OTLP.Receiver.Protocols.HTTP.Enabled
+		}
+		if agent.OTLP.Receiver.Protocols.HTTP.Endpoint == nil {
+			agent.OTLP.Receiver.Protocols.HTTP.Endpoint = defaultOTLP.Receiver.Protocols.HTTP.Endpoint
+			otlpOverride.Receiver.Protocols.HTTP.Endpoint = agent.OTLP.Receiver.Protocols.HTTP.Endpoint
+		}
+	}
+
+	return otlpOverride
 }
 
 // DefaultDatadogFeatureLogCollection used to default an LogCollectionConfig

--- a/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -223,6 +223,10 @@ type DatadogAgentSpecAgentSpec struct {
 	// +optional
 	Security *SecuritySpec `json:"security,omitempty"`
 
+	// OTLP ingest configuration
+	// +optional
+	OTLP *OTLPSpec `json:"otlp,omitempty"`
+
 	// Allow to put custom configuration for the agent, corresponding to the datadog.yaml config file.
 	// See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.
 	// +optional
@@ -719,6 +723,59 @@ type ConfigDirSpec struct {
 	// +listType=map
 	// +listMapKey=key
 	Items []corev1.KeyToPath `json:"items,omitempty"`
+}
+
+// OTLPSpec contains configuration for OTLP ingest.
+// +k8s:openapi-gen=true
+type OTLPSpec struct {
+	// Receiver contains configuration for the OTLP ingest receiver.
+	Receiver OTLPReceiverSpec `json:"receiver,omitempty"`
+}
+
+// OTLPReceiverSpec contains configuration for the OTLP ingest receiver.
+// +k8s:openapi-gen=true
+type OTLPReceiverSpec struct {
+	// Protocols contains configuration for the OTLP ingest receiver protocols.
+	Protocols OTLPProtocolsSpec `json:"protocols,omitempty"`
+}
+
+// OTLPProtocolsSpec contains configuration for the OTLP ingest receiver protocols.
+// +k8s:openapi-gen=true
+type OTLPProtocolsSpec struct {
+	// GRPC contains configuration for the OTLP ingest OTLP/gRPC receiver.
+	// +optional
+	GRPC *OTLPGRPCSpec `json:"grpc,omitempty"`
+	// HTTP contains configuration for the OTLP ingest OTLP/HTTP receiver.
+	// +optional
+	HTTP *OTLPHTTPSpec `json:"http,omitempty"`
+}
+
+// OTLPGRPCSpec contains configuration for the OTLP ingest OTLP/gRPC receiver.
+// +k8s:openapi-gen=true
+type OTLPGRPCSpec struct {
+	// Enable the OTLP/gRPC endpoint.
+	// +optional
+	Enabled *bool
+
+	// Endpoint for OTLP/gRPC.
+	// gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md
+	// The Datadog Operator only supports 'host:port' (usually '0.0.0.0:port').
+	// The default value is '0.0.0.0:4317'.
+	// +optional
+	Endpoint *string
+}
+
+// OTLPHTTPSpec contains configuration for the OTLP ingest OTLP/HTTP receiver.
+// +k8s:openapi-gen=true
+type OTLPHTTPSpec struct {
+	// Enable the OTLP/HTTP endpoint.
+	// +optional
+	Enabled *bool
+
+	// Endpoint for OTLP/HTTP.
+	// The default value is '0.0.0.0:4318'.
+	// +optional
+	Endpoint *string
 }
 
 // ConfigFileConfigMapSpec contains configMap information used to store a config file.

--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -52,6 +52,11 @@ const (
 	defaultDogstatsdSocketEnabled          bool   = true
 	defaultDogstatsdSocketPath             string = "/var/run/datadog/statsd/dsd.socket"
 
+	defaultOTLPGRPCEnabled  bool   = false
+	defaultOTLPGRPCEndpoint string = "0.0.0.0:4317"
+	defaultOTLPHTTPEnabled  bool   = false
+	defaultOTLPHTTPEndpoint string = "0.0.0.0:4318"
+
 	defaultCollectKubernetesEvents bool = true
 
 	// defaultAdmissionControllerEnabled          bool = false
@@ -197,6 +202,23 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.Dogstatsd.UnixDomainSocketConfig.Enabled, defaultDogstatsdSocketEnabled)
 
 	apiutils.DefaultStringIfUnset(&ddaSpec.Features.Dogstatsd.UnixDomainSocketConfig.Path, defaultDogstatsdSocketPath)
+
+	// OTLP ingest feature
+	if ddaSpec.Features.OTLP == nil {
+		ddaSpec.Features.OTLP = &OTLPFeatureConfig{}
+	}
+
+	if ddaSpec.Features.OTLP.Receiver.Protocols.GRPC == nil {
+		ddaSpec.Features.OTLP.Receiver.Protocols.GRPC = &OTLPGRPCConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OTLP.Receiver.Protocols.GRPC.Enabled, defaultOTLPGRPCEnabled)
+	apiutils.DefaultStringIfUnset(&ddaSpec.Features.OTLP.Receiver.Protocols.GRPC.Endpoint, defaultOTLPGRPCEndpoint)
+
+	if ddaSpec.Features.OTLP.Receiver.Protocols.HTTP == nil {
+		ddaSpec.Features.OTLP.Receiver.Protocols.HTTP = &OTLPHTTPConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OTLP.Receiver.Protocols.HTTP.Enabled, defaultOTLPHTTPEnabled)
+	apiutils.DefaultStringIfUnset(&ddaSpec.Features.OTLP.Receiver.Protocols.HTTP.Endpoint, defaultOTLPHTTPEndpoint)
 
 	// Cluster-level features
 

--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -66,6 +66,8 @@ type DatadogFeatures struct {
 	USM *USMFeatureConfig `json:"usm,omitempty"`
 	// Dogstatsd configuration.
 	Dogstatsd *DogstatsdFeatureConfig `json:"dogstatsd,omitempty"`
+	// OTLP ingest configuration
+	OTLP *OTLPFeatureConfig `json:"otlp,omitempty"`
 
 	// Cluster-level features
 
@@ -301,6 +303,59 @@ type DogstatsdFeatureConfig struct {
 	// See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/
 	// +optional
 	MapperProfiles *CustomConfig `json:"mapperProfiles,omitempty"`
+}
+
+// OTLPFeatureConfig contains configuration for OTLP ingest.
+// +k8s:openapi-gen=true
+type OTLPFeatureConfig struct {
+	// Receiver contains configuration for the OTLP ingest receiver.
+	Receiver OTLPReceiverConfig `json:"receiver,omitempty"`
+}
+
+// OTLPReceiverConfig contains configuration for the OTLP ingest receiver.
+// +k8s:openapi-gen=true
+type OTLPReceiverConfig struct {
+	// Protocols contains configuration for the OTLP ingest receiver protocols.
+	Protocols OTLPProtocolsConfig `json:"protocols,omitempty"`
+}
+
+// OTLPProtocolsConfig contains configuration for the OTLP ingest receiver protocols.
+// +k8s:openapi-gen=true
+type OTLPProtocolsConfig struct {
+	// GRPC contains configuration for the OTLP ingest OTLP/gRPC receiver.
+	// +optional
+	GRPC *OTLPGRPCConfig `json:"grpc,omitempty"`
+	// HTTP contains configuration for the OTLP ingest OTLP/HTTP receiver.
+	// +optional
+	HTTP *OTLPHTTPConfig `json:"http,omitempty"`
+}
+
+// OTLPGRPCSpec contains configuration for the OTLP ingest OTLP/gRPC receiver.
+// +k8s:openapi-gen=true
+type OTLPGRPCConfig struct {
+	// Enable the OTLP/gRPC endpoint.
+	// +optional
+	Enabled *bool
+
+	// Endpoint for OTLP/gRPC.
+	// gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md
+	// The Datadog Operator only supports 'host:port' (usually '0.0.0.0:port').
+	// The default value is '0.0.0.0:4317'.
+	// +optional
+	Endpoint *string
+}
+
+// OTLPHTTPConfig contains configuration for the OTLP ingest OTLP/HTTP receiver.
+// +k8s:openapi-gen=true
+type OTLPHTTPConfig struct {
+	// Enable the OTLP/HTTP endpoint.
+	// +optional
+	Enabled *bool
+
+	// Endpoint for OTLP/HTTP.
+	// The default value is '0.0.0.0:4318'.
+	// +optional
+	Endpoint *string
 }
 
 // EventCollectionFeatureConfig contains the Event Collection configuration.

--- a/controllers/datadogagent/feature/ids.go
+++ b/controllers/datadogagent/feature/ids.go
@@ -41,6 +41,8 @@ const (
 	ClusterChecksIDType = "cluster_checks"
 	// APMIDType APM feature
 	APMIDType = "apm"
+	// OTLPIDType OTLP ingest feature
+	OTLPIDType = "otlp"
 	// DummyIDType Dummy feature.
 	DummyIDType = "dummy"
 )

--- a/controllers/datadogagent/feature/otlp/feature.go
+++ b/controllers/datadogagent/feature/otlp/feature.go
@@ -1,0 +1,226 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+package otlp
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+)
+
+var (
+	portRegexp = regexp.MustCompile(":([0-9]+)$")
+)
+
+func init() {
+	err := feature.Register(feature.OTLPIDType, buildOTLPFeature)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func buildOTLPFeature(options *feature.Options) feature.Feature {
+	otlpFeat := &otlpFeature{}
+
+	return otlpFeat
+}
+
+type otlpFeature struct {
+	grpcEnabled  bool
+	grpcEndpoint string
+
+	httpEnabled  bool
+	httpEndpoint string
+
+	usingAPM bool
+}
+
+// ID returns the ID of the Feature
+func (f *otlpFeature) ID() feature.IDType {
+	return feature.OTLPIDType
+}
+
+// Configure is used to configure the feature from a v2alpha1.DatadogAgent instance.
+func (f *otlpFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.RequiredComponents) {
+	otlp := dda.Spec.Features.OTLP
+	if apiutils.BoolValue(otlp.Receiver.Protocols.GRPC.Enabled) {
+		f.grpcEnabled = true
+	}
+	if otlp.Receiver.Protocols.GRPC.Endpoint != nil {
+		f.grpcEndpoint = *otlp.Receiver.Protocols.GRPC.Endpoint
+	}
+
+	if apiutils.BoolValue(otlp.Receiver.Protocols.HTTP.Enabled) {
+		f.httpEnabled = true
+	}
+	if otlp.Receiver.Protocols.HTTP.Endpoint != nil {
+		f.httpEndpoint = *otlp.Receiver.Protocols.HTTP.Endpoint
+	}
+
+	apm := dda.Spec.Features.APM
+	if apm != nil {
+		f.usingAPM = apiutils.BoolValue(apm.Enabled)
+	}
+
+	reqComp = feature.RequiredComponents{
+		Agent: feature.RequiredComponent{
+			IsRequired: apiutils.NewBoolPointer(true),
+			Containers: []apicommonv1.AgentContainerName{
+				apicommonv1.CoreAgentContainerName,
+			},
+		},
+	}
+	// if using APM, require the Trace Agent too.
+	if f.usingAPM {
+		reqComp.Agent.Containers = append(reqComp.Agent.Containers, apicommonv1.TraceAgentContainerName)
+	}
+
+	return reqComp
+}
+
+// ConfigureV1 use to configure the feature from a v1alpha1.DatadogAgent instance.
+func (f *otlpFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) (reqComp feature.RequiredComponents) {
+	otlp := dda.Spec.Agent.OTLP
+	if apiutils.BoolValue(otlp.Receiver.Protocols.GRPC.Enabled) {
+		f.grpcEnabled = true
+	}
+	if otlp.Receiver.Protocols.GRPC.Endpoint != nil {
+		f.grpcEndpoint = *otlp.Receiver.Protocols.GRPC.Endpoint
+	}
+
+	if apiutils.BoolValue(otlp.Receiver.Protocols.HTTP.Enabled) {
+		f.httpEnabled = true
+	}
+	if otlp.Receiver.Protocols.HTTP.Endpoint != nil {
+		f.httpEndpoint = *otlp.Receiver.Protocols.HTTP.Endpoint
+	}
+
+	f.usingAPM = apiutils.BoolValue(dda.Spec.Agent.Apm.Enabled)
+
+	reqComp = feature.RequiredComponents{
+		Agent: feature.RequiredComponent{
+			IsRequired: apiutils.NewBoolPointer(true),
+			Containers: []apicommonv1.AgentContainerName{
+				apicommonv1.CoreAgentContainerName,
+			},
+		},
+	}
+	// if using APM, require the Trace Agent too.
+	if f.usingAPM {
+		reqComp.Agent.Containers = append(reqComp.Agent.Containers, apicommonv1.TraceAgentContainerName)
+	}
+
+	return reqComp
+}
+
+// ManageDependencies allows a feature to manage its dependencies.
+// Feature's dependencies should be added in the store.
+func (f *otlpFeature) ManageDependencies(managers feature.ResourceManagers, components feature.RequiredComponents) error {
+	return nil
+}
+
+// ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec
+// It should do nothing if the feature doesn't need to configure it.
+func (f *otlpFeature) ManageClusterAgent(managers feature.PodTemplateManagers) error {
+	return nil
+}
+
+func validateOTLPGRPCEndpoint(endpoint string) error {
+	for _, protocol := range []string{"unix", "unix-abstract"} {
+		if strings.HasPrefix(endpoint, protocol+":") {
+			return fmt.Errorf("%q protocol is not currently supported", protocol)
+		}
+	}
+
+	return nil
+}
+
+func extractPortEndpoint(endpoint string) (int32, error) {
+	if portStr := portRegexp.FindString(endpoint); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return 0, fmt.Errorf("no match for port on %q: %w", endpoint, err)
+		}
+
+		if port < 0 || port > 65535 {
+			return 0, fmt.Errorf("port is outside valid range: %d", port)
+		}
+
+		return int32(port), nil
+	}
+	return 0, fmt.Errorf("%q does not have a port explicitly set", endpoint)
+}
+
+// ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
+// It should do nothing if the feature doesn't need to configure it.
+func (f *otlpFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
+	if f.grpcEnabled {
+		if err := validateOTLPGRPCEndpoint(f.grpcEndpoint); err != nil {
+			return fmt.Errorf("invalid OTLP/gRPC endpoint: %w", err)
+		}
+
+		port, err := extractPortEndpoint(f.grpcEndpoint)
+		if err != nil {
+			return fmt.Errorf("failed to extract port from OTLP/gRPC endpoint: %w", err)
+		}
+		otlpgrpcPort := &corev1.ContainerPort{
+			Name:          apicommon.OTLPGRPCPortName,
+			ContainerPort: port,
+			Protocol:      corev1.ProtocolTCP,
+		}
+		envVar := &corev1.EnvVar{
+			Name:  apicommon.DDOTLPgRPCEndpoint,
+			Value: f.grpcEndpoint,
+		}
+		managers.Port().AddPortToContainer(apicommonv1.CoreAgentContainerName, otlpgrpcPort)
+		managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, envVar)
+		if f.usingAPM {
+			managers.EnvVar().AddEnvVarToContainer(apicommonv1.TraceAgentContainerName, envVar)
+
+		}
+	}
+
+	if f.httpEnabled {
+		port, err := extractPortEndpoint(f.httpEndpoint)
+		if err != nil {
+			return fmt.Errorf("failed to extract port from OTLP/HTTP endpoint: %w", err)
+		}
+		otlphttpPort := &corev1.ContainerPort{
+			Name:          apicommon.OTLPHTTPPortName,
+			ContainerPort: port,
+			Protocol:      corev1.ProtocolTCP,
+		}
+		envVar := &corev1.EnvVar{
+			Name:  apicommon.DDOTLPHTTPEndpoint,
+			Value: f.grpcEndpoint,
+		}
+		managers.Port().AddPortToContainer(apicommonv1.CoreAgentContainerName, otlphttpPort)
+		managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, envVar)
+		if f.usingAPM {
+			managers.EnvVar().AddEnvVarToContainer(apicommonv1.TraceAgentContainerName, envVar)
+
+		}
+	}
+
+	return nil
+}
+
+// ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunner's corev1.PodTemplateSpec
+// It should do nothing if the feature doesn't need to configure it.
+func (f *otlpFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Add `otlp` feature to configure [OTLP ingest](https://docs.datadoghq.com/tracing/trace_collection/open_standards/otlp_ingest_in_the_agent/?tab=host).

### Motivation

Allow users to configure this feature via the Datadog operator.

### Additional Notes

Configuration has the same schema as DataDog/helm-charts/pull/619. This is slightly different from the Agent's, since it has the `enabled` flags explicitly.

As it happens in the Helm chart, this PR only adds support for defining an OTLP/gRPC endpoint with a host and port, and not via a Unix socket.

### Describe your test plan

TBD
