### PR TITLE
Update `leaderelection` permissions to use `leases`

### DIFF
--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -244,6 +244,19 @@ func GetLeaderElectionPolicyRule(dda metav1.Object) []rbacv1.PolicyRule {
 			Resources: []string{rbac.ConfigMapsResource},
 			Verbs:     []string{rbac.CreateVerb},
 		},
+		{
+			APIGroups: []string{rbac.CoordinationAPIGroup},
+			Resources: []string{rbac.LeasesResource},
+			Verbs:     []string{rbac.CreateVerb},
+		},
+		{
+			APIGroups: []string{rbac.CoordinationAPIGroup},
+			Resources: []string{rbac.LeasesResource},
+			ResourceNames: []string{
+				utils.GetDatadogLeaderElectionResourceName(dda),
+			},
+			Verbs: []string{rbac.GetVerb, rbac.UpdateVerb},
+		},
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR updates RBAC permissions of the leader election to match https://github.com/DataDog/helm-charts/blob/8841bd813540d2acb44eb775b82dab28acd369ab/charts/datadog/templates/cluster-agent-rbac.yaml#L69-L83.

### Motivation

Leader election is broken.

### Additional Notes

N/A

### Describe your test plan

N/A