### PR TITLE
Add md5 hash annotation for custom configs

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -19,6 +19,10 @@ const (
 	AgentDeploymentComponentLabelKey = "agent.datadoghq.com/component"
 	// MD5AgentDeploymentAnnotationKey annotation key used on a Resource in order to identify which AgentDeployment have been used to generate it.
 	MD5AgentDeploymentAnnotationKey = "agent.datadoghq.com/agentspechash"
+	// MD5ChecksumAnnotationKey annotation key is used to identify customConfig configurations
+	MD5ChecksumAnnotationKey = "checksum/%s-custom-config"
+	// MD5ChecksumAnnotationKey is part of the key name to identify custom seccomp configurations
+	MD5ChecksumSeccompProfileAnnotationName = "%s-seccomp"
 
 	// DefaultAgentResourceSuffix use as suffix for agent resource naming
 	DefaultAgentResourceSuffix = "agent"

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -572,7 +572,7 @@ func Test_newClusterAgentDeploymentMountKSMCore(t *testing.T) {
 							"app.kubernetes.io/part-of":     "bar-foo",
 							"app.kubernetes.io/version":     "",
 						},
-						Annotations: map[string]string{},
+						Annotations: map[string]string{"checksum/ksm-custom-config": "49055d1787a4f1c281d0a4dfb3ff6ff4"},
 					},
 					Spec: clusterAgentPodSpec,
 				},

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -60,7 +60,7 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 			if apiutils.BoolValue(componentOverride.Disabled) {
 				disabled = true
 			}
-			override.PodTemplateSpec(podManagers, componentOverride, datadoghqv2alpha1.NodeAgentComponentName, dda.Name)
+			override.PodTemplateSpec(logger, podManagers, componentOverride, datadoghqv2alpha1.NodeAgentComponentName, dda.Name)
 			override.ExtendedDaemonSet(eds, componentOverride)
 		}
 		if disabled {
@@ -100,7 +100,7 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 		if apiutils.BoolValue(componentOverride.Disabled) {
 			disabled = true
 		}
-		override.PodTemplateSpec(podManagers, componentOverride, datadoghqv2alpha1.NodeAgentComponentName, dda.Name)
+		override.PodTemplateSpec(logger, podManagers, componentOverride, datadoghqv2alpha1.NodeAgentComponentName, dda.Name)
 		override.DaemonSet(daemonset, componentOverride)
 	}
 	if disabled {

--- a/controllers/datadogagent/controller_reconcile_ccr.go
+++ b/controllers/datadogagent/controller_reconcile_ccr.go
@@ -74,7 +74,7 @@ func (r *Reconciler) reconcileV2ClusterChecksRunner(logger logr.Logger, required
 			// Delete CCR
 			return r.cleanupV2ClusterChecksRunner(deploymentLogger, dda, deployment, newStatus)
 		}
-		override.PodTemplateSpec(podManagers, componentOverride, datadoghqv2alpha1.ClusterChecksRunnerComponentName, dda.Name)
+		override.PodTemplateSpec(logger, podManagers, componentOverride, datadoghqv2alpha1.ClusterChecksRunnerComponentName, dda.Name)
 		override.Deployment(deployment, componentOverride)
 	} else if !requiredEnabled {
 		return r.cleanupV2ClusterChecksRunner(deploymentLogger, dda, deployment, newStatus)

--- a/controllers/datadogagent/controller_reconcile_dca.go
+++ b/controllers/datadogagent/controller_reconcile_dca.go
@@ -63,7 +63,7 @@ func (r *Reconciler) reconcileV2ClusterAgent(logger logr.Logger, requiredCompone
 			}
 			return r.cleanupV2ClusterAgent(deploymentLogger, dda, deployment, resourcesManager, newStatus)
 		}
