### PR TITLE
[datadogagent/finalizer] Add missing arg in Dependencies()

### DIFF
--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -115,7 +115,7 @@ func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) {
 	}
 
 	// Examine user configuration to override any external dependencies (e.g. RBACs)
-	errs = append(errs, override.Dependencies(resourceManagers, dda.Spec.Override, dda.Namespace)...)
+	errs = append(errs, override.Dependencies(reqLogger, resourceManagers, dda.Spec.Override, dda.Namespace)...)
 
 	if len(errs) > 0 {
 		reqLogger.Info("Errors calculating dependencies while finalizing the DatadogAgent", "errors", errs)


### PR DESCRIPTION
### What does this PR do?

Fixes a compilation error in `main`. The error appeared after merging https://github.com/DataDog/datadog-operator/pull/576 . The tests were passing in the PR but broke `main`.

