### PR TITLE
Use kube-system namespace for clusterrolebinding reference to horizontal-pod-autoscaler service account

### DIFF
--- a/controllers/datadogagent/feature/externalmetrics/feature.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature.go
@@ -257,7 +257,7 @@ func (f *externalMetricsFeature) ManageDependencies(managers feature.ResourceMan
 	if err := managers.RBACManager().AddClusterPolicyRules(ns, rbacResourcesName, f.serviceAccountName, getDCAClusterPolicyRules(f.useDDM, f.useWPA)); err != nil {
 		return fmt.Errorf("error adding external metrics provider dca clusterrole and clusterrolebinding to store: %w", err)
 	}
-	if err := managers.RBACManager().AddClusterPolicyRules(ns, componentdca.GetExternalMetricsReaderClusterRoleName(f.owner, managers.Store().GetVersionInfo()), "horizontal-pod-autoscaler", getExternalMetricsReaderPolicyRules()); err != nil {
+	if err := managers.RBACManager().AddClusterPolicyRules("kube-system", componentdca.GetExternalMetricsReaderClusterRoleName(f.owner, managers.Store().GetVersionInfo()), "horizontal-pod-autoscaler", getExternalMetricsReaderPolicyRules()); err != nil {
 		return fmt.Errorf("error adding external metrics provider external metrics reader clusterrole and clusterrolebinding to store: %w", err)
 	}
 	if err := managers.RBACManager().AddClusterRoleBinding(ns, componentdca.GetHPAClusterRoleBindingName(f.owner), f.serviceAccountName, getAuthDelegatorRoleRef()); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR makes sure the clusterrolebinding for external metrics is correctly created using `kube-system` as the namespace for the `horizontal-pod-autoscaler` ServiceAccount

### Motivation

My colleagues reported today that HPAs based on External Metrics were no longer working since the upgrade to Datadog Operator 1.0.2.

After some investigation I found that the ClusterRoleBinding for `datadog-cluster-agent-metrics-reader` looked like this: 
<details><summary>datadog-cluster-agent-metrics-reader</summary>
<p>
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  creationTimestamp: "2023-04-24T15:55:32Z"
  labels:
    app.kubernetes.io/instance: datadog
    app.kubernetes.io/managed-by: datadog-operator
    app.kubernetes.io/name: datadog-agent-deployment
    app.kubernetes.io/part-of: datadog-datadog
    app.kubernetes.io/version: ""
    operator.datadoghq.com/managed-by-store: "true"
  name: datadog-cluster-agent-metrics-reader
  resourceVersion: "6981"
  uid: f2ffecbb-ff4c-4c49-b521-74a1a6a67c7b
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: datadog-cluster-agent-metrics-reader
subjects:
- kind: ServiceAccount
  name: horizontal-pod-autoscaler
  namespace: datadog
```
</p>
</details> 

Of course, there isn't any service account named `horizontal-pod-autoscaler` in the `datadog` namespace (where our Helm chart deploys datadog-operator) and therefore Horizontal pod autoscaler cannot access external metrics leading to this error in our HPAs: 
```
The HPA was unable to compute the replica count: unable to get external metric console/console.workers.job_pool_size.gauge/&LabelSelector{MatchLabels:map[string]string{worker: resque_default,},MatchExpressions:[]LabelSelectorRequirement{},}: unable to fetch metrics from external metrics API: console.workers.job_pool_size.gauge.external.metrics.k8s.io is forbidden: User "system:serviceaccount:kube-system:horizontal-pod-autoscaler" cannot list resource "console.workers.job_pool_size.gauge" in API group "external.metrics.k8s.io" in the namespace "console"
```

This PR addresses this by passing `kube-system` when the namespace used for resource creation should be `kube-system`. 

Let me know if there's a better way of fixing this.

### Describe your test plan

* Create a v2alpha1/DatadogAgent with external metrics enabled
* Run `kubectl get clusterrolebinding datadog-cluster-agent-metrics-reader -oyaml` to observe which namespace is used for the ref to horizontal-pod-autoscaler
* Build and deploy the fix
* Run `kubectl get clusterrolebinding datadog-cluster-agent-metrics-reader -oyaml` and verify the namespace reference for horizontal-pod-autoscaler is `kube-system` 