-		override.PodTemplateSpec(podManagers, componentOverride, datadoghqv2alpha1.ClusterAgentComponentName, dda.Name)
+		override.PodTemplateSpec(logger, podManagers, componentOverride, datadoghqv2alpha1.ClusterAgentComponentName, dda.Name)
 		override.Deployment(deployment, componentOverride)
 	} else if !requiredEnabled {
 		// If the override is not defined, then disable based on requiredEnabled value

--- a/controllers/datadogagent/dependencies/store.go
+++ b/controllers/datadogagent/dependencies/store.go
@@ -43,6 +43,7 @@ type StoreClient interface {
 	GetPlatformInfo() kubernetes.PlatformInfo
 	Delete(kind kubernetes.ObjectKind, namespace string, name string) bool
 	DeleteAll(ctx context.Context, k8sClient client.Client) []error
+	Logger() logr.Logger
 }
 
 // NewStore returns a new Store instance
@@ -291,6 +292,11 @@ func (ds *Store) GetVersionInfo() *version.Info {
 // GetPlatformInfo returns api-resources info
 func (ds *Store) GetPlatformInfo() kubernetes.PlatformInfo {
 	return ds.platformInfo
+}
+
+// Logger returns the log client
+func (ds *Store) Logger() logr.Logger {
+	return ds.logger
 }
 
 // DeleteAll deletes all the resources that are in the Store

--- a/controllers/datadogagent/feature/cws/feature.go
+++ b/controllers/datadogagent/feature/cws/feature.go
@@ -15,8 +15,11 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/configmap"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/go-logr/logr"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -34,14 +37,22 @@ func init() {
 func buildCWSFeature(options *feature.Options) feature.Feature {
 	cwsFeat := &cwsFeature{}
 
+	if options != nil {
+		cwsFeat.logger = options.Logger
+	}
+
 	return cwsFeat
 }
 
 type cwsFeature struct {
 	syscallMonitorEnabled bool
-	customConfig          *apicommonv1.CustomConfig
-	configMapName         string
 	owner                 metav1.Object
+	logger                logr.Logger
+
+	customConfig                *apicommonv1.CustomConfig
+	configMapName               string
+	customConfigAnnotationKey   string
+	customConfigAnnotationValue string
 }
 
 // ID returns the ID of the Feature
@@ -60,6 +71,12 @@ func (f *cwsFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requ
 
 		if cws.CustomPolicies != nil {
 			f.customConfig = v2alpha1.ConvertCustomConfig(cws.CustomPolicies)
+			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
+			if err != nil {
+				f.logger.Error(err, "couldn't generate hash for cws custom policies config")
+			}
+			f.customConfigAnnotationValue = hash
+			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.CWSIDType)
 		}
 		f.configMapName = apicommonv1.GetConfName(dda, f.customConfig, apicommon.DefaultCWSConf)
 
@@ -89,6 +106,12 @@ func (f *cwsFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) (reqComp feature.Re
 		if runtime.PoliciesDir != nil && runtime.PoliciesDir.ConfigMapName != "" {
 			f.configMapName = runtime.PoliciesDir.ConfigMapName
 			f.customConfig = v1alpha1.ConvertConfigDirSpecToCustomConfig(runtime.PoliciesDir)
+			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
+			if err != nil {
+				f.logger.Error(err, "couldn't generate hash for cws custom policies config")
+			}
+			f.customConfigAnnotationValue = hash
+			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.CWSIDType)
 		}
 
 		reqComp = feature.RequiredComponents{
@@ -114,7 +137,14 @@ func (f *cwsFeature) ManageDependencies(managers feature.ResourceManagers, compo
 		if err != nil {
 			return err
 		}
+
 		if cm != nil {
+			// Add md5 hash annotation for custom config
+			if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
+				annotations := object.MergeAnnotationsLabels(f.logger, cm.GetAnnotations(), map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "")
+				cm.SetAnnotations(annotations)
+			}
+
 			if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {
 				return err
 			}
@@ -224,6 +254,11 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	if f.customConfig != nil {
 		var vol corev1.Volume
 		var volMount corev1.VolumeMount
+
+		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
+			managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
+		}
+
 		if f.customConfig.ConfigMap != nil {
 			// Custom config is referenced via ConfigMap
 			// Cannot use standard GetVolumesFromConfigMap because security features are not under /conf.d

--- a/controllers/datadogagent/feature/ids.go
+++ b/controllers/datadogagent/feature/ids.go
@@ -32,7 +32,7 @@ const (
 	// CSPMIDType CSPM feature.
 	CSPMIDType = "cspm"
 	// CWSIDType CWS feature.
-	CWSIDType = "csw"
+	CWSIDType = "cws"
 	// USMIDType USM feature.
 	USMIDType = "usm"
 	// OOMKillIDType OOM Kill check feature

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/go-logr/logr"
 
@@ -50,9 +52,11 @@ type ksmFeature struct {
 	rbacSuffix         string
 	serviceAccountName string
 
-	owner               metav1.Object
-	customConfig        *apicommonv1.CustomConfig
-	configConfigMapName string
+	owner                       metav1.Object
+	customConfig                *apicommonv1.CustomConfig
+	configConfigMapName         string
+	customConfigAnnotationKey   string
+	customConfigAnnotationValue string
 
 	logger logr.Logger
 }
@@ -72,6 +76,12 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 
 		if dda.Spec.Features.KubeStateMetricsCore.Conf != nil {
 			f.customConfig = v2alpha1.ConvertCustomConfig(dda.Spec.Features.KubeStateMetricsCore.Conf)
+			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
+			if err != nil {
+				f.logger.Error(err, "couldn't generate hash for ksm core custom config")
+			}
+			f.customConfigAnnotationValue = hash
+			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.KubernetesStateCoreIDType)
 		}
 
 		f.serviceAccountName = v2alpha1.GetClusterAgentServiceAccount(dda)
@@ -112,6 +122,12 @@ func (f *ksmFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) feature.RequiredCom
 
 		if dda.Spec.Features.KubeStateMetricsCore.Conf != nil {
 			f.customConfig = v1alpha1.ConvertCustomConfig(dda.Spec.Features.KubeStateMetricsCore.Conf)
+			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
+			if err != nil {
+				f.logger.Error(err, "couldn't generate hash for ksm core custom config")
+			}
+			f.customConfigAnnotationValue = hash
+			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.KubernetesStateCoreIDType)
 		}
 
 		f.configConfigMapName = apicommonv1.GetConfName(dda, f.customConfig, apicommon.DefaultKubeStateMetricsCoreConf)
@@ -131,6 +147,10 @@ func (f *ksmFeature) ManageDependencies(managers feature.ResourceManagers, compo
 		return err
 	}
 	if configCM != nil {
+		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
+			annotations := object.MergeAnnotationsLabels(f.logger, configCM.GetAnnotations(), map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "")
+			configCM.SetAnnotations(annotations)
+		}
 		if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, configCM); err != nil {
 			return err
 		}
@@ -164,6 +184,9 @@ func (f *ksmFeature) ManageClusterAgent(managers feature.PodTemplateManagers) er
 			MountPath: fmt.Sprintf("%s%s/%s", apicommon.ConfigVolumePath, apicommon.ConfdVolumePath, ksmCoreCheckFolderName),
 			ReadOnly:  true,
 		}
+	}
+	if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
+		managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
 	}
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommonv1.ClusterAgentContainerName)
 	managers.Volume().AddVolume(&vol)

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature_test.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature_test.go
@@ -6,6 +6,7 @@
 package kubernetesstatecore
 
 import (
+	"fmt"
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
@@ -17,58 +18,22 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
 	mergerfake "github.com/DataDog/datadog-operator/controllers/datadogagent/merger/fake"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	customData = `cluster_check: true
+init_config:
+instances:
+    collectors:
+    - pods`
+)
+
 func Test_ksmFeature_Configure(t *testing.T) {
-	ddav1KSMDisable := v1alpha1.DatadogAgent{
-		Spec: v1alpha1.DatadogAgentSpec{
-			Features: v1alpha1.DatadogFeatures{
-				KubeStateMetricsCore: &v1alpha1.KubeStateMetricsCore{
-					Enabled: apiutils.NewBoolPointer(false),
-				},
-			},
-		},
-	}
-
-	ddav1KSMEnable := ddav1KSMDisable.DeepCopy()
-	{
-		ddav1KSMEnable.Spec.Features.KubeStateMetricsCore.Enabled = apiutils.NewBoolPointer(true)
-	}
-
-	ddav2KSMDisable := v2alpha1.DatadogAgent{
-		Spec: v2alpha1.DatadogAgentSpec{
-			Features: &v2alpha1.DatadogFeatures{
-				KubeStateMetricsCore: &v2alpha1.KubeStateMetricsCoreFeatureConfig{
-					Enabled: apiutils.NewBoolPointer(false),
-				},
-			},
-		},
-	}
-	ddav2KSMEnable := ddav2KSMDisable.DeepCopy()
-	{
-		ddav2KSMEnable.Spec.Features.KubeStateMetricsCore.Enabled = apiutils.NewBoolPointer(true)
-	}
-
-	ksmClusterAgentWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
-		mgr := mgrInterface.(*fake.PodTemplateManagers)
-		dcaEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
-
-		want := []*corev1.EnvVar{
-			{
-				Name:  apicommon.DDKubeStateMetricsCoreEnabled,
-				Value: "true",
-			},
-			{
-				Name:  apicommon.DDKubeStateMetricsCoreConfigMap,
-				Value: "-kube-state-metrics-core-config",
-			},
-		}
-		assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, want), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, want))
-	}
-
 	ksmAgentNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
 		agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
