### PR TITLE
Default Agent and Cluster-Agent image to 7.39.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.38.1"
+	AgentLatestVersion = "7.39.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "1.22.0"
+	ClusterAgentLatestVersion = "7.39.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

* Default Agent image to `7.39.0`.
* Default Cluster-Agent image to `7.39.0`. Cluster-Agent versioning is now aligned with the Agent.

### Motivation

Keep agent version up-to-date

### Additional Notes

N/A

### Describe your test plan

It has been already tested during the Datadog-Agent 7.39.0 QA with the last Operator release 0.8.1.

steps:
* create a DatadogAgent without specifying the Agent, ClusterAgent and ClusterCheckRunner image tag.
* check if the Daemonset and Deployments are using the 7.39.0 version