### PR TITLE
Add DatadogAgent CR version tags to reconcile metrics

### DIFF
--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -3068,7 +3068,7 @@ func createClusterAgentDependencies(c client.Client, dda *datadoghqv1alpha1.Data
 // the metricForwardersManager logic is tested in the util/datadog package
 type dummyManager struct{}
 
-func (dummyManager) Register(datadog.MonitoredObject) {
+func (dummyManager) Register(client.Object) {
 }
 
 func (dummyManager) Unregister(datadog.MonitoredObject) {

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -216,7 +216,6 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// On `DatadogAgent` object creation, we register a metrics forwarder for it.
 			CreateFunc: func(e event.CreateEvent) bool {
 				metricForwarder.Register(e.Object)
-
 				return true
 			},
 		}))

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -211,7 +211,7 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	var metricForwarder datadog.MetricForwardersManager
 	var builderOptions []ctrlbuilder.ForOption
 	if r.Options.OperatorMetricsEnabled {
-		metricForwarder = datadog.NewForwardersManager(r.Client, r.Options.V2Enabled)
+		metricForwarder = datadog.NewForwardersManager(r.Client, r.Options.V2Enabled, &r.PlatformInfo)
 		builderOptions = append(builderOptions, ctrlbuilder.WithPredicates(predicate.Funcs{
 			// On `DatadogAgent` object creation, we register a metrics forwarder for it.
 			CreateFunc: func(e event.CreateEvent) bool {

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -525,16 +525,17 @@ func (mf *metricsForwarder) tagsWithExtraTag(tagFormat, tag string) []string {
 func (mf *metricsForwarder) getCRVersionTags() []string {
 	ddaPreferredVersion, ddaOtherVersion := mf.platformInfo.GetApiVersions(mf.monitoredObjectKind)
 
+	versionTags := []string{}
+
 	if ddaPreferredVersion == "" {
+		// This should never happen, since forwarder is created for an object created by Kubernetes, implying support for that API.
 		ddaPreferredVersion = "null"
 	}
-	if ddaOtherVersion == "" {
-		ddaOtherVersion = "null"
+	versionTags = append(versionTags, fmt.Sprintf(crPreferredVersionTagFormat, ddaPreferredVersion))
+	if ddaOtherVersion != "" {
+		versionTags = append(versionTags, fmt.Sprintf(crOtherVersionTagFormat, ddaOtherVersion))
 	}
-	return []string{
-		fmt.Sprintf(crPreferredVersionTagFormat, ddaPreferredVersion),
-		fmt.Sprintf(crOtherVersionTagFormat, ddaOtherVersion),
-	}
+	return versionTags
 }
 
 // sendDeploymentMetric is a generic method used to forward component deployment metrics to Datadog

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -68,9 +68,10 @@ func TestMetricsForwarder_sendStatusMetrics(t *testing.T) {
 		Name:      "bar",
 	}
 	mf := &metricsForwarder{
-		namespacedName: nsn,
-		delegator:      fmf,
-		platformInfo:   createPlatformInfo(),
+		namespacedName:      nsn,
+		delegator:           fmf,
+		monitoredObjectKind: "DatadogAgent",
+		platformInfo:        createPlatformInfo(),
 	}
 	mf.initGlobalTags()
 
@@ -1030,8 +1031,9 @@ func Test_metricsForwarder_processReconcileError(t *testing.T) {
 		Name:      "bar",
 	}
 	mf := &metricsForwarder{
-		namespacedName: nsn,
-		platformInfo:   &platformInfo,
+		namespacedName:      nsn,
+		monitoredObjectKind: "DatadogAgent",
+		platformInfo:        &platformInfo,
 	}
 	mf.initGlobalTags()
 
@@ -1175,9 +1177,10 @@ func Test_metricsForwarder_prepareReconcileMetric(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mf := &metricsForwarder{
-				globalTags:   defaultGlobalTags,
-				tags:         defaultTags,
-				platformInfo: createPlatformInfo(),
+				globalTags:          defaultGlobalTags,
+				tags:                defaultTags,
+				monitoredObjectKind: "DatadogAgent",
+				platformInfo:        createPlatformInfo(),
 			}
 			got, got1, err := mf.prepareReconcileMetric(tt.reconcileErr)
 			if (err != nil) != tt.wantErr {

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -1020,9 +1020,7 @@ func TestMetricsForwarder_setTags(t *testing.T) {
 func Test_metricsForwarder_processReconcileError(t *testing.T) {
 	platformInfo := kubernetes.NewPlatformInfoFromVersionMaps(
 		nil,
-		map[string]string{
-			"DatadogAgent": "v1",
-		},
+		map[string]string{},
 		map[string]string{},
 	)
 
@@ -1048,7 +1046,7 @@ func Test_metricsForwarder_processReconcileError(t *testing.T) {
 			name: "last error init value, new unknown error => send unsucess metric",
 			loadFunc: func() (*metricsForwarder, *fakeMetricsForwarder) {
 				f := &fakeMetricsForwarder{}
-				f.On("delegatedSendReconcileMetric", 0.0, []string{"cr_namespace:foo", "cr_name:bar", "reconcile_err:err_msg", "cr_preferred_version:v1", "cr_other_version:null"}).Once()
+				f.On("delegatedSendReconcileMetric", 0.0, []string{"cr_namespace:foo", "cr_name:bar", "reconcile_err:err_msg", "cr_preferred_version:null"}).Once()
 				mf.delegator = f
 				mf.lastReconcileErr = errInitValue
 				return mf, f
@@ -1064,7 +1062,7 @@ func Test_metricsForwarder_processReconcileError(t *testing.T) {
 			name: "last error init value, new auth error => send unsucess metric",
 			loadFunc: func() (*metricsForwarder, *fakeMetricsForwarder) {
 				f := &fakeMetricsForwarder{}
-				f.On("delegatedSendReconcileMetric", 0.0, []string{"cr_namespace:foo", "cr_name:bar", "reconcile_err:Unauthorized", "cr_preferred_version:v1", "cr_other_version:null"}).Once()
+				f.On("delegatedSendReconcileMetric", 0.0, []string{"cr_namespace:foo", "cr_name:bar", "reconcile_err:Unauthorized", "cr_preferred_version:null"}).Once()
 				mf.delegator = f
 				mf.lastReconcileErr = errInitValue
 				return mf, f
@@ -1080,7 +1078,7 @@ func Test_metricsForwarder_processReconcileError(t *testing.T) {
 			name: "last error init value, new error is nil => send success metric",
 			loadFunc: func() (*metricsForwarder, *fakeMetricsForwarder) {
 				f := &fakeMetricsForwarder{}
-				f.On("delegatedSendReconcileMetric", 1.0, []string{"cr_namespace:foo", "cr_name:bar", "reconcile_err:null", "cr_preferred_version:v1", "cr_other_version:null"}).Once()
+				f.On("delegatedSendReconcileMetric", 1.0, []string{"cr_namespace:foo", "cr_name:bar", "reconcile_err:null", "cr_preferred_version:null"}).Once()
 				mf.delegator = f
 				mf.lastReconcileErr = errInitValue
 				return mf, f

--- a/pkg/kubernetes/platforminfo.go
+++ b/pkg/kubernetes/platforminfo.go
@@ -115,8 +115,8 @@ func (platformInfo *PlatformInfo) IsResourceSupported(resource string) bool {
 	return false
 }
 
-func (platformInfo *PlatformInfo) GetDatadogAgentVersions() (preferred string, other string) {
-	preferred = platformInfo.apiPreferredVersions["DatadogAgent"]
-	other = platformInfo.apiOtherVersions["DatadogAgent"]
+func (platformInfo *PlatformInfo) GetApiVersions(name string) (preferred string, other string) {
+	preferred = platformInfo.apiPreferredVersions[name]
+	other = platformInfo.apiOtherVersions[name]
 	return preferred, other
 }

--- a/pkg/kubernetes/platforminfo.go
+++ b/pkg/kubernetes/platforminfo.go
@@ -114,3 +114,9 @@ func (platformInfo *PlatformInfo) IsResourceSupported(resource string) bool {
 	}
 	return false
 }
+
+func (platformInfo *PlatformInfo) GetDatadogAgentVersions() (preferred string, other string) {
+	preferred = platformInfo.apiPreferredVersions["DatadogAgent"]
+	other = platformInfo.apiOtherVersions["DatadogAgent"]
+	return preferred, other
+}

--- a/pkg/kubernetes/platforminfo_test.go
+++ b/pkg/kubernetes/platforminfo_test.go
@@ -141,6 +141,91 @@ func Test_getPDBFlag(t *testing.T) {
 	}
 }
 
+func Test_getDatadogAgentVersions(t *testing.T) {
+	tests := []struct {
+		name            string
+		apiGroups       []*v1.APIGroup
+		apiResourceList []*v1.APIResourceList
+		preferred       string
+		other           string
+	}{
+		{
+			name: "v2 preferred, v1 other",
+			apiGroups: []*v1.APIGroup{
+				newApiGroupPointer(
+					v1.APIGroup{
+						Name: "datadoghq",
+						Versions: []v1.GroupVersionForDiscovery{
+							{
+								GroupVersion: "datadoghq/v1alpha1",
+							},
+							{
+								GroupVersion: "datadoghq/v2alpha1",
+							},
+						},
+						PreferredVersion: v1.GroupVersionForDiscovery{
+							GroupVersion: "datadoghq/v2alpha1",
+						},
+					},
+				),
+			},
+			apiResourceList: createDatadogAgentResourceList(),
+			preferred:       "datadoghq/v2alpha1",
+			other:           "datadoghq/v1alpha1",
+		},
+		{
+			name: "v2 only, v2 preferred, other empty",
+			apiGroups: []*v1.APIGroup{
+				newApiGroupPointer(
+					v1.APIGroup{
+						Name: "datadoghq",
+						Versions: []v1.GroupVersionForDiscovery{
+							{
+								GroupVersion: "datadoghq/v2alpha1",
+							},
+						},
+						PreferredVersion: v1.GroupVersionForDiscovery{
+							GroupVersion: "datadoghq/v2alpha1",
+						},
+					},
+				),
+			},
+			apiResourceList: []*v1.APIResourceList{
+				newApiResourceListPointer(
+					v1.APIResourceList{
+						GroupVersion: "datadoghq/v2alpha1",
+						APIResources: []v1.APIResource{
+							{
+								Kind: "DatadogAgent",
+							},
+						},
+					},
+				)},
+			preferred: "datadoghq/v2alpha1",
+			other:     "",
+		},
+		{
+			name: "No API groups and resources, versions empty",
+			apiGroups: []*v1.APIGroup{
+				newApiGroupPointer(
+					v1.APIGroup{},
+				),
+			},
+			apiResourceList: []*v1.APIResourceList{},
+			preferred:       "",
+			other:           "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			platformInfo := NewPlatformInfo(nil, tt.apiGroups, tt.apiResourceList)
+			preffered, other := platformInfo.GetDatadogAgentVersions()
+			assert.Equal(t, tt.preferred, preffered)
+			assert.Equal(t, tt.other, other)
+		})
+	}
+}
+
 func createDefaultApiResourceList() []*v1.APIResourceList {
 	return []*v1.APIResourceList{
 		newApiResourceListPointer(
@@ -162,6 +247,41 @@ func createDefaultApiResourceList() []*v1.APIResourceList {
 					},
 					{
 						Kind: "PodSecurityPolicy",
+					},
+				},
+			},
+		),
+		newApiResourceListPointer(
+			v1.APIResourceList{
+				GroupVersion: "datadoghq/v1alpha1",
+				APIResources: []v1.APIResource{
+					{
+						Kind: "DatadogAgent",
+					},
+				},
+			},
+		),
+	}
+}
+
+func createDatadogAgentResourceList() []*v1.APIResourceList {
+	return []*v1.APIResourceList{
+		newApiResourceListPointer(
+			v1.APIResourceList{
+				GroupVersion: "datadoghq/v1alpha1",
+				APIResources: []v1.APIResource{
+					{
+						Kind: "DatadogAgent",
+					},
+				},
+			},
+		),
+		newApiResourceListPointer(
+			v1.APIResourceList{
+				GroupVersion: "datadoghq/v2alpha1",
+				APIResources: []v1.APIResource{
+					{
+						Kind: "DatadogAgent",
 					},
 				},
 			},

--- a/pkg/kubernetes/platforminfo_test.go
+++ b/pkg/kubernetes/platforminfo_test.go
@@ -219,7 +219,7 @@ func Test_getDatadogAgentVersions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			platformInfo := NewPlatformInfo(nil, tt.apiGroups, tt.apiResourceList)
-			preffered, other := platformInfo.GetDatadogAgentVersions()
+			preffered, other := platformInfo.GetApiVersions("DatadogAgent")
 			assert.Equal(t, tt.preferred, preffered)
 			assert.Equal(t, tt.other, other)
 		})


### PR DESCRIPTION
### What does this PR do?

Adds `DatadogAgent` custom resource version tags to reconcile metrics (in the `metrics_forwarder.go`. As a result `datadog.operator.reconcile.success` (among others) will have two new tags eg. `cr_other_version:datadoghq.com/v1alpha1` and `cr_preferred_version:datadoghq.com/v2alpha1` for v1.0 with `v2alpha1`.  If there is no 'other' (single version stored and served) version it will have a value `null`.

### Motivation

Visibility in the `v2alpha1` adoption.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Tested using locally running cluster, confirmed tags appear in the app.