### PR TITLE
Fix valuefrom envvar pod overrides

### DIFF
--- a/controllers/datadogagent/override/podtemplatespec.go
+++ b/controllers/datadogagent/override/podtemplatespec.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // PodTemplateSpec use to override a corev1.PodTemplateSpec with a 2alpha1.DatadogAgentPodTemplateOverride.
@@ -42,10 +41,8 @@ func PodTemplateSpec(manager feature.PodTemplateManagers, override *v2alpha1.Dat
 	}
 
 	for _, env := range override.Env {
-		manager.EnvVar().AddEnvVar(&corev1.EnvVar{
-			Name:  env.Name,
-			Value: env.Value,
-		})
+		e := env
+		manager.EnvVar().AddEnvVar(&e)
 	}
 
 	// Override agent configurations such as datadog.yaml, system-probe.yaml, etc.

--- a/controllers/datadogagent/override/podtemplatespec_test.go
+++ b/controllers/datadogagent/override/podtemplatespec_test.go
@@ -233,6 +233,14 @@ func TestPodTemplateSpec(t *testing.T) {
 						Name:  "added-env",
 						Value: "456",
 					},
+					{
+						Name: "added-env-valuefrom",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								FieldPath: common.FieldPathStatusPodIP,
+							},
+						},
+					},
 				},
 			},
 			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers) {
@@ -244,6 +252,14 @@ func TestPodTemplateSpec(t *testing.T) {
 					{
 						Name:  "added-env",
 						Value: "456",
+					},
+					{
+						Name: "added-env-valuefrom",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								FieldPath: common.FieldPathStatusPodIP,
+							},
+						},
 					},
 				}
 


### PR DESCRIPTION
### What does this PR do?

Env vars with a format of `{name: NAME, valueFrom: ...}` weren't being set correctly in the pod overrides.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
