### PR TITLE
update dsd and apm socket paths

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -198,8 +198,8 @@ const (
 	DogstatsdHostPortName                            = "dogstatsdport"
 	DogstatsdHostPortHostPort                        = 8125
 	DogstatsdSocketVolumeName                        = "dsdsocket"
-	DogstatsdAPMSocketVolumePath                     = "/var/run/datadog"
-	DogstatsdSocketLocalPath                         = "/var/run/datadog/statsd"
+	DogstatsdAPMSocketHostPath                       = "/var/run/datadog"
+	DogstatsdSocketLocalPath                         = "/var/run/datadog"
 	DogstatsdSocketName                              = "dsd.socket"
 	SecurityAgentComplianceCustomConfigDirVolumeName = "customcompliancebenchmarks"
 	SecurityAgentComplianceConfigDirVolumeName       = "compliancedir"
@@ -216,7 +216,7 @@ const (
 	APMHostPortName                                  = "traceport"
 	APMHostPortHostPort                              = 8126
 	APMSocketVolumeName                              = "apmsocket"
-	APMSocketVolumeLocalPath                         = "/var/run/datadog/apm"
+	APMSocketVolumeLocalPath                         = "/var/run/datadog"
 	APMSocketName                                    = "apm.socket"
 	AdmissionControllerPortName                      = "admissioncontrollerport"
 	AdmissionControllerSocketCommunicationMode       = "socket"

--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -34,7 +34,7 @@ const (
 	defaultAPMHostPortEnabled bool   = false
 	defaultAPMHostPort        int32  = 8126
 	defaultAPMSocketEnabled   bool   = true
-	defaultAPMSocketHostPath  string = apicommon.DogstatsdAPMSocketVolumePath + "/" + apicommon.APMSocketName
+	defaultAPMSocketHostPath  string = apicommon.DogstatsdAPMSocketHostPath + "/" + apicommon.APMSocketName
 
 	// defaultCSPMEnabled              bool = false
 	// defaultCWSEnabled               bool = false
@@ -52,7 +52,7 @@ const (
 	defaultDogstatsdHostPortEnabled        bool   = false
 	defaultDogstatsdPort                   int32  = 8125
 	defaultDogstatsdSocketEnabled          bool   = true
-	defaultDogstatsdHostSocketPath         string = apicommon.DogstatsdAPMSocketVolumePath + "/" + apicommon.DogstatsdSocketName
+	defaultDogstatsdHostSocketPath         string = apicommon.DogstatsdAPMSocketHostPath + "/" + apicommon.DogstatsdSocketName
 
 	defaultOTLPGRPCEnabled  bool   = false
 	defaultOTLPGRPCEndpoint string = "0.0.0.0:4317"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -602,13 +602,13 @@ func defaultMountVolume() []corev1.VolumeMount {
 		},
 		{
 			Name:      "dsdsocket",
-			MountPath: "/var/run/datadog/statsd",
+			MountPath: "/var/run/datadog",
 			ReadOnly:  true,
 		},
 
 		{
 			Name:      "dsdsocket",
-			MountPath: "/var/run/datadog/statsd",
+			MountPath: "/var/run/datadog",
 		},
 		{
 			Name:      "installinfo",
@@ -661,7 +661,7 @@ func defaultProcessMountVolumes() []corev1.VolumeMount {
 		},
 		{
 			Name:      "dsdsocket",
-			MountPath: "/var/run/datadog/statsd",
+			MountPath: "/var/run/datadog",
 			ReadOnly:  true,
 		},
 		{
@@ -737,7 +737,7 @@ func complianceSecurityAgentMountVolume() []corev1.VolumeMount {
 		},
 		{
 			Name:      "dsdsocket",
-			MountPath: "/var/run/datadog/statsd",
+			MountPath: "/var/run/datadog",
 			ReadOnly:  true,
 		},
 		{
@@ -795,7 +795,7 @@ func runtimeSecurityAgentMountVolume() []corev1.VolumeMount {
 		},
 		{
 			Name:      "dsdsocket",
-			MountPath: "/var/run/datadog/statsd",
+			MountPath: "/var/run/datadog",
 			ReadOnly:  true,
 		},
 		{
@@ -844,7 +844,7 @@ func defaultEnvVars(extraEnv map[string]string) []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_DOGSTATSD_SOCKET",
-			Value: "/var/run/datadog/statsd/statsd.sock",
+			Value: "/var/run/datadog/statsd.sock",
 		},
 		{
 			Name:  "DD_LOGS_ENABLED",
@@ -865,10 +865,6 @@ func defaultEnvVars(extraEnv map[string]string) []corev1.EnvVar {
 		{
 			Name:  "KUBERNETES",
 			Value: "yes",
-		},
-		{
-			Name:  "DD_DOGSTATSD_SOCKET",
-			Value: "/var/run/datadog/statsd/statsd.sock",
 		},
 		{
 			Name: "DD_KUBERNETES_KUBELET_HOST",
@@ -938,7 +934,7 @@ func defaultAPMContainerEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_DOGSTATSD_SOCKET",
-			Value: "/var/run/datadog/statsd/statsd.sock",
+			Value: "/var/run/datadog/statsd.sock",
 		},
 		{
 			Name:  apicommon.DDAuthTokenFilePath,
@@ -1028,7 +1024,7 @@ func securityAgentEnvVars(compliance, runtime bool, policiesdir bool, extraEnv m
 		},
 		{
 			Name:  "DD_DOGSTATSD_SOCKET",
-			Value: "/var/run/datadog/statsd/statsd.sock",
+			Value: "/var/run/datadog/statsd.sock",
 		},
 	}
 
@@ -1152,7 +1148,7 @@ func appendDefaultAPMAgentContainer(podSpec *corev1.PodSpec) {
 			},
 			{
 				Name:      "dsdsocket",
-				MountPath: "/var/run/datadog/statsd",
+				MountPath: "/var/run/datadog",
 				ReadOnly:  true,
 			},
 			{
@@ -1585,7 +1581,7 @@ func defaultOrchestratorEnvVars(dda *datadoghqv1alpha1.DatadogAgent) []corev1.En
 		},
 		{
 			Name:  "DD_DOGSTATSD_SOCKET",
-			Value: "/var/run/datadog/statsd/statsd.sock",
+			Value: "/var/run/datadog/statsd.sock",
 		},
 		{
 			Name: "DD_KUBERNETES_KUBELET_HOST",
@@ -1922,7 +1918,7 @@ func customKubeletConfigPodSpec(kubeletConfig *commonv1.KubeletConfig) corev1.Po
 		},
 		{
 			Name:  "DD_DOGSTATSD_SOCKET",
-			Value: "/var/run/datadog/statsd/statsd.sock",
+			Value: "/var/run/datadog/statsd.sock",
 		},
 		{
 			Name:  "DD_LOGS_ENABLED",
@@ -2516,7 +2512,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 		},
 		{
 			Name:      "dsdsocket",
-			MountPath: "/var/run/datadog/statsd",
+			MountPath: "/var/run/datadog",
 		},
 		{
 			Name:      "installinfo",
@@ -2572,7 +2568,7 @@ func Test_newExtendedDaemonSetFromInstance_CustomDatadogYaml(t *testing.T) {
 		},
 		{
 			Name:      "dsdsocket",
-			MountPath: "/var/run/datadog/statsd",
+			MountPath: "/var/run/datadog",
 			ReadOnly:  true,
 		},
 		{

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -353,7 +353,7 @@ func volumeMountsForTraceAgent() []corev1.VolumeMount {
 		component.GetVolumeMountForCgroups(),
 		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
-		component.GetVolumeMountForDogstatsdSocket(true),
+		component.GetVolumeMountForDogstatsdSocket(false),
 		component.GetVolumeMountForRuntimeSocket(true),
 	}
 }
@@ -363,7 +363,7 @@ func volumeMountsForProcessAgent() []corev1.VolumeMount {
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
-		component.GetVolumeMountForDogstatsdSocket(true),
+		component.GetVolumeMountForDogstatsdSocket(false),
 		component.GetVolumeMountForRuntimeSocket(true),
 		component.GetVolumeMountForProc(),
 	}
@@ -374,7 +374,7 @@ func volumeMountsForSecurityAgent() []corev1.VolumeMount {
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForAuth(true),
 		component.GetVolumeMountForConfig(),
-		component.GetVolumeMountForDogstatsdSocket(true),
+		component.GetVolumeMountForDogstatsdSocket(false),
 		component.GetVolumeMountForRuntimeSocket(true),
 	}
 }

--- a/controllers/datadogagent/feature/apm/feature.go
+++ b/controllers/datadogagent/feature/apm/feature.go
@@ -22,6 +22,7 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 )
@@ -273,7 +274,7 @@ func (f *apmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 		socketVol, socketVolMount := volume.GetVolumes(apicommon.APMSocketVolumeName, udsHostFolder, apicommon.APMSocketVolumeLocalPath, false)
 		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
 		socketVol.VolumeSource.HostPath.Type = &volType
-		managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.TraceAgentContainerName)
+		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, apicommonv1.TraceAgentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
 		managers.Volume().AddVolume(&socketVol)
 	}
 

--- a/controllers/datadogagent/feature/apm/feature_test.go
+++ b/controllers/datadogagent/feature/apm/feature_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	apmSocketHostPath  = apicommon.DogstatsdAPMSocketVolumePath + "/" + apicommon.APMSocketName
+	apmSocketHostPath  = apicommon.DogstatsdAPMSocketHostPath + "/" + apicommon.APMSocketName
 	apmSocketLocalPath = apicommon.APMSocketVolumeLocalPath + "/" + apicommon.APMSocketName
 )
 
@@ -200,7 +200,7 @@ func testAgentUDSOnly() *test.ComponentTest {
 					Name: apicommon.APMSocketVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: apicommon.DogstatsdAPMSocketVolumePath,
+							Path: apicommon.DogstatsdAPMSocketHostPath,
 							Type: &volType,
 						},
 					},
@@ -280,7 +280,7 @@ func testAgentHostPortUDS() *test.ComponentTest {
 					Name: apicommon.APMSocketVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
-							Path: apicommon.DogstatsdAPMSocketVolumePath,
+							Path: apicommon.DogstatsdAPMSocketHostPath,
 							Type: &volType,
 						},
 					},

--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -21,6 +21,7 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"
 )
 
@@ -216,8 +217,9 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers)
 		sockName := filepath.Base(f.udsHostFilepath)
 		socketVol, socketVolMount := volume.GetVolumes(apicommon.DogstatsdSocketVolumeName, udsHostFolder, apicommon.DogstatsdSocketLocalPath, false)
 		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
+
 		socketVol.VolumeSource.HostPath.Type = &volType
-		managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.CoreAgentContainerName)
+		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, apicommonv1.CoreAgentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
 		managers.Volume().AddVolume(&socketVol)
 		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
 			Name:  apicommon.DDDogstatsdSocket,

--- a/controllers/datadogagent/feature/dogstatsd/feature_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_test.go
@@ -117,7 +117,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: apicommon.DogstatsdAPMSocketVolumePath,
+					Path: apicommon.DogstatsdAPMSocketHostPath,
 					Type: &volType,
 				},
 			},
