### PR TITLE
Update golangci-lint version to 1.51.0 and fix related issues

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -89,6 +89,11 @@
     "goconst",
     "errcheck",
     "misspell",
+    "varcheck",
+    "structcheck",
+    "deadcode",
+    "rowserrcheck",
+    "sqlclosecheck",
   ]
 
 [issues]

--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ bin/$(PLATFORM)/yq: Makefile
 	hack/install-yq.sh v4.31.2
 
 bin/$(PLATFORM)/golangci-lint: Makefile
-	hack/golangci-lint.sh -b "bin/$(PLATFORM)" v1.49.0
+	hack/golangci-lint.sh -b "bin/$(PLATFORM)" v1.51.0
 
 bin/$(PLATFORM)/operator-sdk: Makefile
 	hack/install-operator-sdk.sh v1.23.0

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -99,7 +99,7 @@ func (r *Reconciler) createNewClusterAgentDeployment(logger logr.Logger, feature
 		return reconcile.Result{}, err
 	}
 
-	// Set DatadogAgent instance  instance as the owner and controller
+	// Set DatadogAgent instance as the owner and controller
 	if err = controllerutil.SetControllerReference(dda, newDCA, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -136,7 +136,7 @@ func (r *Reconciler) updateClusterAgentDeployment(logger logr.Logger, features [
 		return reconcile.Result{}, nil
 	}
 	logger.Info("Update ClusterAgent deployment", "name", dca.Name, "namespace", dca.Namespace)
-	// Set DatadogAgent instance  instance as the owner and controller
+	// Set DatadogAgent instance as the owner and controller
 	if err = controllerutil.SetControllerReference(dda, dca, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -138,7 +138,7 @@ func (r *Reconciler) updateClusterChecksRunnerDeployment(logger logr.Logger, dda
 
 	logger.Info("update Cluster Checks Runner deployment", "name", dep.Name, "namespace", dep.Namespace)
 
-	// Set DatadogAgent instance  instance as the owner and controller
+	// Set DatadogAgent instance as the owner and controller
 	if err = controllerutil.SetControllerReference(dda, dep, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/datadogagent/common_configmap.go
+++ b/controllers/datadogagent/common_configmap.go
@@ -102,7 +102,7 @@ func (r *Reconciler) createConfigMap(logger logr.Logger, dda *datadoghqv1alpha1.
 	if err != nil {
 		return result, err
 	}
-	// Set DatadogAgent instance  instance as the owner and controller
+	// Set DatadogAgent instance as the owner and controller
 	if err = controllerutil.SetControllerReference(dda, configMap, r.scheme); err != nil {
 		return result, err
 	}

--- a/controllers/datadogagent/feature/types.go
+++ b/controllers/datadogagent/feature/types.go
@@ -96,7 +96,7 @@ func mergeSlices(a, b []apicommonv1.AgentContainerName) []apicommonv1.AgentConta
 	return out
 }
 
-// Feature Feature interface
+// Feature interface
 // It returns `true` if the Feature is used, else it return `false`.
 type Feature interface {
 	// ID returns the ID of the Feature

--- a/controllers/datadogagent/poddisruptionbudget.go
+++ b/controllers/datadogagent/poddisruptionbudget.go
@@ -85,7 +85,7 @@ func (r *Reconciler) managePDB(logger logr.Logger, dda *datadoghqv1alpha1.Datado
 
 func (r *Reconciler) createPDBV1(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, builder pdbBuilder) (reconcile.Result, error) {
 	newPdb := builder(dda)
-	// Set DatadogAgent instance  instance as the owner and controller
+	// Set DatadogAgent instance as the owner and controller
 	if err := controllerutil.SetControllerReference(dda, newPdb, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -101,7 +101,7 @@ func (r *Reconciler) createPDBV1(logger logr.Logger, dda *datadoghqv1alpha1.Data
 
 func (r *Reconciler) createPDBV1Beta1(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent, builder pdbV1Beta1Builder) (reconcile.Result, error) {
 	newPdb := builder(dda)
-	// Set DatadogAgent instance  instance as the owner and controller
+	// Set DatadogAgent instance as the owner and controller
 	if err := controllerutil.SetControllerReference(dda, newPdb, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/datadogagent/secret.go
+++ b/controllers/datadogagent/secret.go
@@ -49,7 +49,7 @@ func (r *Reconciler) manageSecret(logger logr.Logger, secret managedSecret, dda 
 }
 
 func (r *Reconciler) createSecret(logger logr.Logger, newSecret *corev1.Secret, dda *datadoghqv1alpha1.DatadogAgent) (reconcile.Result, error) {
-	// Set DatadogAgent instance  instance as the owner and controller
+	// Set DatadogAgent instance as the owner and controller
 	if err := controllerutil.SetControllerReference(dda, newSecret, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/controllers/datadogagent/testutils/metadata_utils.go
+++ b/controllers/datadogagent/testutils/metadata_utils.go
@@ -79,17 +79,17 @@ func (c *CheckAnnotationsIsNotPresent) Check(t *testing.T, obj *metav1.ObjectMet
 func checkIsPresentInMap(t *testing.T, key, value string, entries map[string]string, msgPrefix string) error {
 	if val, found := entries[key]; found {
 		if val == value {
-			t.Logf("[%s] key [%s] founded with value value [%s]", msgPrefix, key, value)
+			t.Logf("[%s] key [%s] found with value [%s]", msgPrefix, key, value)
 			return nil
 		}
-		return fmt.Errorf("[%s] key %s founded, but wrong value, got [%s], want [%s]", msgPrefix, key, val, value)
+		return fmt.Errorf("[%s] key %s found, but wrong value, got [%s], want [%s]", msgPrefix, key, val, value)
 	}
-	return fmt.Errorf("[%s] key %s not founded", msgPrefix, key)
+	return fmt.Errorf("[%s] key %s not found", msgPrefix, key)
 }
 
 func checkLabelIsNotPresent(_ *testing.T, key string, entries map[string]string, msgPrefix string) error {
 	if value, found := entries[key]; found {
-		return fmt.Errorf("[%s] key [%s] founded with value value [%s]", msgPrefix, key, value)
+		return fmt.Errorf("[%s] key [%s] found with value [%s]", msgPrefix, key, value)
 	}
 	return nil
 }

--- a/controllers/datadogagent/testutils/podtemplate_utils.go
+++ b/controllers/datadogagent/testutils/podtemplate_utils.go
@@ -40,7 +40,7 @@ func CheckContainerInPodTemplate(containerName string, checkFunc ContainerCheckI
 				}
 			}
 		}
-		t.Errorf("Container %s not founded", containerName)
+		t.Errorf("Container %s not found", containerName)
 	}
 	return check
 }
@@ -54,11 +54,11 @@ type CheckVolumeIsPresent struct {
 func (c *CheckVolumeIsPresent) Check(t *testing.T, podTemplate *corev1.PodTemplateSpec) error {
 	for _, volumeIn := range podTemplate.Spec.Volumes {
 		if apiequality.Semantic.DeepEqual(c.Volume, &volumeIn) {
-			t.Logf("Volume %s founded", c.Volume.Name)
+			t.Logf("Volume %s found", c.Volume.Name)
 			return nil
 		}
 	}
-	return fmt.Errorf("volume %s not founded", c.Volume.Name)
+	return fmt.Errorf("volume %s not found", c.Volume.Name)
 }
 
 // CheckVolumeIsNotPresent used to check if a corev1.Volume is not present in a corev1.PodTemplateSpec object.
@@ -76,10 +76,10 @@ func (c *CheckVolumeIsNotPresent) Check(t *testing.T, podTemplate *corev1.PodTem
 		}
 	}
 	if found {
-		t.Logf("Volume %s founded", c.Volume.Name)
+		t.Logf("Volume %s found", c.Volume.Name)
 		return nil
 	}
-	return fmt.Errorf("volume %s not founded", c.Volume.Name)
+	return fmt.Errorf("volume %s not found", c.Volume.Name)
 }
 
 // CheckContainerDeepEqualIsPresent used to check if corev1.Container is equal to a container inside a corev1.PodTemplateSpec object.
@@ -91,11 +91,11 @@ type CheckContainerDeepEqualIsPresent struct {
 func (c *CheckContainerDeepEqualIsPresent) Check(t *testing.T, podTemplate *corev1.PodTemplateSpec) error {
 	for _, containerIn := range podTemplate.Spec.Containers {
 		if diff := testutils.CompareKubeResource(c.Container, &containerIn); diff != "" {
-			t.Logf("container %s founded", c.Container.Name)
+			t.Logf("container %s found", c.Container.Name)
 			return nil
 		}
 	}
-	return fmt.Errorf("container %s not founded", c.Container.Name)
+	return fmt.Errorf("container %s not found", c.Container.Name)
 }
 
 // CheckContainerNameIsPresentFunc used to check if container name is equal to a container name
@@ -109,11 +109,11 @@ type CheckContainerNameIsPresentFunc struct {
 func (c *CheckContainerNameIsPresentFunc) Check(t *testing.T, podTemplate *corev1.PodTemplateSpec) error {
 	for _, containerIn := range podTemplate.Spec.Containers {
 		if containerIn.Name == c.Name {
-			t.Logf("container %s founded", containerIn.Name)
+			t.Logf("container %s found", containerIn.Name)
 			return nil
 		}
 	}
-	return fmt.Errorf("container %s not founded", c.Name)
+	return fmt.Errorf("container %s not found", c.Name)
 }
 
 // CheckEnvVarIsPresent used to check if an corev1.EnvVar is present in a corev1.Container object
@@ -125,11 +125,11 @@ type CheckEnvVarIsPresent struct {
 func (c *CheckEnvVarIsPresent) Check(t *testing.T, container *corev1.Container) error {
 	for _, envVarIn := range container.Env {
 		if diff := testutils.CompareKubeResource(&envVarIn, c.EnvVar); diff == "" {
-			t.Logf("EnvVar %s founded in container %s", c.EnvVar.Name, container.Name)
+			t.Logf("EnvVar %s found in container %s", c.EnvVar.Name, container.Name)
 			return nil
 		}
 	}
-	return fmt.Errorf("EnvVar %s not founded in container %s", c.EnvVar.Name, container.Name)
+	return fmt.Errorf("EnvVar %s not found in container %s", c.EnvVar.Name, container.Name)
 }
 
 // CheckEnvFromIsPresent used to check if an corev1.EnvFromSource is present in a corev1.Container object
@@ -141,11 +141,11 @@ type CheckEnvFromIsPresent struct {
 func (c *CheckEnvFromIsPresent) Check(t *testing.T, container *corev1.Container) error {
 	for _, envVarIn := range container.EnvFrom {
 		if diff := testutils.CompareKubeResource(&envVarIn, c.EnvFrom); diff == "" {
-			t.Logf("EnvVar [%s] founded in container %s", c.EnvFrom.String(), container.Name)
+			t.Logf("EnvVar [%s] found in container %s", c.EnvFrom.String(), container.Name)
 			return nil
 		}
 	}
-	return fmt.Errorf("envVar [%s] not founded in container %s", c.EnvFrom.String(), container.Name)
+	return fmt.Errorf("envVar [%s] not found in container %s", c.EnvFrom.String(), container.Name)
 }
 
 // CheckVolumeMountIsPresent used to check if an corev1.VolumeMount is present in a corev1.Container object
@@ -157,9 +157,9 @@ type CheckVolumeMountIsPresent struct {
 func (c *CheckVolumeMountIsPresent) Check(t *testing.T, container *corev1.Container) error {
 	for _, volumeMountIn := range container.VolumeMounts {
 		if diff := testutils.CompareKubeResource(&volumeMountIn, c.VolumeMount); diff == "" {
-			t.Logf("VolumeMount [%s] founded in container %s", c.VolumeMount.String(), container.Name)
+			t.Logf("VolumeMount [%s] found in container %s", c.VolumeMount.String(), container.Name)
 			return nil
 		}
 	}
-	return fmt.Errorf("volumeMount [%s] not founded in container %s", c.VolumeMount.String(), container.Name)
+	return fmt.Errorf("volumeMount [%s] not found in container %s", c.VolumeMount.String(), container.Name)
 }

--- a/pkg/controller/utils/datadog/forwarders_manager.go
+++ b/pkg/controller/utils/datadog/forwarders_manager.go
@@ -36,7 +36,7 @@ type ForwardersManager struct {
 	sync.Mutex
 }
 
-// NewForwardersManager builds a new ForwardersManager
+// NewForwardersManager builds a new ForwardersManager object
 // ForwardersManager implements the controller-runtime Runnable interface
 func NewForwardersManager(k8sClient client.Client, v2Enabled bool, platformInfo *kubernetes.PlatformInfo) *ForwardersManager {
 	return &ForwardersManager{

--- a/pkg/plugin/common/client.go
+++ b/pkg/plugin/common/client.go
@@ -27,7 +27,7 @@ func NewClient(clientConfig clientcmd.ClientConfig) (client.Client, error) {
 	// Create the mapper provider
 	mapper, err := apiutil.NewDiscoveryRESTMapper(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to to instantiate mapper: %w", err)
+		return nil, fmt.Errorf("unable to instantiate mapper: %w", err)
 	}
 
 	// Register DatadogAgent scheme

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -76,7 +76,7 @@ type Secret struct {
 // NewDummyDecryptor returns a dummy decryptor for tests
 // maxRetries is the number of retries before returning a nil error
 // If maxRetries < 0 Decrypt directly returns a permanent error
-// If maxRetries == 0 Decrypt directly returns a a nil error
+// If maxRetries == 0 Decrypt directly returns a nil error
 // If maxRetries > 0 Decrypt returns a retriable error until it's called maxRetries-times then returns a nil error
 func NewDummyDecryptor(maxRetries int) *DummyDecryptor {
 	return &DummyDecryptor{


### PR DESCRIPTION
### What does this PR do?

Update golangci-lint to 1.51.0 because it is incompatible with go1.20 
Remove related warnings and fix lint issues from new linter in version update

### Motivation

Unblock folks on golang1.20

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
