### PR TITLE
Fixing the defaulting and support of the udsHostFilePath

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -190,10 +190,9 @@ const (
 	SymlinkContainerVolumePath                       = "/var/log/containers"
 	DogstatsdHostPortName                            = "dogstatsdport"
 	DogstatsdHostPortHostPort                        = 8125
-	DogstatsdAPMSocketVolumeName                     = "dsdapmsocket"
 	DogstatsdSocketVolumeName                        = "dsdsocket"
 	DogstatsdSocketVolumePath                        = "/var/run/datadog"
-	DogstatsdSocketOldVolumePath                     = "/var/run/datadog/statsd"
+	DogstatsdSocketLocalPath                         = "/var/run/datadog/statsd"
 	DogstatsdSocketName                              = "dsd.socket"
 	SecurityAgentComplianceCustomConfigDirVolumeName = "customcompliancebenchmarks"
 	SecurityAgentComplianceConfigDirVolumeName       = "compliancedir"
@@ -210,7 +209,7 @@ const (
 	APMHostPortName                                  = "traceport"
 	APMHostPortHostPort                              = 8126
 	APMSocketVolumeName                              = "apmsocket"
-	APMSocketVolumePath                              = "/var/run/datadog/apm"
+	APMSocketVolumeLocalPath                         = "/var/run/datadog/apm"
 	APMSocketName                                    = "apm.socket"
 	AdmissionControllerPortName                      = "admissioncontrollerport"
 	ExternalMetricsPortName                          = "metricsapi"

--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -191,7 +191,7 @@ const (
 	DogstatsdHostPortName                            = "dogstatsdport"
 	DogstatsdHostPortHostPort                        = 8125
 	DogstatsdSocketVolumeName                        = "dsdsocket"
-	DogstatsdSocketVolumePath                        = "/var/run/datadog"
+	DogstatsdAPMSocketVolumePath                     = "/var/run/datadog"
 	DogstatsdSocketLocalPath                         = "/var/run/datadog/statsd"
 	DogstatsdSocketName                              = "dsd.socket"
 	SecurityAgentComplianceCustomConfigDirVolumeName = "customcompliancebenchmarks"

--- a/apis/datadoghq/common/v1/types.go
+++ b/apis/datadoghq/common/v1/types.go
@@ -85,7 +85,8 @@ const (
 	SecurityAgentContainerName AgentContainerName = "security-agent"
 	// SystemProbeContainerName is the name of the System Probe container
 	SystemProbeContainerName AgentContainerName = "system-probe"
-
+	// AllContainers is used internally to reference all containers in the pod
+	AllContainers AgentContainerName = "all"
 	// ClusterAgentContainerName is the name of the Cluster Agent container
 	ClusterAgentContainerName AgentContainerName = "cluster-agent"
 

--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -34,7 +34,7 @@ const (
 	defaultAPMHostPortEnabled bool   = false
 	defaultAPMHostPort        int32  = 8126
 	defaultAPMSocketEnabled   bool   = true
-	defaultAPMSocketPath      string = "/var/run/datadog/apm.socket"
+	defaultAPMSocketHostPath  string = "/var/run/datadog/apm.socket"
 
 	// defaultCSPMEnabled              bool = false
 	// defaultCWSEnabled               bool = false
@@ -50,7 +50,7 @@ const (
 	defaultDogstatsdHostPortEnabled        bool   = false
 	defaultDogstatsdPort                   int32  = 8125
 	defaultDogstatsdSocketEnabled          bool   = true
-	defaultDogstatsdSocketPath             string = "/var/run/datadog/dsd.socket"
+	defaultDogstatsdHostSocketPath         string = "/var/run/datadog/dsd.socket"
 
 	defaultOTLPGRPCEnabled  bool   = false
 	defaultOTLPGRPCEndpoint string = "0.0.0.0:4317"
@@ -165,7 +165,7 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.APM.UnixDomainSocketConfig.Enabled, defaultAPMSocketEnabled)
 
-		apiutils.DefaultStringIfUnset(&ddaSpec.Features.APM.UnixDomainSocketConfig.Path, defaultAPMSocketPath)
+		apiutils.DefaultStringIfUnset(&ddaSpec.Features.APM.UnixDomainSocketConfig.Path, defaultAPMSocketHostPath)
 	}
 
 	// CWS (Cloud Workload Security) Feature
@@ -203,7 +203,8 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 
 	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.Dogstatsd.UnixDomainSocketConfig.Enabled, defaultDogstatsdSocketEnabled)
 
-	apiutils.DefaultStringIfUnset(&ddaSpec.Features.Dogstatsd.UnixDomainSocketConfig.Path, defaultDogstatsdSocketPath)
+	// defaultDogstatsdHostSocketPath matches the default hostPath of the helm chart.
+	apiutils.DefaultStringIfUnset(&ddaSpec.Features.Dogstatsd.UnixDomainSocketConfig.Path, defaultDogstatsdHostSocketPath)
 
 	// OTLP ingest feature
 	if ddaSpec.Features.OTLP == nil {

--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -34,7 +34,7 @@ const (
 	defaultAPMHostPortEnabled bool   = false
 	defaultAPMHostPort        int32  = 8126
 	defaultAPMSocketEnabled   bool   = true
-	defaultAPMSocketHostPath  string = "/var/run/datadog/apm.socket"
+	defaultAPMSocketHostPath  string = apicommon.DogstatsdAPMSocketVolumePath + "/" + apicommon.APMSocketName
 
 	// defaultCSPMEnabled              bool = false
 	// defaultCWSEnabled               bool = false
@@ -50,7 +50,7 @@ const (
 	defaultDogstatsdHostPortEnabled        bool   = false
 	defaultDogstatsdPort                   int32  = 8125
 	defaultDogstatsdSocketEnabled          bool   = true
-	defaultDogstatsdHostSocketPath         string = "/var/run/datadog/dsd.socket"
+	defaultDogstatsdHostSocketPath         string = apicommon.DogstatsdAPMSocketVolumePath + "/" + apicommon.DogstatsdSocketName
 
 	defaultOTLPGRPCEnabled  bool   = false
 	defaultOTLPGRPCEndpoint string = "0.0.0.0:4317"

--- a/apis/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -78,7 +78,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -211,7 +211,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -270,7 +270,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -332,7 +332,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -389,7 +389,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultAPMSocketPath),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
@@ -397,7 +397,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -456,7 +456,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -517,7 +517,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -571,7 +571,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
@@ -630,7 +630,7 @@ func Test_defaultFeatures(t *testing.T) {
 						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdSocketPath),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
 						},
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -130,7 +130,7 @@ func GetVolumeForCgroups() corev1.Volume {
 // GetVolumeForDogstatsd returns the volume with the Dogstatsd socket
 func GetVolumeForDogstatsd() corev1.Volume {
 	return corev1.Volume{
-		Name: apicommon.DogstatsdAPMSocketVolumeName,
+		Name: apicommon.DogstatsdSocketVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
@@ -263,8 +263,8 @@ func GetVolumeMountForCgroups() corev1.VolumeMount {
 // GetVolumeMountForDogstatsdSocket returns the VolumeMount with the Dogstatsd socket
 func GetVolumeMountForDogstatsdSocket(readOnly bool) corev1.VolumeMount {
 	return corev1.VolumeMount{
-		Name:      apicommon.DogstatsdAPMSocketVolumeName,
-		MountPath: apicommon.DogstatsdSocketVolumePath,
+		Name:      apicommon.DogstatsdSocketVolumeName,
+		MountPath: apicommon.DogstatsdSocketLocalPath,
 		ReadOnly:  readOnly,
 	}
 }

--- a/controllers/datadogagent/feature/apm/feature.go
+++ b/controllers/datadogagent/feature/apm/feature.go
@@ -266,11 +266,14 @@ func (f *apmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	// uds
 	if f.udsEnabled {
 		udsHostFolder := filepath.Dir(f.udsHostFilepath)
+		sockName := filepath.Base(f.udsHostFilepath)
 		managers.EnvVar().AddEnvVarToContainer(apicommonv1.TraceAgentContainerName, &corev1.EnvVar{
 			Name:  apicommon.DDAPMReceiverSocket,
-			Value: f.udsHostFilepath,
+			Value: filepath.Join(apicommon.APMSocketVolumeLocalPath, sockName),
 		})
-		socketVol, socketVolMount := volume.GetVolumes(apicommon.DogstatsdAPMSocketVolumeName, udsHostFolder, udsHostFolder, false)
+		socketVol, socketVolMount := volume.GetVolumes(apicommon.APMSocketVolumeName, udsHostFolder, apicommon.APMSocketVolumeLocalPath, false)
+		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
+		socketVol.VolumeSource.HostPath.Type = &volType
 		managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.TraceAgentContainerName)
 		managers.Volume().AddVolume(&socketVol)
 	}

--- a/controllers/datadogagent/feature/apm/feature_test.go
+++ b/controllers/datadogagent/feature/apm/feature_test.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	apmSocketPath = apicommon.APMSocketVolumeLocalPath + "/" + apicommon.APMSocketName
+	apmSocketHostPath  = apicommon.DogstatsdAPMSocketVolumePath + "/" + apicommon.APMSocketName
+	apmSocketLocalPath = apicommon.APMSocketVolumeLocalPath + "/" + apicommon.APMSocketName
 )
 
 func TestAPMFeature(t *testing.T) {
@@ -83,7 +84,7 @@ func newV1Agent(enableAPM bool, uds bool) *v1alpha1.DatadogAgent {
 					HostPort: apiutils.NewInt32Pointer(8126),
 					UnixDomainSocket: &v1alpha1.APMUnixDomainSocketSpec{
 						Enabled:      apiutils.NewBoolPointer(uds),
-						HostFilepath: apiutils.NewStringPointer(apmSocketPath),
+						HostFilepath: apiutils.NewStringPointer(apmSocketHostPath),
 					},
 				},
 			},
@@ -103,7 +104,7 @@ func newV2Agent(enableAPM bool, hostPort bool) *v2alpha1.DatadogAgent {
 					},
 					UnixDomainSocketConfig: &v2alpha1.UnixDomainSocketConfig{
 						Enabled: apiutils.NewBoolPointer(true),
-						Path:    apiutils.NewStringPointer(apmSocketPath),
+						Path:    apiutils.NewStringPointer(apmSocketHostPath),
 					},
 				},
 			},
@@ -169,7 +170,7 @@ func testAgentUDSOnly() *test.ComponentTest {
 				},
 				{
 					Name:  apicommon.DDAPMReceiverSocket,
-					Value: apmSocketPath,
+					Value: apmSocketLocalPath,
 				},
 			}
 			assert.True(
@@ -199,7 +200,7 @@ func testAgentUDSOnly() *test.ComponentTest {
 					Name: apicommon.APMSocketVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: apicommon.APMSocketVolumeLocalPath,
+							Path: apicommon.DogstatsdAPMSocketVolumePath,
 							Type: &volType,
 						},
 					},
@@ -249,7 +250,7 @@ func testAgentHostPortUDS() *test.ComponentTest {
 				},
 				{
 					Name:  apicommon.DDAPMReceiverSocket,
-					Value: apmSocketPath,
+					Value: apmSocketLocalPath,
 				},
 			}
 			assert.True(
@@ -279,7 +280,7 @@ func testAgentHostPortUDS() *test.ComponentTest {
 					Name: apicommon.APMSocketVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: apicommon.APMSocketVolumeLocalPath,
+							Path: apicommon.DogstatsdAPMSocketVolumePath,
 							Type: &volType,
 						},
 					},

--- a/controllers/datadogagent/feature/apm/feature_test.go
+++ b/controllers/datadogagent/feature/apm/feature_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	apmSocketPath = apicommon.DogstatsdSocketVolumePath + "/" + apicommon.APMSocketName
+	apmSocketPath = apicommon.APMSocketVolumeLocalPath + "/" + apicommon.APMSocketName
 )
 
 func TestAPMFeature(t *testing.T) {
@@ -181,8 +181,8 @@ func testAgentUDSOnly() *test.ComponentTest {
 			agentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.TraceAgentContainerName]
 			expectedVolumeMounts := []*corev1.VolumeMount{
 				{
-					Name:      apicommon.DogstatsdAPMSocketVolumeName,
-					MountPath: apicommon.DogstatsdSocketVolumePath,
+					Name:      apicommon.APMSocketVolumeName,
+					MountPath: apicommon.APMSocketVolumeLocalPath,
 					ReadOnly:  false,
 				},
 			}
@@ -193,12 +193,14 @@ func testAgentUDSOnly() *test.ComponentTest {
 			)
 
 			agentVolumes := mgr.VolumeMgr.Volumes
+			volType := corev1.HostPathDirectoryOrCreate
 			expectedVolumes := []*corev1.Volume{
 				{
-					Name: apicommon.DogstatsdAPMSocketVolumeName,
+					Name: apicommon.APMSocketVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: apicommon.DogstatsdSocketVolumePath,
+							Path: apicommon.APMSocketVolumeLocalPath,
+							Type: &volType,
 						},
 					},
 				},
@@ -259,8 +261,8 @@ func testAgentHostPortUDS() *test.ComponentTest {
 			agentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.TraceAgentContainerName]
 			expectedVolumeMounts := []*corev1.VolumeMount{
 				{
-					Name:      apicommon.DogstatsdAPMSocketVolumeName,
-					MountPath: apicommon.DogstatsdSocketVolumePath,
+					Name:      apicommon.APMSocketVolumeName,
+					MountPath: apicommon.APMSocketVolumeLocalPath,
 					ReadOnly:  false,
 				},
 			}
@@ -271,12 +273,14 @@ func testAgentHostPortUDS() *test.ComponentTest {
 			)
 
 			agentVolumes := mgr.VolumeMgr.Volumes
+			volType := corev1.HostPathDirectoryOrCreate
 			expectedVolumes := []*corev1.Volume{
 				{
-					Name: apicommon.DogstatsdAPMSocketVolumeName,
+					Name: apicommon.APMSocketVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: apicommon.DogstatsdSocketVolumePath,
+							Path: apicommon.APMSocketVolumeLocalPath,
+							Type: &volType,
 						},
 					},
 				},

--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -182,12 +182,15 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers)
 	// uds
 	if f.udsEnabled {
 		udsHostFolder := filepath.Dir(f.udsHostFilepath)
-		socketVol, socketVolMount := volume.GetVolumes(apicommon.DogstatsdAPMSocketVolumeName, udsHostFolder, udsHostFolder, false)
+		sockName := filepath.Base(f.udsHostFilepath)
+		socketVol, socketVolMount := volume.GetVolumes(apicommon.DogstatsdSocketVolumeName, udsHostFolder, apicommon.DogstatsdSocketLocalPath, false)
+		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
+		socketVol.VolumeSource.HostPath.Type = &volType
 		managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.CoreAgentContainerName)
 		managers.Volume().AddVolume(&socketVol)
