### PR TITLE
Fix conversion from v1 to v2

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_conversion.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_conversion.go
@@ -28,12 +28,10 @@ func (src *DatadogAgent) ConvertTo(dst conversion.Hub) error {
 }
 
 // ConvertFrom converts a v2alpha1 (Hub) to v1alpha1 (local)
-// Not implemented
+// Not supported. Only match metadata to not block the v1alpha1 to v2alpha1 migration.
 func (dst *DatadogAgent) ConvertFrom(src conversion.Hub) error { //nolint
-	// TODO (operator-ga): uncomment the next line when we find out why this
-	// method is called every second. For now, just return nil to avoid spamming
-	// the logs.
-	// return fmt.Errorf("convert from v2alpha1 to %s is not implemented", dst.GetObjectKind().GroupVersionKind().Version)
+	ddaV2 := src.(*v2alpha1.DatadogAgent)
+	dst.ObjectMeta = ddaV2.ObjectMeta
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Without this, the conversion of v1alpha1 to v2alpha1 is not fully working, the apiserver will return:

```
0920 22:10:47.131288       1 watcher.go:327] failed to prepare current and previous objects: conversion webhook for datadoghq.com/v2alpha1, Kind=DatadogAgent returned invalid object: must have the same name: datadog !=
```

### Motivation

Support converting v1 to v2.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
