### PR TITLE
Fixing name of custom conf file mounted in DCA during migration

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_conversion_dca.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_conversion_dca.go
@@ -94,7 +94,7 @@ func convertClusterAgentSpec(src *DatadogAgentSpecClusterAgentSpec, dst *v2alpha
 			tmpl.CustomConfigurations = make(map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig)
 		}
 
-		tmpl.CustomConfigurations[v2alpha1.AgentGeneralConfigFile] = *convertConfigMapConfig(src.CustomConfig)
+		tmpl.CustomConfigurations[v2alpha1.ClusterAgentConfigFile] = *convertConfigMapConfig(src.CustomConfig)
 	}
 
 	if src.Rbac != nil {

--- a/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
@@ -99,6 +99,13 @@ spec:
             path: test.d/test.yaml
           name: cluster-agent-confd
       replicas: 2
+      customConfigurations:
+        datadog-cluster.yaml:
+          configMap:
+            name: custom-cm-dca
+            items:
+              - key: my-dca-config.yaml
+                path: my-dca-config.yaml
       securityContext:
         runAsUser: 0
         seLinuxOptions:

--- a/apis/datadoghq/v1alpha1/testdata/all.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.yaml
@@ -167,6 +167,10 @@ spec:
         enabled: false
   clusterAgent:
     replicas: 2
+    customConfig:
+      configMap:
+        name: custom-cm-dca
+        fileKey: my-dca-config.yaml
     config:
       securityContext:
         runAsUser: 0

--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -749,7 +749,7 @@ const (
 	// SecurityAgentConfigFile is the name of the Security Agent config file
 	SecurityAgentConfigFile AgentConfigFileName = "security-agent.yaml"
 	// ClusterAgentConfigFile is the name of the Cluster Agent config file
-	ClusterAgentConfigFile AgentConfigFileName = "cluster-agent.yaml"
+	ClusterAgentConfigFile AgentConfigFileName = "datadog-cluster.yaml"
 )
 
 // DatadogAgentComponentOverride is the generic description equivalent to a subset of the PodTemplate for a component.


### PR DESCRIPTION
### What does this PR do?

Upon converting v1alpha1 with a customConfig for the cluster agent, the file should be `datadog-cluster.yaml` so that it's properly processed by the binary.

currently we have:
```
      volumes:
      - configMap:
          defaultMode: 420
          items:
          - key: datadog-cluster.yaml
            path: datadog-cluster.yaml
          name: datadog-cluster-agent-custom-cm
        name: volume-custom-cluster-agent
...
        volumeMounts:
        - mountPath: /etc/datadog-agent/datadog.yaml
          name: volume-custom-cluster-agent
          readOnly: true
          subPath: datadog.yaml
```
with the wrong subPath.
leading to the /etc/datadog-agent/datadog.yaml being a directory since it's empty.
```
root@datadog-cluster-agent-56885cc567-bhmgm:/# cat /etc/datadog-agent/datadog.yaml
cat: /etc/datadog-agent/datadog.yaml/: Is a directory
```

### Motivation

Fix edge case of migration.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
