### PR TITLE
[hack] Adapt generate-docs script to output 2 versions

### DIFF
--- a/docs/configuration.v1alpha1.md
+++ b/docs/configuration.v1alpha1.md
@@ -12,8 +12,8 @@
 ## All configuration options
 
 The following table lists the configurable parameters for the `DatadogAgent`
-resource. For example, if you wanted to set a value for `clusterName`,
-your `DatadogAgent` resource would look like the following:
+resource. For example, if you wanted to set a custom cluster name, your
+`DatadogAgent` resource would look like the following:
 
 ```yaml
 apiVersion: datadoghq.com/v1alpha1

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -12,8 +12,8 @@
 ## All configuration options
 
 The following table lists the configurable parameters for the `DatadogAgent`
-resource. For example, if you wanted to set a value for `global.clusterName`,
-your `DatadogAgent` resource would look like the following:
+resource. For example, if you wanted to set a custom cluster name, your
+`DatadogAgent` resource would look like the following:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -30,7 +30,6 @@ spec:
       appSecret:
         secretName: datadog-secret
         keyName: app-key
-
 ```
 
 | Parameter | Description |

--- a/hack/generate-docs/header.markdown
+++ b/hack/generate-docs/header.markdown
@@ -12,21 +12,5 @@
 ## All configuration options
 
 The following table lists the configurable parameters for the `DatadogAgent`
-resource. For example, if you wanted to set a value for `agent.image.name`,
-your `DatadogAgent` resource would look like the following:
-
-```yaml
-apiVersion: datadoghq.com/v1alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  credentials:
-    apiSecret:
-      secretName: datadog-secret
-      keyName: api-key
-    appSecret:
-      secretName: datadog-secret
-      keyName: app-key
-```
-
+resource. For example, if you wanted to set a custom cluster name, your
+`DatadogAgent` resource would look like the following:

--- a/hack/generate-docs/v1alpha1_example.markdown
+++ b/hack/generate-docs/v1alpha1_example.markdown
@@ -1,0 +1,15 @@
+```yaml
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  clusterName: my-test-cluster
+  credentials:
+    apiSecret:
+      secretName: datadog-secret
+      keyName: api-key
+    appSecret:
+      secretName: datadog-secret
+      keyName: app-key
+```

--- a/hack/generate-docs/v2alpha1_example.markdown
+++ b/hack/generate-docs/v2alpha1_example.markdown
@@ -1,0 +1,16 @@
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    clusterName: my-test-cluster
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+```


### PR DESCRIPTION
### What does this PR do?

Adapts the `generate-docs` script to generate docs both for v1 and v2.

