### PR TITLE
Fix orchestrator explorer yaml error

### DIFF
--- a/controllers/datadogagent/feature/orchestratorexplorer/configmap.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/configmap.go
@@ -52,9 +52,9 @@ instances:
 `, stringClusterCheckRunners, stringClusterCheckRunners)
 
 	if len(crs) > 0 {
-		config = config + "\tcrd_collectors:\n"
+		config = config + "    crd_collectors:\n"
 		for _, cr := range crs {
-			config = config + fmt.Sprintf("\t  - %s\n", cr)
+			config = config + fmt.Sprintf("      - %s\n", cr)
 
 		}
 	}

--- a/controllers/datadogagent/feature/orchestratorexplorer/configmap_test.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/configmap_test.go
@@ -6,9 +6,10 @@
 package orchestratorexplorer
 
 import (
-	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -114,9 +115,9 @@ init_config:
 
 instances:
   - skip_leader_election: false
-	crd_collectors:
-	  - datadoghq.com/v1alpha1/datadogmetrics
-	  - datadoghq.com/v1alpha1/watermarkpodautoscalers
+    crd_collectors:
+      - datadoghq.com/v1alpha1/datadogmetrics
+      - datadoghq.com/v1alpha1/watermarkpodautoscalers
 `
 	require.Equal(t, want, got)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes yaml error:
```
  Config Errors
  ==============
    orchestrator
    ------------
      yaml: line 9: found a tab character that violates indentation
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Enable the orchestrator explorer feature with custom resources:
```yaml
    orchestratorExplorer:
      enabled: true
      customResources: 
        - datadoghq.com/v2alpha1/datadogagents
```
There shouldn't be any configuration errors