### PR TITLE
Adding volumeMounts for APM tagging

### DIFF
--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -347,6 +347,8 @@ func volumeMountsForCoreAgent() []corev1.VolumeMount {
 func volumeMountsForTraceAgent() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
+		component.GetVolumeMountForProc(),
+		component.GetVolumeMountForCgroups(),
 		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
 		component.GetVolumeMountForDogstatsdSocket(true),


### PR DESCRIPTION
### What does this PR do?

Sister change in the helm chart https://github.com/DataDog/helm-charts/pull/803

```
    Mounts:
      /etc/datadog-agent from config (rw)
      /etc/datadog-agent/auth from datadog-agent-auth (ro)
      /host/var/run from runtimesocketdir (ro)
      /var/log/datadog from logdatadog (rw)
      /var/run/datadog/apm from apmsocket (rw)
      /var/run/datadog/statsd from dsdsocket (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gp868 (ro)
```
After
```
    Mounts:
      /etc/datadog-agent from config (rw)
      /etc/datadog-agent/auth from datadog-agent-auth (ro)
      /host/proc from procdir (ro)
      /host/sys/fs/cgroup from cgroups (ro)
      /host/var/run from runtimesocketdir (ro)
      /var/log/datadog from logdatadog (rw)
      /var/run/datadog/apm from apmsocket (rw)
      /var/run/datadog/statsd from dsdsocket (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-hbgh7 (ro)
```

### Motivation

The trace agent, like DSD, supports origin detection via UDS + HostPID. Mounting procfs will allow retrieving container IDs from PIDs.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
