### PR TITLE
feat(v2): support EDS.spec.strategy configuration

### DIFF
--- a/controllers/datadogagent/agent.go
+++ b/controllers/datadogagent/agent.go
@@ -56,7 +56,7 @@ func (r *Reconciler) reconcileAgent(logger logr.Logger, features []feature.Featu
 	}
 	// check if EDS or DS already exist
 	eds := &edsdatadoghqv1alpha1.ExtendedDaemonSet{}
-	if r.options.SupportExtendedDaemonset {
+	if r.options.ExtendedDaemonsetOptions.Enabled {
 		if err2 := r.client.Get(context.TODO(), nameNamespace, eds); err2 != nil {
 			if !errors.IsNotFound(err2) {
 				return result, err2
@@ -90,7 +90,7 @@ func (r *Reconciler) reconcileAgent(logger logr.Logger, features []feature.Featu
 		return result, err
 	}
 
-	if r.options.SupportExtendedDaemonset && apiutils.BoolValue(dda.Spec.Agent.UseExtendedDaemonset) {
+	if r.options.ExtendedDaemonsetOptions.Enabled && apiutils.BoolValue(dda.Spec.Agent.UseExtendedDaemonset) {
 		if ds != nil {
 			// TODO manage properly the migration from DS to EDS
 			err = r.deleteDaemonSet(logger, dda, ds)
@@ -108,7 +108,7 @@ func (r *Reconciler) reconcileAgent(logger logr.Logger, features []feature.Featu
 	}
 
 	// Case when Daemonset is requested
-	if eds != nil && r.options.SupportExtendedDaemonset {
+	if eds != nil && r.options.ExtendedDaemonsetOptions.Enabled {
 		// if EDS exist delete before creating or updating the Daemonset
 		err = r.deleteExtendedDaemonSet(logger, dda, eds)
 		if err != nil {

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -8,6 +8,7 @@ package agent
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 
@@ -27,7 +28,7 @@ import (
 
 // NewDefaultAgentDaemonset return a new default agent DaemonSet
 func NewDefaultAgentDaemonset(dda metav1.Object, requiredContainers []common.AgentContainerName) *appsv1.DaemonSet {
-	daemonset := component.NewDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
+	daemonset := NewDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
 	podTemplate := NewDefaultAgentPodTemplateSpec(dda, requiredContainers, daemonset.GetLabels())
 
 	daemonset.Spec.Template = *podTemplate
@@ -35,10 +36,23 @@ func NewDefaultAgentDaemonset(dda metav1.Object, requiredContainers []common.Age
 }
 
 // NewDefaultAgentExtendedDaemonset return a new default agent DaemonSet
-func NewDefaultAgentExtendedDaemonset(dda metav1.Object, requiredContainers []common.AgentContainerName) *edsv1alpha1.ExtendedDaemonSet {
-	edsDaemonset := component.NewExtendedDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
+func NewDefaultAgentExtendedDaemonset(dda metav1.Object, edsOptions *ExtendedDaemonsetOptions, requiredContainers []common.AgentContainerName) *edsv1alpha1.ExtendedDaemonSet {
+	edsDaemonset := NewExtendedDaemonset(dda, edsOptions, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
 	edsDaemonset.Spec.Template = *NewDefaultAgentPodTemplateSpec(dda, requiredContainers, edsDaemonset.GetLabels())
 	return edsDaemonset
+}
+
+// ExtendedDaemonsetOptions defines ExtendedDaemonset options
+type ExtendedDaemonsetOptions struct {
+	Enabled bool
+
+	MaxPodUnavailable      string
+	MaxPodSchedulerFailure string
+
+	CanaryDuration              time.Duration
+	CanaryPodCount              string
+	CanaryAutoPauseRestartCount int32
+	CanaryAutoFailRestartCount  int32
 }
 
 // NewDefaultAgentPodTemplateSpec return a default node agent for the cluster-agent deployment

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -8,7 +8,6 @@ package agent
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 
@@ -40,19 +39,6 @@ func NewDefaultAgentExtendedDaemonset(dda metav1.Object, edsOptions *ExtendedDae
 	edsDaemonset := NewExtendedDaemonset(dda, edsOptions, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
 	edsDaemonset.Spec.Template = *NewDefaultAgentPodTemplateSpec(dda, requiredContainers, edsDaemonset.GetLabels())
 	return edsDaemonset
-}
-
-// ExtendedDaemonsetOptions defines ExtendedDaemonset options
-type ExtendedDaemonsetOptions struct {
-	Enabled bool
-
-	MaxPodUnavailable      string
-	MaxPodSchedulerFailure string
-
-	CanaryDuration              time.Duration
-	CanaryPodCount              string
-	CanaryAutoPauseRestartCount int32
-	CanaryAutoFailRestartCount  int32
 }
 
 // NewDefaultAgentPodTemplateSpec return a default node agent for the cluster-agent deployment

--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
+
+	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+)
+
+// NewDaemonset use to generate the skeleton of a new daemonset based on few information
+func NewDaemonset(owner metav1.Object, componentKind, componentName, version string, selector *metav1.LabelSelector) *appsv1.DaemonSet {
+	labels, annotations, selector := component.GetDefaultMetadata(owner, componentKind, componentName, version, selector)
+
+	daemonset := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        componentName,
+			Namespace:   owner.GetNamespace(),
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: selector,
+		},
+	}
+	return daemonset
+}
+
+// NewExtendedDaemonset use to generate the skeleton of a new extended daemonset based on few information
+func NewExtendedDaemonset(owner metav1.Object, edsOptions *ExtendedDaemonsetOptions, componentKind, componentName, version string, selector *metav1.LabelSelector) *edsv1alpha1.ExtendedDaemonSet {
+	// FIXME (@CharlyF): The EDS controller uses the Spec.Selector as a node selector to get the NodeList to rollout the agent.
+	// Per https://github.com/DataDog/extendeddaemonset/blob/28a8e082cee9890ae6d925a7d6247a36c6f6ba5d/controllers/extendeddaemonsetreplicaset/controller.go#L344-L360
+	// Up until v0.8.2, the Datadog Operator set the selector to nil, which circumvented this case.
+	// Until the EDS controller uses the Affinity field to get the NodeList instead of Spec.Selector, let's keep the previous behavior.
+	labels, annotations, _ := component.GetDefaultMetadata(owner, componentKind, componentName, version, selector)
+
+	daemonset := &edsv1alpha1.ExtendedDaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        componentName,
+			Namespace:   owner.GetNamespace(),
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: defaultEDSSpec(edsOptions),
+	}
+
+	return daemonset
+}
+
+func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemonSetSpec {
+	spec := edsv1alpha1.ExtendedDaemonSetSpec{}
+	edsv1alpha1.DefaultExtendedDaemonSetSpec(&spec, edsv1alpha1.ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto)
+
+	if options.MaxPodUnavailable != "" {
+		spec.Strategy.RollingUpdate.MaxUnavailable = newIntOrStringPointer(options.MaxPodUnavailable)
+	}
+
+	if options.MaxPodSchedulerFailure != "" {
+		spec.Strategy.RollingUpdate.MaxPodSchedulerFailure = newIntOrStringPointer(options.MaxPodSchedulerFailure)
+	}
+
+	if options.CanaryDuration != 0 {
+		spec.Strategy.Canary.Duration = &metav1.Duration{Duration: options.CanaryDuration}
+	}
+
+	if options.CanaryPodCount != "" {
+		spec.Strategy.Canary.Replicas = newIntOrStringPointer(options.CanaryPodCount)
+	}
+
+	if options.CanaryAutoFailRestartCount > 0 {
+		spec.Strategy.Canary.AutoFail.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoFailRestartCount)
+	}
+
+	if options.CanaryAutoPauseRestartCount > 0 {
+		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseRestartCount)
+	}
+	return spec
+}
+
+func newIntOrStringPointer(str string) *intstr.IntOrString {
+	val := intstr.FromString(str)
+	return &val
+}

--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -66,7 +66,9 @@ type ExtendedDaemonsetOptions struct {
 
 	CanaryDuration              time.Duration
 	CanaryReplicas              string
+	CanaryAutoPauseEnabled      bool
 	CanaryAutoPauseRestartCount int32
+	CanaryAutoFailEnabled       bool
 	CanaryAutoFailRestartCount  int32
 }
 
@@ -90,10 +92,12 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 		spec.Strategy.Canary.Replicas = newIntOrStringPointer(options.CanaryReplicas)
 	}
 
+	spec.Strategy.Canary.AutoFail.Enabled = edsv1alpha1.NewBool(options.CanaryAutoFailEnabled)
 	if options.CanaryAutoFailRestartCount > 0 {
 		spec.Strategy.Canary.AutoFail.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoFailRestartCount)
 	}
 
+	spec.Strategy.Canary.AutoPause.Enabled = edsv1alpha1.NewBool(options.CanaryAutoPauseEnabled)
 	if options.CanaryAutoPauseRestartCount > 0 {
 		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseRestartCount)
 	}

--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -6,6 +6,8 @@
 package agent
 
 import (
+	"time"
+
 	appsv1 "k8s.io/api/apps/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,6 +57,19 @@ func NewExtendedDaemonset(owner metav1.Object, edsOptions *ExtendedDaemonsetOpti
 	return daemonset
 }
 
+// ExtendedDaemonsetOptions defines ExtendedDaemonset options
+type ExtendedDaemonsetOptions struct {
+	Enabled bool
+
+	MaxPodUnavailable      string
+	MaxPodSchedulerFailure string
+
+	CanaryDuration              time.Duration
+	CanaryReplicas              string
+	CanaryAutoPauseRestartCount int32
+	CanaryAutoFailRestartCount  int32
+}
+
 func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemonSetSpec {
 	spec := edsv1alpha1.ExtendedDaemonSetSpec{}
 	edsv1alpha1.DefaultExtendedDaemonSetSpec(&spec, edsv1alpha1.ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto)
@@ -71,8 +86,8 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 		spec.Strategy.Canary.Duration = &metav1.Duration{Duration: options.CanaryDuration}
 	}
 
-	if options.CanaryPodCount != "" {
-		spec.Strategy.Canary.Replicas = newIntOrStringPointer(options.CanaryPodCount)
+	if options.CanaryReplicas != "" {
+		spec.Strategy.Canary.Replicas = newIntOrStringPointer(options.CanaryReplicas)
 	}
 
 	if options.CanaryAutoFailRestartCount > 0 {

--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -64,12 +64,12 @@ type ExtendedDaemonsetOptions struct {
 	MaxPodUnavailable      string
 	MaxPodSchedulerFailure string
 
-	CanaryDuration            time.Duration
-	CanaryReplicas            string
-	CanaryAutoPauseEnabled    bool
-	CanaryAutoPauseMaxRestart int32
-	CanaryAutoFailEnabled     bool
-	CanaryAutoFailMaxRestarts int32
+	CanaryDuration             time.Duration
+	CanaryReplicas             string
+	CanaryAutoPauseEnabled     bool
+	CanaryAutoPauseMaxRestarts int32
+	CanaryAutoFailEnabled      bool
+	CanaryAutoFailMaxRestarts  int32
 }
 
 func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemonSetSpec {
@@ -98,8 +98,8 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 	}
 
 	spec.Strategy.Canary.AutoPause.Enabled = edsv1alpha1.NewBool(options.CanaryAutoPauseEnabled)
-	if options.CanaryAutoPauseMaxRestart > 0 {
-		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseMaxRestart)
+	if options.CanaryAutoPauseMaxRestarts > 0 {
+		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseMaxRestarts)
 	}
 	return spec
 }

--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -64,12 +64,12 @@ type ExtendedDaemonsetOptions struct {
 	MaxPodUnavailable      string
 	MaxPodSchedulerFailure string
 
-	CanaryDuration              time.Duration
-	CanaryReplicas              string
-	CanaryAutoPauseEnabled      bool
-	CanaryAutoPauseRestartCount int32
-	CanaryAutoFailEnabled       bool
-	CanaryAutoFailRestartCount  int32
+	CanaryDuration            time.Duration
+	CanaryReplicas            string
+	CanaryAutoPauseEnabled    bool
+	CanaryAutoPauseMaxRestart int32
+	CanaryAutoFailEnabled     bool
+	CanaryAutoFailMaxRestarts int32
 }
 
 func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemonSetSpec {
@@ -93,13 +93,13 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 	}
 
 	spec.Strategy.Canary.AutoFail.Enabled = edsv1alpha1.NewBool(options.CanaryAutoFailEnabled)
-	if options.CanaryAutoFailRestartCount > 0 {
-		spec.Strategy.Canary.AutoFail.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoFailRestartCount)
+	if options.CanaryAutoFailMaxRestarts > 0 {
+		spec.Strategy.Canary.AutoFail.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoFailMaxRestarts)
 	}
 
 	spec.Strategy.Canary.AutoPause.Enabled = edsv1alpha1.NewBool(options.CanaryAutoPauseEnabled)
-	if options.CanaryAutoPauseRestartCount > 0 {
-		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseRestartCount)
+	if options.CanaryAutoPauseMaxRestart > 0 {
+		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseMaxRestart)
 	}
 	return spec
 }

--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
+	componentagent "github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 
@@ -61,7 +62,7 @@ const (
 
 // ReconcilerOptions provides options read from command line
 type ReconcilerOptions struct {
-	SupportExtendedDaemonset bool
+	ExtendedDaemonsetOptions componentagent.ExtendedDaemonsetOptions
 	SupportCilium            bool
 	OperatorMetricsEnabled   bool
 	V2Enabled                bool
@@ -157,7 +158,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, request reconcile.Re
 
 func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logger) *feature.Options {
 	return &feature.Options{
-		SupportExtendedDaemonset: opts.SupportExtendedDaemonset,
+		SupportExtendedDaemonset: opts.ExtendedDaemonsetOptions.Enabled,
 		Logger:                   logger,
 	}
 }

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -40,9 +40,9 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 
 	requiredEnabled := requiredComponents.Agent.IsEnabled()
 
-	if r.options.SupportExtendedDaemonset {
+	if r.options.ExtendedDaemonsetOptions.Enabled {
 		// Start by creating the Default Agent extendeddaemonset
-		eds = componentagent.NewDefaultAgentExtendedDaemonset(dda, requiredContainers)
+		eds = componentagent.NewDefaultAgentExtendedDaemonset(dda, &r.options.ExtendedDaemonsetOptions, requiredContainers)
 		podManagers = feature.NewPodTemplateManagers(&eds.Spec.Template)
 
 		// Set Global setting on the default extendeddaemonset

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -22,6 +22,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	test "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	componentagent "github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
@@ -114,7 +115,7 @@ func TestReconcileDatadogAgent_createNewExtendedDaemonSet(t *testing.T) {
 				recorder:   recorder,
 				forwarders: forwarders,
 				options: ReconcilerOptions{
-					SupportExtendedDaemonset: true,
+					ExtendedDaemonsetOptions: componentagent.ExtendedDaemonsetOptions{Enabled: true},
 					SupportCilium:            true,
 				},
 			}
@@ -2855,8 +2856,10 @@ func TestReconcileDatadogAgent_Reconcile(t *testing.T) {
 				log:          logf.Log.WithName(tt.name),
 				forwarders:   forwarders,
 				options: ReconcilerOptions{
-					SupportExtendedDaemonset: true,
-					SupportCilium:            true,
+					ExtendedDaemonsetOptions: componentagent.ExtendedDaemonsetOptions{
+						Enabled: true,
+					},
+					SupportCilium: true,
 				},
 			}
 

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -194,7 +194,7 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder.Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, handlerEnqueue)
 	builder.Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, handlerEnqueue)
 
-	if r.Options.SupportExtendedDaemonset {
+	if r.Options.ExtendedDaemonsetOptions.Enabled {
 		builder = builder.Owns(&edsdatadoghqv1alpha1.ExtendedDaemonSet{})
 	}
 

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -49,7 +49,9 @@ type ExtendedDaemonsetOptions struct {
 
 	CanaryDuration              time.Duration
 	CanaryReplicas              string
+	CanaryAutoPauseEnabled      bool
 	CanaryAutoPauseRestartCount int
+	CanaryAutoFailEnabled       bool
 	CanaryAutoFailRestartCount  int
 }
 
@@ -122,7 +124,9 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 				MaxPodSchedulerFailure:      options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
 				CanaryDuration:              options.SupportExtendedDaemonset.CanaryDuration,
 				CanaryReplicas:              options.SupportExtendedDaemonset.CanaryReplicas,
+				CanaryAutoPauseEnabled:      options.SupportExtendedDaemonset.CanaryAutoPauseEnabled,
 				CanaryAutoPauseRestartCount: int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
+				CanaryAutoFailEnabled:       options.SupportExtendedDaemonset.CanaryAutoFailEnabled,
 				CanaryAutoFailRestartCount:  int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
 			},
 			SupportCilium:          options.SupportCilium,

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -47,12 +47,12 @@ type ExtendedDaemonsetOptions struct {
 	MaxPodUnavailable      string
 	MaxPodSchedulerFailure string
 
-	CanaryDuration              time.Duration
-	CanaryReplicas              string
-	CanaryAutoPauseEnabled      bool
-	CanaryAutoPauseRestartCount int
-	CanaryAutoFailEnabled       bool
-	CanaryAutoFailRestartCount  int
+	CanaryDuration            time.Duration
+	CanaryReplicas            string
+	CanaryAutoPauseEnabled    bool
+	CanaryAutoPauseMaxRestart int
+	CanaryAutoFailEnabled     bool
+	CanaryAutoFailMaxRestarts int
 }
 
 type starterFunc func(logr.Logger, manager.Manager, *version.Info, kubernetes.PlatformInfo, SetupOptions) error
@@ -119,15 +119,15 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 		Recorder:     mgr.GetEventRecorderFor(agentControllerName),
 		Options: datadogagent.ReconcilerOptions{
 			ExtendedDaemonsetOptions: componentagent.ExtendedDaemonsetOptions{
-				Enabled:                     options.SupportExtendedDaemonset.Enabled,
-				MaxPodUnavailable:           options.SupportExtendedDaemonset.MaxPodUnavailable,
-				MaxPodSchedulerFailure:      options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
-				CanaryDuration:              options.SupportExtendedDaemonset.CanaryDuration,
-				CanaryReplicas:              options.SupportExtendedDaemonset.CanaryReplicas,
-				CanaryAutoPauseEnabled:      options.SupportExtendedDaemonset.CanaryAutoPauseEnabled,
-				CanaryAutoPauseRestartCount: int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
-				CanaryAutoFailEnabled:       options.SupportExtendedDaemonset.CanaryAutoFailEnabled,
-				CanaryAutoFailRestartCount:  int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
+				Enabled:                   options.SupportExtendedDaemonset.Enabled,
+				MaxPodUnavailable:         options.SupportExtendedDaemonset.MaxPodUnavailable,
+				MaxPodSchedulerFailure:    options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
+				CanaryDuration:            options.SupportExtendedDaemonset.CanaryDuration,
+				CanaryReplicas:            options.SupportExtendedDaemonset.CanaryReplicas,
+				CanaryAutoPauseEnabled:    options.SupportExtendedDaemonset.CanaryAutoPauseEnabled,
+				CanaryAutoPauseMaxRestart: int32(options.SupportExtendedDaemonset.CanaryAutoPauseMaxRestart),
+				CanaryAutoFailEnabled:     options.SupportExtendedDaemonset.CanaryAutoFailEnabled,
+				CanaryAutoFailMaxRestarts: int32(options.SupportExtendedDaemonset.CanaryAutoPauseMaxRestart),
 			},
 			SupportCilium:          options.SupportCilium,
 			OperatorMetricsEnabled: options.OperatorMetricsEnabled,

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -7,12 +7,14 @@ package controllers
 
 import (
 	"fmt"
+	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/DataDog/datadog-operator/controllers/datadogagent"
+	componentagent "github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/datadogclient"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
@@ -30,13 +32,25 @@ const (
 
 // SetupOptions defines options for setting up controllers to ease testing
 type SetupOptions struct {
-	SupportExtendedDaemonset bool
+	SupportExtendedDaemonset ExtendedDaemonsetOptions
 	SupportCilium            bool
 	Creds                    config.Creds
 	DatadogAgentEnabled      bool
 	DatadogMonitorEnabled    bool
 	OperatorMetricsEnabled   bool
 	V2APIEnabled             bool
+}
+
+// ExtendedDaemonsetOptions defines ExtendedDaemonset options
+type ExtendedDaemonsetOptions struct {
+	Enabled                bool
+	MaxPodUnavailable      string
+	MaxPodSchedulerFailure string
+
+	CanaryDuration              time.Duration
+	CanaryPodCount              string
+	CanaryAutoPauseRestartCount int
+	CanaryAutoFailRestartCount  int
 }
 
 type starterFunc func(logr.Logger, manager.Manager, *version.Info, kubernetes.PlatformInfo, SetupOptions) error
@@ -102,10 +116,18 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 		Scheme:       mgr.GetScheme(),
 		Recorder:     mgr.GetEventRecorderFor(agentControllerName),
 		Options: datadogagent.ReconcilerOptions{
-			SupportExtendedDaemonset: options.SupportExtendedDaemonset,
-			SupportCilium:            options.SupportCilium,
-			OperatorMetricsEnabled:   options.OperatorMetricsEnabled,
-			V2Enabled:                options.V2APIEnabled,
+			ExtendedDaemonsetOptions: componentagent.ExtendedDaemonsetOptions{
+				Enabled:                     options.SupportExtendedDaemonset.Enabled,
+				MaxPodUnavailable:           options.SupportExtendedDaemonset.MaxPodUnavailable,
+				MaxPodSchedulerFailure:      options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
+				CanaryDuration:              options.SupportExtendedDaemonset.CanaryDuration,
+				CanaryPodCount:              options.SupportExtendedDaemonset.CanaryPodCount,
+				CanaryAutoPauseRestartCount: int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
+				CanaryAutoFailRestartCount:  int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
+			},
+			SupportCilium:          options.SupportCilium,
+			OperatorMetricsEnabled: options.OperatorMetricsEnabled,
+			V2Enabled:              options.V2APIEnabled,
 		},
 	}).SetupWithManager(mgr)
 }

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -48,7 +48,7 @@ type ExtendedDaemonsetOptions struct {
 	MaxPodSchedulerFailure string
 
 	CanaryDuration              time.Duration
-	CanaryPodCount              string
+	CanaryReplicas              string
 	CanaryAutoPauseRestartCount int
 	CanaryAutoFailRestartCount  int
 }
@@ -121,7 +121,7 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 				MaxPodUnavailable:           options.SupportExtendedDaemonset.MaxPodUnavailable,
 				MaxPodSchedulerFailure:      options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
 				CanaryDuration:              options.SupportExtendedDaemonset.CanaryDuration,
-				CanaryPodCount:              options.SupportExtendedDaemonset.CanaryPodCount,
+				CanaryReplicas:              options.SupportExtendedDaemonset.CanaryReplicas,
 				CanaryAutoPauseRestartCount: int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
 				CanaryAutoFailRestartCount:  int32(options.SupportExtendedDaemonset.CanaryAutoPauseRestartCount),
 			},

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -47,12 +47,12 @@ type ExtendedDaemonsetOptions struct {
 	MaxPodUnavailable      string
 	MaxPodSchedulerFailure string
 
-	CanaryDuration            time.Duration
-	CanaryReplicas            string
-	CanaryAutoPauseEnabled    bool
-	CanaryAutoPauseMaxRestart int
-	CanaryAutoFailEnabled     bool
-	CanaryAutoFailMaxRestarts int
+	CanaryDuration             time.Duration
+	CanaryReplicas             string
+	CanaryAutoPauseEnabled     bool
+	CanaryAutoPauseMaxRestarts int
+	CanaryAutoFailEnabled      bool
+	CanaryAutoFailMaxRestarts  int
 }
 
 type starterFunc func(logr.Logger, manager.Manager, *version.Info, kubernetes.PlatformInfo, SetupOptions) error
@@ -119,15 +119,15 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 		Recorder:     mgr.GetEventRecorderFor(agentControllerName),
 		Options: datadogagent.ReconcilerOptions{
 			ExtendedDaemonsetOptions: componentagent.ExtendedDaemonsetOptions{
-				Enabled:                   options.SupportExtendedDaemonset.Enabled,
-				MaxPodUnavailable:         options.SupportExtendedDaemonset.MaxPodUnavailable,
-				MaxPodSchedulerFailure:    options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
-				CanaryDuration:            options.SupportExtendedDaemonset.CanaryDuration,
-				CanaryReplicas:            options.SupportExtendedDaemonset.CanaryReplicas,
-				CanaryAutoPauseEnabled:    options.SupportExtendedDaemonset.CanaryAutoPauseEnabled,
-				CanaryAutoPauseMaxRestart: int32(options.SupportExtendedDaemonset.CanaryAutoPauseMaxRestart),
-				CanaryAutoFailEnabled:     options.SupportExtendedDaemonset.CanaryAutoFailEnabled,
-				CanaryAutoFailMaxRestarts: int32(options.SupportExtendedDaemonset.CanaryAutoPauseMaxRestart),
+				Enabled:                    options.SupportExtendedDaemonset.Enabled,
+				MaxPodUnavailable:          options.SupportExtendedDaemonset.MaxPodUnavailable,
+				MaxPodSchedulerFailure:     options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
+				CanaryDuration:             options.SupportExtendedDaemonset.CanaryDuration,
+				CanaryReplicas:             options.SupportExtendedDaemonset.CanaryReplicas,
+				CanaryAutoPauseEnabled:     options.SupportExtendedDaemonset.CanaryAutoPauseEnabled,
+				CanaryAutoPauseMaxRestarts: int32(options.SupportExtendedDaemonset.CanaryAutoPauseMaxRestarts),
+				CanaryAutoFailEnabled:      options.SupportExtendedDaemonset.CanaryAutoFailEnabled,
+				CanaryAutoFailMaxRestarts:  int32(options.SupportExtendedDaemonset.CanaryAutoFailMaxRestarts),
 			},
 			SupportCilium:          options.SupportCilium,
 			OperatorMetricsEnabled: options.OperatorMetricsEnabled,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -99,10 +99,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	options := SetupOptions{
-		SupportExtendedDaemonset: false,
-		Creds:                    config.Creds{APIKey: "dummy_api_key", AppKey: "dummy_app_key"},
-		DatadogAgentEnabled:      true,
-		DatadogMonitorEnabled:    true,
+		SupportExtendedDaemonset: ExtendedDaemonsetOptions{
+			Enabled: false,
+		},
+		Creds:                 config.Creds{APIKey: "dummy_api_key", AppKey: "dummy_app_key"},
+		DatadogAgentEnabled:   true,
+		DatadogMonitorEnabled: true,
 	}
 
 	err = SetupControllers(logger, mgr, options)

--- a/controllers/suite_v2_test.go
+++ b/controllers/suite_v2_test.go
@@ -100,11 +100,13 @@ var _ = BeforeSuite(func() {
 	})
 
 	options := SetupOptions{
-		SupportExtendedDaemonset: false,
-		Creds:                    config.Creds{APIKey: "dummy_api_key", AppKey: "dummy_app_key"},
-		DatadogAgentEnabled:      true,
-		DatadogMonitorEnabled:    true,
-		V2APIEnabled:             true,
+		SupportExtendedDaemonset: ExtendedDaemonsetOptions{
+			Enabled: false,
+		},
+		Creds:                 config.Creds{APIKey: "dummy_api_key", AppKey: "dummy_app_key"},
+		DatadogAgentEnabled:   true,
+		DatadogMonitorEnabled: true,
+		V2APIEnabled:          true,
 	}
 
 	err = SetupControllers(logger, mgr, options)

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ type options struct {
 	edsMaxPodUnavailable           string
 	edsMaxPodSchedulerFailure      string
 	edsCanaryDuration              time.Duration
-	edsCanaryPodCount              string
+	edsCanaryReplicas              string
 	edsCanaryAutoPauseRestartCount int
 	edsCanaryAutoFailRestartCount  int
 	supportCilium                  bool
@@ -146,12 +146,11 @@ func (opts *options) Parse() {
 	flag.StringVar(&opts.edsMaxPodUnavailable, "eds-max-pod-unavailable", "", "ExtendedDaemonset number of max unavailable pods during rolling-update")
 	flag.StringVar(&opts.edsMaxPodSchedulerFailure, "eds-max-pod-scheduler-failure", "", "ExtendedDaemonset number of max pod scheduler failure")
 	flag.DurationVar(&opts.edsCanaryDuration, "eds-canary-duration", 10*time.Minute, "ExtendedDaemonset canary duration")
-	flag.StringVar(&opts.edsCanaryPodCount, "eds-canary-pod-count", "", "ExtendedDaemonset number of canary pods")
+	flag.StringVar(&opts.edsCanaryReplicas, "eds-canary-pod-count", "", "ExtendedDaemonset number of canary pods")
 	flag.IntVar(&opts.edsCanaryAutoPauseRestartCount, "eds-canary-auto-pause-restart-count", 0, "ExtendedDaemonset canary auto pause restart count")
 	flag.IntVar(&opts.edsCanaryAutoFailRestartCount, "eds-canary-auto-fail-restart-count", 0, "ExtendedDaemonset canary auto fail restart count")
 
-	// trigger flag parsing
-	// in needs to be the last function call
+	// Parsing flags
 	flag.Parse()
 }
 
@@ -234,7 +233,7 @@ func run(opts *options) error {
 			Enabled:           opts.supportExtendedDaemonset,
 			MaxPodUnavailable: opts.edsMaxPodUnavailable,
 			CanaryDuration:    opts.edsCanaryDuration,
-			CanaryPodCount:    opts.edsCanaryPodCount,
+			CanaryReplicas:    opts.edsCanaryReplicas,
 		},
 		SupportCilium:          opts.supportCilium,
 		Creds:                  creds,

--- a/main.go
+++ b/main.go
@@ -100,22 +100,22 @@ type options struct {
 	leaderElectionLeaseDuration time.Duration
 
 	// Controllers options
-	supportExtendedDaemonset       bool
-	edsMaxPodUnavailable           string
-	edsMaxPodSchedulerFailure      string
-	edsCanaryDuration              time.Duration
-	edsCanaryReplicas              string
-	edsCanaryAutoPauseEnabled      bool
-	edsCanaryAutoPauseRestartCount int
-	edsCanaryAutoFailedEnabled     bool
-	edsCanaryAutoFailRestartCount  int
-	supportCilium                  bool
-	datadogAgentEnabled            bool
-	datadogMonitorEnabled          bool
-	operatorMetricsEnabled         bool
-	webhookEnabled                 bool
-	v2APIEnabled                   bool
-	maximumGoroutines              int
+	supportExtendedDaemonset     bool
+	edsMaxPodUnavailable         string
+	edsMaxPodSchedulerFailure    string
+	edsCanaryDuration            time.Duration
+	edsCanaryReplicas            string
+	edsCanaryAutoPauseEnabled    bool
+	edsCanaryAutoPauseMaxRestart int
+	edsCanaryAutoFailedEnabled   bool
+	edsCanaryAutoFailMaxRestarts int
+	supportCilium                bool
+	datadogAgentEnabled          bool
+	datadogMonitorEnabled        bool
+	operatorMetricsEnabled       bool
+	webhookEnabled               bool
+	v2APIEnabled                 bool
+	maximumGoroutines            int
 
 	// Secret Backend options
 	secretBackendCommand string
@@ -159,9 +159,9 @@ func (opts *options) Parse() {
 	flag.DurationVar(&opts.edsCanaryDuration, "eds-canary-duration", 10*time.Minute, "ExtendedDaemonset canary duration")
 	flag.StringVar(&opts.edsCanaryReplicas, "eds-canary-pod-count", "", "ExtendedDaemonset number of canary pods")
 	flag.BoolVar(&opts.edsCanaryAutoPauseEnabled, "eds-canary-auto-pause-enabled", defaultCanaryAutoPauseEnabled, "ExtendedDaemonset canary auto pause enabled")
-	flag.IntVar(&opts.edsCanaryAutoPauseRestartCount, "eds-canary-auto-pause-restart-count", defaultCanaryAutoPauseMaxRestarts, "ExtendedDaemonset canary auto pause restart count")
+	flag.IntVar(&opts.edsCanaryAutoPauseMaxRestart, "eds-canary-auto-pause-max-restart-count", defaultCanaryAutoPauseMaxRestarts, "ExtendedDaemonset canary auto pause restart count")
 	flag.BoolVar(&opts.edsCanaryAutoFailedEnabled, "eds-canary-auto-failed-enabled", defaultCanaryAutoFailEnabled, "ExtendedDaemonset canary auto failed enabled")
-	flag.IntVar(&opts.edsCanaryAutoFailRestartCount, "eds-canary-auto-fail-restart-count", defaultCanaryAutoFailMaxRestarts, "ExtendedDaemonset canary auto fail restart count")
+	flag.IntVar(&opts.edsCanaryAutoFailMaxRestarts, "eds-canary-auto-max-fail-restart-count", defaultCanaryAutoFailMaxRestarts, "ExtendedDaemonset canary auto fail restart count")
 
 	// Parsing flags
 	flag.Parse()
@@ -243,15 +243,15 @@ func run(opts *options) error {
 
 	options := controllers.SetupOptions{
 		SupportExtendedDaemonset: controllers.ExtendedDaemonsetOptions{
-			Enabled:                     opts.supportExtendedDaemonset,
-			MaxPodUnavailable:           opts.edsMaxPodUnavailable,
-			CanaryDuration:              opts.edsCanaryDuration,
-			CanaryReplicas:              opts.edsCanaryReplicas,
-			CanaryAutoPauseEnabled:      opts.edsCanaryAutoPauseEnabled,
-			CanaryAutoPauseRestartCount: opts.edsCanaryAutoPauseRestartCount,
-			CanaryAutoFailEnabled:       opts.edsCanaryAutoFailedEnabled,
-			CanaryAutoFailRestartCount:  opts.edsCanaryAutoFailRestartCount,
-			MaxPodSchedulerFailure:      opts.edsMaxPodSchedulerFailure,
+			Enabled:                   opts.supportExtendedDaemonset,
+			MaxPodUnavailable:         opts.edsMaxPodUnavailable,
+			CanaryDuration:            opts.edsCanaryDuration,
+			CanaryReplicas:            opts.edsCanaryReplicas,
+			CanaryAutoPauseEnabled:    opts.edsCanaryAutoPauseEnabled,
+			CanaryAutoPauseMaxRestart: opts.edsCanaryAutoPauseMaxRestart,
+			CanaryAutoFailEnabled:     opts.edsCanaryAutoFailedEnabled,
+			CanaryAutoFailMaxRestarts: opts.edsCanaryAutoFailMaxRestarts,
+			MaxPodSchedulerFailure:    opts.edsMaxPodSchedulerFailure,
 		},
 		SupportCilium:          opts.supportCilium,
 		Creds:                  creds,

--- a/main.go
+++ b/main.go
@@ -100,22 +100,22 @@ type options struct {
 	leaderElectionLeaseDuration time.Duration
 
 	// Controllers options
-	supportExtendedDaemonset     bool
-	edsMaxPodUnavailable         string
-	edsMaxPodSchedulerFailure    string
-	edsCanaryDuration            time.Duration
-	edsCanaryReplicas            string
-	edsCanaryAutoPauseEnabled    bool
-	edsCanaryAutoPauseMaxRestart int
-	edsCanaryAutoFailedEnabled   bool
-	edsCanaryAutoFailMaxRestarts int
-	supportCilium                bool
-	datadogAgentEnabled          bool
-	datadogMonitorEnabled        bool
-	operatorMetricsEnabled       bool
-	webhookEnabled               bool
-	v2APIEnabled                 bool
-	maximumGoroutines            int
+	supportExtendedDaemonset      bool
+	edsMaxPodUnavailable          string
+	edsMaxPodSchedulerFailure     string
+	edsCanaryDuration             time.Duration
+	edsCanaryReplicas             string
+	edsCanaryAutoPauseEnabled     bool
+	edsCanaryAutoPauseMaxRestarts int
+	edsCanaryAutoFailEnabled      bool
+	edsCanaryAutoFailMaxRestarts  int
+	supportCilium                 bool
+	datadogAgentEnabled           bool
+	datadogMonitorEnabled         bool
+	operatorMetricsEnabled        bool
+	webhookEnabled                bool
+	v2APIEnabled                  bool
+	maximumGoroutines             int
 
 	// Secret Backend options
 	secretBackendCommand string
@@ -154,14 +154,14 @@ func (opts *options) Parse() {
 
 	// ExtendedDaemonset configuration
 	flag.BoolVar(&opts.supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
-	flag.StringVar(&opts.edsMaxPodUnavailable, "eds-max-pod-unavailable", "", "ExtendedDaemonset number of max unavailable pods during rolling-update")
-	flag.StringVar(&opts.edsMaxPodSchedulerFailure, "eds-max-pod-scheduler-failure", "", "ExtendedDaemonset number of max pod scheduler failure")
-	flag.DurationVar(&opts.edsCanaryDuration, "eds-canary-duration", 10*time.Minute, "ExtendedDaemonset canary duration")
-	flag.StringVar(&opts.edsCanaryReplicas, "eds-canary-pod-count", "", "ExtendedDaemonset number of canary pods")
-	flag.BoolVar(&opts.edsCanaryAutoPauseEnabled, "eds-canary-auto-pause-enabled", defaultCanaryAutoPauseEnabled, "ExtendedDaemonset canary auto pause enabled")
-	flag.IntVar(&opts.edsCanaryAutoPauseMaxRestart, "eds-canary-auto-pause-max-restart-count", defaultCanaryAutoPauseMaxRestarts, "ExtendedDaemonset canary auto pause restart count")
-	flag.BoolVar(&opts.edsCanaryAutoFailedEnabled, "eds-canary-auto-failed-enabled", defaultCanaryAutoFailEnabled, "ExtendedDaemonset canary auto failed enabled")
-	flag.IntVar(&opts.edsCanaryAutoFailMaxRestarts, "eds-canary-auto-max-fail-restart-count", defaultCanaryAutoFailMaxRestarts, "ExtendedDaemonset canary auto fail restart count")
+	flag.StringVar(&opts.edsMaxPodUnavailable, "edsMaxPodUnavailable", "", "ExtendedDaemonset number of max unavailable pods during the rolling update")
+	flag.StringVar(&opts.edsMaxPodSchedulerFailure, "edsMaxPodSchedulerFailure", "", "ExtendedDaemonset number of max pod scheduler failures")
+	flag.DurationVar(&opts.edsCanaryDuration, "edsCanaryDuration", 10*time.Minute, "ExtendedDaemonset canary duration")
+	flag.StringVar(&opts.edsCanaryReplicas, "edsCanaryReplicas", "", "ExtendedDaemonset number of canary pods")
+	flag.BoolVar(&opts.edsCanaryAutoPauseEnabled, "edsCanaryAutoPauseEnabled", defaultCanaryAutoPauseEnabled, "ExtendedDaemonset canary auto pause enabled")
+	flag.IntVar(&opts.edsCanaryAutoPauseMaxRestarts, "edsCanaryAutoPauseMaxRestarts", defaultCanaryAutoPauseMaxRestarts, "ExtendedDaemonset canary auto pause max restart count")
+	flag.BoolVar(&opts.edsCanaryAutoFailEnabled, "edsCanaryAutoFailEnabled", defaultCanaryAutoFailEnabled, "ExtendedDaemonset canary auto fail enabled")
+	flag.IntVar(&opts.edsCanaryAutoFailMaxRestarts, "edsCanaryAutoFailMaxRestarts", defaultCanaryAutoFailMaxRestarts, "ExtendedDaemonset canary auto fail max restart count")
 
 	// Parsing flags
 	flag.Parse()
@@ -243,15 +243,15 @@ func run(opts *options) error {
 
 	options := controllers.SetupOptions{
 		SupportExtendedDaemonset: controllers.ExtendedDaemonsetOptions{
-			Enabled:                   opts.supportExtendedDaemonset,
-			MaxPodUnavailable:         opts.edsMaxPodUnavailable,
-			CanaryDuration:            opts.edsCanaryDuration,
-			CanaryReplicas:            opts.edsCanaryReplicas,
-			CanaryAutoPauseEnabled:    opts.edsCanaryAutoPauseEnabled,
-			CanaryAutoPauseMaxRestart: opts.edsCanaryAutoPauseMaxRestart,
-			CanaryAutoFailEnabled:     opts.edsCanaryAutoFailedEnabled,
-			CanaryAutoFailMaxRestarts: opts.edsCanaryAutoFailMaxRestarts,
-			MaxPodSchedulerFailure:    opts.edsMaxPodSchedulerFailure,
+			Enabled:                    opts.supportExtendedDaemonset,
+			MaxPodUnavailable:          opts.edsMaxPodUnavailable,
+			CanaryDuration:             opts.edsCanaryDuration,
+			CanaryReplicas:             opts.edsCanaryReplicas,
+			CanaryAutoPauseEnabled:     opts.edsCanaryAutoPauseEnabled,
+			CanaryAutoPauseMaxRestarts: opts.edsCanaryAutoPauseMaxRestarts,
+			CanaryAutoFailEnabled:      opts.edsCanaryAutoFailEnabled,
+			CanaryAutoFailMaxRestarts:  opts.edsCanaryAutoFailMaxRestarts,
+			MaxPodSchedulerFailure:     opts.edsMaxPodSchedulerFailure,
 		},
 		SupportCilium:          opts.supportCilium,
 		Creds:                  creds,


### PR DESCRIPTION
### What does this PR do?

With v2alpha1.DatadogAgent CRD, ExtendedDaemonset configuration is
not present on purpose, to allow sunseting EDS support maybe later.

This PR allow to configure EDS.spec.stragy thanks to Operator global
settings.

### Motivation

With v2alpha1.DatadogAgent CRD, ExtendedDaemonset configuration is
not present on purpose, to allow sunseting EDS support maybe later.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

test the Operator new command line options when `-supportExtendedDaemonset true`.
The options value should be visible in the created `ExtendedDaemonset.spec.strategy`

```
  -eds-canary-auto-fail-restart-count int
        ExtendedDaemonset canary auto fail restart count
  -eds-canary-auto-pause-restart-count int
        ExtendedDaemonset canary auto pause restart count
  -eds-canary-duration duration
        ExtendedDaemonset canary duration (default 10m0s)
  -eds-canary-pod-count string
        ExtendedDaemonset number of canary pods
  -eds-max-pod-scheduler-failure string
        ExtendedDaemonset number of max pod scheduler failure
  -eds-max-pod-unavailable string
        ExtendedDaemonset number of max unavailable pods during rolling-update
````
