### PR TITLE
Use default dogstatsd port for creating agent local service

### DIFF
--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	localServiceMinimumVersion        = "1.21-0"
 	localServiceDefaultMinimumVersion = "1.22-0"
 )
 
@@ -593,9 +592,8 @@ func ShouldCreateAgentLocalService(versionInfo *version.Info, forceEnableLocalSe
 	if versionInfo == nil || versionInfo.GitVersion == "" {
 		return false
 	}
-	// Service Internal Traffic Policy exists in Kube 1.21 but it is enabled by default since 1.22
-	return utils.IsAboveMinVersion(versionInfo.GitVersion, localServiceDefaultMinimumVersion) ||
-		(utils.IsAboveMinVersion(versionInfo.GitVersion, localServiceMinimumVersion) && forceEnableLocalService)
+	// Service Internal Traffic Policy is enabled by default since 1.22
+	return utils.IsAboveMinVersion(versionInfo.GitVersion, localServiceDefaultMinimumVersion) || forceEnableLocalService
 }
 
 // BuildCiliumPolicy creates the base node agent, DCA, or CCR cilium network policy

--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -140,20 +140,18 @@ func (f *dogstatsdFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) (reqComp feat
 // ManageDependencies allows a feature to manage its dependencies.
 // Feature's dependencies should be added in the store.
 func (f *dogstatsdFeature) ManageDependencies(managers feature.ResourceManagers, components feature.RequiredComponents) error {
-	if f.hostPortEnabled {
-		// agent local service
-		if component.ShouldCreateAgentLocalService(managers.Store().GetVersionInfo(), f.forceEnableLocalService) {
-			apmPort := []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolUDP,
-					TargetPort: intstr.FromInt(int(f.hostPortHostPort)),
-					Port:       f.hostPortHostPort,
-					Name:       apicommon.DogstatsdHostPortName,
-				},
-			}
-			if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), nil, apmPort, nil); err != nil {
-				return err
-			}
+	// agent local service
+	if component.ShouldCreateAgentLocalService(managers.Store().GetVersionInfo(), f.forceEnableLocalService) {
+		dsdPort := []corev1.ServicePort{
+			{
+				Protocol:   corev1.ProtocolUDP,
+				TargetPort: intstr.FromInt(apicommon.DefaultDogstatsdPort),
+				Port:       apicommon.DefaultDogstatsdPort,
+				Name:       apicommon.DefaultDogstatsdPortName,
+			},
+		}
+		if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), nil, dsdPort, nil); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

* Remove dependency on `features.dogstatsd.hostPortConfig.enabled` to create the agent local service. Instead use the default dogstatsd port, 8125
* Remove checking for minimum supported local service version 1.21 if `forceEnableLocalService=true` before creating agent local service. Instead, `ShouldCreateAgentLocalService` returns `true` if Kubernetes version is 1.22+ or `forceEnableLocalService=true`

### Motivation

* Bug fix
* Improve parity with datadog helm chart. 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

* Deploy datadog-operator and minimal datadogagent manifest
* Check that the `dogstatsdport` is present on the agent service object: `kubectl get service datadog-agent -oyaml`

```

```
