### PR TITLE
[defaulting/images] Update agents to 7.43.1

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.43.0"
+	AgentLatestVersion = "7.43.1"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.43.0"
+	ClusterAgentLatestVersion = "7.43.1"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

Update datadog `agent` and `cluster-agent` default version to `7.43.1`.

### Motivation

https://github.com/DataDog/datadog-agent/releases/tag/7.43.1

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Check which version of the agent is deployed by default.
