### PR TITLE
Disable otlp feature by default

### DIFF
--- a/controllers/datadogagent/feature/otlp/feature.go
+++ b/controllers/datadogagent/feature/otlp/feature.go
@@ -79,17 +79,19 @@ func (f *otlpFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Req
 		f.usingAPM = apiutils.BoolValue(apm.Enabled)
 	}
 
-	reqComp = feature.RequiredComponents{
-		Agent: feature.RequiredComponent{
-			IsRequired: apiutils.NewBoolPointer(true),
-			Containers: []apicommonv1.AgentContainerName{
-				apicommonv1.CoreAgentContainerName,
+	if f.grpcEnabled || f.httpEnabled {
+		reqComp = feature.RequiredComponents{
+			Agent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommonv1.AgentContainerName{
+					apicommonv1.CoreAgentContainerName,
+				},
 			},
-		},
-	}
-	// if using APM, require the Trace Agent too.
-	if f.usingAPM {
-		reqComp.Agent.Containers = append(reqComp.Agent.Containers, apicommonv1.TraceAgentContainerName)
+		}
+		// if using APM, require the Trace Agent too.
+		if f.usingAPM {
+			reqComp.Agent.Containers = append(reqComp.Agent.Containers, apicommonv1.TraceAgentContainerName)
+		}
 	}
 
 	return reqComp
@@ -114,17 +116,19 @@ func (f *otlpFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) (reqComp feature.R
 
 	f.usingAPM = apiutils.BoolValue(dda.Spec.Agent.Apm.Enabled)
 
-	reqComp = feature.RequiredComponents{
-		Agent: feature.RequiredComponent{
-			IsRequired: apiutils.NewBoolPointer(true),
-			Containers: []apicommonv1.AgentContainerName{
-				apicommonv1.CoreAgentContainerName,
+	if f.grpcEnabled || f.httpEnabled {
+		reqComp = feature.RequiredComponents{
+			Agent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommonv1.AgentContainerName{
+					apicommonv1.CoreAgentContainerName,
+				},
 			},
-		},
-	}
-	// if using APM, require the Trace Agent too.
-	if f.usingAPM {
-		reqComp.Agent.Containers = append(reqComp.Agent.Containers, apicommonv1.TraceAgentContainerName)
+		}
+		// if using APM, require the Trace Agent too.
+		if f.usingAPM {
+			reqComp.Agent.Containers = append(reqComp.Agent.Containers, apicommonv1.TraceAgentContainerName)
+		}
 	}
 
 	return reqComp


### PR DESCRIPTION
### What does this PR do?

Disables the OTLP feature when not explicitly enabled. Previously, the operator logs showed the feature as enabled when `features.otlp.*` wasn't set in the manifest:

```
{"level":"INFO","ts":"2022-11-22T15:58:56Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":"default/datadog"}
...
{"level":"INFO","ts":"2022-11-22T15:58:56Z","logger":"controllers.DatadogAgent","msg":"Dependency ManageDependencies","datadogagent":"default/datadog","featureID":"otlp"}
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