-		managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
 			Name:  apicommon.DDDogstatsdSocket,
-			Value: f.udsHostFilepath,
+			Value: filepath.Join(apicommon.DogstatsdSocketLocalPath, sockName),
 		})
 	}
 

--- a/controllers/datadogagent/feature/dogstatsd/feature_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_test.go
@@ -116,7 +116,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: apicommon.DogstatsdSocketVolumePath,
+					Path: apicommon.DogstatsdAPMSocketVolumePath,
 					Type: &volType,
 				},
 			},
@@ -129,7 +129,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: apicommon.DogstatsdSocketVolumePath,
+					Path: apicommon.DogstatsdAPMSocketVolumePath,
 					Type: &volType,
 				},
 			},

--- a/controllers/datadogagent/feature/dogstatsd/feature_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_test.go
@@ -23,7 +23,8 @@ import (
 
 const (
 	customVolumePath = "/custom/host"
-	customPath       = "/custom/host/filepath"
+	customPath       = "/custom/host/filepath.sock"
+	customSock       = "filepath.sock"
 )
 
 func Test_DogstatsdFeature_Configure(t *testing.T) {
@@ -94,27 +95,29 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 	// v1alpha1 default uds volume mount
 	wantVolumeMountsV1 := []corev1.VolumeMount{
 		{
-			Name:      apicommon.DogstatsdAPMSocketVolumeName,
-			MountPath: apicommon.DogstatsdSocketVolumePath,
+			Name:      apicommon.DogstatsdSocketVolumeName,
+			MountPath: apicommon.DogstatsdSocketLocalPath,
 			ReadOnly:  false,
 		},
 	}
 	// v2alpha1 default uds volume mount
 	wantVolumeMounts := []corev1.VolumeMount{
 		{
-			Name:      apicommon.DogstatsdAPMSocketVolumeName,
-			MountPath: apicommon.DogstatsdSocketVolumePath,
+			Name:      apicommon.DogstatsdSocketVolumeName,
+			MountPath: apicommon.DogstatsdSocketLocalPath,
 			ReadOnly:  false,
 		},
 	}
 
 	// v1alpha1 default uds volume
+	volType := corev1.HostPathDirectoryOrCreate
 	wantVolumesV1 := []corev1.Volume{
 		{
-			Name: apicommon.DogstatsdAPMSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: apicommon.DogstatsdSocketVolumePath,
+					Type: &volType,
 				},
 			},
 		},
@@ -123,10 +126,11 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 	// v2alpha1 default uds volume
 	wantVolumes := []corev1.Volume{
 		{
-			Name: apicommon.DogstatsdAPMSocketVolumeName,
+			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: apicommon.DogstatsdSocketVolumePath,
+					Type: &volType,
 				},
 			},
 		},
