### PR TITLE
feat: default agent/dca to 7.46.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,10 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.45.0"
+	AgentLatestVersion = "7.46.0"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.45.0"
-
+	ClusterAgentLatestVersion = "7.46.0"
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"
 	// DockerHubContainerRegistry correspond to the datadoghq docker.io registry


### PR DESCRIPTION
### What does this PR do?

Default Agent and Cluster-Agent image tag to 7.46.0

### Motivation

New release is there 🚀 

### Additional Notes

N/A

### Describe your test plan

Deploy the agent with the default settings. The operator should deploy 7.46.0.