### PR TITLE
upgrade(remoteConfig): Explicitely disable Remote Configuration when parameter is set to false

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 images:
 - name: controller
   newName: gcr.io/datadoghq/operator
-  newTag: 1.0.3
+  newTag: v1.0.3-rc.2_db9c830b
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
### What does this PR do?

Makes sure to always set the environment variable `DD_REMOTE_CONFIGURATION_ENABLED` regardless of its value

### Motivation

Prep work for [RCM-1079]: we want to make sure that if Remote Configuration is specifically disabled in the operator, even if we switch to enabling Remote Configuration by default in the agent or in the operator, it will stay disabled.

The previous behavior was falling back to the agent's default if the `remoteConfig.enabled` field was unset or set to `false`, which works well for Remote Config disabled by default but not for the enabled by default case.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
