### PR TITLE
[process-agent] Add /host/proc mount by default

### DIFF
--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -361,6 +361,7 @@ func volumeMountsForProcessAgent() []corev1.VolumeMount {
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForDogstatsdSocket(true),
 		component.GetVolumeMountForRuntimeSocket(true),
+		component.GetVolumeMountForProc(),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds this mount to resolve these problems:
- Currently if neither process nor container collection features are enabled we fail to run process_discovery
- Cannot run `process-agent status` because gopsutil fails without `/host/proc` mount - the agent panics but recovers.

To repro the issues:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    kubelet:
      tlsVerify: false
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  features:
    liveProcessCollection:
      enabled: false
    liveContainerCollection:
      enabled: false
```
### Motivation

Allow disabling live process and live container collection and run remaining features (process discovery, pod check, connections for NPM).


### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