@@ -130,7 +130,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 			Name: apicommon.DogstatsdSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: apicommon.DogstatsdAPMSocketVolumePath,
+					Path: apicommon.DogstatsdAPMSocketHostPath,
 					Type: &volType,
 				},
 			},

--- a/controllers/datadogagent/merger/volume_mount.go
+++ b/controllers/datadogagent/merger/volume_mount.go
@@ -86,7 +86,7 @@ func (impl *volumeMountManagerImpl) AddVolumeMountToContainerWithMergeFunc(volum
 func AddVolumeMountToContainerWithMergeFunc(container *corev1.Container, volumeMount *corev1.VolumeMount, mergeFunc VolumeMountMergeFunction) ([]corev1.VolumeMount, error) {
 	var found bool
 	for id, cVolumeMount := range container.VolumeMounts {
-		if volumeMount.Name == cVolumeMount.Name {
+		if volumeMount.Name == cVolumeMount.Name || volumeMount.MountPath == cVolumeMount.MountPath {
 			if mergeFunc == nil {
 				mergeFunc = DefaultVolumeMountMergeFunction
 			}

--- a/controllers/datadogagent/utils_test.go
+++ b/controllers/datadogagent/utils_test.go
@@ -81,7 +81,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			want: []v1.VolumeMount{
 				{Name: "logdatadog", MountPath: "/var/log/datadog"},
 				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
-				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog/statsd"},
+				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				{Name: "runtimesocketdir", ReadOnly: true, MountPath: "/host/var/run/containerd"},
@@ -93,7 +93,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			want: []v1.VolumeMount{
 				{Name: "logdatadog", MountPath: "/var/log/datadog"},
 				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
-				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog/statsd"},
+				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				{Name: "custom-datadog-yaml", ReadOnly: true, MountPath: "/etc/datadog-agent/datadog.yaml", SubPath: "datadog.yaml", SubPathExpr: ""},
@@ -106,7 +106,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			want: []v1.VolumeMount{
 				{Name: "logdatadog", MountPath: "/var/log/datadog"},
 				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
-				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog/statsd"},
+				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				{Name: "extra", MountPath: "/etc/datadog-agent/extra"},
@@ -119,7 +119,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			want: []v1.VolumeMount{
 				{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
-				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog/statsd"},
+				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				{Name: "cgroups", ReadOnly: true, MountPath: "/host/sys/fs/cgroup"},
@@ -137,7 +137,7 @@ func Test_getVolumeMountsForSecurityAgent(t *testing.T) {
 			want: []v1.VolumeMount{
 				{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 				{Name: "datadog-agent-auth", ReadOnly: true, MountPath: "/etc/datadog-agent/auth"},
-				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog/statsd"},
+				{Name: "dsdsocket", ReadOnly: true, MountPath: "/var/run/datadog"},
 				{Name: "config", ReadOnly: false, MountPath: "/etc/datadog-agent"},
 				{Name: "hostroot", ReadOnly: true, MountPath: "/host/root"},
 				{Name: "runtimepoliciesdir", ReadOnly: true, MountPath: "/etc/datadog-agent/runtime-security.d"},


### PR DESCRIPTION
### What does this PR do?

Updates the Dogstatsd and APM socket paths when mounted in containers.
Gracefully handle expected conflict of volume mounts using merge functions in the volume mount manager

### Motivation

A bug was surfaced that occurs when the Admission Controller is enabled (with `muteUnlabelled: true`) and when Dogstatsd UDS is enabled (which it is by default) that caused CLB during container initiation.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test a DatadogAgent with the following:

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: system
spec:
  global:
    credentials:
      apiKey: <redacted>
      appKey: <redacted>
    # need this for kind
    kubelet:
      tlsVerify: false
  features:
    admissionController:
      enabled: true
      mutateUnlabelled: true
```

Also test:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: system
spec:
  global:
    credentials:
      apiKey: <redacted>
      appKey: <redacted>
    # need this for kind
    kubelet:
      tlsVerify: false
  features:
    admissionController:
      enabled: true
      mutateUnlabelled: true
    apm:
      enabled: true
```

and

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: system
spec:
  global:
    credentials:
      apiKey: <redacted>
      appKey: <redacted>
    # need this for kind
    kubelet:
      tlsVerify: false
  features:
    apm:
      enabled: true
```