### PR TITLE
Operator FIXME to circumvent selector issue in EDS

### DIFF
--- a/controllers/datadogagent/component/new.go
+++ b/controllers/datadogagent/component/new.go
@@ -55,7 +55,11 @@ func NewDaemonset(owner metav1.Object, componentKind, componentName, version str
 
 // NewExtendedDaemonset use to generate the skeleton of a new extended daemonset based on few information
 func NewExtendedDaemonset(owner metav1.Object, componentKind, componentName, version string, selector *metav1.LabelSelector) *edsv1alpha1.ExtendedDaemonSet {
-	labels, annotations, selector := getDefaultMetadata(owner, componentKind, componentName, version, selector)
+	// FIXME (@CharlyF): The EDS controller uses the Spec.Selector as a node selector to get the NodeList to rollout the agent.
+	// Per https://github.com/DataDog/extendeddaemonset/blob/28a8e082cee9890ae6d925a7d6247a36c6f6ba5d/controllers/extendeddaemonsetreplicaset/controller.go#L344-L360
+	// Up until v0.8.2, the Datadog Operator set the selector to nil, which circumvented this case.
+	// Until the EDS controller uses the Affinity field to get the NodeList instead of Spec.Selector, let's keep the previous behavior.
+	labels, annotations, _ := getDefaultMetadata(owner, componentKind, componentName, version, selector)
 
 	daemonset := &edsv1alpha1.ExtendedDaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -65,7 +69,7 @@ func NewExtendedDaemonset(owner metav1.Object, componentKind, componentName, ver
 			Annotations: annotations,
 		},
 		Spec: edsv1alpha1.ExtendedDaemonSetSpec{
-			Selector: selector,
+			Selector: nil,
 			Strategy: defaultEDSStrategy(),
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

Per the fixme in the PR:
The EDS controller uses the Spec.Selector as a node selector to get the NodeList to rollout the agent. Per https://github.com/DataDog/extendeddaemonset/blob/28a8e082cee9890ae6d925a7d6247a36c6f6ba5d/controllers/extendeddaemonsetreplicaset/controller.go#L344-L360
Up until v0.8.2, the Datadog Operator set the selector to nil, which circumvented this case.
https://github.com/DataDog/datadog-operator/blob/v0.8.2/controllers/datadogagent/agent.go#L148
Until the EDS controller uses the Affinity field to get the NodeList instead of Spec.Selector, let's keep the previous behavior.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
