### PR TITLE
instruct the core agent that CWS/CSPM is enabled

### DIFF
--- a/controllers/datadogagent/feature/cspm/feature.go
+++ b/controllers/datadogagent/feature/cspm/feature.go
@@ -346,6 +346,7 @@ func (f *cspmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) erro
 		Name:  apicommon.DDComplianceConfigEnabled,
 		Value: "true",
 	}
+	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enabledEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SecurityAgentContainerName, enabledEnvVar)
 
 	hostRootEnvVar := &corev1.EnvVar{

--- a/controllers/datadogagent/feature/cws/feature.go
+++ b/controllers/datadogagent/feature/cws/feature.go
@@ -184,6 +184,7 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 		Name:  apicommon.DDRuntimeSecurityConfigEnabled,
 		Value: "true",
 	}
+	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enabledEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SecurityAgentContainerName, enabledEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enabledEnvVar)
 


### PR DESCRIPTION
### What does this PR do?

The core agent communicates through the inventories if CWS is enabled. To do that correctly it needs to know if CWS is enabled, which is doesn't if the env vars are only set on other containers.

This PR fixes this issue for CWS and for CSPM as well.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
