### PR TITLE
Update policy/v1beta1 to policy/v1

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -323,7 +323,6 @@ core,"k8s.io/api/node/v1",Apache-2.0
 core,"k8s.io/api/node/v1alpha1",Apache-2.0
 core,"k8s.io/api/node/v1beta1",Apache-2.0
 core,"k8s.io/api/policy/v1",Apache-2.0
-core,"k8s.io/api/policy/v1beta1",Apache-2.0
 core,"k8s.io/api/rbac/v1",Apache-2.0
 core,"k8s.io/api/rbac/v1alpha1",Apache-2.0
 core,"k8s.io/api/rbac/v1beta1",Apache-2.0
@@ -428,7 +427,6 @@ core,"k8s.io/client-go/applyconfigurations/node/v1",Apache-2.0
 core,"k8s.io/client-go/applyconfigurations/node/v1alpha1",Apache-2.0
 core,"k8s.io/client-go/applyconfigurations/node/v1beta1",Apache-2.0
 core,"k8s.io/client-go/applyconfigurations/policy/v1",Apache-2.0
-core,"k8s.io/client-go/applyconfigurations/policy/v1beta1",Apache-2.0
 core,"k8s.io/client-go/applyconfigurations/rbac/v1",Apache-2.0
 core,"k8s.io/client-go/applyconfigurations/rbac/v1alpha1",Apache-2.0
 core,"k8s.io/client-go/applyconfigurations/rbac/v1beta1",Apache-2.0
@@ -478,7 +476,6 @@ core,"k8s.io/client-go/kubernetes/typed/node/v1",Apache-2.0
 core,"k8s.io/client-go/kubernetes/typed/node/v1alpha1",Apache-2.0
 core,"k8s.io/client-go/kubernetes/typed/node/v1beta1",Apache-2.0
 core,"k8s.io/client-go/kubernetes/typed/policy/v1",Apache-2.0
-core,"k8s.io/client-go/kubernetes/typed/policy/v1beta1",Apache-2.0
 core,"k8s.io/client-go/kubernetes/typed/rbac/v1",Apache-2.0
 core,"k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",Apache-2.0
 core,"k8s.io/client-go/kubernetes/typed/rbac/v1beta1",Apache-2.0

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -33,7 +33,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/datadogagent/merger/pod_security.go
+++ b/controllers/datadogagent/merger/pod_security.go
@@ -13,17 +13,12 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	securityv1 "github.com/openshift/api/security/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 )
 
 // PodSecurityManager use to manage Security resources.
 type PodSecurityManager interface {
 	// AddSecurityContextConstraints updates a SecurityContextConstraints
 	AddSecurityContextConstraints(name, namespace string, sccUpdates *securityv1.SecurityContextConstraints) error
-	// GetPodSecurityPolicy gets a PodSecurityPolicy
-	GetPodSecurityPolicy(namespace string, pspName string) (*policyv1beta1.PodSecurityPolicy, error)
-	// UpdatePodSecurityPolicy updates a PodSecurityPolicy
-	UpdatePodSecurityPolicy(*policyv1beta1.PodSecurityPolicy)
 }
 
 // NewPodSecurityManager return new PodSecurityManager instance
@@ -116,19 +111,4 @@ func (m *podSecurityManagerImpl) AddSecurityContextConstraints(name, namespace s
 	}
 
 	return m.store.AddOrUpdate(kubernetes.SecurityContextConstraintsKind, scc)
-}
-
-func (m *podSecurityManagerImpl) GetPodSecurityPolicy(namespace string, pspName string) (psp *policyv1beta1.PodSecurityPolicy, err error) {
-	// TODO
-	// obj, _ := m.store.GetOrCreate(kubernetes.PodSecurityPoliciesKind, namespace, pspName)
-	// psp, ok := obj.(*policyv1beta1.PodSecurityPolicy)
-	// if !ok {
-	// 	return nil, fmt.Errorf("unable to get from the store the PodSecurityPolicy %s", pspName)
-	// }
-	return psp, err
-}
-
-func (m *podSecurityManagerImpl) UpdatePodSecurityPolicy(psp *policyv1beta1.PodSecurityPolicy) {
-	// TODO
-	// m.store.AddOrUpdate(kubernetes.PodSecurityPoliciesKind, psp)
 }

