### PR TITLE
Fix volume mount to have auth token for agent

### DIFF
--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -296,6 +296,7 @@ func volumeMountsForInitConfig() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForChecksd(),
+		component.GetVolumeMountForAuth(false),
 		component.GetVolumeMountForConfd(),
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForProc(),
@@ -333,7 +334,7 @@ func volumesForAgent(dda metav1.Object, requiredContainers []common.AgentContain
 func volumeMountsForCoreAgent() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
-		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForAuth(false),
 		component.GetVolumeMountForInstallInfo(),
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForProc(),
@@ -346,7 +347,7 @@ func volumeMountsForCoreAgent() []corev1.VolumeMount {
 func volumeMountsForTraceAgent() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
-		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForDogstatsdSocket(true),
 		component.GetVolumeMountForRuntimeSocket(true),
@@ -356,7 +357,7 @@ func volumeMountsForTraceAgent() []corev1.VolumeMount {
 func volumeMountsForProcessAgent() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
-		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForDogstatsdSocket(true),
 		component.GetVolumeMountForRuntimeSocket(true),
@@ -366,7 +367,7 @@ func volumeMountsForProcessAgent() []corev1.VolumeMount {
 func volumeMountsForSecurityAgent() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
-		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForDogstatsdSocket(true),
 		component.GetVolumeMountForRuntimeSocket(true),
@@ -376,7 +377,7 @@ func volumeMountsForSecurityAgent() []corev1.VolumeMount {
 func volumeMountsForSystemProbe() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
-		component.GetVolumeMountForAuth(),
+		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
 	}
 }

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -177,11 +177,11 @@ func GetVolumeMountForRmCorechecks() corev1.VolumeMount {
 }
 
 // GetVolumeMountForAuth returns the VolumeMount that contains the authentication information
-func GetVolumeMountForAuth() corev1.VolumeMount {
+func GetVolumeMountForAuth(readOnly bool) corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      apicommon.AuthVolumeName,
 		MountPath: apicommon.AuthVolumePath,
-		ReadOnly:  true,
+		ReadOnly:  readOnly,
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

the init config container does not have access to the auth volume to communicate with the agent.
The correct config is to have the agent and the init config have RW access and the other containers have RO.
Otherwise you see:

```
Error: Error while starting api server, exiting: error writing authentication token file on fs: open /etc/datadog-agent/auth/token: read-only file system
```

### Motivation

Make sure the containers are not restarted.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
