### PR TITLE
daniel.calderon - Jira-contecto-12 - including <app.kubernetes.io/component> label

### DIFF
--- a/controllers/datadogagent/component/new.go
+++ b/controllers/datadogagent/component/new.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 // NewDeployment use to generate the skeleton of a new deployment based on few information
@@ -111,8 +113,10 @@ func getDefaultMetadata(owner metav1.Object, componentKind, componentName, versi
 
 func getDefaultLabels(owner metav1.Object, componentKind, componentName, version string) map[string]string {
 	labels := object.GetDefaultLabels(owner, componentName, version)
+	labels[kubernetes.AppKubernetesComponentLabelKey] = componentName
 	labels[apicommon.AgentDeploymentNameLabelKey] = owner.GetName()
 	labels[apicommon.AgentDeploymentComponentLabelKey] = componentKind
+
 
 	return labels
 }


### PR DESCRIPTION
### What does this PR do?

This PR includes the label <app.kubernetes.io/component> in the resources created by datadog-operator 

### Motivation

Jira card https://datadoghq.atlassian.net/browse/CONTECO-12 

### Additional Notes

Path to file modified datadog-operator/controllers/datadogagent/component/new.go

### Describe your test plan

Verify if the label <app.kubernetes.io/component> it's included in the new resource created by datadog-operator 
