### PR TITLE
fix: docker image in gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ variables:
   PROJECTNAME_CHECK: "datadog-operator-check"
   GOPATH: "$CI_PROJECT_DIR/.cache"
   BUILD_DOCKER_REGISTRY: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci"
+  JOB_DOCKER_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-containers-project:v13932656-a1b1db4-v1.0.0"
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
@@ -57,7 +58,7 @@ generate_code:
 build_operator_image_amd64:
   stage: image
   tags: ["runner:docker", "size:large"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: amd64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
@@ -72,7 +73,7 @@ build_operator_image_amd64:
 build_operator_image_arm64:
   stage: image
   tags: ["runner:docker-arm", "platform:arm64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718787-3888eda-18.09.6-arm64-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: arm64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
@@ -87,7 +88,7 @@ build_operator_image_arm64:
 build_operator_check_image_amd64:
   stage: image
   tags: ["runner:docker", "size:large"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: amd64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
@@ -102,7 +103,7 @@ build_operator_check_image_amd64:
 build_operator_check_image_arm64:
   stage: image
   tags: ["runner:docker-arm", "platform:arm64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718787-3888eda-18.09.6-arm64-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: arm64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME_CHECK:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
@@ -117,7 +118,7 @@ build_operator_check_image_arm64:
 build_bundle_image:
   stage: image
   tags: ["runner:docker", "size:large"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
+  image: $JOB_DOCKER_IMAGE
   variables:
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-bundle
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-bundle
@@ -133,7 +134,7 @@ preflight_redhat_image_amd64:
       when: on_success
     - when: never
   tags: ["runner:docker", "size:large"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v7284591-9d865ea-20.10.13
+  image: $JOB_DOCKER_IMAGE
   variables:
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
   script:
@@ -252,7 +253,7 @@ submit_preflight_redhat_public_tag:
   needs:
     - "publish_redhat_public_tag"
   tags: ["runner:docker", "size:large"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v7284591-9d865ea-20.10.13
+  image: $JOB_DOCKER_IMAGE
   variables:
     RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
     RH_PARTNER_SCAN_REGISTRY_PATH: /ospid-e18c96b6-0524-4c5c-8ada-ce2fca845c8c/operator


### PR DESCRIPTION
### What does this PR do?

Update the docker image used in the CI (gitlab) to use a more recent image that still exist in the registry. The new image should also be a multi-arch image

### Motivation

the current docker image was removed from the registry.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

The CI (gitlab) should be green