--- a/controllers/datadogagent/poddisruptionbudget.go
+++ b/controllers/datadogagent/poddisruptionbudget.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/datadogagent/testutils/client_utils.go
+++ b/controllers/datadogagent/testutils/client_utils.go
@@ -12,7 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -13,7 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/equality/equality.go
+++ b/pkg/equality/equality.go
@@ -52,8 +52,6 @@ func IsEqualObject(kind kubernetes.ObjectKind, a, b client.Object) bool {
 		return IsEqualPodDisruptionBudgets(a, b)
 	case kubernetes.NetworkPoliciesKind:
 		return IsEqualNetworkPolicies(a, b)
-	case kubernetes.PodSecurityPoliciesKind:
-		return IsEqualPodSecurityPolicies(a, b)
 	case kubernetes.CiliumNetworkPoliciesKind:
 		return IsEqualCiliumNetworkPolicies(a, b)
 	default:
@@ -188,16 +186,6 @@ func IsEqualPodDisruptionBudgets(objA, objB client.Object) bool {
 func IsEqualNetworkPolicies(objA, objB client.Object) bool {
 	a, okA := objA.(*networkingv1.NetworkPolicy)
 	b, okB := objB.(*networkingv1.NetworkPolicy)
-	if okA && okB && a != nil && b != nil {
-		return apiequality.Semantic.DeepEqual(a.Spec, b.Spec)
-	}
-	return false
-}
-
-// IsEqualPodSecurityPolicies return true if the two PodSecurityPolicies are equal
-func IsEqualPodSecurityPolicies(objA, objB client.Object) bool {
-	a, okA := objA.(*policyv1.PodSecurityPolicy)
-	b, okB := objB.(*policyv1.PodSecurityPolicy)
 	if okA && okB && a != nil && b != nil {
 		return apiequality.Semantic.DeepEqual(a.Spec, b.Spec)
 	}

--- a/pkg/equality/equality.go
+++ b/pkg/equality/equality.go
@@ -9,7 +9,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/kubernetes/const.go
+++ b/pkg/kubernetes/const.go
@@ -48,8 +48,6 @@ const (
 	PodDisruptionBudgetsKind = "poddisruptionbudgets"
 	// NetworkPoliciesKind NetworkPolicies resource kind
 	NetworkPoliciesKind = "networkpolicies"
-	// PodSecurityPoliciesKind PodSecurityPolicies resource kind
-	PodSecurityPoliciesKind = "podsecuritypolicies"
 	// CiliumNetworkPoliciesKind CiliumNetworkPolicies resource kind
 	CiliumNetworkPoliciesKind = "ciliumnetworkpolicies"
 	// SecurityContextConstraintsKind SecurityContextConstraints resource kind
@@ -71,7 +69,6 @@ func GetResourcesKind(withCiliumResources bool) []ObjectKind {
 		ServiceAccountsKind,
 		PodDisruptionBudgetsKind,
 		NetworkPoliciesKind,
-		PodSecurityPoliciesKind,
 		// SecurityContextConstraintsKind,
 	}
 

--- a/pkg/kubernetes/objects.go
+++ b/pkg/kubernetes/objects.go
@@ -10,7 +10,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/kubernetes/objects.go
+++ b/pkg/kubernetes/objects.go
@@ -45,8 +45,6 @@ func ObjectFromKind(kind ObjectKind) client.Object {
 		return &policyv1.PodDisruptionBudget{}
 	case NetworkPoliciesKind:
 		return &networkingv1.NetworkPolicy{}
-	case PodSecurityPoliciesKind:
-		return &policyv1.PodSecurityPolicy{}
 	case CiliumNetworkPoliciesKind:
 		return ciliumv1.EmptyCiliumUnstructuredPolicy()
 	case SecurityContextConstraintsKind:

--- a/pkg/kubernetes/objectslist.go
+++ b/pkg/kubernetes/objectslist.go
@@ -44,8 +44,6 @@ func ObjectListFromKind(kind ObjectKind) client.ObjectList {
 		return &policyv1.PodDisruptionBudgetList{}
 	case NetworkPoliciesKind:
 		return &networkingv1.NetworkPolicyList{}
-	case PodSecurityPoliciesKind:
-		return &policyv1.PodSecurityPolicyList{}
 	case CiliumNetworkPoliciesKind:
 		return ciliumv1.EmptyCiliumUnstructuredListPolicy()
 		// case SecurityContextConstraintsKind:

--- a/pkg/kubernetes/objectslist.go
+++ b/pkg/kubernetes/objectslist.go
@@ -9,7 +9,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
### What does this PR do?

This PR updates references to the `k8s.io/api/policy/v1beta1` package to `/v1`, and (in order to perform that update) removes references to `v1beta1.PodSecurityPolicy`, which was [deprecated](https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/) in k8s 1.21, and was [removed](https://kubernetes.io/blog/2022/08/04/upcoming-changes-in-kubernetes-1-25/) in 1.25.

Fixes #619.

### Motivation

I tried to use this operator to install agents in my cluster, and it didn't work. It said:

```
{
  "level": "ERROR",
  "ts": "2022-12-25T02:22:15Z",
  "logger": "controller-runtime.source",
  "kind": "PodDisruptionBudget.policy",
  "error": "no matches for kind \"PodDisruptionBudget\" in version \"policy/v1beta1\"",
  "msg": "if kind is a CRD, it should be installed before calling Start"
}
```

PodDisruptionBudget [graduated to stable](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/#graduated-to-stable) in 1.21, and was [removed](https://kubernetes.io/blog/2022/08/04/upcoming-changes-in-kubernetes-1-25/) from the v1beta1 api in 1.25, which I assume is when this problem started. Upgrading the package fixes the problem.

### Additional Notes

The current release of this operator doesn't work at all with the latest kube release (1.25), so even if you don't like my PR, please do something 🙏

### Describe your test plan

Caveat emptor, but I ran the tests 🤷🏾‍♀️