### PR TITLE
Remove duplicate flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,12 +138,8 @@ func (opts *options) Parse() {
 	flag.DurationVar(&opts.leaderElectionLeaseDuration, "leader-election-lease-duration", 60*time.Second, "Define LeaseDuration as well as RenewDeadline (leaseDuration / 2) and RetryPeriod (leaseDuration / 4)")
 
 	// Custom flags
-	flag.StringVar(&opts.logEncoder, "logEncoder", "json", "log encoding ('json' or 'console')")
 	flag.StringVar(&opts.secretBackendCommand, "secretBackendCommand", "", "Secret backend command")
 	flag.Var(&opts.secretBackendArgs, "secretBackendArgs", "Space separated arguments of the secret backend command")
-	opts.logLevel = zap.LevelFlag("loglevel", zapcore.InfoLevel, "Set log level")
-	flag.BoolVar(&opts.printVersion, "version", false, "Print version and exit")
-	flag.BoolVar(&opts.pprofActive, "pprof", false, "Enable pprof endpoint")
 	flag.BoolVar(&opts.supportCilium, "supportCilium", false, "Support usage of Cilium network policies.")
 	flag.BoolVar(&opts.datadogAgentEnabled, "datadogAgentEnabled", true, "Enable the DatadogAgent controller")
 	flag.BoolVar(&opts.datadogMonitorEnabled, "datadogMonitorEnabled", false, "Enable the DatadogMonitor controller")


### PR DESCRIPTION
### What does this PR do?

Attempting to set a flag twice was causing the operator to panic:
```
/manager flag redefined: logEncoder
panic: /manager flag redefined: logEncoder
```

Removed duplicates

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
