### PR TITLE
Remove envtest/printer package dependency

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -578,7 +578,6 @@ core,"sigs.k8s.io/controller-runtime/pkg/controller",Apache-2.0
 core,"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",Apache-2.0
 core,"sigs.k8s.io/controller-runtime/pkg/conversion",Apache-2.0
 core,"sigs.k8s.io/controller-runtime/pkg/envtest",Apache-2.0
-core,"sigs.k8s.io/controller-runtime/pkg/envtest/printer",Apache-2.0
 core,"sigs.k8s.io/controller-runtime/pkg/event",Apache-2.0
 core,"sigs.k8s.io/controller-runtime/pkg/handler",Apache-2.0
 core,"sigs.k8s.io/controller-runtime/pkg/healthz",Apache-2.0

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -21,10 +21,12 @@ import (
 	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
+	gc "github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	st "github.com/onsi/ginkgo/reporters/stenographer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -47,9 +49,11 @@ var (
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
+	stenographer := st.NewFakeStenographer()
+	reporterConfig := gc.DefaultReporterConfigType{}
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+		[]Reporter{reporters.NewDefaultReporter(reporterConfig, stenographer)})
 }
 
 var _ = BeforeSuite(func() {

--- a/controllers/suite_v2_test.go
+++ b/controllers/suite_v2_test.go
@@ -24,10 +24,12 @@ import (
 	"k8s.io/client-go/rest"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
+	gc "github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	st "github.com/onsi/ginkgo/reporters/stenographer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -50,9 +52,11 @@ var (
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
+	stenographer := st.NewFakeStenographer()
+	reporterConfig := gc.DefaultReporterConfigType{}
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+		[]Reporter{reporters.NewDefaultReporter(reporterConfig, stenographer)})
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
### What does this PR do?

`envtest/printer` is removed in `sigs.k8s.io/controller-runtime v0.14.0`, we are on `v0.11.2` but dependency on this package impacts some shared package builds. 

Replaced the `printer` with a default `Reporter` from Ginkgo. I didn't see noticeable difference in test output so not certain if I was looking at the right place.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
