### PR TITLE
Add a flag to enable/disable DatadogAgent controller

### DIFF
--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -33,6 +33,7 @@ type SetupOptions struct {
 	SupportExtendedDaemonset bool
 	SupportCilium            bool
 	Creds                    config.Creds
+	DatadogAgentEnabled      bool
 	DatadogMonitorEnabled    bool
 	OperatorMetricsEnabled   bool
 	V2APIEnabled             bool
@@ -87,6 +88,12 @@ func getServerGroupsAndResources(log logr.Logger, discoveryClient *discovery.Dis
 }
 
 func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, pInfo kubernetes.PlatformInfo, options SetupOptions) error {
+	if !options.DatadogAgentEnabled {
+		logger.Info("Feature disabled, not starting the controller", "controller", agentControllerName)
+
+		return nil
+	}
+
 	return (&DatadogAgentReconciler{
 		Client:       mgr.GetClient(),
 		VersionInfo:  vInfo,

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	flag.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 60*time.Second, "Define LeaseDuration as well as RenewDeadline (leaseDuration / 2) and RetryPeriod (leaseDuration / 4)")
 
 	// Custom flags
-	var printVersion, pprofActive, supportExtendedDaemonset, supportCilium, datadogMonitorEnabled, operatorMetricsEnabled, webhookEnabled, v2APIEnabled bool
+	var printVersion, pprofActive, supportExtendedDaemonset, supportCilium, datadogAgentEnabled, datadogMonitorEnabled, operatorMetricsEnabled, webhookEnabled, v2APIEnabled bool
 	var logEncoder, secretBackendCommand string
 	var secretBackendArgs stringSlice
 	flag.StringVar(&logEncoder, "logEncoder", "json", "log encoding ('json' or 'console')")
@@ -96,7 +96,8 @@ func main() {
 	flag.BoolVar(&pprofActive, "pprof", false, "Enable pprof endpoint")
 	flag.BoolVar(&supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
 	flag.BoolVar(&supportCilium, "supportCilium", false, "Support usage of Cilium network policies.")
-	flag.BoolVar(&datadogMonitorEnabled, "datadogMonitorEnabled", false, "Enable the DatadogMonitor controller")
+	flag.BoolVar(&datadogAgentEnabled, "datadogAgentEnabled", false, "Enable the DatadogAgent controller")
+	flag.BoolVar(&datadogMonitorEnabled, "datadogMonitorEnabled", true, "Enable the DatadogMonitor controller")
 	flag.BoolVar(&operatorMetricsEnabled, "operatorMetricsEnabled", true, "Enable sending operator metrics to Datadog")
 	flag.BoolVar(&v2APIEnabled, "v2APIEnabled", true, "Enable the v2 api")
 	flag.BoolVar(&webhookEnabled, "webhookEnabled", true, "Enable CRD conversion webhook.")
@@ -155,6 +156,7 @@ func main() {
 		SupportExtendedDaemonset: supportExtendedDaemonset,
 		SupportCilium:            supportCilium,
 		Creds:                    creds,
+		DatadogAgentEnabled:      datadogAgentEnabled,
 		DatadogMonitorEnabled:    datadogMonitorEnabled,
 		OperatorMetricsEnabled:   operatorMetricsEnabled,
 		V2APIEnabled:             v2APIEnabled,
@@ -165,7 +167,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if webhookEnabled {
+	if webhookEnabled && datadogAgentEnabled {
 		if err = (&datadoghqv2alpha1.DatadogAgent{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "DatadogAgent")
 			os.Exit(1)


### PR DESCRIPTION
### What does this PR do?

Adding a flag to control creation of `DatadogAgent` controller, similar to what we have `DatadogMonitor` [here](https://github.com/DataDog/datadog-operator/blob/main/main.go#L99). 

Helm change an doc update to follow. 

### Motivation

https://github.com/DataDog/datadog-operator/issues/721

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Set flag to false, build and deploy Operator.
* Delete `DatadogAgent` CRD if exists.
* Watch for any Operator errors.
* Apply `DatadogMonitor` manifest, confirm monitor is created.