### PR TITLE
Add vpa config to ksm core

### DIFF
--- a/controllers/datadogagent/dependencies/store.go
+++ b/controllers/datadogagent/dependencies/store.go
@@ -40,6 +40,7 @@ type StoreClient interface {
 	Get(kind kubernetes.ObjectKind, namespace, name string) (client.Object, bool)
 	GetOrCreate(kind kubernetes.ObjectKind, namespace, name string) (client.Object, bool)
 	GetVersionInfo() *version.Info
+	GetPlatformInfo() kubernetes.PlatformInfo
 	Delete(kind kubernetes.ObjectKind, namespace string, name string) bool
 	DeleteAll(ctx context.Context, k8sClient client.Client) []error
 }
@@ -285,6 +286,11 @@ func (ds *Store) Cleanup(ctx context.Context, k8sClient client.Client, ddaNs, dd
 // GetVersionInfo returns the Kubernetes version
 func (ds *Store) GetVersionInfo() *version.Info {
 	return ds.versionInfo
+}
+
+// GetPlatformInfo returns api-resources info
+func (ds *Store) GetPlatformInfo() kubernetes.PlatformInfo {
+	return ds.platformInfo
 }
 
 // DeleteAll deletes all the resources that are in the Store

--- a/controllers/datadogagent/feature/kubernetesstatecore/configmap_test.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/configmap_test.go
@@ -34,6 +34,7 @@ instances:
 		owner                    metav1.Object
 		customConfig             *apicommonv1.CustomConfig
 		configConfigMapName      string
+		vpaSupported             bool
 	}
 	tests := []struct {
 		name    string
@@ -49,7 +50,7 @@ instances:
 				runInClusterChecksRunner: true,
 				configConfigMapName:      apicommon.DefaultKubeStateMetricsCoreConf,
 			},
-			want: buildDefaultConfigMap(owner.GetNamespace(), apicommon.DefaultKubeStateMetricsCoreConf, ksmCheckConfig(true)),
+			want: buildDefaultConfigMap(owner.GetNamespace(), apicommon.DefaultKubeStateMetricsCoreConf, ksmCheckConfig(true, false)),
 		},
 		{
 			name: "override",
@@ -72,7 +73,18 @@ instances:
 				runInClusterChecksRunner: false,
 				configConfigMapName:      apicommon.DefaultKubeStateMetricsCoreConf,
 			},
-			want: buildDefaultConfigMap(owner.GetNamespace(), apicommon.DefaultKubeStateMetricsCoreConf, ksmCheckConfig(false)),
+			want: buildDefaultConfigMap(owner.GetNamespace(), apicommon.DefaultKubeStateMetricsCoreConf, ksmCheckConfig(false, false)),
+		},
+		{
+			name: "vpa supported",
+			fields: fields{
+				owner:                    owner,
+				enable:                   true,
+				runInClusterChecksRunner: true,
+				configConfigMapName:      apicommon.DefaultKubeStateMetricsCoreConf,
+				vpaSupported:             true,
+			},
+			want: buildDefaultConfigMap(owner.GetNamespace(), apicommon.DefaultKubeStateMetricsCoreConf, ksmCheckConfig(true, true)),
 		},
 	}
 	for _, tt := range tests {
@@ -85,7 +97,7 @@ instances:
 				customConfig:             tt.fields.customConfig,
 				configConfigMapName:      tt.fields.configConfigMapName,
 			}
-			got, err := f.buildKSMCoreConfigMap()
+			got, err := f.buildKSMCoreConfigMap(tt.fields.vpaSupported)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ksmFeature.buildKSMCoreConfigMap() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -125,7 +125,8 @@ func (f *ksmFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) feature.RequiredCom
 func (f *ksmFeature) ManageDependencies(managers feature.ResourceManagers, components feature.RequiredComponents) error {
 	// Create a configMap if CustomConfig.ConfigData is provided and CustomConfig.ConfigMap == nil,
 	// OR if the default configMap is needed.
-	configCM, err := f.buildKSMCoreConfigMap()
+	pInfo := managers.Store().GetPlatformInfo()
+	configCM, err := f.buildKSMCoreConfigMap(pInfo.IsResourceSupported("VerticalPodAutoscaler"))
 	if err != nil {
 		return err
 	}

--- a/pkg/kubernetes/platforminfo.go
+++ b/pkg/kubernetes/platforminfo.go
@@ -100,3 +100,17 @@ func (platformInfo *PlatformInfo) supportsPSP() bool {
 	_, preferredExists := platformInfo.apiPreferredVersions["PodSecurityPolicy"]
 	return otherExists || preferredExists
 }
+
+// IsResourceSupported returns true if a Kubernetes resource is supported by the server
+func (platformInfo *PlatformInfo) IsResourceSupported(resource string) bool {
+	if platformInfo == nil {
+		return false
+	}
+	if _, ok := platformInfo.apiPreferredVersions[resource]; ok {
+		return true
+	}
+	if _, ok := platformInfo.apiOtherVersions[resource]; ok {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
### What does this PR do?

Adds vpa collector to ksm core if vpas are a supported resource:

```
$ kubectl exec -it datadog-cluster-agent-xxxxxxxxxx-xxxxx -- cat /etc/datadog-agent/conf.d/kubernetes_state_core.d/kubernetes_state_core.yaml.default
---
cluster_check: false
init_config:
instances:
  - telemetry: true
    skip_leader_election: false
    collectors:
    - pods
...
    - ingresses
    - verticalpodautoscalers
```
![Image 2023-01-19 at 3 14 00 PM](https://user-images.githubusercontent.com/39867936/213549938-24d35793-3d68-45c1-87e0-bb6cafdb9350.jpg)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
