### PR TITLE
Fix segfault to prevent Operator crash when credentials are missing in DDA

### DIFF
--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -7,6 +7,7 @@ package datadogagent
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -44,6 +45,10 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, request reconcile.
 		}
 		// Error reading the object - requeue the request.
 		return result, err
+	}
+
+	if instance.Spec.Global == nil || instance.Spec.Global.Credentials == nil {
+		return result, fmt.Errorf("credentials not configured in the DatadogAgent, can't reconcile")
 	}
 
 	// check it the resource was properly decoded in v2

--- a/controllers/testutils/agent.go
+++ b/controllers/testutils/agent.go
@@ -316,6 +316,10 @@ func NewDatadogAgentWithGlobalConfigSettings(namespace string, name string) v2al
 		ClusterAgentToken: apiutils.NewStringPointer("my-cluster-agent-token"),
 		ClusterName:       apiutils.NewStringPointer("my-cluster"),
 		Site:              apiutils.NewStringPointer("some-dd-site"),
+		Credentials: &v2alpha1.DatadogCredentials{
+			APIKey: apiutils.NewStringPointer("my-api-key"),
+			AppKey: apiutils.NewStringPointer("my-app-key"),
+		},
 		Endpoint: &v2alpha1.Endpoint{
 			URL: apiutils.NewStringPointer("some-url"),
 			Credentials: &v2alpha1.DatadogCredentials{

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -600,6 +600,10 @@ func (mf *metricsForwarder) getDatadogAgentV2() (*v2alpha1.DatadogAgent, error) 
 }
 
 func (mf *metricsForwarder) getCredentialsV2(dda *v2alpha1.DatadogAgent) (string, string, error) {
+	if dda.Spec.Global.Credentials == nil {
+		return "", "", fmt.Errorf("credentials not configured in the DatadogAgent")
+	}
+
 	var err error
 	apiKey, appKey := "", ""
 
@@ -608,10 +612,6 @@ func (mf *metricsForwarder) getCredentialsV2(dda *v2alpha1.DatadogAgent) (string
 	if dda.Spec.Global != nil && dda.Spec.Global.Credentials != nil && dda.Spec.Global.Credentials.APIKey != nil && *dda.Spec.Global.Credentials.APIKey != "" {
 		apiKey = *dda.Spec.Global.Credentials.APIKey
 	} else {
-		if dda.Spec.Global.Credentials == nil {
-			return "", "", fmt.Errorf("credentials not configured in the DatadogAgent")
-		}
-
 		_, secretName, secretKeyName := v2alpha1.GetAPIKeySecret(dda.Spec.Global.Credentials, defaultSecretName)
 		apiKey, err = mf.getKeyFromSecret(dda.Namespace, secretName, secretKeyName)
 		if err != nil {

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -608,6 +608,10 @@ func (mf *metricsForwarder) getCredentialsV2(dda *v2alpha1.DatadogAgent) (string
 	if dda.Spec.Global != nil && dda.Spec.Global.Credentials != nil && dda.Spec.Global.Credentials.APIKey != nil && *dda.Spec.Global.Credentials.APIKey != "" {
 		apiKey = *dda.Spec.Global.Credentials.APIKey
 	} else {
+		if dda.Spec.Global.Credentials == nil {
+			return "", "", fmt.Errorf("credentials not configured in the DatadogAgent")
+		}
+
 		_, secretName, secretKeyName := v2alpha1.GetAPIKeySecret(dda.Spec.Global.Credentials, defaultSecretName)
 		apiKey, err = mf.getKeyFromSecret(dda.Namespace, secretName, secretKeyName)
 		if err != nil {

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -600,7 +600,7 @@ func (mf *metricsForwarder) getDatadogAgentV2() (*v2alpha1.DatadogAgent, error) 
 }
 
 func (mf *metricsForwarder) getCredentialsV2(dda *v2alpha1.DatadogAgent) (string, string, error) {
-	if dda.Spec.Global.Credentials == nil {
+	if dda.Spec.Global == nil || dda.Spec.Global.Credentials == nil {
 		return "", "", fmt.Errorf("credentials not configured in the DatadogAgent")
 	}
 

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -621,6 +621,16 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "nil credentials not causes segmentation fault",
+			fields: fields{
+				client: fake.NewFakeClient(),
+			},
+			args: args{
+				dda: testV2.NewDatadogAgent("foo", "bar", &datadoghqv2alpha1.GlobalConfig{}),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -622,7 +622,7 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 			},
 		},
 		{
-			name: "nil credentials not causes segmentation fault",
+			name: "nil credentials doesn't cause segmentation fault",
 			fields: fields{
 				client: fake.NewFakeClient(),
 			},


### PR DESCRIPTION
### What does this PR do?

Adds a check to avoid segmentation violation when looking up credentials during `metrics_forwarder` registration. 
Also skips reconciling `DatadogAgent` if credentials are missing.

From the current behavior of CLB and nothing happening, we will get:
* Operator retrying to get the credentials from `DatadogAgent` and register `metrics_forwarder` once credentials are present. 
* ~~Operator will create agent deployments but since they need same credentials, they will not function properly.~~
* Operator will run and log info from `metrics_forwarder` errors from the reconciler.

### Motivation

https://github.com/DataDog/datadog-operator/issues/662, and few other Github mentions of the issue. 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Added unit test when credentials are missing.
* Locally tested scenario without credentials, adding them and seeing recovery.