### PR TITLE
[feature] Fix log volumemounts

### DIFF
--- a/controllers/datadogagent/feature/logcollection/feature.go
+++ b/controllers/datadogagent/feature/logcollection/feature.go
@@ -134,17 +134,17 @@ func (f *logCollectionFeature) ManageNodeAgent(managers feature.PodTemplateManag
 	managers.Volume().AddVolume(&pointerVol)
 
 	// pod logs volume mount
-	podLogVol, podLogVolMount := volume.GetVolumes(apicommon.PodLogVolumeName, f.podLogsPath, f.podLogsPath, true)
+	podLogVol, podLogVolMount := volume.GetVolumes(apicommon.PodLogVolumeName, f.podLogsPath, apicommon.PodLogVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&podLogVolMount, apicommonv1.CoreAgentContainerName)
 	managers.Volume().AddVolume(&podLogVol)
 
 	// container logs volume mount
-	containerLogVol, containerLogVolMount := volume.GetVolumes(apicommon.ContainerLogVolumeName, f.containerLogsPath, f.containerLogsPath, true)
+	containerLogVol, containerLogVolMount := volume.GetVolumes(apicommon.ContainerLogVolumeName, f.containerLogsPath, apicommon.ContainerLogVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&containerLogVolMount, apicommonv1.CoreAgentContainerName)
 	managers.Volume().AddVolume(&containerLogVol)
 
 	// symlink volume mount
-	symlinkVol, symlinkVolMount := volume.GetVolumes(apicommon.SymlinkContainerVolumeName, f.containerSymlinksPath, f.containerSymlinksPath, true)
+	symlinkVol, symlinkVolMount := volume.GetVolumes(apicommon.SymlinkContainerVolumeName, f.containerSymlinksPath, apicommon.SymlinkContainerVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&symlinkVolMount, apicommonv1.CoreAgentContainerName)
 	managers.Volume().AddVolume(&symlinkVol)
 

--- a/controllers/datadogagent/feature/logcollection/feature_test.go
+++ b/controllers/datadogagent/feature/logcollection/feature_test.go
@@ -295,17 +295,17 @@ func Test_LogCollectionFeature_Configure(t *testing.T) {
 						},
 						{
 							Name:      apicommon.PodLogVolumeName,
-							MountPath: "/custom/pod/logs",
+							MountPath: apicommon.PodLogVolumePath,
 							ReadOnly:  true,
 						},
 						{
 							Name:      apicommon.ContainerLogVolumeName,
-							MountPath: "/custom/container/logs",
+							MountPath: apicommon.ContainerLogVolumePath,
 							ReadOnly:  true,
 						},
 						{
 							Name:      apicommon.SymlinkContainerVolumeName,
-							MountPath: "/custom/symlink",
+							MountPath: apicommon.SymlinkContainerVolumePath,
 							ReadOnly:  true,
 						},
 					}
@@ -513,17 +513,17 @@ func Test_LogCollectionFeature_Configure(t *testing.T) {
 						},
 						{
 							Name:      apicommon.PodLogVolumeName,
-							MountPath: "/custom/pod/logs",
+							MountPath: apicommon.PodLogVolumePath,
 							ReadOnly:  true,
 						},
 						{
 							Name:      apicommon.ContainerLogVolumeName,
-							MountPath: "/custom/container/logs",
+							MountPath: apicommon.ContainerLogVolumePath,
 							ReadOnly:  true,
 						},
 						{
 							Name:      apicommon.SymlinkContainerVolumeName,
-							MountPath: "/custom/symlink",
+							MountPath: apicommon.SymlinkContainerVolumePath,
 							ReadOnly:  true,
 						},
 					}


### PR DESCRIPTION
### What does this PR do?

When using a custom host path for some of the log collection options, the volumemount paths were also being changed when they should consistently be in the same locations inside the agent container.

### Motivation

Match the helm chart implementation: 
* https://github.com/DataDog/helm-charts/blob/54ea81fbbc88562a2258303ada98b8fde69be5f2/charts/datadog/templates/_daemonset-volumes-linux.yaml#L156-L171
* https://github.com/DataDog/helm-charts/blob/54ea81fbbc88562a2258303ada98b8fde69be5f2/charts/datadog/templates/_container-agent.yaml#L188-L204

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
