### PR TITLE
Operator SDK only supports arm starting on 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ bin/$(PLATFORM)/golangci-lint: Makefile
 	hack/golangci-lint.sh -b "bin/$(PLATFORM)" v1.49.0
 
 bin/$(PLATFORM)/operator-sdk: Makefile
-	hack/install-operator-sdk.sh v1.13.1
+	hack/install-operator-sdk.sh v1.23.0
 
 bin/$(PLATFORM)/wwhrd: Makefile
 	hack/install-wwhrd.sh 0.2.4


### PR DESCRIPTION
### What does this PR do?

To release the bundle on an ARM machine, operator SDK needs to be updated, otherwise we get:
```
bin/Darwin-arm64/operator-sdk generate kustomize manifests -q
bin/Darwin-arm64/operator-sdk: line 1: Not: command not found
```
with this update:
```
[...]
INFO[0000] Creating bundle.Dockerfile
INFO[0000] Creating bundle/metadata/annotations.yaml
INFO[0000] Bundle metadata generated suceessfully
hack/patch-bundle.sh
bin/Darwin-arm64/operator-sdk bundle validate ./bundle
[...]
INFO[0000] All validation tests have completed successfully
```
### Motivation

Smoother release process.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
