### PR TITLE
Fix EDS canary panic

### DIFF
--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -73,7 +73,11 @@ type ExtendedDaemonsetOptions struct {
 }
 
 func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemonSetSpec {
-	spec := edsv1alpha1.ExtendedDaemonSetSpec{}
+	spec := edsv1alpha1.ExtendedDaemonSetSpec{
+		Strategy: edsv1alpha1.ExtendedDaemonSetSpecStrategy{
+			Canary: &edsv1alpha1.ExtendedDaemonSetSpecStrategyCanary{},
+		},
+	}
 	edsv1alpha1.DefaultExtendedDaemonSetSpec(&spec, edsv1alpha1.ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto)
 
 	if options.MaxPodUnavailable != "" {


### PR DESCRIPTION
### What does this PR do?

Fixes the operator crashing when using the EDS and not adding canary settings. The EDS defaulting code doesn't create a default `ExtendedDaemonSetSpecStrategyCanary` struct if there are no canary settings set in the EDS spec, so attempting to access `spec.Strategy.Canary.xxx` causes a nil pointer error:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf7ed18]

goroutine 515 [running]:
github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent.defaultEDSSpec(_)
        /workspace/controllers/datadogagent/component/agent/new.go:88 +0x158
github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent.NewExtendedDaemonset({0x1a9f540, 0x4000656420}, 0x400053f8c0?, {0x17d8d95?, 0x1?}, {0x40006f7a90, 0xd}, {0x0?, 0x0?}, 0x148a360?)
        /workspace/controllers/datadogagent/component/agent/new.go:54 +0x84
github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent.NewDefaultAgentExtendedDaemonset({0x1a9f540, 0x4000656420}, 0x2?, {0x40004ae400, 0x2, 0x2})
        /workspace/controllers/datadogagent/component/agent/default.go:39 +0x64
github.com/DataDog/datadog-operator/controllers/datadogagent.(*Reconciler).reconcileV2Agent(0x400051e410, {{0x1a90270?, 0x400084c420?}, 0x0?}, {{0x40008781ec, {0x0, 0x0, 0x0}}, {0x40008781ed, {0x40004ae400, ...}}, ...}, ...)
        /workspace/controllers/datadogagent/controller_reconcile_agent.go:45 +0x14c
github.com/DataDog/datadog-operator/controllers/datadogagent.(*Reconciler).reconcileInstanceV2(0x400051e410, {0x1a8d678, 0x400084c3f0}, {{0x1a90270?, 0x400084c420?}, 0x4000656160?}, 0x4000656420)
        /workspace/controllers/datadogagent/controller_reconcile_v2.go:144 +0x5b0
github.com/DataDog/datadog-operator/controllers/datadogagent.(*Reconciler).internalReconcileV2(0x400051e410, {0x1a8d678, 0x400084c3f0}, {{{0x40008780d7, 0x7}, {0x40008780d0, 0x7}}})
        /workspace/controllers/datadogagent/controller_reconcile_v2.go:90 +0x234
github.com/DataDog/datadog-operator/controllers/datadogagent.(*Reconciler).Reconcile(0x400051e410, {0x1a8d678?, 0x400084c3f0?}, {{{0x40008780d7?, 0x15171a0?}, {0x40008780d0?, 0x15171a0?}}})
        /workspace/controllers/datadogagent/controller.go:105 +0x4c
github.com/DataDog/datadog-operator/controllers.(*DatadogAgentReconciler).Reconcile(0x1a8d678?, {0x1a8d678?, 0x400084c3f0?}, {{{0x40008780d7?, 0x16a9220?}, {0x40008780d0?, 0x4000180000?}}})
        /workspace/controllers/datadogagent_controller.go:176 +0x30
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x40001d93f0, {0x1a8d678, 0x400084c330}, {{{0x40008780d7?, 0x16a9220?}, {0x40008780d0?, 0x1518a60?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:114 +0x22c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0x40001d93f0, {0x1a8d5d0, 0x40003b9000}, {0x1593f20?, 0x40004ae140?})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:311 +0x28c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0x40001d93f0, {0x1a8d5d0, 0x40003b9000})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:266 +0x1b0
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:227 +0x74
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.2/pkg/internal/controller/controller.go:223 +0x278
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Set up the operator with `supportExtendedDaemonset=true` and no other [EDS configs](https://github.com/DataDog/datadog-operator/blob/e49d03ae831ed45008f4f2732e9408ec9297a2dc/main.go#L152-L161). The operator pod shouldn't crash.
