### PR TITLE
Default Agent/Cluster-Agent version to 7.44.1

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.44.0"
+	AgentLatestVersion = "7.44.1"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.44.0"
+	ClusterAgentLatestVersion = "7.44.1"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

Default Agent/Cluster-Agent version to `7.44.1`

### Motivation

As Agent `7.44.1` release manager, I need to update the default agent/cluster-agent version in the datadog-operator, so that the operator always install the latest version.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

compatibility testing has been made during Agent QA