@@ -144,7 +148,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 	wantUDSEnvVarsV1 := []*corev1.EnvVar{
 		{
 			Name:  apicommon.DDDogstatsdSocket,
-			Value: apicommon.DogstatsdSocketVolumePath + "/" + "statsd.sock",
+			Value: apicommon.DogstatsdSocketLocalPath + "/" + "statsd.sock",
 		},
 	}
 
@@ -152,7 +156,13 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 	wantUDSEnvVarsV2 := []*corev1.EnvVar{
 		{
 			Name:  apicommon.DDDogstatsdSocket,
-			Value: apicommon.DogstatsdSocketVolumePath + "/" + apicommon.DogstatsdSocketName,
+			Value: apicommon.DogstatsdSocketLocalPath + "/" + apicommon.DogstatsdSocketName,
+		},
+	}
+	customEnvVar := []*corev1.EnvVar{
+		{
+			Name:  apicommon.DDDogstatsdSocket,
+			Value: apicommon.DogstatsdSocketLocalPath + "/" + customSock,
 		},
 	}
 
@@ -171,7 +181,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 	// custom uds filepath envvar
 	customFilepathEnvVar := corev1.EnvVar{
 		Name:  apicommon.DDDogstatsdSocket,
-		Value: customPath,
+		Value: apicommon.DogstatsdSocketLocalPath + "/" + customSock,
 	}
 
 	// v1alpha1 default udp port
