### PR TITLE
update metrics forwarder manager to use an interface for the status condition

### DIFF
--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -262,9 +262,10 @@ func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, agentdeployment *d
 // setMetricsForwarderStatus sets the metrics forwarder status condition if enabled
 func (r *Reconciler) setMetricsForwarderStatus(logger logr.Logger, agentdeployment *datadoghqv1alpha1.DatadogAgent, newStatus *datadoghqv1alpha1.DatadogAgentStatus) {
 	if r.options.OperatorMetricsEnabled {
-		if metricsCondition := r.forwarders.MetricsForwarderStatusForObj(agentdeployment); metricsCondition != nil {
+		if agentCondition := r.forwarders.MetricsForwarderStatusForObj(agentdeployment); agentCondition != nil {
 			logger.V(1).Info("metrics conditions status not available")
-			condition.SetDatadogAgentStatusCondition(newStatus, metricsCondition)
+			agentConditionCast, _ := agentCondition.(datadoghqv1alpha1.DatadogAgentCondition)
+			condition.SetDatadogAgentStatusCondition(newStatus, &agentConditionCast)
 		}
 	}
 }

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -2849,7 +2849,7 @@ func (dummyManager) ProcessError(datadog.MonitoredObject, error) {
 func (dummyManager) ProcessEvent(datadog.MonitoredObject, datadog.Event) {
 }
 
-func (dummyManager) MetricsForwarderStatusForObj(obj datadog.MonitoredObject) *datadoghqv1alpha1.DatadogAgentCondition {
+func (dummyManager) MetricsForwarderStatusForObj(obj datadog.MonitoredObject) datadog.ConditionInterface {
 	return nil
 }
 

--- a/pkg/controller/utils/datadog/forwarders_manager.go
+++ b/pkg/controller/utils/datadog/forwarders_manager.go
@@ -11,7 +11,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
@@ -21,7 +20,7 @@ type MetricForwardersManager interface {
 	Unregister(MonitoredObject)
 	ProcessError(MonitoredObject, error)
 	ProcessEvent(MonitoredObject, Event)
-	MetricsForwarderStatusForObj(obj MonitoredObject) *datadoghqv1alpha1.DatadogAgentCondition
+	MetricsForwarderStatusForObj(obj MonitoredObject) ConditionInterface
 }
 
 // ForwardersManager is a collection of metricsForwarder per DatadogAgent
@@ -115,7 +114,7 @@ func (f *ForwardersManager) ProcessEvent(obj MonitoredObject, event Event) {
 }
 
 // MetricsForwarderStatusForObj used to retrieve the Metrics forwarder status for a given object
-func (f *ForwardersManager) MetricsForwarderStatusForObj(obj MonitoredObject) *datadoghqv1alpha1.DatadogAgentCondition {
+func (f *ForwardersManager) MetricsForwarderStatusForObj(obj MonitoredObject) ConditionInterface {
 	id := getObjID(obj)
 	forwarder, err := f.getForwarder(id)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Update metrics forwarder manager to use an interface in lieu of the custom status condition. This is an intermediary step to support a metrics forwarder v2 that uses the metav1.Condition rather than the custom v1alpha1.DatadogAgentCondition.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy the operator with `operatorMetricsEnabled=true` and test a v1 DatadogAgent custom resource. Make sure metrics report as expected.