### PR TITLE
Use `configmapsleases` as default leader election resource

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func (opts *options) Parse() {
 	// Leader Election options flags
 	flag.BoolVar(&opts.enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&opts.leaderElectionResourceLock, "leader-election-resource", "configmaps", "determines which resource lock to use for leader election. option:[configmapsleases|endpointsleases|configmaps]")
+	flag.StringVar(&opts.leaderElectionResourceLock, "leader-election-resource", "configmapsleases", "determines which resource lock to use for leader election. option:[configmapsleases|endpointsleases|leases]")
 	flag.DurationVar(&opts.leaderElectionLeaseDuration, "leader-election-lease-duration", 60*time.Second, "Define LeaseDuration as well as RenewDeadline (leaseDuration / 2) and RetryPeriod (leaseDuration / 4)")
 
 	// Custom flags


### PR DESCRIPTION
### What does this PR do?

Use `configmapsleases` as the default leader election resource. `configmaps` is being deprecated and `controller-runtime` suggests migrating over to `leases` by first using the multilock `configmapsleases`: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#Options.LeaderElectionResourceLock

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
