### PR TITLE
Remove Get verb from Orchestrator Explorer RBAC

### DIFF
--- a/controllers/datadogagent/orchestrator.go
+++ b/controllers/datadogagent/orchestrator.go
@@ -224,7 +224,6 @@ func buildOrchestratorExplorerRBAC(dda *datadoghqv1alpha1.DatadogAgent, name, ve
 			Resources: []string{rbac.VPAResource},
 			Verbs: []string{
 				rbac.ListVerb,
-				rbac.GetVerb,
 				rbac.WatchVerb,
 			},
 		},

--- a/controllers/datadogagent/testdata/orchestrator_clusterrole.yaml
+++ b/controllers/datadogagent/testdata/orchestrator_clusterrole.yaml
@@ -90,5 +90,4 @@ rules:
       - verticalpodautoscalers
     verbs:
       - list
-      - get
       - watch


### PR DESCRIPTION
### What does this PR do?

Merging #685 broke v1 controller when orchestrator explorer is enabled, removing redundant verb.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