@@ -205,13 +215,13 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)), "1. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
+					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "1. Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar(nil)), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar(nil)))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar(nil)), "1. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar(nil)))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "1. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},
@@ -223,11 +233,11 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)), "2. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
+					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "2. Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDPEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDPEnvVars), "2. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
 					customPorts := []*corev1.ContainerPort{
 						{
@@ -237,7 +247,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 							Protocol:      corev1.ProtocolUDP,
 						},
 					}
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, customPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, customPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, customPorts), "2. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, customPorts))
 				},
 			),
 		},
@@ -249,14 +259,14 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)), "3. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
+					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "3. Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
 					customEnvVars := append([]*corev1.EnvVar{}, &originDetectionEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "3. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "3. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},
@@ -268,13 +278,13 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMountsV1), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMountsV1))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMountsV1), "4. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMountsV1))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumesV1), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumesV1))
-					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDSEnvVarsV1), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV1))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumesV1), "4. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumesV1))
+					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDSEnvVarsV1), "4. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV1))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "4. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},
@@ -288,29 +298,30 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
 					customVolumeMounts := []corev1.VolumeMount{
 						{
-							Name:      apicommon.DogstatsdAPMSocketVolumeName,
-							MountPath: customVolumePath,
+							Name:      apicommon.DogstatsdSocketVolumeName,
+							MountPath: apicommon.DogstatsdSocketLocalPath,
 							ReadOnly:  false,
 						},
 					}
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, customVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, customVolumeMounts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, customVolumeMounts), "5. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, customVolumeMounts))
 					volumes := mgr.VolumeMgr.Volumes
 					customVolumes := []corev1.Volume{
 						{
-							Name: apicommon.DogstatsdAPMSocketVolumeName,
+							Name: apicommon.DogstatsdSocketVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: customVolumePath,
+									Type: &volType,
 								},
 							},
 						},
 					}
