### PR TITLE
Update manager managed field

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,9 @@ func main() {
 	renewDeadline := leaderElectionLeaseDuration / 2
 	retryPeriod := leaderElectionLeaseDuration / 4
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), config.ManagerOptionsWithNamespaces(setupLog, ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = "datadog-operator"
+	mgr, err := ctrl.NewManager(restConfig, config.ManagerOptionsWithNamespaces(setupLog, ctrl.Options{
 		Scheme:                     scheme,
 		MetricsBindAddress:         metricsAddr,
 		HealthProbeBindAddress:     ":8081",


### PR DESCRIPTION
### What does this PR do?

Configure a controller manager name, `datadog-operator` for the `manager` managedField. 

### Motivation

Previously, the `DatadogAgent` resource created by the datadog-operator had the managed field, `Manager: manager`, which was ambiguous and confusing. 

```
Name: datadog
[...]
API Version:  datadoghq.com/v2alpha1
Kind:         DatadogAgent
Metadata:
[...]
  Managed Fields:
[...]
    Manager:      manager
[...]
    Manager:      manager
```

This change customizes the `Manager` name to a more meaningful name, `datadog-operator`. 

```
[...]
Name: datadog
API Version:  datadoghq.com/v2alpha1
Kind:         DatadogAgent
Metadata:
[...]
  Managed Fields:
[...]
    Manager:      datadog-operator
[...]
    Manager:      datadog-operator
```

### Additional Notes

This change also updates the `manager` field for the `DatadogMonitor` resource to `datadog-operator`.

### Describe your test plan

1. Deploy datadog-operator
2. Deploy a `DatadogAgent` manifest file
3. Check that the `DatadogAgent` CRD field `Metadata.Managed Fields.Manager` is `datadog-operator`