@@ -87,33 +52,117 @@ func Test_ksmFeature_Configure(t *testing.T) {
 		// v1Alpha1.DatadogAgent
 		//////////////////////////
 		{
-			Name:          "v1alpha1 ksm-core not enable",
-			DDAv1:         ddav1KSMDisable.DeepCopy(),
+			Name:          "v1alpha1 ksm-core not enabled",
+			DDAv1:         newV1Agent(false, false),
 			WantConfigure: false,
 		},
 		{
-			Name:          "v1alpha1 ksm-core not enable",
-			DDAv1:         ddav1KSMEnable,
+			Name:          "v1alpha1 ksm-core enabled",
+			DDAv1:         newV1Agent(true, false),
 			WantConfigure: true,
-			ClusterAgent:  test.NewDefaultComponentTest().WithWantFunc(ksmClusterAgentWantFunc),
+			ClusterAgent:  ksmClusterAgentWantFunc(false),
+			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
+		},
+		{
+			Name:          "v1alpha1 ksm-core enabled, custom config",
+			DDAv1:         newV1Agent(true, true),
+			WantConfigure: true,
+			ClusterAgent:  ksmClusterAgentWantFunc(true),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
 		},
 		//////////////////////////
 		// v2Alpha1.DatadogAgent
 		//////////////////////////
 		{
-			Name:          "v2alpha1 ksm-core not enable",
-			DDAv2:         ddav2KSMDisable.DeepCopy(),
+			Name:          "v2alpha1 ksm-core not enabled",
+			DDAv2:         newV2Agent(false, false),
 			WantConfigure: false,
 		},
 		{
-			Name:          "v2alpha1 ksm-core not enable",
-			DDAv2:         ddav2KSMEnable,
+			Name:          "v2alpha1 ksm-core enabled",
+			DDAv2:         newV2Agent(true, false),
 			WantConfigure: true,
-			ClusterAgent:  test.NewDefaultComponentTest().WithWantFunc(ksmClusterAgentWantFunc),
+			ClusterAgent:  ksmClusterAgentWantFunc(false),
+			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
+		},
+		{
+			Name:          "v2alpha1 ksm-core enabled, custom config",
+			DDAv2:         newV2Agent(true, true),
+			WantConfigure: true,
+			ClusterAgent:  ksmClusterAgentWantFunc(true),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
 		},
 	}
 
 	tests.Run(t, buildKSMFeature)
