### PR TITLE
[defaulting/images] Update agents to 7.39.2

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.39.0"
+	AgentLatestVersion = "7.39.2"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.39.0"
+	ClusterAgentLatestVersion = "7.39.2"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

Deploys 7.39.2 by default.

