### PR TITLE
Avoid PodSecurityPolicy cleanup if the resource is not supported by Kubernetes API

### DIFF
--- a/controllers/datadogagent/dependencies/store.go
+++ b/controllers/datadogagent/dependencies/store.go
@@ -264,7 +264,7 @@ func (ds *Store) Cleanup(ctx context.Context, k8sClient client.Client, ddaNs, dd
 	listOptions := &client.ListOptions{
 		LabelSelector: labels.NewSelector().Add(*requirementLabel),
 	}
-	for _, kind := range kubernetes.GetResourcesKind(ds.supportCilium) {
+	for _, kind := range ds.platformInfo.GetAgentResourcesKind(ds.supportCilium) {
 		objList := kubernetes.ObjectListFromKind(kind, ds.platformInfo)
 		if err := k8sClient.List(ctx, objList, listOptions); err != nil {
 			errs = append(errs, err)
@@ -294,7 +294,7 @@ func (ds *Store) DeleteAll(ctx context.Context, k8sClient client.Client) []error
 
 	var objsToDelete []client.Object
 
-	for _, kind := range kubernetes.GetResourcesKind(ds.supportCilium) {
+	for _, kind := range ds.platformInfo.GetAgentResourcesKind(ds.supportCilium) {
 		requirementLabel, _ := labels.NewRequirement(operatorStoreLabelKey, selection.Exists, nil)
 		listOptions := &client.ListOptions{
 			LabelSelector: labels.NewSelector().Add(*requirementLabel),

--- a/pkg/kubernetes/const.go
+++ b/pkg/kubernetes/const.go
@@ -57,7 +57,7 @@ const (
 )
 
 // GetResourcesKind return the list of all possible ObjectKind supported as DatadogAgent dependencies
-func GetResourcesKind(withCiliumResources bool) []ObjectKind {
+func getResourcesKind(withCiliumResources, withPodSecurityPolicy bool) []ObjectKind {
 	resources := []ObjectKind{
 		ConfigMapKind,
 		ClusterRolesKind,
@@ -71,12 +71,15 @@ func GetResourcesKind(withCiliumResources bool) []ObjectKind {
 		ServiceAccountsKind,
 		PodDisruptionBudgetsKind,
 		NetworkPoliciesKind,
-		PodSecurityPoliciesKind,
 		// SecurityContextConstraintsKind,
 	}
 
 	if withCiliumResources {
 		resources = append(resources, CiliumNetworkPoliciesKind)
+	}
+
+	if withPodSecurityPolicy {
+		resources = append(resources, PodSecurityPoliciesKind)
 	}
 
 	return resources

--- a/pkg/kubernetes/platforminfo.go
+++ b/pkg/kubernetes/platforminfo.go
@@ -96,7 +96,7 @@ func (platformInfo *PlatformInfo) supportsPSP() bool {
 	if platformInfo.apiOtherVersions == nil || platformInfo.apiPreferredVersions == nil {
 		return true
 	}
-	_, ok1 := platformInfo.apiOtherVersions["PodSecurityPolicy"]
-	_, ok2 := platformInfo.apiPreferredVersions["PodSecurityPolicy"]
-	return ok1 || ok2
+	_, otherExists := platformInfo.apiOtherVersions["PodSecurityPolicy"]
+	_, preferredExists := platformInfo.apiPreferredVersions["PodSecurityPolicy"]
+	return otherExists || preferredExists
 }

--- a/pkg/kubernetes/platforminfo.go
+++ b/pkg/kubernetes/platforminfo.go
@@ -87,3 +87,16 @@ func (platformInfo *PlatformInfo) CreatePDBObjectList() client.ObjectList {
 		return &policyv1.PodDisruptionBudgetList{}
 	}
 }
+
+func (platformInfo *PlatformInfo) GetAgentResourcesKind(withCiliumResources bool) []ObjectKind {
+	return getResourcesKind(withCiliumResources, platformInfo.supportsPSP())
+}
+
+func (platformInfo *PlatformInfo) supportsPSP() bool {
+	if platformInfo.apiOtherVersions == nil || platformInfo.apiPreferredVersions == nil {
+		return true
+	}
+	_, ok1 := platformInfo.apiOtherVersions["PodSecurityPolicy"]
+	_, ok2 := platformInfo.apiPreferredVersions["PodSecurityPolicy"]
+	return ok1 || ok2
+}

--- a/pkg/kubernetes/platforminfo_test.go
+++ b/pkg/kubernetes/platforminfo_test.go
@@ -94,16 +94,19 @@ func Test_getPDBFlag(t *testing.T) {
 		preferred     map[string]string
 		other         map[string]string
 		useV1Beta1PDB bool
+		supportsPSP   bool
 	}{
 		{
 			name: "Chooses preferred version of PodDisruptionBudget",
 			preferred: map[string]string{
 				"PodDisruptionBudget": "policy/v1",
+				"PodSecurityPolicy":   "anything",
 			},
 			other: map[string]string{
 				"PodDisruptionBudget": "policy/v1beta1",
 			},
 			useV1Beta1PDB: false,
+			supportsPSP:   false,
 		},
 		{
 			name: "Chooses preferred version of PodDisruptionBudget",
@@ -112,8 +115,10 @@ func Test_getPDBFlag(t *testing.T) {
 			},
 			other: map[string]string{
 				"PodDisruptionBudget": "policy/v1",
+				"PodSecurityPolicy":   "anything",
 			},
 			useV1Beta1PDB: true,
+			supportsPSP:   true,
 		},
 		{
 			name: "Unrecognized preferred version, defaults to v1",
@@ -122,6 +127,7 @@ func Test_getPDBFlag(t *testing.T) {
 			},
 			other:         map[string]string{},
 			useV1Beta1PDB: false,
+			supportsPSP:   false,
 		},
 	}
 
@@ -129,6 +135,8 @@ func Test_getPDBFlag(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			platformInfo := NewPlatformInfoFromVersionMaps(nil, tt.preferred, tt.other)
 			assert.Equal(t, tt.useV1Beta1PDB, platformInfo.UseV1Beta1PDB())
+			assert.Equal(t, tt.supportsPSP, platformInfo.supportsPSP())
+			assert.Equal(t, tt.supportsPSP, containsObjectKind(platformInfo.GetAgentResourcesKind(false), "PodDisruptionBudget"))
 		})
 	}
 }
@@ -167,4 +175,13 @@ func newApiGroupPointer(apiGroup v1.APIGroup) *v1.APIGroup {
 
 func newApiResourceListPointer(apiResourceList v1.APIResourceList) *v1.APIResourceList {
 	return &apiResourceList
+}
+
+func containsObjectKind(list []ObjectKind, s ObjectKind) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kubernetes/platforminfo_test.go
+++ b/pkg/kubernetes/platforminfo_test.go
@@ -106,7 +106,7 @@ func Test_getPDBFlag(t *testing.T) {
 				"PodDisruptionBudget": "policy/v1beta1",
 			},
 			useV1Beta1PDB: false,
-			supportsPSP:   false,
+			supportsPSP:   true,
 		},
 		{
 			name: "Chooses preferred version of PodDisruptionBudget",
@@ -136,7 +136,7 @@ func Test_getPDBFlag(t *testing.T) {
 			platformInfo := NewPlatformInfoFromVersionMaps(nil, tt.preferred, tt.other)
 			assert.Equal(t, tt.useV1Beta1PDB, platformInfo.UseV1Beta1PDB())
 			assert.Equal(t, tt.supportsPSP, platformInfo.supportsPSP())
-			assert.Equal(t, tt.supportsPSP, containsObjectKind(platformInfo.GetAgentResourcesKind(false), "PodDisruptionBudget"))
+			assert.Equal(t, tt.supportsPSP, containsObjectKind(platformInfo.GetAgentResourcesKind(false), PodSecurityPoliciesKind))
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?
This change addresses the Kubernetes 1.25 compatibility issue caused by Operator attempting to handle `PodDisruptionPolicy` resource not available in aforementioned version. 

Operator 1.0.0 deployed on v1.25 would log following error on every reconcile
```
{"level":"ERROR","ts":"2023-01-17T21:19:23Z","logger":"controller.datadogagent","msg":"Reconciler error","reconciler group":"datadoghq.com","reconciler kind":"DatadogAgent","name":"datadog","namespace":"system","error":"no matches for kind \"PodSecurityPolicy\" in version \"policy/v1beta1\"","errorCauses":[{"error":"no matches for kind \"PodSecurityPolicy\" in version \"policy/v1beta1\""}]}
```

### Motivation

Make Operator 1.0.0 run on v1.25.

### Additional Notes

This change ***does not*** solve PSP usage across Operator. 

PSP resource isn't utilized/implemented (see [this](https://github.com/DataDog/datadog-operator/blob/main/controllers/datadogagent/merger/pod_security.go#L121-L134)) and only places attempting to handle PSP were resource cleanup routines. This PR changes the logic producing list of Kinds for the cleanup - it includes PSP only if it's supported by current Kubernetes version.

Once PSP resource implementation is done additional work will be need to control PSP creation. 

### Describe your test plan

Tested Kubernetes version 1.24, 1.25 using Kind cluster. Deployed agent locally, installed DDA v2 with DCA, CCR enabled - confirmed no errors are thrown.