### PR TITLE
[Makefile] Update envtest k8s version to 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ IMG_CHECK ?= gcr.io/datadoghq/operator-check:latest
 
 CRD_OPTIONS ?= "crd:preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.20
+ENVTEST_K8S_VERSION = 1.24
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
### What does this PR do?

Updates the k8s version used by `envtest` to 1.24.

### Motivation

`envtest` with 1.20 doesn't work on M1s:
```
unable to find a version that was supported for platform darwin/arm64
```

1.24 instead of 1.25 because the known issue about the Operator not working properly on 1.25.


### Describe your test plan

`make integration-tests-v2` should work on M1s.
