### PR TITLE
Expose the `…ENABLE_OOM_KILL` and `…TCP_QUEUE_LENGTH` env vars to the `init-config` container

### DIFF
--- a/apis/datadoghq/common/v1/types.go
+++ b/apis/datadoghq/common/v1/types.go
@@ -70,6 +70,8 @@ type AgentContainerName string
 const (
 	// InitVolumeContainerName is the name of the Init Volume init container
 	InitVolumeContainerName AgentContainerName = "init-volume"
+	// InitConfigContainerName is the name of the Init config Volume init container
+	InitConfigContainerName AgentContainerName = "init-config"
 	// SeccompSetupContainerName is the name of the Seccomp Setup init container
 	SeccompSetupContainerName AgentContainerName = "seccomp-setup"
 

--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -103,6 +103,7 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers) e
 
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enableEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
+	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
 
 	return nil
 }

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -106,6 +106,7 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enableEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
+	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
 
 	return nil
 }

--- a/controllers/datadogagent/merger/fake/envvar_manager.go
+++ b/controllers/datadogagent/merger/fake/envvar_manager.go
@@ -28,6 +28,12 @@ func (_m *EnvVarManager) AddEnvVarToContainer(containerName commonv1.AgentContai
 	_m.EnvVarsByC[containerName] = append(_m.EnvVarsByC[containerName], newEnvVar)
 }
 
+// AddEnvVarToInitContainer provides a mock function with given fields: containerName, newEnvVar
+func (_m *EnvVarManager) AddEnvVarToInitContainer(initContainerName commonv1.AgentContainerName, newEnvVar *v1.EnvVar) {
+	_m.t.Logf("AddEnvVar %s: %#v", newEnvVar.Name, newEnvVar.Value)
+	_m.EnvVarsByC[initContainerName] = append(_m.EnvVarsByC[initContainerName], newEnvVar)
+}
+
 // AddEnvVarToContainerWithMergeFunc provides a mock function with given fields: containerName, newEnvVar, mergeFunc
 func (_m *EnvVarManager) AddEnvVarToContainerWithMergeFunc(containerName commonv1.AgentContainerName, newEnvVar *v1.EnvVar, mergeFunc merger.EnvVarMergeFunction) error {
 	found := false


### PR DESCRIPTION
### What does this PR do?

Make the `DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL` and `DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH` environment variable available in the `init-config` init container.

### Motivation

The [`Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh`](https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh) script needs to access the system-probe configuration in order to enable the core agent part of the `oom_kill` and `tcp_queue_length` checks.

### Additional Notes

This change also requires an agent that has DataDog/datadog-agent#14332.

### Describe your test plan

Start a datadog agent with a manifest like:
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  features:
    oomKill:
      enabled: true
    tcpQueueLength:
      enabled: true
```
and an agent version that contains DataDog/datadog-agent#14332 and check that the `oom_kill` and `tcp_queue_length` checks are correctly scheduled in the core agent.