### PR TITLE
update feature factory to process feature if disabled but configured

### DIFF
--- a/controllers/datadogagent/controller_reconcile_dca.go
+++ b/controllers/datadogagent/controller_reconcile_dca.go
@@ -44,12 +44,12 @@ func (r *Reconciler) reconcileV2ClusterAgent(logger logr.Logger, requiredCompone
 	deploymentLogger := logger.WithValues("component", datadoghqv2alpha1.ClusterAgentComponentName)
 
 	// The requiredComponents can change depending on if updates to features result in disabled components
-	requiredEnabled := requiredComponents.ClusterAgent.IsEnabled()
+	dcaEnabled := requiredComponents.ClusterAgent.IsEnabled()
 
 	// If Override is defined for the clusterAgent component, apply the override on the PodTemplateSpec, it will cascade to container.
 	if componentOverride, ok := dda.Spec.Override[datadoghqv2alpha1.ClusterAgentComponentName]; ok {
 		if apiutils.BoolValue(componentOverride.Disabled) {
-			if requiredEnabled {
+			if dcaEnabled {
 				// The override supersedes what's set in requiredComponents; update status to reflect the conflict
 				datadoghqv2alpha1.UpdateDatadogAgentStatusConditions(
 					newStatus,
@@ -65,8 +65,8 @@ func (r *Reconciler) reconcileV2ClusterAgent(logger logr.Logger, requiredCompone
 		}
 		override.PodTemplateSpec(logger, podManagers, componentOverride, datadoghqv2alpha1.ClusterAgentComponentName, dda.Name)
 		override.Deployment(deployment, componentOverride)
-	} else if !requiredEnabled {
-		// If the override is not defined, then disable based on requiredEnabled value
+	} else if !dcaEnabled {
+		// If the override is not defined, then disable based on dcaEnabled value
 		return r.cleanupV2ClusterAgent(deploymentLogger, dda, deployment, resourcesManager, newStatus)
 	}
 	return r.createOrUpdateDeployment(deploymentLogger, dda, deployment, newStatus, updateStatusV2WithClusterAgent)

--- a/controllers/datadogagent/feature/factory.go
+++ b/controllers/datadogagent/feature/factory.go
@@ -49,12 +49,12 @@ func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options) ([]Feature, Req
 
 	for _, id := range sortedkeys {
 		feat := featureBuilders[id](options)
-		config := feat.Configure(dda)
-		// only add feat to the output if the feature is enabled
-		if config.IsEnabled() {
+		reqComponents := feat.Configure(dda)
+		// only add feature to the output if one of the components is configured (but not necessarily required)
+		if reqComponents.IsConfigured() {
 			output = append(output, feat)
 		}
-		requiredComponents.Merge(&config)
+		requiredComponents.Merge(&reqComponents)
 	}
 
 	return output, requiredComponents

--- a/controllers/datadogagent/feature/types_test.go
+++ b/controllers/datadogagent/feature/types_test.go
@@ -182,3 +182,55 @@ func TestRequiredComponent_IsEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestRequiredComponent_IsConfigured(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	type fields struct {
+		IsRequired *bool
+		Containers []apicommonv1.AgentContainerName
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "IsConfigured == false, empty",
+			fields: fields{
+				IsRequired: nil,
+				Containers: nil,
+			},
+			want: false,
+		},
+		{
+			name: "IsConfigured == true, isRequired == true",
+			fields: fields{
+				IsRequired: &trueValue,
+				Containers: nil,
+			},
+			want: true,
+		},
+		{
+			name: "IsConfigured == true, isRequired == false",
+			fields: fields{
+				IsRequired: &falseValue,
+				Containers: nil,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := &RequiredComponent{
+				IsRequired: tt.fields.IsRequired,
+				Containers: tt.fields.Containers,
+			}
+			if got := rc.IsConfigured(); got != tt.want {
+				t.Errorf("RequiredComponent.IsConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add `IsConfigured` to FeatureFactory
Update naming of a few bool variables
Use `IsConfigured` when collating list of features to manage in each component reconciler

### Motivation

An issue arose regarding a feature that needs to be explicitly disabled when it's not enabled, but we didn't fully form the ability to do this with the FeatureFactory. This PR finishes what was started several months ago

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Deploy the operator and add a section to one of the features such as this, where an envvar is set when a feature is **disabled** (this example was tested in remote config):

```
       } else {
               reqComp = feature.RequiredComponents{
                       Agent: feature.RequiredComponent{
                               IsRequired: apiutils.NewBoolPointer(false),
                               Containers: []apicommonv1.AgentContainerName{
                                       apicommonv1.CoreAgentContainerName,
                               },
                       },
               }
        }
```

Apply a DatadogAgent manifest without the feature enabled, and ensure the expected configuration is set