### PR TITLE
[github/workflows/main] Fix codecov reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,5 +30,5 @@ jobs:
     - uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: cover.out
+        files: cover.out,cover_integration_v1.out,cover_integration_v2.out
         flags: unittests

--- a/Makefile
+++ b/Makefile
@@ -187,11 +187,11 @@ gotest:
 
 .PHONY: integration-tests
 integration-tests: $(ENVTEST) ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test --tags=integration github.com/DataDog/datadog-operator/controllers -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test --tags=integration github.com/DataDog/datadog-operator/controllers -coverprofile cover_integration_v1.out
 
 .PHONY: integration-tests-v2
 integration-tests-v2: $(ENVTEST) ## Run tests with reconciler V2
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test --tags=integration_v2 github.com/DataDog/datadog-operator/controllers -coverprofile cover_v2.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test --tags=integration_v2 github.com/DataDog/datadog-operator/controllers -coverprofile cover_integration_v2.out
 
 .PHONY: bundle
 bundle: bin/$(PLATFORM)/operator-sdk bin/$(PLATFORM)/yq $(KUSTOMIZE) manifests ## Generate bundle manifests and metadata, then validate generated files.


### PR DESCRIPTION
### What does this PR do?

Fixes the codecov reporting by using a different report file for each kind of test.

Codecov reporting was broken because both the v1 integration tests and the unit tests were exporting their results to `cover.out`. When running `make test`, which is what we use in the Github CI, the v1 integration tests run after the unit ones, so their results are overridden.

