### PR TITLE
Set local agent service port overrides

### DIFF
--- a/controllers/datadogagent/feature/apm/feature.go
+++ b/controllers/datadogagent/feature/apm/feature.go
@@ -15,12 +15,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-
-	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
-	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"

--- a/controllers/datadogagent/feature/dogstatsd/feature_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_test.go
@@ -6,6 +6,7 @@
 package dogstatsd
 
 import (
+	"strconv"
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
@@ -139,6 +140,22 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 	// default udp envvar
 	wantUDPEnvVars := []*corev1.EnvVar{
 		{
+			Name:  apicommon.DDDogstatsdPort,
+			Value: strconv.Itoa(apicommon.DogstatsdHostPortHostPort),
+		},
+		{
+			Name:  apicommon.DDDogstatsdNonLocalTraffic,
+			Value: "true",
+		},
+	}
+
+	// custom udp envvar
+	wantCustomUDPEnvVars := []*corev1.EnvVar{
+		{
+			Name:  apicommon.DDDogstatsdPort,
+			Value: "1234",
+		},
+		{
 			Name:  apicommon.DDDogstatsdNonLocalTraffic,
 			Value: "true",
 		},
@@ -237,7 +254,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 					volumes := mgr.VolumeMgr.Volumes
 					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "2. Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDPEnvVars), "2. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantCustomUDPEnvVars), "2. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
 					customPorts := []*corev1.ContainerPort{
 						{
@@ -401,7 +418,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 					volumes := mgr.VolumeMgr.Volumes
 					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "9. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantUDPEnvVars), "9. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, wantCustomUDPEnvVars), "9. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDPEnvVars))
 					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
 					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV2), "9. All Containers envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV2))
 

--- a/controllers/datadogagent/override/global.go
+++ b/controllers/datadogagent/override/global.go
@@ -174,19 +174,6 @@ func ApplyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 	}
 
 	if componentName == v2alpha1.NodeAgentComponentName {
-		// LocalService contains configuration to customize the internal traffic policy service.
-		forceEnableLocalService := config.LocalService != nil && apiutils.BoolValue(config.LocalService.ForceEnableLocalService)
-		if component.ShouldCreateAgentLocalService(resourcesManager.Store().GetVersionInfo(), forceEnableLocalService) {
-			var serviceName string
-			if config.LocalService != nil && config.LocalService.NameOverride != nil {
-				serviceName = *config.LocalService.NameOverride
-			}
-			err := resourcesManager.ServiceManager().AddService(component.BuildAgentLocalService(dda, serviceName))
-			if err != nil {
-				logger.Error(err, "Error adding Local Service to the store")
-			}
-		}
-
 		// Kubelet contains the kubelet configuration parameters.
 		if config.Kubelet != nil {
 			var kubeletHostValueFrom *corev1.EnvVarSource


### PR DESCRIPTION
### What does this PR do?

Override local service ports when custom host ports are set in dogstatsd and apm features.

### Motivation

https://github.com/DataDog/datadog-operator/issues/820

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Set custom host ports for dogstatsd and/or apm and make sure the local agent service uses those same ports. Example:
