### PR TITLE
Fix goroutines error formatting

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func customSetupHealthChecks(logger logr.Logger, mgr manager.Manager, maximumGor
 	setupLog.Info("configuring manager health check", "maximumGoroutines", *maximumGoroutines)
 	err := mgr.AddHealthzCheck("goroutines-number", func(req *http.Request) error {
 		if goruntime.NumGoroutine() > *maximumGoroutines {
-			return fmt.Errorf("too much goroutines: %d > limit: %d", goruntime.NumGoroutine(), maximumGoroutines)
+			return fmt.Errorf("too much goroutines: %d > limit: %d", goruntime.NumGoroutine(), *maximumGoroutines)
 		}
 		return nil
 	})

--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func customSetupHealthChecks(logger logr.Logger, mgr manager.Manager, maximumGor
 	setupLog.Info("configuring manager health check", "maximumGoroutines", *maximumGoroutines)
 	err := mgr.AddHealthzCheck("goroutines-number", func(req *http.Request) error {
 		if goruntime.NumGoroutine() > *maximumGoroutines {
-			return fmt.Errorf("too much goroutines: %d > limit: %d", goruntime.NumGoroutine(), *maximumGoroutines)
+			return fmt.Errorf("too many goroutines: %d > limit: %d", goruntime.NumGoroutine(), *maximumGoroutines)
 		}
 		return nil
 	})


### PR DESCRIPTION
### What does this PR do?

Fixes missing int pointer dereference when formatting error.

### Motivation

Customer reporting log line with `“too much goroutines: 466 > limit: 824634953576"` 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
