### PR TITLE
fix image pullpolicy and pullsecrets overrides

### DIFF
--- a/controllers/datadogagent/override/podtemplatespec.go
+++ b/controllers/datadogagent/override/podtemplatespec.go
@@ -38,10 +38,20 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 	if override.Image != nil {
 		for i, container := range manager.PodTemplateSpec().Spec.Containers {
 			manager.PodTemplateSpec().Spec.Containers[i].Image = overrideImage(container.Image, override.Image)
+			if override.Image.PullPolicy != nil {
+				manager.PodTemplateSpec().Spec.Containers[i].ImagePullPolicy = *override.Image.PullPolicy
+			}
 		}
 
 		for i, initContainer := range manager.PodTemplateSpec().Spec.InitContainers {
 			manager.PodTemplateSpec().Spec.InitContainers[i].Image = overrideImage(initContainer.Image, override.Image)
+			if override.Image.PullPolicy != nil {
+				manager.PodTemplateSpec().Spec.InitContainers[i].ImagePullPolicy = *override.Image.PullPolicy
+			}
+		}
+
+		if override.Image.PullSecrets != nil {
+			manager.PodTemplateSpec().Spec.ImagePullSecrets = *override.Image.PullSecrets
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

- Fix usage of PullPolicy and PullSecrets options in the v2 component overrides
- Add a struct for use in tests

### Motivation

Bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test manifests for kind cluster:

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: system
spec:
  global:
    credentials:
      apiKey: redacted
      appKey: redacted
    kubelet:
      tlsVerify: false
  override:
    nodeAgent:
      image:
        tag: 7.46.0-rc.3
        pullPolicy: Never
        pullSecrets:
          - name: regcred
```

To create secret:
```
$ kubectl create secret generic regcred \
    --from-file=.dockerconfigjson=path/to/docker/config.json \
    --type=kubernetes.io/dockerconfigjson
```

`kubectl describe` agent daemonset to see overrides have taken place.