### PR TITLE
[v2alpha1/default] Default Features.ClusterChecks.Enabled if unset

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -268,6 +268,8 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 		}
 	}
 
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ClusterChecks.Enabled, defaultClusterChecksEnabled)
+
 	if *ddaSpec.Features.ClusterChecks.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ClusterChecks.UseClusterChecksRunners, defaultUseClusterChecksRunners)
 	}

--- a/apis/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -576,6 +576,55 @@ func Test_defaultFeatures(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ClusterChecks feature with a field set, but \"enabled\" field not set",
+			ddaSpec: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					ClusterChecks: &ClusterChecksFeatureConfig{
+						UseClusterChecksRunners: apiutils.NewBoolPointer(false),
+					},
+				},
+			},
+			want: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					Dogstatsd: &DogstatsdFeatureConfig{
+						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
+						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+						},
+					},
+					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
+						GRPC: &OTLPGRPCConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPGRPCEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPGRPCEndpoint),
+						},
+						HTTP: &OTLPHTTPConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPHTTPEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
+						},
+					}}},
+					EventCollection: &EventCollectionFeatureConfig{
+						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
+					},
+					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
+						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
+						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
+					},
+					ClusterChecks: &ClusterChecksFeatureConfig{
+						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
+						UseClusterChecksRunners: apiutils.NewBoolPointer(false),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Fixes a panic when using a configuration that sets a field for the clusterChecks feature without setting the "enabled" one:
```
  features:
    clusterChecks:
      useClusterChecksRunners: false
```

This is the panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe6e844]

goroutine 401 [running]:
github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1.defaultFeaturesConfig(0x400044bb38)
        /workspace/apis/datadoghq/v2alpha1/datadogagent_default.go:271 +0xec4
github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1.DefaultDatadogAgent(0x400044b340?)
        /workspace/apis/datadoghq/v2alpha1/datadogagent_default.go:90 +0x34
github.com/DataDog/datadog-operator/controllers/datadogagent.(*Reconciler).internalReconcileV2(0x40002e0de0, {0x1975ce8, 0x400014c4b0}, {{{0x40007f43d7, 0x7}, {0x40007f43d0, 0x7}}})
        /workspace/controllers/datadogagent/controller_reconcile_v2.go:83 +0x24c
github.com/DataDog/datadog-operator/controllers/datadogagent.(*Reconciler).Reconcile(0x40002e0de0, {0x1975ce8?, 0x400014c4b0?}, {{{0x40007f43d7?, 0x1448940?}, {0x40007f43d0?, 0x1448940?}}})
        /workspace/controllers/datadogagent/controller.go:101 +0x4c
github.com/DataDog/datadog-operator/controllers.(*DatadogAgentReconciler).Reconcile(0x1975ce8?, {0x1975ce8?, 0x400014c4b0?}, {{{0x40007f43d7?, 0x15c5620?}, {0x40007f43d0?, 0x4000101400?}}})
        /workspace/controllers/datadogagent_controller.go:172 +0x34
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x40006508f0, {0x1975ce8, 0x400014c390}, {{{0x40007f43d7?, 0x15c5620?}, {0x40007f43d0?, 0x40009abe18?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:114 +0x22c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x40006508f0, {0x1975c40, 0x400066fb40}, {0x14bf520?, 0x40006301e0?})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:311 +0x290
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x40006508f0, {0x1975c40, 0x400066fb40})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:266 +0x1b0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:227 +0x78
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:223 +0x280

```


### Describe your test plan

Create an agent with the above config and verify that the operator doesn't panic.
