### PR TITLE
Fix annotation key form MD5 annotation

### DIFF
--- a/controllers/datadogagent/override/podtemplatespec.go
+++ b/controllers/datadogagent/override/podtemplatespec.go
@@ -67,7 +67,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		if err != nil {
 			logger.Error(err, "couldn't generate hash for extra confd custom config")
 		}
-		annotationKey := object.GetChecksumAnnotationKey(v2alpha1.ExtraConfdConfigMapName)
+		annotationKey := object.GetChecksumAnnotationKey(cmName)
 		manager.Annotation().AddAnnotation(annotationKey, hash)
 	}
 
@@ -82,7 +82,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		if err != nil {
 			logger.Error(err, "couldn't generate hash for extra checks custom config")
 		}
-		annotationKey := object.GetChecksumAnnotationKey(v2alpha1.ExtraChecksdConfigMapName)
+		annotationKey := object.GetChecksumAnnotationKey(cmName)
 		manager.Annotation().AddAnnotation(annotationKey, hash)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Annotation key is missing the Component name, leading to:
```
{"level":"ERROR","ts":"2023-03-01T22:23:05Z","logger":"controller.datadogagent","msg":"Reconciler error","reconciler group":"datadoghq.com","reconciler kind":"DatadogAgent","name":"datadog-agent","namespace":"datadog-agent","error":"Deployment.apps \"datadog-cluster-agent\" is invalid: spec.template.annotations: Invalid value: \"checksum/%s-extra-confd-custom-config\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"}
```

### Motivation

bugfix
### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
