### PR TITLE
Cluster Agent Auth Lifecycle Improvment

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_conversion.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_conversion.go
@@ -59,7 +59,11 @@ func convertSpec(src *DatadogAgentSpec, dst *v2alpha1.DatadogAgent) error {
 	// Convert credentials
 	if src.Credentials != nil {
 		if dstCred := convertCredentials(&src.Credentials.DatadogCredentials); dstCred != nil {
-			getV2GlobalConfig(dst).Credentials = dstCred
+			dstCredGlobal := getV2GlobalConfig(dst)
+			dstCredGlobal.Credentials = dstCred
+			if src.Credentials.Token != "" {
+				dstCredGlobal.ClusterAgentToken = &src.Credentials.Token
+			}
 		}
 	}
 

--- a/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
@@ -71,6 +71,7 @@ spec:
       enabled: true
   global:
     clusterName: foo
+    clusterAgentToken: "foo-bar-baz"
     credentials:
       apiKey: api-key-inline
       apiSecret:

--- a/apis/datadoghq/v1alpha1/testdata/all.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.yaml
@@ -16,7 +16,7 @@ spec:
     appSecret:
       secretName: datadog-secret
       keyName: app-key
-    token: "foo-bar-baz" # ignored by conversion
+    token: "foo-bar-baz"
     useSecretBackend: true
   features:
     orchestratorExplorer:

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -21,8 +21,8 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/version"
-	"github.com/go-logr/logr"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -252,7 +252,7 @@ func (f *defaultFeature) ManageDependencies(managers feature.ResourceManagers, c
 	// manage credential secret
 	if f.credentialsInfo.secretCreation.createSecret {
 		for key, value := range f.credentialsInfo.secretCreation.data {
-			if err := managers.SecretManager().AddSecret(f.logger, f.owner.GetNamespace(), f.credentialsInfo.secretCreation.name, key, value, nil); err != nil {
+			if err := managers.SecretManager().AddSecret(f.owner.GetNamespace(), f.credentialsInfo.secretCreation.name, key, value); err != nil {
 				errs = append(errs, err)
 			}
 		}
@@ -260,9 +260,13 @@ func (f *defaultFeature) ManageDependencies(managers feature.ResourceManagers, c
 
 	if components.ClusterAgent.IsEnabled() && f.dcaTokenInfo.secretCreation.createSecret {
 		for key, value := range f.dcaTokenInfo.secretCreation.data {
-			if err := managers.SecretManager().AddSecret(f.logger, f.owner.GetNamespace(), f.dcaTokenInfo.secretCreation.name, key, value, map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}); err != nil {
+			if err := managers.SecretManager().AddSecret(f.owner.GetNamespace(), f.dcaTokenInfo.secretCreation.name, key, value); err != nil {
 				errs = append(errs, err)
 			}
+		}
+		// Adding Annotation containing data hash to secret.
+		if err := managers.SecretManager().AddAnnotations(f.logger, f.owner.GetNamespace(), f.dcaTokenInfo.secretCreation.name, map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}); err != nil {
+			errs = append(errs, err)
 		}
 
 	}

--- a/controllers/datadogagent/feature/externalmetrics/feature.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature.go
@@ -245,7 +245,7 @@ func (f *externalMetricsFeature) ManageDependencies(managers feature.ResourceMan
 	if len(f.keySecret) != 0 {
 		for idx, s := range f.keySecret {
 			if len(s.data) != 0 {
-				if err := managers.SecretManager().AddSecret(f.logger, ns, componentdca.GetDefaultExternalMetricSecretName(f.owner), idx, string(s.data), nil); err != nil {
+				if err := managers.SecretManager().AddSecret(ns, componentdca.GetDefaultExternalMetricSecretName(f.owner), idx, string(s.data)); err != nil {
 					return fmt.Errorf("error adding external metrics provider credentials secret to store: %w", err)
 				}
 			}

--- a/controllers/datadogagent/merger/secret.go
+++ b/controllers/datadogagent/merger/secret.go
@@ -44,7 +44,6 @@ func (m *secretManagerImpl) AddSecret(logger logr.Logger, secretNamespace, secre
 		secret.Data = make(map[string][]byte)
 	}
 	secret.Data[key] = []byte(value)
-
 	if len(extraMetadata) > 0 {
 		annotations := object.MergeAnnotationsLabels(logger, secret.GetAnnotations(), extraMetadata, "*")
 		secret.SetAnnotations(annotations)

--- a/controllers/datadogagent/merger/secret_test.go
+++ b/controllers/datadogagent/merger/secret_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,9 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: secretNs,
+			Annotations: map[string]string{
+				"checksum/default-custom-config": "0fe60b5fsweqe3224werwer",
+			},
 		},
 		Data: map[string][]byte{
 			"key1": []byte("defaultvalue"),
@@ -99,6 +103,9 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 				}
 				if _, ok := secret.Data["key"]; !ok {
 					t.Errorf("key not found in Secret %s/%s", secretNs, secretName)
+				}
+				if _, ok := secret.Annotations[object.GetChecksumAnnotationKey("default")]; !ok {
+					t.Errorf("missing extraMetadata in Secret %s/%s", secretNs, secretName)
 				}
 			},
 		},

--- a/controllers/datadogagent/merger/secret_test.go
+++ b/controllers/datadogagent/merger/secret_test.go
@@ -15,9 +15,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Test_secretManagerImpl_AddSecret(t *testing.T) {
+	logger := logf.Log.WithName(t.Name())
 	secretNs := "foo"
 	secretName := "bar"
 
@@ -106,7 +108,7 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 			m := &secretManagerImpl{
 				store: tt.store,
 			}
-			if err := m.AddSecret(tt.args.secretNamespace, tt.args.secretName, tt.args.key, tt.args.value); (err != nil) != tt.wantErr {
+			if err := m.AddSecret(logger, tt.args.secretNamespace, tt.args.secretName, tt.args.key, tt.args.value, nil); (err != nil) != tt.wantErr {
 				t.Errorf("secretManagerImpl.AddSecret() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.validateFunc != nil {

--- a/controllers/datadogagent/merger/secret_test.go
+++ b/controllers/datadogagent/merger/secret_test.go
@@ -23,7 +23,9 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 	logger := logf.Log.WithName(t.Name())
 	secretNs := "foo"
 	secretName := "bar"
-
+	secretAnnotations := map[string]string{
+		"checksum/default-custom-config": "0fe60b5fsweqe3224werwer",
+	}
 	owner := &v2alpha1.DatadogAgent{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: secretNs,
@@ -39,11 +41,9 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 
 	secret1 := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: secretNs,
-			Annotations: map[string]string{
-				"checksum/default-custom-config": "0fe60b5fsweqe3224werwer",
-			},
+			Name:        secretName,
+			Namespace:   secretNs,
+			Annotations: secretAnnotations,
 		},
 		Data: map[string][]byte{
 			"key1": []byte("defaultvalue"),
@@ -115,8 +115,11 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 			m := &secretManagerImpl{
 				store: tt.store,
 			}
-			if err := m.AddSecret(logger, tt.args.secretNamespace, tt.args.secretName, tt.args.key, tt.args.value, nil); (err != nil) != tt.wantErr {
+			if err := m.AddSecret(tt.args.secretNamespace, tt.args.secretName, tt.args.key, tt.args.value); (err != nil) != tt.wantErr {
 				t.Errorf("secretManagerImpl.AddSecret() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := m.AddAnnotations(logger, tt.args.secretNamespace, tt.args.secretName, secretAnnotations); (err != nil) != tt.wantErr {
+				t.Errorf("secretManagerImpl.AddAnnotations() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.validateFunc != nil {
 				tt.validateFunc(t, tt.store)


### PR DESCRIPTION
### What does this PR do?

At the moment, if a token is specified to authenticate the communication between the Datadog Agents and the Datadog Cluster Agent resources will not be rotated if it is changed. This can result in communication errors following up on the upadte of the token.
Secondly, this also adds supports for the conversion of the token when migrating from v1alpha1 to v2alpha1.

This uses the MD5 hashing pattern introduced for Lifecycle improvement.

### Motivation

Ensuring smooth migration.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploying:

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: default
spec:
  global:
    clusterAgentToken: abc123 # Make sure it's 32 characters
```

should result in the creation of the secret with the config hash for the token:
```
apiVersion: v1
data:
  token: XXXXXXX
kind: Secret
metadata:
  annotations:
    checksum/default-custom-config: 0fe60b5ffa7bdd8c0b26ca3ba0775ff7
  labels:
    app.kubernetes.io/instance: datadog
    app.kubernetes.io/managed-by: datadog-operator
  name: datadog-token
  namespace: default
  ownerReferences:
  - apiVersion: datadoghq.com/v2alpha1
[...]
```

And both the Datadog Agent and Datadog Cluster Agent  pods will have the hash to, ensuring the update if the token is rotated:
```
➜  ~ k describe pod datadog-cluster-agent-7bf844fcd5-gwtmm
Name:             datadog-cluster-agent-7bf844fcd5-gwtmm
[...]
Labels:           agent.datadoghq.com/component=cluster-agent
[...]
Annotations:      checksum/default-custom-config: 0fe60b5ffa7bdd8c0b26ca3ba0775ff7
```

(note that this still works if you don't specify the token)