+}
+
+func newV1Agent(enableKSM bool, hasCustomConfig bool) *v1alpha1.DatadogAgent {
+	ddaV1 := &v1alpha1.DatadogAgent{
+		Spec: v1alpha1.DatadogAgentSpec{
+			Features: v1alpha1.DatadogFeatures{
+				KubeStateMetricsCore: &v1alpha1.KubeStateMetricsCore{
+					Enabled: apiutils.NewBoolPointer(enableKSM),
+				},
+			},
+		},
+	}
+	if hasCustomConfig {
+		ddaV1.Spec.Features.KubeStateMetricsCore.Conf = &v1alpha1.CustomConfigSpec{
+			ConfigData: apiutils.NewStringPointer(customData),
+		}
+	}
+	return ddaV1
+}
+
+func newV2Agent(enableKSM bool, hasCustomConfig bool) *v2alpha1.DatadogAgent {
+	ddaV2 := &v2alpha1.DatadogAgent{
+		Spec: v2alpha1.DatadogAgentSpec{
+			Features: &v2alpha1.DatadogFeatures{
+				KubeStateMetricsCore: &v2alpha1.KubeStateMetricsCoreFeatureConfig{
+					Enabled: apiutils.NewBoolPointer(enableKSM),
+				},
+			},
+		},
+	}
+	if hasCustomConfig {
+		ddaV2.Spec.Features.KubeStateMetricsCore.Conf = &v2alpha1.CustomConfig{
+			ConfigData: apiutils.NewStringPointer(customData),
+		}
+	}
+	return ddaV2
+}
+
+func ksmClusterAgentWantFunc(hasCustomConfig bool) *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+			dcaEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
+
+			want := []*corev1.EnvVar{
+				{
+					Name:  apicommon.DDKubeStateMetricsCoreEnabled,
+					Value: "true",
+				},
+				{
+					Name:  apicommon.DDKubeStateMetricsCoreConfigMap,
+					Value: "-kube-state-metrics-core-config",
+				},
+			}
+			assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, want), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, want))
+
+			if hasCustomConfig {
+				customConfig := apicommonv1.CustomConfig{
+					ConfigData: apiutils.NewStringPointer(customData),
+				}
+				hash, err := comparison.GenerateMD5ForSpec(&customConfig)
+				assert.NoError(t, err)
+				wantAnnotations := map[string]string{
+					fmt.Sprintf(apicommon.MD5ChecksumAnnotationKey, feature.KubernetesStateCoreIDType): hash,
+				}
+				annotations := mgr.AnnotationMgr.Annotations
+				assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+			}
+		},
+	)
 }

