### PR TITLE
fix: replace deprecated newHostDelay with newGroupDelay

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -72,7 +72,7 @@ type DatadogMonitorOptions struct {
 	Locked *bool `json:"locked,omitempty"`
 	// Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
 	// monitor results. Should be a non negative integer.
-	NewHostDelay *int64 `json:"newHostDelay,omitempty"`
+	NewGroupDelay *int64 `json:"newGroupDelay,omitempty"`
 	// The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
 	// monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
 	// is used for metric alerts, and 24 hours is used for service checks.

--- a/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -1272,8 +1272,8 @@ func (in *DatadogMonitorOptions) DeepCopyInto(out *DatadogMonitorOptions) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.NewHostDelay != nil {
-		in, out := &in.NewHostDelay, &out.NewHostDelay
+	if in.NewGroupDelay != nil {
+		in, out := &in.NewGroupDelay, &out.NewGroupDelay
 		*out = new(int64)
 		**out = **in
 	}

--- a/bundle/manifests/datadoghq.com_datadogmonitors.yaml
+++ b/bundle/manifests/datadoghq.com_datadogmonitors.yaml
@@ -86,7 +86,7 @@ spec:
                     description: Whether or not the monitor is locked (only editable
                       by creator and admins).
                     type: boolean
-                  newHostDelay:
+                  newGroupDelay:
                     description: Time (in seconds) to allow a host to boot and applications
                       to fully start before starting the evaluation of monitor results.
                       Should be a non negative integer.

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -88,7 +88,7 @@ spec:
                     description: Whether or not the monitor is locked (only editable
                       by creator and admins).
                     type: boolean
-                  newHostDelay:
+                  newGroupDelay:
                     description: Time (in seconds) to allow a host to boot and applications
                       to fully start before starting the evaluation of monitor results.
                       Should be a non negative integer.

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -87,7 +87,7 @@ spec:
                   description: Whether or not the monitor is locked (only editable
                     by creator and admins).
                   type: boolean
-                newHostDelay:
+                newGroupDelay:
                   description: Time (in seconds) to allow a host to boot and applications
                     to fully start before starting the evaluation of monitor results.
                     Should be a non negative integer.

--- a/controllers/datadogmonitor/monitor.go
+++ b/controllers/datadogmonitor/monitor.go
@@ -111,8 +111,8 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 		o.SetLocked(*options.Locked)
 	}
 
-	if options.NewHostDelay != nil {
-		o.SetNewHostDelay(*options.NewHostDelay)
+	if options.NewGroupDelay != nil {
+		o.SetNewGroupDelay(*options.NewGroupDelay)
 	}
 
 	if options.NoDataTimeframe != nil {

--- a/controllers/datadogmonitor/monitor_test.go
+++ b/controllers/datadogmonitor/monitor_test.go
@@ -29,7 +29,7 @@ func Test_buildMonitor(t *testing.T) {
 	evalDelay := int64(100)
 	escalationMsg := "This is an escalation message"
 	valTrue := true
-	newHostDelay := int64(400)
+	newGroupDelay := int64(400)
 	noDataTimeframe := int64(15)
 	renotifyInterval := int64(1440)
 	timeoutH := int64(2)
@@ -54,7 +54,7 @@ func Test_buildMonitor(t *testing.T) {
 				EscalationMessage: &escalationMsg,
 				IncludeTags:       &valTrue,
 				Locked:            &valTrue,
-				NewHostDelay:      &newHostDelay,
+				NewGroupDelay:     &newGroupDelay,
 				NotifyNoData:      &valTrue,
 				NoDataTimeframe:   &noDataTimeframe,
 				RenotifyInterval:  &renotifyInterval,
@@ -99,8 +99,8 @@ func Test_buildMonitor(t *testing.T) {
 	assert.Equal(t, *dm.Spec.Options.Locked, monitor.Options.GetLocked(), "discrepancy found in parameter: Locked")
 	assert.Equal(t, *dm.Spec.Options.Locked, monitorUR.Options.GetLocked(), "discrepancy found in parameter: Locked")
 
-	assert.Equal(t, *dm.Spec.Options.NewHostDelay, monitor.Options.GetNewHostDelay(), "discrepancy found in parameter: NewHostDelay")
-	assert.Equal(t, *dm.Spec.Options.NewHostDelay, monitorUR.Options.GetNewHostDelay(), "discrepancy found in parameter: NewHostDelay")
+	assert.Equal(t, *dm.Spec.Options.NewGroupDelay, monitor.Options.GetNewGroupDelay(), "discrepancy found in parameter: NewGroupDelay")
+	assert.Equal(t, *dm.Spec.Options.NewGroupDelay, monitorUR.Options.GetNewGroupDelay(), "discrepancy found in parameter: NewGroupDelay")
 
 	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitor.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
 	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitorUR.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")

--- a/examples/datadogmonitor/audit-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/audit-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/event-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/event-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/event-v2-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/event-v2-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/log-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/log-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/metric-monitor-test.yaml
+++ b/examples/datadogmonitor/metric-monitor-test.yaml
@@ -15,7 +15,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/process-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/process-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/rum-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/rum-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/service-check-monitor-test.yaml
+++ b/examples/datadogmonitor/service-check-monitor-test.yaml
@@ -15,7 +15,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/slo-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/slo-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440

--- a/examples/datadogmonitor/trace-analytics-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/trace-analytics-alert-monitor-test.yaml
@@ -16,7 +16,7 @@ spec:
     evaluationDelay: 300
     includeTags: true
     locked: false
-    newHostDelay: 300
+    newGroupDelay: 300
     notifyNoData: true
     noDataTimeframe: 30
     renotifyInterval: 1440


### PR DESCRIPTION
### What does this PR do?

Updates the use of the now [deprecated](https://github.com/DataDog/datadog-api-client-go/blob/ac14372d2bc7820a099fecb2e29d78ec92d47575/api/v1/datadog/model_monitor_options.go#L57-L58) `newHostDelay` to the new `newGroupDelay` 

fixes #525 

### Motivation

newHostDelay is deprecated and ignored by the api, so alerts are currently triggered on new hosts even with this set

### Additional Notes

N/A

### Describe your test plan

Write there any instructions and details you may have to test your PR.
