### PR TITLE
Default Agent|Cluster-Agent to 7.41.1

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.40.1"
+	AgentLatestVersion = "7.41.1"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.40.1"
+	ClusterAgentLatestVersion = "7.41.1"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

* Default Agent image to `7.41.1`.
* Default Cluster-Agent image to `7.41.1`. Cluster-Agent versioning is now aligned with the Agent.

### Motivation

Keep agent version up-to-date

### Additional Notes

This PR can be cherry-pick on the `v0.8` branch.

### Describe your test plan

testing has been done during the Datadog-Agent QA