--- a/controllers/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/feature.go
@@ -14,12 +14,15 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/go-logr/logr"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	common "github.com/DataDog/datadog-operator/controllers/datadogagent/common"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"
 )
 
@@ -35,6 +38,10 @@ func buildOrchestratorExplorerFeature(options *feature.Options) feature.Feature 
 		rbacSuffix: common.ClusterAgentSuffix,
 	}
 
+	if options != nil {
+		orchestratorExplorerFeat.logger = options.Logger
+	}
+
 	return orchestratorExplorerFeat
 }
 
@@ -48,6 +55,10 @@ type orchestratorExplorerFeature struct {
 	owner                    metav1.Object
 	customConfig             *apicommonv1.CustomConfig
 	configConfigMapName      string
+
+	logger                      logr.Logger
+	customConfigAnnotationKey   string
+	customConfigAnnotationValue string
 }
 
 // ID returns the ID of the Feature
@@ -69,6 +80,12 @@ func (f *orchestratorExplorerFeature) Configure(dda *v2alpha1.DatadogAgent) (req
 
 		if orchestratorExplorer.Conf != nil {
 			f.customConfig = v2alpha1.ConvertCustomConfig(orchestratorExplorer.Conf)
+			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
+			if err != nil {
+				f.logger.Error(err, "couldn't generate hash for orchestrator explorer custom config")
+			}
+			f.customConfigAnnotationValue = hash
+			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.OrchestratorExplorerIDType)
 		}
 		f.configConfigMapName = apicommonv1.GetConfName(dda, f.customConfig, apicommon.DefaultOrchestratorExplorerConf)
 		f.scrubContainers = apiutils.BoolValue(orchestratorExplorer.ScrubContainers)
