### PR TITLE
Fixing ReadWrite access on UDS in core agent

### DIFF
--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -182,7 +182,7 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers)
 	// uds
 	if f.udsEnabled {
 		udsHostFolder := filepath.Dir(f.udsHostFilepath)
-		socketVol, socketVolMount := volume.GetVolumes(apicommon.DogstatsdSocketVolumeName, udsHostFolder, udsHostFolder, true)
+		socketVol, socketVolMount := volume.GetVolumes(apicommon.DogstatsdSocketVolumeName, udsHostFolder, udsHostFolder, false)
 		managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.CoreAgentContainerName)
 		managers.Volume().AddVolume(&socketVol)
 		managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, &corev1.EnvVar{

--- a/controllers/datadogagent/feature/dogstatsd/feature_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_test.go
@@ -99,7 +99,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 		{
 			Name:      apicommon.DogstatsdSocketVolumeName,
 			MountPath: v1DogstatsdSocketPath,
-			ReadOnly:  true,
+			ReadOnly:  false,
 		},
 	}
 	// v2alpha1 default uds volume mount
@@ -107,7 +107,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 		{
 			Name:      apicommon.DogstatsdSocketVolumeName,
 			MountPath: apicommon.DogstatsdSocketVolumePath,
-			ReadOnly:  true,
+			ReadOnly:  false,
 		},
 	}
 
@@ -293,7 +293,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 						{
 							Name:      apicommon.DogstatsdSocketVolumeName,
 							MountPath: customVolumePath,
-							ReadOnly:  true,
+							ReadOnly:  false,
 						},
 					}
 					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, customVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, customVolumeMounts))
@@ -455,7 +455,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 						{
 							Name:      apicommon.DogstatsdSocketVolumeName,
 							MountPath: customVolumePath,
-							ReadOnly:  true,
+							ReadOnly:  false,
 						},
 					}
 					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, customVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, customVolumeMounts))


### PR DESCRIPTION
### What does this PR do?

In the core agent the UDS needs to be mounted as RW.
```
2022-11-15 23:38:00 UTC | CORE | ERROR | (pkg/dogstatsd/server.go:269 in NewServer) | can't listen: listen unixgram /var/run/datadog/statsd/dsd.socket: bind: read-only file system
```

As is the case for v1 https://github.com/DataDog/datadog-operator/blob/main/controllers/datadogagent/utils.go#L1440
(note that for other containers we have RO, e.g. [process-agent](https://github.com/DataDog/datadog-operator/blob/main/controllers/datadogagent/utils.go#L1570)).

### Motivation

Fix DSD feature with UDS.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
