### PR TITLE
Fix orchestrator explorer default panic

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -250,6 +250,10 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 		}
 	}
 
+	if ddaSpec.Features.OrchestratorExplorer != nil {
+		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OrchestratorExplorer.Enabled, defaultOrchestratorExplorerEnabled)
+	}
+
 	if *ddaSpec.Features.OrchestratorExplorer.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OrchestratorExplorer.ScrubContainers, defaultOrchestratorExplorerScrubContainers)
 	}

--- a/apis/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -728,6 +728,61 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 		},
 		{
+			name: "Orchestrator explorer enabled unset, other fields set",
+			ddaSpec: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
+						CustomResources: []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+					},
+				},
+			},
+			want: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					Dogstatsd: &DogstatsdFeatureConfig{
+						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
+						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
+						},
+					},
+					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
+						GRPC: &OTLPGRPCConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPGRPCEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPGRPCEndpoint),
+						},
+						HTTP: &OTLPHTTPConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPHTTPEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
+						},
+					}}},
+					EventCollection: &EventCollectionFeatureConfig{
+						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
+					},
+					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
+						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
+						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+						CustomResources: []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+					},
+					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
+					},
+					ClusterChecks: &ClusterChecksFeatureConfig{
+						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
+						UseClusterChecksRunners: apiutils.NewBoolPointer(false),
+					},
+					AdmissionController: &AdmissionControllerFeatureConfig{
+						Enabled:          apiutils.NewBoolPointer(defaultAdmissionControllerEnabled),
+						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
+						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
+					},
+				},
+			},
+		},
+		{
 			// This test sets same defaults as the one with `Features: nil`; and leaves other configs as empty structs.
 			name: "all feature configs are empty structs, configures defaults where applicable, leaves others empty",
 			ddaSpec: &DatadogAgentSpec{


### PR DESCRIPTION
### What does this PR do?

The orchestrator explorer defaulting panicked with this config:
```yaml
    orchestratorExplorer:
      extraTags: ["key1:value1", "key2:value2"]
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Set a config the orchestrator explorer feature without setting `enabled: true` like in the above example. The operator pod shouldn't panic and the orchestrator explorer check should run without issue