-					assert.True(t, apiutils.IsEqualStruct(volumes, customVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, customVolumes))
-					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
+					assert.True(t, apiutils.IsEqualStruct(volumes, customVolumes), "5. Volumes \ndiff = %s", cmp.Diff(volumes, customVolumes))
+					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
 					customEnvVars := append([]*corev1.EnvVar{}, &customFilepathEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "5. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "5. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},
@@ -322,15 +333,16 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMountsV1), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMountsV1))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMountsV1), "6. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMountsV1))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumesV1), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumesV1))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumesV1), "6. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumesV1))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append(wantUDSEnvVarsV1, &originDetectionEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar}), "6. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar}))
+					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV1), "6. All Containers envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV2))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
-					assert.True(t, mgr.Tpl.Spec.HostPID, "Host PID \ndiff = %s", cmp.Diff(mgr.Tpl.Spec.HostPID, true))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "6. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, mgr.Tpl.Spec.HostPID, "6. Host PID \ndiff = %s", cmp.Diff(mgr.Tpl.Spec.HostPID, true))
 				},
 			),
 		},
@@ -342,14 +354,15 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMountsV1), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMountsV1))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMountsV1), "7. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMountsV1))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumesV1), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumesV1))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumesV1), "7. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumesV1))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append(wantUDSEnvVarsV1, &mapperProfilesEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar{&mapperProfilesEnvVar}), "7. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar{&mapperProfilesEnvVar}))
+					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV1), "7. All Containers envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV2))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "7. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},
@@ -364,14 +377,15 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "8. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "8. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append(wantUDPEnvVars, wantUDSEnvVarsV2...)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDPEnvVars), "8. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
+					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV2), "8. All Containers envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV2))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantHostPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantHostPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantHostPorts), "8. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantHostPorts))
 				},
 			),
 		},
