### PR TITLE
Fix to properly handle image name override containing repo, related to #652

### DIFF
--- a/apis/datadoghq/common/common_test.go
+++ b/apis/datadoghq/common/common_test.go
@@ -109,6 +109,26 @@ func Test_GetImage(t *testing.T) {
 			registry: nil,
 			want:     "gcr.io/datadoghq/agent:7",
 		},
+		{
+			name: "repo+image:tag input, drop repo, prefix default registry",
+			imageSpec: &commonv1.AgentImageConfig{
+				Name:       "datadog/agent:7",
+				Tag:        "8",
+				JMXEnabled: true,
+			},
+			registry: nil,
+			want:     "gcr.io/datadoghq/agent:7",
+		},
+		{
+			name: "repo+image:tag and override input, use override registry",
+			imageSpec: &commonv1.AgentImageConfig{
+				Name:       "datadog/agent:7",
+				Tag:        "8",
+				JMXEnabled: true,
+			},
+			registry: apiutils.NewStringPointer("docker.io/datadog"),
+			want:     "docker.io/datadog/agent:7",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/apis/datadoghq/common/v1/agent_types.go
+++ b/apis/datadoghq/common/v1/agent_types.go
@@ -19,6 +19,7 @@ type AgentImageConfig struct {
 	// Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent.
 	// Use "agent" with the registry and tag configurations for <registry>/agent:<tag>.
 	// Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>.
+	// Use `global.registry` if you are using a custom registry.
 	Name string `json:"name,omitempty"`
 
 	// Define the image tag to use.

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -4366,7 +4366,8 @@ spec:
                           standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest"
                           for Datadog Cluster Agent. Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag>. Use "cluster-agent"
-                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.'
+                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.
+                          Use `global.registry` if you are using a custom registry.'
                         type: string
                       pullPolicy:
                         description: 'The Kubernetes pull policy: Use Always, Never
@@ -8688,7 +8689,8 @@ spec:
                           standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest"
                           for Datadog Cluster Agent. Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag>. Use "cluster-agent"
-                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.'
+                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.
+                          Use `global.registry` if you are using a custom registry.'
                         type: string
                       pullPolicy:
                         description: 'The Kubernetes pull policy: Use Always, Never
@@ -12093,7 +12095,8 @@ spec:
                           standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest"
                           for Datadog Cluster Agent. Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag>. Use "cluster-agent"
-                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.'
+                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.
+                          Use `global.registry` if you are using a custom registry.'
                         type: string
                       pullPolicy:
                         description: 'The Kubernetes pull policy: Use Always, Never
@@ -15804,7 +15807,8 @@ spec:
                             for Datadog Cluster Agent. Use "agent" with the registry
                             and tag configurations for <registry>/agent:<tag>. Use
                             "cluster-agent" with the registry and tag configurations
-                            for <registry>/cluster-agent:<tag>.'
+                            for <registry>/cluster-agent:<tag>. Use `global.registry`
+                            if you are using a custom registry.'
                           type: string
                         pullPolicy:
                           description: 'The Kubernetes pull policy: Use Always, Never

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -4370,7 +4370,8 @@ spec:
                           standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest"
                           for Datadog Cluster Agent. Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag>. Use "cluster-agent"
-                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.'
+                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.
+                          Use `global.registry` if you are using a custom registry.'
                         type: string
                       pullPolicy:
                         description: 'The Kubernetes pull policy: Use Always, Never
@@ -8692,7 +8693,8 @@ spec:
                           standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest"
                           for Datadog Cluster Agent. Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag>. Use "cluster-agent"
-                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.'
+                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.
+                          Use `global.registry` if you are using a custom registry.'
                         type: string
                       pullPolicy:
                         description: 'The Kubernetes pull policy: Use Always, Never
@@ -12097,7 +12099,8 @@ spec:
                           standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest"
                           for Datadog Cluster Agent. Use "agent" with the registry
                           and tag configurations for <registry>/agent:<tag>. Use "cluster-agent"
-                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.'
+                          with the registry and tag configurations for <registry>/cluster-agent:<tag>.
+                          Use `global.registry` if you are using a custom registry.'
                         type: string
                       pullPolicy:
                         description: 'The Kubernetes pull policy: Use Always, Never
@@ -17181,7 +17184,8 @@ spec:
                               for Datadog Cluster Agent. Use "agent" with the registry
                               and tag configurations for <registry>/agent:<tag>. Use
                               "cluster-agent" with the registry and tag configurations
-                              for <registry>/cluster-agent:<tag>.'
+                              for <registry>/cluster-agent:<tag>. Use `global.registry`
+                              if you are using a custom registry.'
                             type: string
                           pullPolicy:
                             description: 'The Kubernetes pull policy: Use Always,
@@ -21671,7 +21675,8 @@ spec:
                               for Datadog Cluster Agent. Use "agent" with the registry
                               and tag configurations for <registry>/agent:<tag>. Use
                               "cluster-agent" with the registry and tag configurations
-                              for <registry>/cluster-agent:<tag>.'
+                              for <registry>/cluster-agent:<tag>. Use `global.registry`
+                              if you are using a custom registry.'
                             type: string
                           pullPolicy:
                             description: 'The Kubernetes pull policy: Use Always,
@@ -25218,7 +25223,8 @@ spec:
                               for Datadog Cluster Agent. Use "agent" with the registry
                               and tag configurations for <registry>/agent:<tag>. Use
                               "cluster-agent" with the registry and tag configurations
-                              for <registry>/cluster-agent:<tag>.'
+                              for <registry>/cluster-agent:<tag>. Use `global.registry`
+                              if you are using a custom registry.'
                             type: string
                           pullPolicy:
                             description: 'The Kubernetes pull policy: Use Always,
@@ -28748,7 +28754,8 @@ spec:
                             for Datadog Cluster Agent. Use "agent" with the registry
                             and tag configurations for <registry>/agent:<tag>. Use
                             "cluster-agent" with the registry and tag configurations
-                            for <registry>/cluster-agent:<tag>.'
+                            for <registry>/cluster-agent:<tag>. Use `global.registry`
+                            if you are using a custom registry.'
                           type: string
                         pullPolicy:
                           description: 'The Kubernetes pull policy: Use Always, Never

--- a/docs/configuration.v1alpha1.md
+++ b/docs/configuration.v1alpha1.md
@@ -195,7 +195,7 @@ spec:
 | agent.hostNetwork | Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false. |
 | agent.hostPID | Use the host's pid namespace. Optional: Default to false. |
 | agent.image.jmxEnabled | Define whether the Agent image should support JMX. |
-| agent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7. Use "datadog/dogstatsd:latest" for standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent. Use "agent" with the registry and tag configurations for <registry>/agent:<tag>. Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>. |
+| agent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7. Use "datadog/dogstatsd:latest" for standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent. Use "agent" with the registry and tag configurations for <registry>/agent:<tag>. Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>. Use `global.registry` if you are using a custom registry. |
 | agent.image.pullPolicy | The Kubernetes pull policy: Use Always, Never or IfNotPresent. |
 | agent.image.pullSecrets | It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
 | agent.image.tag | Define the image tag to use. To be used if the Name field does not correspond to a full image string. |
@@ -344,7 +344,7 @@ spec:
 | clusterAgent.deploymentName | Name of the Cluster Agent Deployment to create or migrate from. |
 | clusterAgent.enabled | Enabled |
 | clusterAgent.image.jmxEnabled | Define whether the Agent image should support JMX. |
-| clusterAgent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7. Use "datadog/dogstatsd:latest" for standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent. Use "agent" with the registry and tag configurations for <registry>/agent:<tag>. Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>. |
+| clusterAgent.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7. Use "datadog/dogstatsd:latest" for standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent. Use "agent" with the registry and tag configurations for <registry>/agent:<tag>. Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>. Use `global.registry` if you are using a custom registry. |
 | clusterAgent.image.pullPolicy | The Kubernetes pull policy: Use Always, Never or IfNotPresent. |
 | clusterAgent.image.pullSecrets | It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
 | clusterAgent.image.tag | Define the image tag to use. To be used if the Name field does not correspond to a full image string. |
@@ -431,7 +431,7 @@ spec:
 | clusterChecksRunner.deploymentName | Name of the cluster checks deployment to create or migrate from. |
 | clusterChecksRunner.enabled | Enabled |
 | clusterChecksRunner.image.jmxEnabled | Define whether the Agent image should support JMX. |
-| clusterChecksRunner.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7. Use "datadog/dogstatsd:latest" for standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent. Use "agent" with the registry and tag configurations for <registry>/agent:<tag>. Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>. |
+| clusterChecksRunner.image.name | Define the image to use: Use "gcr.io/datadoghq/agent:latest" for Datadog Agent 7. Use "datadog/dogstatsd:latest" for standalone Datadog Agent DogStatsD 7. Use "gcr.io/datadoghq/cluster-agent:latest" for Datadog Cluster Agent. Use "agent" with the registry and tag configurations for <registry>/agent:<tag>. Use "cluster-agent" with the registry and tag configurations for <registry>/cluster-agent:<tag>. Use `global.registry` if you are using a custom registry. |
 | clusterChecksRunner.image.pullPolicy | The Kubernetes pull policy: Use Always, Never or IfNotPresent. |
 | clusterChecksRunner.image.pullSecrets | It is possible to specify Docker registry credentials. See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod |
 | clusterChecksRunner.image.tag | Define the image tag to use. To be used if the Name field does not correspond to a full image string. |


### PR DESCRIPTION
### What does this PR do?

Change introduced in #652 causes duplication of repo in image URI if we use default image registry with override given as `repo/name:tag`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
