### PR TITLE
[CONT-4042] Pass its pod name to the cluster-agent

### DIFF
--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -82,6 +82,7 @@ const (
 	DDOrchestratorExplorerContainerScrubbingEnabled   = "DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED"
 	DDPodAnnotationsAsTags                            = "DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS"
 	DDPodLabelsAsTags                                 = "DD_KUBERNETES_POD_LABELS_AS_TAGS"
+	DDPodName                                         = "DD_POD_NAME"
 	DDPPMReceiverSocket                               = "DD_APM_RECEIVER_SOCKET"
 	DDProcessCollectionEnabled                        = "DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED"
 	DDProcessConfigScrubArgs                          = "DD_PROCESS_CONFIG_SCRUB_ARGS"

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -505,6 +505,14 @@ func getEnvVarsForClusterAgent(logger logr.Logger, dda *datadoghqv1alpha1.Datado
 
 	envVars := []corev1.EnvVar{
 		{
+			Name: apicommon.DDPodName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
 			Name:  apicommon.DDClusterChecksEnabled,
 			Value: strconv.FormatBool(isClusterChecksEnabled(&dda.Spec)),
 		},

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -144,6 +144,14 @@ func clusterAgentPodSpectWithConfd(configDirSpec *datadoghqv1alpha1.ConfigDirSpe
 func clusterAgentDefaultEnvVars() []v1.EnvVar {
 	return []v1.EnvVar{
 		{
+			Name: "DD_POD_NAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
 			Name:  "DD_CLUSTER_CHECKS_ENABLED",
 			Value: "false",
 		},

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -123,6 +123,14 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{
 		{
+			Name: apicommon.DDPodName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
 			Name:  apicommon.DDClusterAgentKubeServiceName,
 			Value: GetClusterAgentServiceName(dda),
 		},


### PR DESCRIPTION
### What does this PR do?

Pass its pod name to the cluster agent.

### Motivation

It’s used by DataDog/datadog-agent#17305 to improve the leader election when the cluster-agent runs with `hostNetwork: true`.

### Additional Notes

The corresponding `helm-charts` PR is DataDog/helm-charts#1065.

### Describe your test plan

It’s the same test plan as for DataDog/datadog-agent#17305, but with the agent being deployed by the operator :

Start the cluster agent with `hostNetwork: true`.
Without this change, the cluster agents were logging errors like:
```
2023-05-25 15:48:35 UTC | CLUSTER | WARN | (pkg/clusteragent/clusterchecks/handler.go:192 in leaderWatch) | Could not refresh leadership status: "target named gke-gke-lenaic-ubuntu-containerd-2a3618a5-lzg5" not found, will only log every 100 errors
```

These errors should go away with this change.

In the output of `agent status`, the leader name was a node name before this change. With this change, it should now be the pod name. Same behavior as without `hostNetwork: true`.