### PR TITLE
[datadogmonitor] add support for site envvar

### DIFF
--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -143,7 +143,7 @@ func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, vInfo *version
 		return nil
 	}
 
-	ddClient, err := datadogclient.InitDatadogClient(options.Creds)
+	ddClient, err := datadogclient.InitDatadogClient(logger, options.Creds)
 	if err != nil {
 		return fmt.Errorf("unable to create Datadog API Client: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ const (
 	// DDURLEnvVar is the constant for the env variable DD_URL which is the
 	// host of the Datadog intake server to send data to.
 	DDURLEnvVar = "DD_URL"
+	// TODO consider moving DDSite here as well
 )
 
 // GetWatchNamespaces returns the Namespaces the operator should be watching for changes.

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -249,7 +249,7 @@ func (mf *metricsForwarder) setupV2() error {
 	}
 
 	mf.baseURL = getbaseURLV2(dda)
-	mf.logger.Info("Got Datadog Site", "site", mf.baseURL)
+	mf.logger.Info("Got site for DatadogAgent", "site", mf.baseURL)
 
 	if dda.Spec.Global != nil && dda.Spec.Global.ClusterName != nil {
 		mf.clusterName = *dda.Spec.Global.ClusterName

--- a/pkg/datadogclient/client.go
+++ b/pkg/datadogclient/client.go
@@ -11,11 +11,17 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
 
 	"github.com/DataDog/datadog-operator/pkg/config"
 
 	datadogapiclientv1 "github.com/DataDog/datadog-api-client-go/api/v1/datadog"
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 )
+
+const prefix = "https://api."
 
 // DatadogClient contains the Datadog API Client and Authentication context.
 type DatadogClient struct {
@@ -24,7 +30,7 @@ type DatadogClient struct {
 }
 
 // InitDatadogClient initializes the Datadog API Client and establishes credentials.
-func InitDatadogClient(creds config.Creds) (DatadogClient, error) {
+func InitDatadogClient(logger logr.Logger, creds config.Creds) (DatadogClient, error) {
 	if creds.APIKey == "" || creds.AppKey == "" {
 		return DatadogClient{}, errors.New("error obtaining API key and/or app key")
 	}
@@ -44,21 +50,30 @@ func InitDatadogClient(creds config.Creds) (DatadogClient, error) {
 	)
 	configV1 := datadogapiclientv1.NewConfiguration()
 
-	if apiURL := os.Getenv(config.DDURLEnvVar); apiURL != "" {
+	apiURL := ""
+	if os.Getenv(config.DDURLEnvVar) != "" {
+		apiURL = os.Getenv(config.DDURLEnvVar)
+	} else if site := os.Getenv(apicommon.DDSite); site != "" {
+		apiURL = prefix + strings.TrimSpace(site)
+	}
+
+	if apiURL != "" {
+		logger.Info("Got API URL for DatadogOperator controller", "URL", apiURL)
 		parsedAPIURL, parseErr := url.Parse(apiURL)
 		if parseErr != nil {
-			return DatadogClient{}, fmt.Errorf(`invalid API Url : %w`, parseErr)
+			return DatadogClient{}, fmt.Errorf(`invalid API URL : %w`, parseErr)
 		}
 		if parsedAPIURL.Host == "" || parsedAPIURL.Scheme == "" {
 			return DatadogClient{}, fmt.Errorf(`missing protocol or host : %s`, apiURL)
 		}
-		// If api url is passed, set and use the api name and protocol on ServerIndex{1}.
+		// If API URL is passed, set and use the API name and protocol on ServerIndex{1}.
 		authV1 = context.WithValue(authV1, datadogapiclientv1.ContextServerIndex, 1)
 		authV1 = context.WithValue(authV1, datadogapiclientv1.ContextServerVariables, map[string]string{
 			"name":     parsedAPIURL.Host,
 			"protocol": parsedAPIURL.Scheme,
 		})
 	}
+
 	client := datadogapiclientv1.NewAPIClient(configV1)
 
 	return DatadogClient{Client: client, Auth: authV1}, nil


### PR DESCRIPTION
### What does this PR do?

Add support for site envvar (`DD_SITE`) in the operator controller which can be used to configure client endpoint for DatadogMonitor.

### Motivation

Request/bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Set DD_SITE (something other than datadoghq.com), and corresponding keys DD_API_KEY, and DD_APP_KEY in the Operator deployment. Try creating a DatadogMonitor and check it is created successfully in the corresponding account.