### PR TITLE
add agent version format function to support images with dashes

### DIFF
--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -86,6 +86,8 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 		f.collectAPIServiceMetrics = true
 		f.collectCRDMetrics = true
 
+		versionTag := ""
+
 		// This check will only run in the Cluster Checks Runners or Cluster Agent (not the Node Agent)
 		if dda.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.Enabled) && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners) {
 			f.runInClusterChecksRunner = true
@@ -94,14 +96,16 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 			output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 
 			if ccrOverride, ok := dda.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName]; ok {
-				if ccrOverride.Image != nil && !utils.IsAboveMinVersion(component.GetAgentVersionFromImage(*ccrOverride.Image), crdAPIServiceCollectionMinVersion) {
+				versionTag = utils.FormatVersionTag(component.GetAgentVersionFromImage(*ccrOverride.Image))
+				if ccrOverride.Image != nil && versionTag != "" && !utils.IsAboveMinVersion(versionTag, crdAPIServiceCollectionMinVersion) {
 					// Disable if image is overridden to an unsupported version
 					f.collectAPIServiceMetrics = false
 					f.collectCRDMetrics = false
 				}
 			}
 		} else if clusterAgentOverride, ok := dda.Spec.Override[v2alpha1.ClusterAgentComponentName]; ok {
-			if clusterAgentOverride.Image != nil && !utils.IsAboveMinVersion(component.GetAgentVersionFromImage(*clusterAgentOverride.Image), crdAPIServiceCollectionMinVersion) {
+			versionTag = utils.FormatVersionTag(component.GetAgentVersionFromImage(*clusterAgentOverride.Image))
+			if clusterAgentOverride.Image != nil && versionTag != "" && !utils.IsAboveMinVersion(versionTag, crdAPIServiceCollectionMinVersion) {
 				// Disable if image is overridden to an unsupported version
 				f.collectAPIServiceMetrics = false
 				f.collectCRDMetrics = false

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -97,16 +97,14 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 			output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 
 			if ccrOverride, ok := dda.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName]; ok {
-				versionTag = utils.FormatVersionTag(component.GetAgentVersionFromImage(*ccrOverride.Image))
-				if ccrOverride.Image != nil && versionTag != "" && !utils.IsAboveMinVersion(versionTag, crdAPIServiceCollectionMinVersion) {
+				if ccrOverride.Image != nil && versionTag != "" && !utils.IsAboveMinVersion(component.GetAgentVersionFromImage(*ccrOverride.Image), crdAPIServiceCollectionMinVersion) {
 					// Disable if image is overridden to an unsupported version
 					f.collectAPIServiceMetrics = false
 					f.collectCRDMetrics = false
 				}
 			}
 		} else if clusterAgentOverride, ok := dda.Spec.Override[v2alpha1.ClusterAgentComponentName]; ok {
-			versionTag = utils.FormatVersionTag(component.GetAgentVersionFromImage(*clusterAgentOverride.Image))
-			if clusterAgentOverride.Image != nil && versionTag != "" && !utils.IsAboveMinVersion(versionTag, crdAPIServiceCollectionMinVersion) {
+			if clusterAgentOverride.Image != nil && versionTag != "" && !utils.IsAboveMinVersion(component.GetAgentVersionFromImage(*clusterAgentOverride.Image), crdAPIServiceCollectionMinVersion) {
 				// Disable if image is overridden to an unsupported version
 				f.collectAPIServiceMetrics = false
 				f.collectCRDMetrics = false

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -17,6 +17,7 @@ var versionWithDashesRx = regexp.MustCompile(`(\d+\-\d+\-\d+)(\-[^\+]+)*(\+.+)*`
 
 // IsAboveMinVersion uses semver to check if `version` is >= minVersion
 func IsAboveMinVersion(version, minVersion string) bool {
+	version = formatVersionTag(version)
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		return false
@@ -30,8 +31,8 @@ func IsAboveMinVersion(version, minVersion string) bool {
 	return c.Check(v)
 }
 
-func FormatVersionTag(versionTag string) string {
-	// Check if version tag uses dashes in lieu of periods. If so, then replace first two dashes with periods to convert to expected format.
+// formatVersionTag checks if the version tag uses dashes in lieu of periods, and replaces the first two dashes if so.
+func formatVersionTag(versionTag string) string {
 	if versionWithDashesRx.FindString(versionTag) != "" {
 		versionTag = strings.Replace(versionTag, "-", ".", 2)
 	}

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -5,7 +5,15 @@
 
 package utils
 
-import "github.com/Masterminds/semver/v3"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var versionRx = regexp.MustCompile(`(\d+\.\d+\.\d+)(\-[^\+]+)*(\+.+)*`)
+var versionWithDashesRx = regexp.MustCompile(`(\d+\-\d+\-\d+)(\-[^\+]+)*(\+.+)*`)
 
 // IsAboveMinVersion uses semver to check if `version` is >= minVersion
 func IsAboveMinVersion(version, minVersion string) bool {
@@ -20,4 +28,14 @@ func IsAboveMinVersion(version, minVersion string) bool {
 	}
 
 	return c.Check(v)
+}
+
+func FormatVersionTag(versionTag string) string {
+	// Check if version tag uses dashes in lieu of periods. If so, then replace first two dashes with periods to convert to expected format.
+	if versionWithDashesRx.FindString(versionTag) != "" {
+		versionTag = strings.Replace(versionTag, "-", ".", 2)
+	}
+
+	// Return versionTag if it matches with versionRx regex, or "".
+	return versionRx.FindString(versionTag)
 }

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -111,7 +111,7 @@ func TestIsAboveMinVersion(t *testing.T) {
 	}
 }
 
-func TestFormatVersionTag(t *testing.T) {
+func Test_formatVersionTag(t *testing.T) {
 	testCases := []struct {
 		version  string
 		expected string
@@ -176,7 +176,7 @@ func TestFormatVersionTag(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.version, func(t *testing.T) {
-			result := FormatVersionTag(test.version)
+			result := formatVersionTag(test.version)
 			assert.Equal(t, test.expected, result)
 		})
 	}

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCompareVersion(t *testing.T) {
+func TestIsAboveMinVersion(t *testing.T) {
 	testCases := []struct {
 		version    string
 		minVersion string
@@ -62,10 +62,121 @@ func TestCompareVersion(t *testing.T) {
 			minVersion: "1.22-0",
 			expected:   true,
 		},
+		{
+			version:    "7.27.0-beta",
+			minVersion: "7.26.0-0",
+			expected:   true,
+		},
+		{
+			version:    "7.27.0-beta",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-beta",
+			minVersion: "7.26.0-0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-beta",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
+		{
+			version:    "7.27.0-rc-3-jmx",
+			minVersion: "7.26.0-0",
+			expected:   true,
+		},
+		{
+			version:    "7.27.0-rc-3-jmx",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-rc-3-jmx",
+			minVersion: "7.26.0-0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-rc-3-jmx",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.version, func(t *testing.T) {
 			result := IsAboveMinVersion(test.version, test.minVersion)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestFormatVersionTag(t *testing.T) {
+	testCases := []struct {
+		version  string
+		expected string
+	}{
+		{
+			version:  "7.46.0",
+			expected: "7.46.0",
+		},
+		{
+			version:  "7.46.0-jmx",
+			expected: "7.46.0-jmx",
+		},
+		{
+			version:  "7.46.0-rc.3",
+			expected: "7.46.0-rc.3",
+		},
+		{
+			version:  "7.46.0-rc.3-jmx",
+			expected: "7.46.0-rc.3-jmx",
+		},
+		{
+			version:  "7.46.0-beta",
+			expected: "7.46.0-beta",
+		},
+		// dashes ("-") in lieu of periods (".")
+		{
+			version:  "7-46-0",
+			expected: "7.46.0",
+		},
+		{
+			version:  "7-46-0-jmx",
+			expected: "7.46.0-jmx",
+		},
+		{
+			version:  "7-46-0-rc-3-jmx",
+			expected: "7.46.0-rc-3-jmx",
+		},
+		{
+			version:  "7-46-0-rc.3.jmx",
+			expected: "7.46.0-rc.3.jmx",
+		},
+		{
+			version:  "7-46-0-beta",
+			expected: "7.46.0-beta",
+		},
+		{
+			version:  "customImage",
+			expected: "",
+		},
+		{
+			version:  "customImage",
+			expected: "",
+		},
+		{
+			version:  "custom-image",
+			expected: "",
+		},
+		{
+			version:  "custom-image-long-name",
+			expected: "",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.version, func(t *testing.T) {
+			result := FormatVersionTag(test.version)
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a format function in pkg/utils/version to support image tags that use dashes in lieu of periods.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test a DatadogAgent CR with the node agent image override set to something like `7-46-0-jmx` . Ensure that the KSMFeature RBACs and collectors are present as expected.