### PR TITLE
Handle empty feature structs

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -130,7 +130,7 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// LogsCollection Feature
-	if ddaSpec.Features.LogCollection != nil && *ddaSpec.Features.LogCollection.Enabled {
+	if ddaSpec.Features.LogCollection != nil && ddaSpec.Features.LogCollection.Enabled != nil && *ddaSpec.Features.LogCollection.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.LogCollection.ContainerCollectUsingFiles, defaultLogContainerCollectUsingFiles)
 
 		apiutils.DefaultStringIfUnset(&ddaSpec.Features.LogCollection.ContainerLogsPath, defaultLogContainerLogsPath)
@@ -143,14 +143,14 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// LiveContainerCollection Feature
-	if ddaSpec.Features.LiveContainerCollection == nil {
+	if ddaSpec.Features.LiveContainerCollection == nil || apiutils.IsEqualStruct(*ddaSpec.Features.LiveContainerCollection, LiveContainerCollectionFeatureConfig{}) {
 		ddaSpec.Features.LiveContainerCollection = &LiveContainerCollectionFeatureConfig{
 			Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 		}
 	}
 
 	// APM Feature
-	if ddaSpec.Features.APM != nil && *ddaSpec.Features.APM.Enabled {
+	if ddaSpec.Features.APM != nil && ddaSpec.Features.APM.Enabled != nil && *ddaSpec.Features.APM.Enabled {
 		if ddaSpec.Features.APM.HostPortConfig == nil {
 			ddaSpec.Features.APM.HostPortConfig = &HostPortConfig{}
 		}
@@ -169,12 +169,12 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// CWS (Cloud Workload Security) Feature
-	if ddaSpec.Features.CWS != nil && *ddaSpec.Features.CWS.Enabled {
+	if ddaSpec.Features.CWS != nil && ddaSpec.Features.CWS.Enabled != nil && *ddaSpec.Features.CWS.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.CWS.SyscallMonitorEnabled, defaultCWSSyscallMonitorEnabled)
 	}
 
 	// NPM (Network Performance Monitoring) Feature
-	if ddaSpec.Features.NPM != nil && *ddaSpec.Features.NPM.Enabled {
+	if ddaSpec.Features.NPM != nil && ddaSpec.Features.NPM.Enabled != nil && *ddaSpec.Features.NPM.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.NPM.EnableConntrack, defaultNPMEnableConntrack)
 
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.NPM.CollectDNSStats, defaultNPMCollectDNSStats)
@@ -226,14 +226,14 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	// Cluster-level features
 
 	// EventCollection Feature
-	if ddaSpec.Features.EventCollection == nil {
+	if ddaSpec.Features.EventCollection == nil || apiutils.IsEqualStruct(*ddaSpec.Features.EventCollection, EventCollectionFeatureConfig{}) {
 		ddaSpec.Features.EventCollection = &EventCollectionFeatureConfig{
 			CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 		}
 	}
 
 	// OrchestratorExplorer check Feature
-	if ddaSpec.Features.OrchestratorExplorer == nil {
+	if ddaSpec.Features.OrchestratorExplorer == nil || apiutils.IsEqualStruct(*ddaSpec.Features.OrchestratorExplorer, OrchestratorExplorerFeatureConfig{}) {
 		ddaSpec.Features.OrchestratorExplorer = &OrchestratorExplorerFeatureConfig{
 			Enabled: apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 		}
@@ -244,7 +244,7 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// KubeStateMetricsCore check Feature
-	if ddaSpec.Features.KubeStateMetricsCore == nil {
+	if ddaSpec.Features.KubeStateMetricsCore == nil || apiutils.IsEqualStruct(*ddaSpec.Features.KubeStateMetricsCore, KubeStateMetricsCoreFeatureConfig{}) {
 		ddaSpec.Features.KubeStateMetricsCore = &KubeStateMetricsCoreFeatureConfig{
 			Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
 		}
@@ -264,7 +264,7 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// ExternalMetricsServer Feature
-	if ddaSpec.Features.ExternalMetricsServer != nil && *ddaSpec.Features.ExternalMetricsServer.Enabled {
+	if ddaSpec.Features.ExternalMetricsServer != nil && ddaSpec.Features.ExternalMetricsServer.Enabled != nil && *ddaSpec.Features.ExternalMetricsServer.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ExternalMetricsServer.UseDatadogMetrics, defaultDatadogMetricsEnabled)
 
 		apiutils.DefaultInt32IfUnset(&ddaSpec.Features.ExternalMetricsServer.Port, defaultMetricsProviderPort)

--- a/apis/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -721,6 +721,88 @@ func Test_defaultFeatures(t *testing.T) {
 				},
 			},
 		},
+		{
+			// This test sets same defaults as the one with `Features: nil`; and leaves other configs as empty structs.
+			name: "all feature configs are empty structs, configures defaults where applicable, leaves others empty",
+			ddaSpec: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					LogCollection:           &LogCollectionFeatureConfig{},
+					LiveProcessCollection:   &LiveProcessCollectionFeatureConfig{},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{},
+					OOMKill:                 &OOMKillFeatureConfig{},
+					TCPQueueLength:          &TCPQueueLengthFeatureConfig{},
+					APM:                     &APMFeatureConfig{},
+					CSPM:                    &CSPMFeatureConfig{},
+					CWS:                     &CWSFeatureConfig{},
+					NPM:                     &NPMFeatureConfig{},
+					USM:                     &USMFeatureConfig{},
+					OTLP:                    &OTLPFeatureConfig{},
+					EventCollection:         &EventCollectionFeatureConfig{},
+					OrchestratorExplorer:    &OrchestratorExplorerFeatureConfig{},
+					KubeStateMetricsCore:    &KubeStateMetricsCoreFeatureConfig{},
+					AdmissionController:     &AdmissionControllerFeatureConfig{},
+					ExternalMetricsServer:   &ExternalMetricsServerFeatureConfig{},
+					ClusterChecks:           &ClusterChecksFeatureConfig{},
+					PrometheusScrape:        &PrometheusScrapeFeatureConfig{},
+				},
+			},
+			want: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					LogCollection:         &LogCollectionFeatureConfig{},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{},
+					OOMKill:               &OOMKillFeatureConfig{},
+					TCPQueueLength:        &TCPQueueLengthFeatureConfig{},
+					APM:                   &APMFeatureConfig{},
+					CSPM:                  &CSPMFeatureConfig{},
+					CWS:                   &CWSFeatureConfig{},
+					NPM:                   &NPMFeatureConfig{},
+					USM:                   &USMFeatureConfig{},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{},
+					PrometheusScrape:      &PrometheusScrapeFeatureConfig{},
+
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					Dogstatsd: &DogstatsdFeatureConfig{
+						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
+						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
+						},
+					},
+					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
+						GRPC: &OTLPGRPCConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPGRPCEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPGRPCEndpoint),
+						},
+						HTTP: &OTLPHTTPConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPHTTPEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
+						},
+					}}},
+					EventCollection: &EventCollectionFeatureConfig{
+						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
+					},
+					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
+						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
+						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
+					},
+					ClusterChecks: &ClusterChecksFeatureConfig{
+						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
+						UseClusterChecksRunners: apiutils.NewBoolPointer(defaultUseClusterChecksRunners),
+					},
+					AdmissionController: &AdmissionControllerFeatureConfig{
+						Enabled:          apiutils.NewBoolPointer(defaultAdmissionControllerEnabled),
+						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
+						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Conversion routine initializes one of the features with empty struct, leading to segfault in the defaulting code. Empty struct can be set in the DDA as well, leading to same error. 

Features configured with empty structs are handled same as nils. Certain features have implicit defaults which should be set even if input is empty/nil.

### Motivation

Avoid potential segfaults in defaulting logic.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Unit test and local test on Kind cluster.