### PR TITLE
Add feature-specific network policies

### DIFF
--- a/apis/datadoghq/v1alpha1/utils.go
+++ b/apis/datadoghq/v1alpha1/utils.go
@@ -112,3 +112,23 @@ func GetLocalAgentServiceName(dda *DatadogAgent) string {
 	}
 	return fmt.Sprintf("%s-%s", dda.Name, common.DefaultAgentResourceSuffix)
 }
+
+// IsAgentNetworkPolicyEnabled returns whether a network policy should be created for the node agent and which flavor to use
+func IsAgentNetworkPolicyEnabled(dda *DatadogAgent) (bool, NetworkPolicyFlavor) {
+	if dda.Spec.Agent.NetworkPolicy != nil && apiutils.BoolValue(dda.Spec.Agent.NetworkPolicy.Create) {
+		if dda.Spec.Agent.NetworkPolicy.Flavor != "" {
+			return true, dda.Spec.Agent.NetworkPolicy.Flavor
+		}
+	}
+	return false, ""
+}
+
+// IsClusterAgentNetworkPolicyEnabled returns whether a network policy should be created for the cluster agent and which flavor to use
+func IsClusterAgentNetworkPolicyEnabled(dda *DatadogAgent) (bool, NetworkPolicyFlavor) {
+	if dda.Spec.ClusterAgent.NetworkPolicy != nil && apiutils.BoolValue(dda.Spec.ClusterAgent.NetworkPolicy.Create) {
+		if dda.Spec.ClusterAgent.NetworkPolicy.Flavor != "" {
+			return true, dda.Spec.ClusterAgent.NetworkPolicy.Flavor
+		}
+	}
+	return false, ""
+}

--- a/apis/datadoghq/v2alpha1/utils.go
+++ b/apis/datadoghq/v2alpha1/utils.go
@@ -94,3 +94,14 @@ func GetLocalAgentServiceName(dda *DatadogAgent) string {
 	}
 	return fmt.Sprintf("%s-%s", dda.Name, common.DefaultAgentResourceSuffix)
 }
+
+// IsNetworkPolicyEnabled returns whether a network policy should be created and which flavor to use
+func IsNetworkPolicyEnabled(dda *DatadogAgent) (bool, NetworkPolicyFlavor) {
+	if dda.Spec.Global != nil && dda.Spec.Global.NetworkPolicy != nil && apiutils.BoolValue(dda.Spec.Global.NetworkPolicy.Create) {
+		if dda.Spec.Global.NetworkPolicy.Flavor != "" {
+			return true, dda.Spec.Global.NetworkPolicy.Flavor
+		}
+		return true, NetworkPolicyFlavorKubernetes
+	}
+	return false, ""
+}

--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -611,7 +611,7 @@ func (b agentNetworkPolicyBuilder) BuildCiliumPolicy() *cilium.NetworkPolicy {
 							Ports: []cilium.PortProtocol{
 								{
 									Port:     strconv.Itoa(int(*b.dda.Spec.Agent.Apm.HostPort)),
-									Protocol: cilium.ProtocolUDP,
+									Protocol: cilium.ProtocolTCP,
 								},
 							},
 						},


### PR DESCRIPTION
### What does this PR do?

Add a couple of the missing feature-specific kubernetes and cilium network policies from operator v1. The external metrics provider policies are still TODO since that feature hasn't been implemented yet.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Enable APM (with hostport) and/or cluster checks with a network policy. Example spec section:

```yaml
spec:
  global:
    networkPolicy:
      create: true
      flavor: kubernetes
      # flavor: cilium
  features:
    apm:
      enabled: true
      hostPortConfig:
        enabled: true
    clusterChecks:
      enabled: true
      useClusterChecksRunners: true
```
