### PR TITLE
Fixing subpath custom conf

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_conversion.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_conversion.go
@@ -181,7 +181,8 @@ func convertConfigMapConfig(src *CustomConfigSpec) *v2alpha1.CustomConfig {
 		// TODO: Check if that was the intended usage of `FileKey`
 		if src.ConfigMap.FileKey != "" {
 			dstConfig.ConfigMap.Items = append(dstConfig.ConfigMap.Items, v1.KeyToPath{
-				Key: src.ConfigMap.FileKey,
+				Key:  src.ConfigMap.FileKey,
+				Path: src.ConfigMap.FileKey,
 			})
 		}
 	}

--- a/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
@@ -48,7 +48,7 @@ spec:
         configMap:
           items:
           - key: config.yaml
-            path: ""
+            path: "config.yaml"
           name: orch-cm
       enabled: true
       ddUrl: https://orch-explorer.com

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -322,7 +322,7 @@ func newClusterAgentPodTemplate(logger logr.Logger, dda *datadoghqv1alpha1.Datad
 		customConfigVolumeSource := objectvolume.GetVolumeFromCustomConfigSpec(
 			datadoghqv1alpha1.ConvertCustomConfig(dda.Spec.ClusterAgent.CustomConfig),
 			getClusterAgentCustomConfigConfigMapName(dda),
-			apicommon.AgentCustomConfigVolumeName,
+			apicommon.ClusterAgentCustomConfigVolumeName,
 		)
 		volumes = append(volumes, customConfigVolumeSource)
 


### PR DESCRIPTION
### What does this PR do?

Without this fix, converting a v1 to v2 when using a custom conf file will block the deployment of the cluster agent with the following message:
```
  Warning  Failed     25m (x4 over 26m)    kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/lib/kubelet/pods/ed3b360b-8f77-40bf-90b5-88aff9460358/volumes/kubernetes.io~configmap/custom-datadog-yaml" to rootfs at "/etc/datadog-agent/datadog.yaml": mount /var/lib/kubelet/pods/ed3b360b-8f77-40bf-90b5-88aff9460358/volumes/kubernetes.io~configmap/custom-datadog-yaml:/etc/datadog-agent/datadog.yaml (via /proc/self/fd/6), flags: 0x5001: not a directory: unknown
```
This is because the conversion did not specify the subpath. This can be verified by submitting a conversion to the webhook:

```
[root@datadog-operator-7bdc4ccc89-khqz5 /]# curl --cacert /tmp/k8s-webhook-server/serving-certs/ca.pem https://datadog-operator-webhook-service.datadog-agent.svc.muk.cluster.local:443/convert -X POST -d 
```
using the following payload:
```json
{"request":{"uid":"123", "desiredAPIVersion":"datadoghq.com/v2alpha1", "objects":[{ "apiVersion": "datadoghq.com/v1alpha1", "kind": "DatadogAgent", "spec": { "agent": { "customConfig": { "configMap": { "fileKey": "datadog.yaml", "name": "datadog-agent-config-abc" } }, "systemProbe": {"customConfig": { "configMap": { "fileKey": "system-probe.yaml", "name": "datadog-agent-system-probe-config-abc" } } } }, "clusterAgent": { "config": {"confd": { "configMapName": "cluster-agent-confd-0.1.2", "items": [ { "key": "helm-yaml", "path": "./helm.yaml" }, { "key": "kubernetes-apiserver-yaml", "path": "./kubernetes_apiserver.yaml" }, { "key": "orchestrator-yaml-default", "path": "./orchestrator.yaml.default" } ] } }, "customConfig": { "configMap": { "fileKey": "datadog-cluster.yaml", "name": "datadog-cluster-agent-abc" } } } } }]}}
```
it yields:
```json
{"response":{"uid":"123","convertedObjects":[{"kind":"DatadogAgent","apiVersion":"datadoghq.com/v2alpha1","metadata":{"creationTimestamp":null},"spec":{"features":{"npm":{}},"override":{"clusterAgent":{"customConfigurations":{"datadog.yaml":{"configMap":{"name":"datadog-cluster-agent-abc","items":[{"key":"datadog-cluster.yaml","path":"datadog-cluster.yaml"}]}}},"extraConfd":{"configMap":{"name":"cluster-agent-confd-0.1.2","items":[{"key":"helm-yaml","path":"./helm.yaml"},{"key":"kubernetes-apiserver-yaml","path":"./kubernetes_apiserver.yaml"},{"key":"orchestrator-yaml-default","path":"./orchestrator.yaml.default"}]}}},"nodeAgent":{"customConfigurations":{"datadog.yaml":{"configMap":{"name":"datadog-agent-config-abc","items":[{"key":"datadog.yaml","path":"datadog.yaml"}]}},"system-probe.yaml":{"configMap":{"name":"datadog-agent-system-probe-config-abc","items":[{"key":"system-probe.yaml","path":"system-probe.yaml"}]}}}}}},"status":{"conditions":null}}],"result":{"metadata":{},"status":"Success"}}}
```
with the fix we have the `"path":"datadog.yaml"`, as well as `"path":"datadog-cluster.yaml"` etc.

### Motivation

Unblock the conversion/deployment of a custom use case.

### Describe your test plan

you can use the above payload and endpoint to convert before and after the fix to confirm that the new fields are added.
