### PR TITLE
Fix volume mounts example

### DIFF
--- a/docs/custom_check.md
+++ b/docs/custom_check.md
@@ -144,14 +144,16 @@ spec:
     nodeAgent:
       image:
         name: "gcr.io/datadoghq/agent:latest"
-        volumes:
-          - name: secrets
-            secret:
-              secretName: secrets
-        volumeMounts:
-          - name: secrets
-            mountPath: /etc/secrets
-            readOnly: true
+      volumes:
+        - name: secrets
+          secret:
+            secretName: secrets
+      containers:
+        agent:
+          volumeMounts:
+            - name: secrets
+              mountPath: /etc/secrets
+              readOnly: true
 ```
 
 [1]: https://docs.datadoghq.com/agent/autodiscovery/


### PR DESCRIPTION
### What does this PR do?

In `v2alpha1` version of the `DatadogAgent` resource the volume mounts are per container, not per pod.

This PR fixes the example

### Motivation

I was trying out the Operator GA and this example failed.


