### PR TITLE
Address Dogstatsd HostPort configuration not being converted by the webhook

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_conversion_agent.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_conversion_agent.go
@@ -52,6 +52,18 @@ func convertDatadogAgentSpec(src *DatadogAgentSpecAgentSpec, dst *v2alpha1.Datad
 			getV2TemplateOverride(&dst.Spec, v2alpha1.NodeAgentComponentName).ExtraChecksd = ConvertConfigDirSpec(src.Config.Checksd)
 		}
 
+		if src.Config.HostPort != nil {
+			features := getV2Features(dst)
+			if features.Dogstatsd == nil {
+				features.Dogstatsd = &v2alpha1.DogstatsdFeatureConfig{}
+			}
+			if features.Dogstatsd.HostPortConfig == nil {
+				features.Dogstatsd.HostPortConfig = &v2alpha1.HostPortConfig{}
+			}
+			features.Dogstatsd.HostPortConfig.Enabled = utils.NewBoolPointer(true)
+			features.Dogstatsd.HostPortConfig.Port = src.Config.HostPort
+		}
+
 		if src.Config.PodLabelsAsTags != nil {
 			getV2GlobalConfig(dst).PodLabelsAsTags = src.Config.PodLabelsAsTags
 		}

--- a/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
+++ b/apis/datadoghq/v1alpha1/testdata/all.expected.yaml
@@ -25,6 +25,9 @@ spec:
       originDetectionEnabled: true
       unixDomainSocketConfig:
         enabled: true
+      hostPortConfig:
+        enabled: true
+        hostPort: 420
     eventCollection:
       collectKubernetesEvents: true
     externalMetricsServer:
@@ -47,14 +50,14 @@ spec:
       conf:
         configMap:
           items:
-          - key: config.yaml
-            path: "config.yaml"
+            - key: config.yaml
+              path: "config.yaml"
           name: orch-cm
       enabled: true
       ddUrl: https://orch-explorer.com
       extraTags:
-      - orch
-      - exp
+        - orch
+        - exp
       scrubContainers: true
     prometheusScrape:
       additionalConfigs: |-
@@ -97,15 +100,15 @@ spec:
       tlsVerify: false
     registry: public.ecr.aws/datadog
     tags:
-    - hostTag1
-    - hostTag2
+      - hostTag1
+      - hostTag2
   override:
     clusterAgent:
       extraConfd:
         configMap:
           items:
-          - key: test
-            path: test.d/test.yaml
+            - key: test
+              path: test.d/test.yaml
           name: cluster-agent-confd
       replicas: 2
       customConfigurations:
@@ -127,11 +130,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       annotations:
         baz: foo
         foo: bar
@@ -161,7 +164,7 @@ spec:
           user: system_u
       serviceAccountName: datadog-agent-clc
       tolerations:
-      - operator: Foo
+        - operator: Foo
     nodeAgent:
       annotations:
         baz: foo
@@ -169,14 +172,14 @@ spec:
       containers:
         agent:
           args:
-          - config
-          - foo.yaml
+            - config
+            - foo.yaml
           command:
-          - custom-agent
-          - start
+            - custom-agent
+            - start
           env:
-          - name: TEST_VAR_CONT
-            value: TEST_VALUE_CONT
+            - name: TEST_VAR_CONT
+              value: TEST_VALUE_CONT
           healthPort: 42
           livenessProbe:
             initialDelaySeconds: 30
@@ -186,22 +189,22 @@ spec:
             limits:
               cpu: 400m
           volumeMounts:
-          - mountPath: ""
-            name: agent-volumeMount
+            - mountPath: ""
+              name: agent-volumeMount
         system-probe:
           securityContext:
-            seccompProfile: 
+            seccompProfile:
               type: Localhost
               localhostProfile: seccomp-profile
-          seccompConfig: 
+          seccompConfig:
             customRootPath: /custom/root/path
-            customProfile: 
-              configMap: 
+            customProfile:
+              configMap:
                 name: seccomp-configmap
       createRbac: true
       env:
-      - name: TEST_VAR_DS
-        value: TEST_VALUE_DS
+        - name: TEST_VAR_DS
+          value: TEST_VALUE_DS
       extraChecksd:
         configMap:
           name: agent-checksd
@@ -227,7 +230,7 @@ spec:
           user: system_u
       serviceAccountName: datadog-agent-scc
       tolerations:
-      - operator: Exists
+        - operator: Exists
       volumes:
-      - name: agent-volume
+        - name: agent-volume
 status: {}


### PR DESCRIPTION
### What does this PR do?

This PR updates the conversion logic for DatadogAgent to account for `.Config.hostPort` being set, and if set to set `.Features.Dogstatsd.HostPortConfig.HostPort` accordingly.

### Motivation

I created this PR after converting my manifests and noticing that there was no hostPort configuration being converted. This led to my agents no longer being able to receive any metrics.

