### PR TITLE
Fix to handle partial image overrides input correctly

### DIFF
--- a/apis/datadoghq/common/common.go
+++ b/apis/datadoghq/common/common.go
@@ -6,6 +6,9 @@
 package common
 
 import (
+	"fmt"
+	"strings"
+
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	corev1 "k8s.io/api/core/v1"
@@ -51,13 +54,21 @@ func GetDefaultReadinessProbe() *corev1.Probe {
 // GetImage builds the image string based on ImageConfig and the registry configuration.
 func GetImage(imageSpec *commonv1.AgentImageConfig, registry *string) string {
 	if defaulting.IsImageNameContainsTag(imageSpec.Name) {
-		// The image name corresponds to a full image string
-		return imageSpec.Name
+		// If the image name corresponds to a full URI we return it, otherwise
+		// we prefix name with passed registry or default one if former is empty/nil.
+		if len(strings.Split(imageSpec.Name, "/")) > 2 {
+			return imageSpec.Name
+		} else if registry != nil && *registry != "" {
+			return fmt.Sprintf("%s/%s", *registry, imageSpec.Name)
+		} else {
+			return fmt.Sprintf("%s/%s", DefaultImageRegistry, imageSpec.Name)
+		}
 	}
 
 	img := defaulting.NewImage(imageSpec.Name, imageSpec.Tag, imageSpec.JMXEnabled)
 
-	if registry != nil {
+	// Image is created with default registry, change it if non-empty one is provided
+	if registry != nil && *registry != "" {
 		defaulting.WithRegistry(defaulting.ContainerRegistry(*registry))(img)
 	}
 

--- a/apis/datadoghq/common/common_test.go
+++ b/apis/datadoghq/common/common_test.go
@@ -91,6 +91,24 @@ func Test_GetImage(t *testing.T) {
 			registry: nil,
 			want:     "gcr.io/datadoghq/agent:latest-jmx",
 		},
+		{
+			name: "image:tag and registry input, prefix registry",
+			imageSpec: &commonv1.AgentImageConfig{
+				Name: "agent:7",
+				Tag:  "8",
+			},
+			registry: apiutils.NewStringPointer("docker.io/datadog"),
+			want:     "docker.io/datadog/agent:7",
+		},
+		{
+			name: "image:tag input, prefix default registry",
+			imageSpec: &commonv1.AgentImageConfig{
+				Name: "agent:7",
+				Tag:  "8",
+			},
+			registry: nil,
+			want:     "gcr.io/datadoghq/agent:7",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/controllers/datadogagent/override/podtemplatespec.go
+++ b/controllers/datadogagent/override/podtemplatespec.go
@@ -159,7 +159,8 @@ func overrideImage(currentImg string, overrideImg *common.AgentImageConfig) stri
 
 	splitName := strings.Split(splitImg[len(splitImg)-1], ":")
 
-	overrideImgCopy := overrideImg
+	// This deep copies primitives of the struct, we don't care about other fields
+	overrideImgCopy := *overrideImg
 	if overrideImgCopy.Name == "" {
 		overrideImgCopy.Name = splitName[0]
 	}
@@ -169,7 +170,7 @@ func overrideImage(currentImg string, overrideImg *common.AgentImageConfig) stri
 		overrideImgCopy.Tag = strings.TrimSuffix(splitName[1], defaulting.JMXTagSuffix)
 	}
 
-	return apicommon.GetImage(overrideImgCopy, &registry)
+	return apicommon.GetImage(&overrideImgCopy, &registry)
 }
 
 func sortKeys(keysMap map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig) []v2alpha1.AgentConfigFileName {

--- a/controllers/datadogagent/override/podtemplatespec.go
+++ b/controllers/datadogagent/override/podtemplatespec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -156,7 +157,19 @@ func overrideImage(currentImg string, overrideImg *common.AgentImageConfig) stri
 		registry = splitImg[0] + "/" + splitImg[1]
 	}
 
-	return apicommon.GetImage(overrideImg, &registry)
+	splitName := strings.Split(splitImg[len(splitImg)-1], ":")
+
+	overrideImgCopy := overrideImg
+	if overrideImgCopy.Name == "" {
+		overrideImgCopy.Name = splitName[0]
+	}
+
+	if overrideImgCopy.Tag == "" {
+		// If present need to drop JMX tag suffix
+		overrideImgCopy.Tag = strings.TrimSuffix(splitName[1], defaulting.JMXTagSuffix)
+	}
+
+	return apicommon.GetImage(overrideImgCopy, &registry)
 }
 
 func sortKeys(keysMap map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig) []v2alpha1.AgentConfigFileName {


### PR DESCRIPTION
### What does this PR do?

Proposes a fix for an issue report in this Slack message - summarizing below.

When `override.nodeAgent.image` isn't fully provided the image URI in agent pod/deployment is corrupt. 
For
```
  override:
    nodeAgent:
      image:
        tag: 7.41.0-rc.5
```
Generated image URI is
```
    image: gcr.io/datadoghq/:7.41.0-rc.5
```

Same happens with DCA and CCR as well.

### Motivation

Fix will allow users to provide only partial overrides and use previuos defaults.

### Additional Notes

n/a

### Describe your test plan

* Added unit test for missing scenarios.
* Tested locally with default operator setup and combinations of overrides, making sure final image URI is as expected.


