### PR TITLE
upgrade(remoteConfig): Explicitly disable Remote Configuration when …

### DIFF
--- a/controllers/datadogagent/feature/remoteconfig/feature.go
+++ b/controllers/datadogagent/feature/remoteconfig/feature.go
@@ -28,7 +28,10 @@ func init() {
 }
 
 func buildRCFeature(options *feature.Options) feature.Feature {
-	rcFeat := &rcFeature{}
+	rcFeat := &rcFeature{
+		// Current default for Remote Config enablement
+		enabled: false,
+	}
 
 	if options != nil {
 		rcFeat.logger = options.Logger
@@ -53,16 +56,18 @@ func (f *rcFeature) ID() feature.IDType {
 func (f *rcFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.RequiredComponents) {
 	f.owner = dda
 
-	if dda.Spec.Features != nil && dda.Spec.Features.RemoteConfiguration != nil && apiutils.BoolValue(dda.Spec.Features.RemoteConfiguration.Enabled) {
-		f.enabled = true
-		reqComp = feature.RequiredComponents{
-			Agent: feature.RequiredComponent{
-				IsRequired: apiutils.NewBoolPointer(true),
-				Containers: []apicommonv1.AgentContainerName{
-					apicommonv1.CoreAgentContainerName,
-				},
+	if dda.Spec.Features != nil && dda.Spec.Features.RemoteConfiguration != nil && dda.Spec.Features.RemoteConfiguration.Enabled != nil {
+		// If a value exists, explicitly enable or disable Remote Config and override the default
+		f.enabled = apiutils.BoolValue(dda.Spec.Features.RemoteConfiguration.Enabled)
+	}
+
+	reqComp = feature.RequiredComponents{
+		Agent: feature.RequiredComponent{
+			IsRequired: apiutils.NewBoolPointer(f.enabled),
+			Containers: []apicommonv1.AgentContainerName{
+				apicommonv1.CoreAgentContainerName,
 			},
-		}
+		},
 	}
 
 	return reqComp


### PR DESCRIPTION
…parameter is set to false (#831)

* upgrade(remoteConfig): Explicitely disable Remote Configuration when parameter is set to false

* address review

* remove kustomize tag

* address review after #835

### What does this PR do?

Cherry-pick #831 onto v1.1 branch

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
