### PR TITLE
Disabling OE running on CLCR by default

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -74,7 +74,7 @@ const (
 	defaultKubeStateMetricsCoreEnabled bool = true
 
 	defaultClusterChecksEnabled    bool = true
-	defaultUseClusterChecksRunners bool = true
+	defaultUseClusterChecksRunners bool = false
 
 	// defaultPrometheusScrapeEnabled                bool = false
 	defaultPrometheusScrapeEnableServiceEndpoints bool = false

--- a/controllers/datadogagent/feature/orchestratorexplorer/configmap.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/configmap.go
@@ -22,7 +22,7 @@ func (f *orchestratorExplorerFeature) buildOrchestratorExplorerConfigMap() (*cor
 		return configmap.BuildConfigMapConfigData(f.owner.GetNamespace(), f.customConfig.ConfigData, f.configConfigMapName, orchestratorExplorerConfFileName)
 	}
 
-	configMap := buildDefaultConfigMap(f.owner.GetNamespace(), f.configConfigMapName, orchestratorExplorerCheckConfig(f.clusterChecksEnabled))
+	configMap := buildDefaultConfigMap(f.owner.GetNamespace(), f.configConfigMapName, orchestratorExplorerCheckConfig(f.runInClusterChecksRunner))
 	return configMap, nil
 }
 
@@ -39,8 +39,8 @@ func buildDefaultConfigMap(namespace, cmName string, content string) *corev1.Con
 	return configMap
 }
 
-func orchestratorExplorerCheckConfig(clusterCheck bool) string {
-	stringClusterCheck := strconv.FormatBool(clusterCheck)
+func orchestratorExplorerCheckConfig(clusterCheckRunners bool) string {
+	stringClusterCheckRunners := strconv.FormatBool(clusterCheckRunners)
 	return fmt.Sprintf(`---
 cluster_check: %s
 ad_identifiers:
@@ -48,5 +48,5 @@ ad_identifiers:
 init_config:
 instances:
   - skip_leader_election: %s
-`, stringClusterCheck, stringClusterCheck)
+`, stringClusterCheckRunners, stringClusterCheckRunners)
 }

--- a/controllers/datadogagent/feature/orchestratorexplorer/configmap_test.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/configmap_test.go
@@ -28,13 +28,13 @@ instances:
       - services
 `
 	type fields struct {
-		enable               bool
-		clusterChecksEnabled bool
-		rbacSuffix           string
-		serviceAccountName   string
-		owner                metav1.Object
-		customConfig         *apicommonv1.CustomConfig
-		configConfigMapName  string
+		enable                   bool
+		runInClusterChecksRunner bool
+		rbacSuffix               string
+		serviceAccountName       string
+		owner                    metav1.Object
+		customConfig             *apicommonv1.CustomConfig
+		configConfigMapName      string
 	}
 	tests := []struct {
 		name    string
@@ -45,20 +45,20 @@ instances:
 		{
 			name: "default",
 			fields: fields{
-				owner:                owner,
-				enable:               true,
-				clusterChecksEnabled: true,
-				configConfigMapName:  apicommon.DefaultOrchestratorExplorerConf,
+				owner:                    owner,
+				enable:                   true,
+				runInClusterChecksRunner: false,
+				configConfigMapName:      apicommon.DefaultOrchestratorExplorerConf,
 			},
-			want: buildDefaultConfigMap(owner.GetNamespace(), apicommon.DefaultOrchestratorExplorerConf, orchestratorExplorerCheckConfig(true)),
+			want: buildDefaultConfigMap(owner.GetNamespace(), apicommon.DefaultOrchestratorExplorerConf, orchestratorExplorerCheckConfig(false)),
 		},
 		{
 			name: "override",
 			fields: fields{
-				owner:                owner,
-				enable:               true,
-				clusterChecksEnabled: true,
-				configConfigMapName:  apicommon.DefaultOrchestratorExplorerConf,
+				owner:                    owner,
+				enable:                   true,
+				runInClusterChecksRunner: true,
+				configConfigMapName:      apicommon.DefaultOrchestratorExplorerConf,
 				customConfig: &apicommonv1.CustomConfig{
 					ConfigData: &overrideConf,
 				},
@@ -69,12 +69,12 @@ instances:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &orchestratorExplorerFeature{
-				clusterChecksEnabled: tt.fields.clusterChecksEnabled,
-				rbacSuffix:           tt.fields.rbacSuffix,
-				serviceAccountName:   tt.fields.serviceAccountName,
-				owner:                tt.fields.owner,
-				customConfig:         tt.fields.customConfig,
-				configConfigMapName:  tt.fields.configConfigMapName,
+				runInClusterChecksRunner: tt.fields.runInClusterChecksRunner,
+				rbacSuffix:               tt.fields.rbacSuffix,
+				serviceAccountName:       tt.fields.serviceAccountName,
+				owner:                    tt.fields.owner,
+				customConfig:             tt.fields.customConfig,
+				configConfigMapName:      tt.fields.configConfigMapName,
 			}
 			got, err := f.buildOrchestratorExplorerConfigMap()
 			if (err != nil) != tt.wantErr {

--- a/controllers/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/feature.go
@@ -39,7 +39,6 @@ func buildOrchestratorExplorerFeature(options *feature.Options) feature.Feature 
 }
 
 type orchestratorExplorerFeature struct {
-	clusterChecksEnabled     bool
 	runInClusterChecksRunner bool
 	scrubContainers          bool
 	extraTags                []string
@@ -80,8 +79,6 @@ func (f *orchestratorExplorerFeature) Configure(dda *v2alpha1.DatadogAgent) (req
 		f.serviceAccountName = v2alpha1.GetClusterAgentServiceAccount(dda)
 
 		if v2alpha1.IsClusterChecksEnabled(dda) {
-			f.clusterChecksEnabled = true
-
 			if v2alpha1.IsCCREnabled(dda) {
 				f.runInClusterChecksRunner = true
 				f.rbacSuffix = common.ChecksRunnerSuffix
@@ -120,8 +117,6 @@ func (f *orchestratorExplorerFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) (r
 		f.serviceAccountName = v1alpha1.GetClusterAgentServiceAccount(dda)
 
 		if v1alpha1.IsClusterChecksEnabled(dda) && apiutils.BoolValue(orchestratorExplorer.ClusterCheck) {
-			f.clusterChecksEnabled = true
-
 			if v1alpha1.IsCCREnabled(dda) {
 				f.runInClusterChecksRunner = true
 				reqComp.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)


### PR DESCRIPTION
### What does this PR do?

- Clear up the internal struct for the Orchestrator Explorer. 
- Fix the default so that the feature runs on the Cluster Agent by default and not on the Cluster Check Runners.
- Cluster Check Runners are not enabled by default anymore.

### Motivation

Fix the feature to be aligned with the helm default.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
