### PR TITLE
Share the system-probe socket when `oom_kill` or `tcp_queue_length` checks are enabled

### DIFF
--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -96,6 +96,14 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers) e
 	managers.Volume().AddVolume(&debugfsVol)
 	managers.VolumeMount().AddVolumeMountToContainers(&debugfsVolMount, []apicommonv1.AgentContainerName{apicommonv1.ProcessAgentContainerName, apicommonv1.SystemProbeContainerName})
 
+	// socket volume mount (needs write perms for the system probe container but not the others)
+	socketVol, socketVolMount := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, false)
+	managers.Volume().AddVolume(&socketVol)
+	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.SystemProbeContainerName)
+
+	_, socketVolMountReadOnly := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMountReadOnly, apicommonv1.CoreAgentContainerName)
+
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDEnableOOMKillEnvVar,
 		Value: "true",
@@ -104,6 +112,14 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers) e
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enableEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
 	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
+
+	socketEnvVar := &corev1.EnvVar{
+		Name:  apicommon.DDSystemProbeSocket,
+		Value: apicommon.DefaultSystemProbeSocketPath,
+	}
+
+	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, socketEnvVar)
+	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, socketEnvVar)
 
 	return nil
 }

--- a/controllers/datadogagent/feature/oomkill/feature_test.go
+++ b/controllers/datadogagent/feature/oomkill/feature_test.go
@@ -66,7 +66,15 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 		)
 
 		// check volume mounts
-		wantVolumeMounts := []corev1.VolumeMount{
+		wantCoreAgentVolMounts := []corev1.VolumeMount{
+			{
+				Name:      apicommon.SystemProbeSocketVolumeName,
+				MountPath: apicommon.SystemProbeSocketVolumePath,
+				ReadOnly:  true,
+			},
+		}
+
+		wantSystemProbeVolMounts := []corev1.VolumeMount{
 			{
 				Name:      apicommon.ModulesVolumeName,
 				MountPath: apicommon.ModulesVolumePath,
@@ -82,10 +90,18 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 				MountPath: apicommon.DebugfsPath,
 				ReadOnly:  false,
 			},
+			{
+				Name:      apicommon.SystemProbeSocketVolumeName,
+				MountPath: apicommon.SystemProbeSocketVolumePath,
+				ReadOnly:  false,
+			},
 		}
 
+		coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
+		assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantCoreAgentVolMounts), "Core agent volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantCoreAgentVolMounts))
+
 		systemProbeVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.SystemProbeContainerName]
-		assert.True(t, apiutils.IsEqualStruct(systemProbeVolumeMounts, wantVolumeMounts), "System Probe volume mounts \ndiff = %s", cmp.Diff(systemProbeVolumeMounts, wantVolumeMounts))
+		assert.True(t, apiutils.IsEqualStruct(systemProbeVolumeMounts, wantSystemProbeVolMounts), "System Probe volume mounts \ndiff = %s", cmp.Diff(systemProbeVolumeMounts, wantSystemProbeVolMounts))
 
 		// check volumes
 		wantVolumes := []corev1.Volume{
@@ -113,6 +129,12 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 					},
 				},
 			},
+			{
+				Name: apicommon.SystemProbeSocketVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
 		}
 
 		volumes := mgr.VolumeMgr.Volumes
@@ -123,6 +145,10 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 			{
 				Name:  apicommon.DDEnableOOMKillEnvVar,
 				Value: "true",
+			},
+			{
+				Name:  apicommon.DDSystemProbeSocket,
+				Value: apicommon.DefaultSystemProbeSocketPath,
 			},
 		}
 		agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -99,6 +99,14 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 	managers.Volume().AddVolume(&debugfsVol)
 	managers.VolumeMount().AddVolumeMountToContainers(&debugfsVolMount, []apicommonv1.AgentContainerName{apicommonv1.ProcessAgentContainerName, apicommonv1.SystemProbeContainerName})
 
+	// socket volume mount (needs write perms for the system probe container but not the others)
+	socketVol, socketVolMount := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, false)
+	managers.Volume().AddVolume(&socketVol)
+	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.SystemProbeContainerName)
+
+	_, socketVolMountReadOnly := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMountReadOnly, apicommonv1.CoreAgentContainerName)
+
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDEnableTCPQueueLengthEnvVar,
 		Value: "true",
@@ -107,6 +115,14 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enableEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
 	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
+
+	socketEnvVar := &corev1.EnvVar{
+		Name:  apicommon.DDSystemProbeSocket,
+		Value: apicommon.DefaultSystemProbeSocketPath,
+	}
+
+	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, socketEnvVar)
+	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, socketEnvVar)
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Share the system-probe socket with the core agent when the `oom_kill` or `tcp_queue_length` checks are enabled.

### Motivation

This is a followup of #642 to fix the activation of `oom_kill` and `tcp_queue_length` checks.

### Additional Notes

### Describe your test plan

Start a datadog agent with a manifest like:
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  features:
    oomKill:
      enabled: true
    tcpQueueLength:
      enabled: true
```
and an agent version that contains DataDog/datadog-agent#14332 and check that the `oom_kill` and `tcp_queue_length` checks are correctly scheduled in the core agent.