### PR TITLE
[ksmfeature] fix bug where service account was being overwritten

### DIFF
--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -85,6 +85,7 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 
 		f.collectAPIServiceMetrics = true
 		f.collectCRDMetrics = true
+		f.serviceAccountName = v2alpha1.GetClusterAgentServiceAccount(dda)
 
 		// This check will only run in the Cluster Checks Runners or Cluster Agent (not the Node Agent)
 		if dda.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.Enabled) && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners) {
@@ -120,7 +121,6 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.KubernetesStateCoreIDType)
 		}
 
-		f.serviceAccountName = v2alpha1.GetClusterAgentServiceAccount(dda)
 		f.configConfigMapName = apicommonv1.GetConfName(dda, f.customConfig, apicommon.DefaultKubeStateMetricsCoreConf)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Service Account was being overridden to always use the cluster agent SA even when the check is running on cluster checks runners.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run the KSM Core feature and ensure that the cluster role binding is pointing to the Cluster Checks Worker service account