### PR TITLE
[metrics_forwarder] Add missing nil check in setupV2

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -238,7 +238,10 @@ func (mf *metricsForwarder) setupV2() error {
 	mf.baseURL = getbaseURLV2(dda)
 	mf.logger.Info("Got Datadog Site", "site", mf.baseURL)
 
-	mf.clusterName = *dda.Spec.Global.ClusterName
+	if dda.Spec.Global != nil && dda.Spec.Global.ClusterName != nil {
+		mf.clusterName = *dda.Spec.Global.ClusterName
+	}
+
 	mf.labels = dda.GetLabels()
 
 	status := dda.Status.DeepCopy()


### PR DESCRIPTION
### What does this PR do?

Adds a missing nil check in the metrics forwarder.

Enabling metrics forwarder with V2 without providing a cluster name resulted in a panic.

### Describe your test plan

Shouldn't panic.