@@ -105,6 +122,12 @@ func (f *orchestratorExplorerFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) (r
 
 		if orchestratorExplorer.Conf != nil {
 			f.customConfig = v1alpha1.ConvertCustomConfig(orchestratorExplorer.Conf)
+			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
+			if err != nil {
+				f.logger.Error(err, "couldn't generate hash for orchestrator explorer custom config")
+			}
+			f.customConfigAnnotationValue = hash
+			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.OrchestratorExplorerIDType)
 		}
 		f.configConfigMapName = apicommonv1.GetConfName(dda, f.customConfig, apicommon.DefaultOrchestratorExplorerConf)
 		if orchestratorExplorer.Scrubbing != nil {
@@ -140,6 +163,11 @@ func (f *orchestratorExplorerFeature) ManageDependencies(managers feature.Resour
 		return err
 	}
 	if configCM != nil {
+		// Add md5 hash annotation for custom config
+		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
+			annotations := object.MergeAnnotationsLabels(f.logger, configCM.GetAnnotations(), map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "")
+			configCM.SetAnnotations(annotations)
+		}
 		if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, configCM); err != nil {
 			return err
 		}
@@ -178,6 +206,10 @@ func (f *orchestratorExplorerFeature) ManageClusterAgent(managers feature.PodTem
 
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommonv1.ClusterAgentContainerName)
 	managers.Volume().AddVolume(&vol)
+
+	if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
+		managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
+	}
 
 	for _, env := range f.getEnvVars() {
 		managers.EnvVar().AddEnvVar(env)

--- a/controllers/datadogagent/feature/orchestratorexplorer/feature_test.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/feature_test.go
@@ -6,6 +6,7 @@
 package orchestratorexplorer
 
 import (
+	"fmt"
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
@@ -17,10 +18,18 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
 	mergerfake "github.com/DataDog/datadog-operator/controllers/datadogagent/merger/fake"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
+
+var customConfData = `cluster_check: false
+init_config:
+instances:
+  - skip_leader_election: false
+    collectors:
+      - clusterrolebindings`
 
 func Test_orchestratorExplorerFeature_Configure(t *testing.T) {
 	ddav1OrchestratorExplorerDisable := v1alpha1.DatadogAgent{
@@ -41,6 +50,9 @@ func Test_orchestratorExplorerFeature_Configure(t *testing.T) {
 		}
 		ddav1OrchestratorExplorerEnable.Spec.Features.OrchestratorExplorer.ExtraTags = []string{"a:z", "b:y", "c:x"}
 		ddav1OrchestratorExplorerEnable.Spec.Features.OrchestratorExplorer.DDUrl = apiutils.NewStringPointer("https://foo.bar")
+		ddav1OrchestratorExplorerEnable.Spec.Features.OrchestratorExplorer.Conf = &v1alpha1.CustomConfigSpec{
+			ConfigData: &customConfData,
+		}
 
 	}
 
@@ -71,6 +83,9 @@ func Test_orchestratorExplorerFeature_Configure(t *testing.T) {
 		ddav2OrchestratorExplorerEnable.Spec.Features.OrchestratorExplorer.ScrubContainers = apiutils.NewBoolPointer(true)
 		ddav2OrchestratorExplorerEnable.Spec.Features.OrchestratorExplorer.ExtraTags = []string{"a:z", "b:y", "c:x"}
 		ddav2OrchestratorExplorerEnable.Spec.Features.OrchestratorExplorer.DDUrl = apiutils.NewStringPointer("https://foo.bar")
+		ddav2OrchestratorExplorerEnable.Spec.Features.OrchestratorExplorer.Conf = &v2alpha1.CustomConfig{
+			ConfigData: &customConfData,
+		}
 	}
 
 	ddaV2EnabledAndRunInRunner := ddav2OrchestratorExplorerEnable.DeepCopy()
@@ -104,6 +119,17 @@ func Test_orchestratorExplorerFeature_Configure(t *testing.T) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
 		dcaEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
 		assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, expectedOrchestratorEnvs), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, expectedOrchestratorEnvs))
