### PR TITLE
Change event type to be datadog instead of datadog_operator

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -50,7 +50,7 @@ const (
 	reconcileFailureValue       = 0.0
 	reconcileMetricFormat       = "%s.reconcile.success"
 	reconcileErrTagFormat       = "reconcile_err:%s"
-	datadogOperatorSourceType   = "datadog_operator"
+	datadogOperatorSourceType   = "datadog"
 	defaultbaseURL              = "https://api.datadoghq.com"
 )
 


### PR DESCRIPTION
### What does this PR do?

Without corresponding changes in the backend, using the datadog_operator source results in the events to be considered as custom.
The Event team recommended we switch to the `datadog` source type. 

### Motivation

Recommendation from the Event Pipeline team.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
