### PR TITLE
[leaderelection][rbac] Add permissions to `leaderelection` for `leases/status`

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -4,51 +4,50 @@ kind: Role
 metadata:
   name: leader-election-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - "coordination.k8s.io"
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - "coordination.k8s.op"
-  resources:
-  - leases/status
-  verbs:
-  - get
-  - update
-  - patch
-
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases/status
+    verbs:
+      - get
+      - update
+      - patch

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -43,3 +43,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - "coordination.k8s.op"
+  resources:
+  - leases/status
+  verbs:
+  - get
+  - update
+  - patch
+


### PR DESCRIPTION
### What does this PR do?

This PR adds `get`, `update` and `patch` permission for `leases/status` to `leaderelection` since we now use leases to store the leader election token.

### Motivation

`leaderelection` now uses leases for the leader election.
https://github.com/DataDog/datadog-agent/pull/16652

### Additional Notes

N/A

### Describe your test plan

N/A