@@ -383,12 +397,14 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "9. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "9. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append(wantUDPEnvVars, wantUDSEnvVarsV2...)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDPEnvVars), "9. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
+					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV2), "9. All Containers envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV2))
+
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
 					customPorts := []*corev1.ContainerPort{
 						{
@@ -398,7 +414,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 							Protocol:      corev1.ProtocolUDP,
 						},
 					}
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, customPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, customPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, customPorts), "9. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, customPorts))
 				},
 			),
 		},
@@ -410,15 +426,16 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "10. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "10. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append(wantUDPEnvVars, wantUDSEnvVarsV2...)
-					customEnvVars = append(customEnvVars, &originDetectionEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					customEnvVars := append(wantUDPEnvVars, &originDetectionEnvVar)
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "10. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV2), "10. All Containers envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV2))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantHostPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantHostPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantHostPorts), "10. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantHostPorts))
 				},
 			),
 		},
@@ -430,13 +447,13 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.Volume(nil)), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, []*corev1.Volume(nil)), "11. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, []*corev1.VolumeMount(nil)))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
+					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "11. Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, agentEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, agentEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, nil), "11. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, nil))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "11. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},
@@ -450,29 +467,30 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
 					customVolumeMounts := []corev1.VolumeMount{
 						{
-							Name:      apicommon.DogstatsdAPMSocketVolumeName,
-							MountPath: customVolumePath,
+							Name:      apicommon.DogstatsdSocketVolumeName,
+							MountPath: apicommon.DogstatsdSocketLocalPath,
 							ReadOnly:  false,
 						},
 					}
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, customVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, customVolumeMounts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, customVolumeMounts), "12. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, customVolumeMounts))
 					volumes := mgr.VolumeMgr.Volumes
 					customVolumes := []corev1.Volume{
 						{
-							Name: apicommon.DogstatsdAPMSocketVolumeName,
+							Name: apicommon.DogstatsdSocketVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: customVolumePath,
+									Type: &volType,
 								},
 							},
 						},
 					}
-					assert.True(t, apiutils.IsEqualStruct(volumes, customVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, customVolumes))
-					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append([]*corev1.EnvVar{}, &customFilepathEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(volumes, customVolumes), "12. Volumes \ndiff = %s", cmp.Diff(volumes, customVolumes))
+					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					customEnvVars := append([]*corev1.EnvVar{}, customEnvVar...)
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "12. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "12. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},
@@ -484,15 +502,16 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "13. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "13. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append(wantUDSEnvVarsV2, &originDetectionEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar}), "13. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar}))
+					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV2), "13. All Containers envvars \ndiff = %s", cmp.Diff(allEnvVars, wantUDSEnvVarsV2))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
-					assert.True(t, mgr.Tpl.Spec.HostPID, "Host PID \ndiff = %s", cmp.Diff(mgr.Tpl.Spec.HostPID, true))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "13. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, mgr.Tpl.Spec.HostPID, "13. Host PID \ndiff = %s", cmp.Diff(mgr.Tpl.Spec.HostPID, true))
 				},
 			),
 		},
