### PR TITLE
[feature] Create secret for external metrics creds when not using existing secret

### DIFF
--- a/controllers/datadogagent/feature/externalmetrics/feature.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature.go
@@ -96,18 +96,24 @@ func (f *externalMetricsFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 						}
 					}
 				}
-				if isSet, secretName, secretKey := v2alpha1.GetAPIKeySecret(creds, componentdca.GetDefaultExternalMetricSecretName(f.owner)); isSet {
-					// api key secret exists; store secret name and key instead
-					f.keySecret[apicommon.DefaultAPIKeyKey] = secret{
-						name: secretName,
-						key:  secretKey,
+				if creds.APISecret != nil {
+					_, secretName, secretKey := v2alpha1.GetAPIKeySecret(creds, componentdca.GetDefaultExternalMetricSecretName(f.owner))
+					if secretName != "" && secretKey != "" {
+						// api key secret exists; store secret name and key instead
+						f.keySecret[apicommon.DefaultAPIKeyKey] = secret{
+							name: secretName,
+							key:  secretKey,
+						}
 					}
 				}
-				if isSet, secretName, secretKey := v2alpha1.GetAppKeySecret(creds, componentdca.GetDefaultExternalMetricSecretName(f.owner)); isSet {
-					// app key secret exists; store secret name and key instead
-					f.keySecret[apicommon.DefaultAPPKeyKey] = secret{
-						name: secretName,
-						key:  secretKey,
+				if creds.AppSecret != nil {
+					_, secretName, secretKey := v2alpha1.GetAppKeySecret(creds, componentdca.GetDefaultExternalMetricSecretName(f.owner))
+					if secretName != "" && secretKey != "" {
+						// app key secret exists; store secret name and key instead
+						f.keySecret[apicommon.DefaultAPPKeyKey] = secret{
+							name: secretName,
+							key:  secretKey,
+						}
 					}
 				}
 			}

--- a/controllers/datadogagent/feature/externalmetrics/feature_test.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature_test.go
@@ -24,7 +24,6 @@ import (
 const (
 	secretName = "apisecretname"
 	apiKeyName = "apikeyname"
-	appKeyName = "appkeyname"
 )
 
 func TestExternalMetricsFeature(t *testing.T) {
@@ -45,10 +44,6 @@ func TestExternalMetricsFeature(t *testing.T) {
 			KeyName:    apiKeyName,
 		},
 		AppKey: apiutils.NewStringPointer("09876"),
-		AppSecret: &apicommonv1.SecretConfig{
-			SecretName: secretName,
-			KeyName:    appKeyName,
-		},
 	}
 
 	tests := test.FeatureTestSuite{
@@ -200,9 +195,9 @@ func testDCAResources(useDDM, wpaController, keySecrets bool) *test.ComponentTes
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
 								LocalObjectReference: corev1.LocalObjectReference{
-									Name: secretName,
+									Name: "-metrics-server", // from default secret name
 								},
-								Key: appKeyName,
+								Key: apicommon.DefaultAPPKeyKey,
 							},
 						},
 					},


### PR DESCRIPTION
### What does this PR do?

The external metrics provider secret for credentials wasn't being created when an API/APP key was provided that wasn't part of an existing secret. The following example would previously cause the DCA to CLBO with `Error: secret "datadog-metrics-server" not found`:

```yaml
    externalMetricsServer:
      enabled: true
      endpoint:
        credentials:
          apiKey: "test"
```

---

The same config should now create a secret containing the api key:

```
> kubectl describe secret datadog-metrics-server
Name:         datadog-metrics-server
Namespace:    default
Labels:       app.kubernetes.io/instance=datadog
              app.kubernetes.io/managed-by=datadog-operator
              app.kubernetes.io/name=datadog-agent-deployment
              app.kubernetes.io/part-of=default-datadog
              app.kubernetes.io/version=
              operator.datadoghq.com/managed-by-store=true
Annotations:  <none>

Type:  Opaque

Data
====
api_key:  4 bytes
```

In the DCA, the env var should be set:

```
> kubectl describe <dca-pod>
[...]
      DD_EXTERNAL_METRICS_PROVIDER_API_KEY:                      <set to the key 'api_key' in secret 'datadog-metrics-server'>  Optional: false

> kubectl exec -it <dca-pod> -- env | grep DD_EXTERNAL_METRICS_PROVIDER_API_KEY
[...]
DD_EXTERNAL_METRICS_PROVIDER_API_KEY=test
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
