### PR TITLE
fix: make capability unique in securityContext

### DIFF
--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -278,7 +278,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -293,7 +293,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -326,7 +326,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -341,7 +341,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -374,7 +374,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -389,7 +389,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -436,7 +436,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -451,7 +451,7 @@ func Test_newClusterAgentDeploymentFromInstance(t *testing.T) {
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -560,7 +560,7 @@ func Test_newClusterAgentDeploymentMountKSMCore(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "foo-cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -575,7 +575,7 @@ func Test_newClusterAgentDeploymentMountKSMCore(t *testing.T) {
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "foo-cluster-agent",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -628,7 +628,7 @@ func Test_newClusterAgentPrometheusScrapeEnabled(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "foo-cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -643,7 +643,7 @@ func Test_newClusterAgentPrometheusScrapeEnabled(t *testing.T) {
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "foo-cluster-agent",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -709,7 +709,7 @@ func Test_newClusterAgentDeploymentFromInstance_UserVolumes(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "foo-cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -724,7 +724,7 @@ func Test_newClusterAgentDeploymentFromInstance_UserVolumes(t *testing.T) {
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "foo-cluster-agent",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -787,7 +787,7 @@ func Test_newClusterAgentDeploymentFromInstance_EnvVars(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "foo-cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -802,7 +802,7 @@ func Test_newClusterAgentDeploymentFromInstance_EnvVars(t *testing.T) {
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "foo-cluster-agent",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -855,7 +855,7 @@ func Test_newClusterAgentDeploymentFromInstance_CustomDeploymentName(t *testing.
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "custom-cluster-agent-deployment",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -871,7 +871,7 @@ func Test_newClusterAgentDeploymentFromInstance_CustomDeploymentName(t *testing.
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "custom-cluster-agent-deployment",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1033,7 +1033,7 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1049,7 +1049,7 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1087,7 +1087,7 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1103,7 +1103,7 @@ func Test_newClusterAgentDeploymentFromInstance_MetricsServer(t *testing.T) {
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1132,7 +1132,7 @@ func Test_newClusterAgentDeploymentFromInstance_AdmissionController(t *testing.T
 	commonLabels := map[string]string{
 		"agent.datadoghq.com/name":      "foo",
 		"agent.datadoghq.com/component": "cluster-agent",
-		"app.kubernetes.io/component":	"cluster-agent",
+		"app.kubernetes.io/component":   "cluster-agent",
 		"app.kubernetes.io/instance":    "foo-cluster-agent",
 		"app.kubernetes.io/managed-by":  "datadog-operator",
 		"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1266,7 +1266,7 @@ func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T)
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1281,7 +1281,7 @@ func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T)
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1321,7 +1321,7 @@ func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T)
 					Labels: map[string]string{
 						"agent.datadoghq.com/name":      "foo",
 						"agent.datadoghq.com/component": "cluster-agent",
-						"app.kubernetes.io/component":	"cluster-agent",
+						"app.kubernetes.io/component":   "cluster-agent",
 						"app.kubernetes.io/instance":    "foo-cluster-agent",
 						"app.kubernetes.io/managed-by":  "datadog-operator",
 						"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1336,7 +1336,7 @@ func Test_newClusterAgentDeploymentFromInstance_UserProvidedSecret(t *testing.T)
 							Labels: map[string]string{
 								"agent.datadoghq.com/name":      "foo",
 								"agent.datadoghq.com/component": "cluster-agent",
-								"app.kubernetes.io/component":	"cluster-agent",
+								"app.kubernetes.io/component":   "cluster-agent",
 								"app.kubernetes.io/instance":    "foo-cluster-agent",
 								"app.kubernetes.io/managed-by":  "datadog-operator",
 								"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1386,7 +1386,7 @@ func Test_newClusterAgentDeploymentFromInstance_Compliance(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "foo-cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1401,7 +1401,7 @@ func Test_newClusterAgentDeploymentFromInstance_Compliance(t *testing.T) {
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "foo-cluster-agent",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1454,7 +1454,7 @@ func Test_newClusterAgentDeploymentFromInstance_CustomReplicas(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "foo-cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1470,7 +1470,7 @@ func Test_newClusterAgentDeploymentFromInstance_CustomReplicas(t *testing.T) {
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "foo-cluster-agent",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1665,7 +1665,7 @@ func Test_newClusterAgentDeploymentFromInstance_CustomSecurityContext(t *testing
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-agent",
-					"app.kubernetes.io/component":	"cluster-agent",
+					"app.kubernetes.io/component":   "cluster-agent",
 					"app.kubernetes.io/instance":    "foo-cluster-agent",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -1680,7 +1680,7 @@ func Test_newClusterAgentDeploymentFromInstance_CustomSecurityContext(t *testing
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-agent",
-							"app.kubernetes.io/component":	"cluster-agent",
+							"app.kubernetes.io/component":   "cluster-agent",
 							"app.kubernetes.io/instance":    "foo-cluster-agent",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -310,7 +310,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_UserVolumes(t *testing.T)
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-checks-runner",
-					"app.kubernetes.io/component":	"cluster-checks-runner",
+					"app.kubernetes.io/component":   "cluster-checks-runner",
 					"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -325,7 +325,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_UserVolumes(t *testing.T)
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-checks-runner",
-							"app.kubernetes.io/component":	"cluster-checks-runner",
+							"app.kubernetes.io/component":   "cluster-checks-runner",
 							"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -391,7 +391,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_EnvVars(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-checks-runner",
-					"app.kubernetes.io/component":	"cluster-checks-runner",
+					"app.kubernetes.io/component":   "cluster-checks-runner",
 					"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -406,7 +406,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_EnvVars(t *testing.T) {
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-checks-runner",
-							"app.kubernetes.io/component":	"cluster-checks-runner",
+							"app.kubernetes.io/component":   "cluster-checks-runner",
 							"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -458,7 +458,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_CustomReplicas(t *testing
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-checks-runner",
-					"app.kubernetes.io/component":	"cluster-checks-runner",
+					"app.kubernetes.io/component":   "cluster-checks-runner",
 					"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -473,7 +473,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_CustomReplicas(t *testing
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-checks-runner",
-							"app.kubernetes.io/component":	"cluster-checks-runner",
+							"app.kubernetes.io/component":   "cluster-checks-runner",
 							"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -597,7 +597,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_CustomSecurityContext(t *
 				Labels: map[string]string{
 					"agent.datadoghq.com/name":      "foo",
 					"agent.datadoghq.com/component": "cluster-checks-runner",
-					"app.kubernetes.io/component":	"cluster-checks-runner",
+					"app.kubernetes.io/component":   "cluster-checks-runner",
 					"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 					"app.kubernetes.io/managed-by":  "datadog-operator",
 					"app.kubernetes.io/name":        "datadog-agent-deployment",
@@ -612,7 +612,7 @@ func Test_newClusterChecksRunnerDeploymentFromInstance_CustomSecurityContext(t *
 						Labels: map[string]string{
 							"agent.datadoghq.com/name":      "foo",
 							"agent.datadoghq.com/component": "cluster-checks-runner",
-							"app.kubernetes.io/component":	"cluster-checks-runner",
+							"app.kubernetes.io/component":   "cluster-checks-runner",
 							"app.kubernetes.io/instance":    "foo-cluster-checks-runner",
 							"app.kubernetes.io/managed-by":  "datadog-operator",
 							"app.kubernetes.io/name":        "datadog-agent-deployment",

--- a/controllers/datadogagent/merger/security_context_test.go
+++ b/controllers/datadogagent/merger/security_context_test.go
@@ -6,6 +6,7 @@
 package merger
 
 import (
+	"reflect"
 	"testing"
 
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -116,6 +117,62 @@ func TestAddCapabilitiesToContainer(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func TestSortAndUnique(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []corev1.Capability
+		want []corev1.Capability
+	}{
+		{
+			name: "empty in",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "2 capabilities already sorted",
+			in: []corev1.Capability{
+				"BAR",
+				"FOO",
+			},
+			want: []corev1.Capability{
+				"BAR",
+				"FOO",
+			},
+		},
+		{
+			name: "2 capability not sorted",
+			in: []corev1.Capability{
+				"FOO",
+				"BAR",
+			},
+			want: []corev1.Capability{
+				"BAR",
+				"FOO",
+			},
+		},
+		{
+			name: "Input not unique",
+			in: []corev1.Capability{
+				"BAR",
+				"BAR",
+				"FOO",
+				"BAR",
+			},
+			want: []corev1.Capability{
+				"BAR",
+				"FOO",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SortAndUnique(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SortAndUnique() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduce the function ` SortAndUnique(in []corev1.Capability) []corev1.Capability` and use it in `AddCapabilitiesToContainer(...)` to create a valid `SecurityContext`

### Motivation

Before this pull request, if several features needed the same capabilities, they were duplicated in the `securityContext.capabilities.add` section.

example of previous behaviour
```yaml
       securityContext:
          capabilities:
            add:
            - SYS_ADMIN
            - SYS_RESOURCE
            - SYS_PTRACE
            - NET_ADMIN
            - NET_BROADCAST
            - NET_RAW
            - IPC_LOCK
            - CHOWN
            - DAC_READ_SEARCH
            - SYS_ADMIN
            - SYS_RESOURCE
            - SYS_PTRACE
            - NET_ADMIN
            - NET_BROADCAST
            - NET_RAW
            - IPC_LOCK
            - CHOWN
            - DAC_READ_SEARCH
            - SYS_ADMIN
            - SYS_RESOURCE
            - SYS_PTRACE
            - NET_ADMIN
            - NET_BROADCAST
            - NET_RAW
            - IPC_LOCK
            - CHOWN
            - DAC_READ_SEARCH
            - SYS_ADMIN
            - SYS_RESOURCE
            - SYS_PTRACE
            - NET_ADMIN
            - NET_BROADCAST
            - NET_RAW
            - IPC_LOCK
            - CHOWN
            - DAC_READ_SEARCH
          seccompProfile:
            localhostProfile: system-probe
            type: Localhost
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy the Agent with at least 2 features enabled that require system-probe like `TCPQueue` and `OOMKill`. 

Check the Daemonset manifest to see if the `system-probe` securitycontexct contains the proper capabilities.