@@ -504,14 +523,15 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentVolumeMounts, wantVolumeMounts), "14. Volume mounts \ndiff = %s", cmp.Diff(coreAgentVolumeMounts, wantVolumeMounts))
 					volumes := mgr.VolumeMgr.Volumes
-					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
+					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "14. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append(wantUDSEnvVarsV2, &mapperProfilesEnvVar)
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar{&mapperProfilesEnvVar}), "14. Agent Container envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar{&mapperProfilesEnvVar}))
+					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV2), "14. All Containers envvars \ndiff = %s", cmp.Diff(allEnvVars, wantUDSEnvVarsV2))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
+					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "14. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
 				},
 			),
 		},

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -561,7 +561,7 @@ func getConfigInitContainers(spec *datadoghqv1alpha1.DatadogAgentSpec, volumeMou
 func getEnvVarDogstatsdSocket(dda *datadoghqv1alpha1.DatadogAgent) corev1.EnvVar {
 	return corev1.EnvVar{
 		Name:  apicommon.DDDogstatsdSocket,
-		Value: getLocalFilepath(*dda.Spec.Agent.Config.Dogstatsd.UnixDomainSocket.HostFilepath, apicommon.DogstatsdSocketOldVolumePath),
+		Value: getLocalFilepath(*dda.Spec.Agent.Config.Dogstatsd.UnixDomainSocket.HostFilepath, apicommon.DogstatsdSocketLocalPath),
 	}
 }
 
@@ -579,7 +579,7 @@ func getEnvVarsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) ([]corev1.EnvVar
 	if apiutils.BoolValue(dda.Spec.Agent.Apm.UnixDomainSocket.Enabled) {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  apicommon.DDPPMReceiverSocket,
-			Value: getLocalFilepath(*dda.Spec.Agent.Apm.UnixDomainSocket.HostFilepath, apicommon.APMSocketVolumePath),
+			Value: getLocalFilepath(*dda.Spec.Agent.Apm.UnixDomainSocket.HostFilepath, apicommon.APMSocketVolumeLocalPath),
 		})
 	}
 
@@ -1532,7 +1532,7 @@ func getVolumeMountForChecksd() corev1.VolumeMount {
 func getVolumeMountDogstatsdSocket(readOnly bool) corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      apicommon.DogstatsdSocketVolumeName,
-		MountPath: apicommon.DogstatsdSocketOldVolumePath,
+		MountPath: apicommon.DogstatsdSocketLocalPath,
 		ReadOnly:  readOnly,
 	}
 }
@@ -1636,7 +1636,7 @@ func getVolumeMountsForAPMAgent(dda *datadoghqv1alpha1.DatadogAgent) []corev1.Vo
 	if apiutils.BoolValue(dda.Spec.Agent.Apm.UnixDomainSocket.Enabled) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      apicommon.APMSocketVolumeName,
-			MountPath: apicommon.APMSocketVolumePath,
+			MountPath: apicommon.APMSocketVolumeLocalPath,
 		})
 	}
 


### PR DESCRIPTION
### What does this PR do?

```
spec:
  features:
    admissionController:
      enabled: true
    apm:
      enabled: true
    dogstatsd:
      originDetectionEnabled: true
      unixDomainSocketConfig:
        enabled: true
        path: /var/run/datadog-agent/statsd.sock
```
yields:
```
Containers:
  agent:
[...]
      DD_DOGSTATSD_SOCKET:                       /var/run/datadog/statsd/statsd.sock
[...]
      /var/run/datadog/statsd from dsdsocket (rw)
[...]
  trace-agent:
[...]
      DD_APM_RECEIVER_SOCKET:                    /var/run/datadog/apm/apm.socket
      DD_DOGSTATSD_SOCKET:                       /var/run/datadog/statsd/statsd.sock

[...]
      /var/run/datadog/apm from apmsocket (rw)
      /var/run/datadog/statsd from dsdsocket (ro)
[...]
  dsdsocket:
    Type:          HostPath (bare host directory volume)
    Path:          /var/run/datadog-agent
    HostPathType:  DirectoryOrCreate
  apmsocket:
    Type:          HostPath (bare host directory volume)
    Path:          /var/run/datadog
    HostPathType:  DirectoryOrCreate
```
### Motivation

Fix the defaulting of the UDS sockets for DSD and APM. 
We keep the same defaults as with helm for the host paths and the same internal paths as with the v1alpha1

### Additional Notes
 
### Describe your test plan

Write there any instructions and details you may have to test your PR.