+
+		customConfig := apicommonv1.CustomConfig{
+			ConfigData: apiutils.NewStringPointer(customConfData),
+		}
+		hash, err := comparison.GenerateMD5ForSpec(&customConfig)
+		assert.NoError(t, err)
+		wantAnnotations := map[string]string{
+			fmt.Sprintf(apicommon.MD5ChecksumAnnotationKey, feature.OrchestratorExplorerIDType): hash,
+		}
+		annotations := mgr.AnnotationMgr.Annotations
+		assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
 	}
 
 	orchestratorExplorerNodeAgentWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {

--- a/controllers/datadogagent/object/labels.go
+++ b/controllers/datadogagent/object/labels.go
@@ -6,9 +6,12 @@
 package object
 
 import (
+	"fmt"
 	"strings"
 
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+
 	"github.com/go-logr/logr"
 	"github.com/gobwas/glob"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,4 +68,12 @@ func MergeAnnotationsLabels(logger logr.Logger, previousVal map[string]string, n
 	}
 
 	return mergedMap
+}
+
+func GetChecksumAnnotationKey(keyName string) string {
+	if keyName == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(apicommon.MD5ChecksumAnnotationKey, keyName)
 }

--- a/controllers/datadogagent/override/dependencies.go
+++ b/controllers/datadogagent/override/dependencies.go
@@ -17,7 +17,9 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/configmap"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -33,13 +35,13 @@ func Dependencies(logger logr.Logger, manager feature.ResourceManagers, dda *v2a
 		}
 
 		// Handle custom agent configurations (datadog.yaml, cluster-agent.yaml, etc.)
-		errs = append(errs, overrideCustomConfigs(manager, override.CustomConfigurations, dda.Name, namespace)...)
+		errs = append(errs, overrideCustomConfigs(logger, manager, override.CustomConfigurations, dda.Name, namespace)...)
 
 		// Handle custom check configurations
-		errs = append(errs, overrideExtraConfigs(manager, override.ExtraConfd, namespace, v2alpha1.ExtraConfdConfigMapName, true)...)
+		errs = append(errs, overrideExtraConfigs(logger, manager, override.ExtraConfd, namespace, v2alpha1.ExtraConfdConfigMapName, true)...)
 
 		// Handle custom check files
-		errs = append(errs, overrideExtraConfigs(manager, override.ExtraChecksd, namespace, v2alpha1.ExtraChecksdConfigMapName, false)...)
+		errs = append(errs, overrideExtraConfigs(logger, manager, override.ExtraChecksd, namespace, v2alpha1.ExtraChecksdConfigMapName, false)...)
 
 		// Handle scc
 		errs = append(errs, overrideSCC(manager, dda)...)
@@ -61,7 +63,7 @@ func overrideRBAC(logger logr.Logger, manager feature.ResourceManagers, override
 	return errors.NewAggregate(errs)
 }
 
