### PR TITLE
Move external metrics rolebinding to kube-system namespace

### DIFF
--- a/controllers/datadogagent/feature/externalmetrics/feature.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature.go
@@ -260,7 +260,7 @@ func (f *externalMetricsFeature) ManageDependencies(managers feature.ResourceMan
 	if err := managers.RBACManager().AddClusterRoleBinding(ns, componentdca.GetHPAClusterRoleBindingName(f.owner), f.serviceAccountName, getAuthDelegatorRoleRef()); err != nil {
 		return fmt.Errorf("error adding external metrics provider auth delegator clusterrolebinding to store: %w", err)
 	}
-	if err := managers.RBACManager().AddRoleBinding(ns, componentdca.GetApiserverAuthReaderRoleBindingName(f.owner), f.serviceAccountName, getAPIServerAuthReaderRoleRef()); err != nil {
+	if err := managers.RBACManager().AddRoleBinding("kube-system", componentdca.GetApiserverAuthReaderRoleBindingName(f.owner), ns, f.serviceAccountName, getAPIServerAuthReaderRoleRef()); err != nil {
 		return fmt.Errorf("error adding external metrics provider apiserver auth rolebinding to store: %w", err)
 	}
 


### PR DESCRIPTION
### What does this PR do?

When enabling the external metrics provider feature, a rolebinding is placed in the wrong namespace if the DDA is created in a namespace other than `kube-system` because the `extension-apiserver-authentication-reader` role referenced in the rolebinding is in the `kube-system` namespace. Operator error:

```json
{"level":"ERROR","ts":"2022-12-05T19:07:56Z","logger":"controllers.DatadogAgent","msg":"dependencies.store Create","datadogagent":"default/datadog-agent","obj.namespace":"default","obj.name":"datadog-agent-cluster-agent-apiserver","error":"roles.rbac.authorization.k8s.io \"extension-apiserver-authentication-reader\" not found"}
```

The owner-reference also needs to be removed because cross-namespace ownership isn't allowed: https://kubernetes.io/docs/concepts/architecture/garbage-collection/#owners-dependents


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
