### PR TITLE
Fix seccomp conversion

### DIFF
--- a/apis/datadoghq/v1alpha1/testdata/all.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.yaml
@@ -158,7 +158,7 @@ spec:
     systemProbe:
       bpfDebugEnabled: true
       secCompCustomProfileConfigMap: seccomp-configmap
-      secCompProfileName: seccomp-profile
+      secCompProfileName: localhost/seccomp-profile
       secCompRootPath: /custom/root/path
     security:
       compliance:


### PR DESCRIPTION
### What does this PR do?

v1alpha1 expects a `secCompProfileName` of something like `localhost/system-probe` whereas v2alpha1 would expect that to be split out in the securitycontext into `Type: Localhost` and `LocalhostProfile: system-probe`. The conversion wasn't splitting the v1alpha1 name properly

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
