### PR TITLE
feat: default agent/dca to 7.45.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.44.0"
+	AgentLatestVersion = "7.45.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.44.0"
+	ClusterAgentLatestVersion = "7.45.0"
 
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"


### PR DESCRIPTION
### What does this PR do?

Default `Agent` and `Cluster-Agent` image tag to `7.45.0`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy the operator and create a DatadogAgent without specifying the Agent and Cluster Agent image tag. 
The operator should deploy the Agent and Cluster-Agent with the image tag 7.45.0