My original v1alpha1/datadogagent manifest looked like this:
<details><summary>Details</summary>
<p>

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: datadog
spec:
  site: datadoghq.eu
  credentials:
    apiKey: asdf
    appKey: asdf
  features:
    logCollection:
      enabled: true
      logsConfigContainerCollectAll: true
    networkMonitoring:
      enabled: true
    orchestratorExplorer:
      enabled: true

  agent:
    image:
      name: "datadog/agent:1.2.3-jmx"
      pullSecrets:
        - name: dockerhub-credentials
    config:
      logLevel: "WARN"
      hostPort: 8125
      tolerations:
        - operator: Exists
      criSocket:
        criSocketPath: /var/run/containerd/containerd.sock
        useCriSocketVolume: true
      env:
        - name: DD_CLUSTER_NAME
          value: "test"
        - name: DD_TAGS
          value: "cluster_name:test"
        - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
          value: "true"
        - name: DD_APM_NON_LOCAL_TRAFFIC
          value: "true"
        - name: DD_LOGS_CONFIG_OPEN_FILES_LIMIT
          value: "400"
        - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
          value: "true"
        - name: DD_EXTRA_CONFIG_PROVIDERS
          value: "endpointschecks"
        - name: DD_EC2_PREFER_IMDSV2
          value: "true"
    apm:
      enabled: true
      hostPort: 8126
    process:
      enabled: true
      processCollectionEnabled: true
    systemProbe:
      enabled: true
      bpfDebugEnabled: true
      collectDNSStats: true
      conntrackEnabled: true
      enableOOMKill: true
  clusterAgent:
    image:
      name: "datadog/cluster-agent:1.2.3"
      pullSecrets:
        - name: dockerhub-credentials
    config:
      clusterChecksEnabled: true
      collectEvents: true
      externalMetrics:
        enabled: true
      env:
        - name: DD_CLUSTER_NAME
          value: "test"
        - name: DD_TAGS
          value: "cluster_name:test"
        - name: DD_EXTRA_CONFIG_PROVIDERS
          value: "kube_services kube_endpoints"
        - name: DD_EXTRA_LISTENERS
          value: "kube_services kube_endpoints"
        - name: DATADOG_HOST
          value: "https://app.datadoghq.eu/"
        - name: DD_COLLECT_KUBERNETES_EVENTS
          value: "true"
        - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
          value: "true"
    replicas: 2
```

</p>
</details> 

and was converted to this v2alpha1.datadogagent 
<details><summary>Details</summary>
<p>

```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: datadog
spec:
  features:
    apm:
      enabled: true
      hostPortConfig:
        enabled: true
        hostPort: 8126
    clusterChecks:
      enabled: true
    eventCollection:
      collectKubernetesEvents: true
    externalMetricsServer:
      enabled: true
      useDatadogMetrics: false
    liveContainerCollection:
      enabled: true
    liveProcessCollection:
      enabled: true
    logCollection:
      containerCollectAll: true
      enabled: true
    npm:
      collectDNSStats: true
      enableConntrack: true
      enabled: true
    oomKill:
      enabled: true
    orchestratorExplorer:
      enabled: true
  global:
    credentials:
      apiKey: asdf
      appKey: asdf
    criSocketPath: /var/run/containerd/containerd.sock
    site: datadoghq.eu
  override:
    nodeAgent:
      containers:
        agent:
          env:
          - name: DD_CLUSTER_NAME
            value: "test"
          - name: DD_TAGS
            value: "cluster_name:test"
          - name: DD_DOGSTATSD_NON_LOCAL_TRAFFIC
            value: "true"
          - name: DD_APM_NON_LOCAL_TRAFFIC
            value: "true"
          - name: DD_LOGS_CONFIG_OPEN_FILES_LIMIT
            value: "400"
          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
            value: "true"
          - name: DD_EXTRA_CONFIG_PROVIDERS
            value: "endpointschecks"
          - name: DD_EC2_PREFER_IMDSV2
            value: "true"
      image:
        name: "datadog/agent:1.2.3-jmx"
        pullSecrets:
        - name: dockerhub-credentials
      tolerations:
          - operator: Exists
    clusterAgent:
      containers:
        cluster-agent:
          env:
          - name: DD_CLUSTER_NAME
            value: "test"
          - name: DD_TAGS
            value: "cluster_name:test"
          - name: DD_EXTRA_CONFIG_PROVIDERS
            value: "kube_services kube_endpoints"
          - name: DD_EXTRA_LISTENERS
            value: "kube_services kube_endpoints"
          - name: DATADOG_HOST
            value: "https://app.datadoghq.eu/"
          - name: DD_COLLECT_KUBERNETES_EVENTS
            value: "true"
          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
            value: "true"
      image:
        name: "datadog/cluster-agent:1.2.3"
        pullSecrets:
          - name: dockerhub-credentials
      replicas: 2
``` 

</p>
</details> 