-func overrideCustomConfigs(manager feature.ResourceManagers, customConfigMap map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig, ddaName, namespace string) (errs []error) {
+func overrideCustomConfigs(logger logr.Logger, manager feature.ResourceManagers, customConfigMap map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig, ddaName, namespace string) (errs []error) {
 	for fileName, customConfig := range customConfigMap {
 		// Favor ConfigMap setting; if it is specified, then move on
 		if customConfig.ConfigMap != nil {
@@ -72,6 +74,16 @@ func overrideCustomConfigs(manager feature.ResourceManagers, customConfigMap map
 			if err != nil {
 				errs = append(errs, err)
 			}
+
+			// Add md5 hash annotation for custom config
+			hash, err := comparison.GenerateMD5ForSpec(customConfig)
+			if err != nil {
+				logger.Error(err, "couldn't generate hash for custom config", "filename", fileName)
+			}
+			annotationKey := object.GetChecksumAnnotationKey(string(fileName))
+			annotations := object.MergeAnnotationsLabels(logger, cm.GetAnnotations(), map[string]string{annotationKey: hash}, "")
+			cm.SetAnnotations(annotations)
+
 			if cm != nil {
 				if err := manager.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {
 					errs = append(errs, err)
@@ -82,12 +94,22 @@ func overrideCustomConfigs(manager feature.ResourceManagers, customConfigMap map
 	return errs
 }
 
-func overrideExtraConfigs(manager feature.ResourceManagers, multiCustomConfig *v2alpha1.MultiCustomConfig, namespace, configMapName string, isYaml bool) (errs []error) {
+func overrideExtraConfigs(logger logr.Logger, manager feature.ResourceManagers, multiCustomConfig *v2alpha1.MultiCustomConfig, namespace, configMapName string, isYaml bool) (errs []error) {
 	if multiCustomConfig != nil && multiCustomConfig.ConfigMap == nil && len(multiCustomConfig.ConfigDataMap) > 0 {
 		cm, err := configmap.BuildConfigMapMulti(namespace, multiCustomConfig.ConfigDataMap, configMapName, isYaml)
 		if err != nil {
 			errs = append(errs, err)
 		}
+
+		// Add md5 hash annotation for custom config
+		hash, err := comparison.GenerateMD5ForSpec(multiCustomConfig)
+		if err != nil {
+			logger.Error(err, "couldn't generate hash for extra custom config")
+		}
+		annotationKey := object.GetChecksumAnnotationKey(configMapName)
+		annotations := object.MergeAnnotationsLabels(logger, cm.GetAnnotations(), map[string]string{annotationKey: hash}, "")
+		cm.SetAnnotations(annotations)
+
 		if cm != nil {
 			if err := manager.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {
 				errs = append(errs, err)

--- a/controllers/datadogagent/override/podtemplatespec_test.go
+++ b/controllers/datadogagent/override/podtemplatespec_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestPodTemplateSpec(t *testing.T) {
@@ -640,8 +642,10 @@ func TestPodTemplateSpec(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			manager := test.existingManager()
+			testLogger := zap.New(zap.UseDevMode(true))
+			logger := testLogger.WithValues("test", t.Name())
 
-			PodTemplateSpec(manager, &test.override, v2alpha1.NodeAgentComponentName, "datadog-agent")
+			PodTemplateSpec(logger, manager, &test.override, v2alpha1.NodeAgentComponentName, "datadog-agent")
 
 			test.validateManager(t, manager)
 		})


### PR DESCRIPTION
### What does this PR do?

Adds md5 hash annotations to features and overrides using custom configs. The relevant resources will have a `checksum/<identifier>` annotation on them.

```
Annotations:  checksum/ksm-custom-config: 48e2697a05cf4f948508699146c311e2
```

### Motivation

Changes to custom config sections weren't triggering a restart of the relevant component(s) so the new configs were being ignored.

### Additional Notes

The `checksum/<identifier>` notation is from attempting to use the same convention as we do in the [agent helm chart](https://github.com/DataDog/helm-charts/blob/087458b2557ef8f8b54dc13c3bd7d963a9068a05/charts/datadog/templates/daemonset.yaml#L41). The identifiers used in this PR are different though, in order to try and reuse existing constants in the operator.

### Describe your test plan

Write there any instructions and details you may have to test your PR.
