### PR TITLE
Convert podLabelsAsTags and podAnnotationsAsTags from v1alpha1 to v2alpha1

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_conversion_agent.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_conversion_agent.go
@@ -52,6 +52,14 @@ func convertDatadogAgentSpec(src *DatadogAgentSpecAgentSpec, dst *v2alpha1.Datad
 			getV2TemplateOverride(&dst.Spec, v2alpha1.NodeAgentComponentName).ExtraChecksd = ConvertConfigDirSpec(src.Config.Checksd)
 		}
 
+		if src.Config.PodLabelsAsTags != nil {
+			getV2GlobalConfig(dst).PodLabelsAsTags = src.Config.PodLabelsAsTags
+		}
+
+		if src.Config.PodAnnotationsAsTags != nil {
+			getV2GlobalConfig(dst).PodAnnotationsAsTags = src.Config.PodAnnotationsAsTags
+		}
+
 		if src.Config.Tags != nil {
 			getV2GlobalConfig(dst).Tags = append(getV2GlobalConfig(dst).Tags, src.Config.Tags...)
 		}

--- a/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
@@ -80,6 +80,10 @@ spec:
       appSecret:
         keyName: app-key
         secretName: datadog-secret
+    podLabelsAsTags:
+      custom-tag1: custom-tag1
+    podAnnotationsAsTags:
+      custom-tag2: custom-tag2
     criSocketPath: /var/run/crio/crio.sock
     dockerSocketPath: /var/docker.sock
     endpoint:


### PR DESCRIPTION
### What does this PR do?

`podLabelsAsTags` and `podAnnotationsAsTags` were being ignored when converting v1alpha1 to v2alpha1

Converting this object:
```json
{"apiVersion":"datadoghq.com/v1alpha1","kind":"DatadogAgent","metadata":{"name":"datadog"},"spec":{"agent":{"config":{"env":[{"name":"DD_KUBELET_TLS_VERIFY","value":"false"}],"podLabelsAsTags":{"test_key":"test_value","key_test":"value_test"}}}}}
```

Would previously give:
```json
{"kind":"DatadogAgent","apiVersion":"datadoghq.com/v2alpha1","metadata":{"name":"datadog","creationTimestamp":null},"spec":{"features":{},"override":{"nodeAgent":{"containers":{"agent":{"env":[{"name":"DD_KUBELET_TLS_VERIFY","value":"false"}]}}}}},"status":{"conditions":null}}
```

It now gives:
```json
{"kind":"DatadogAgent","apiVersion":"datadoghq.com/v2alpha1","metadata":{"name":"datadog","creationTimestamp":null},"spec":{"features":{},"global":{"podLabelsAsTags":{"key_test":"value_test","test_key":"test_value"}},"override":{"nodeAgent":{"containers":{"agent":{"env":[{"name":"DD_KUBELET_TLS_VERIFY","value":"false"}]}}}}},"status":{"conditions":null}}
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
