### PR TITLE
format agent version check

### DIFF
--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -5,10 +5,19 @@
 
 package utils
 
-import "github.com/Masterminds/semver/v3"
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var versionRx = regexp.MustCompile(`(\d+\.\d+\.\d+)(\-[^\+]+)*(\+.+)*`)
+var versionWithDashesRx = regexp.MustCompile(`(\d+\-\d+\-\d+)(\-[^\+]+)*(\+.+)*`)
 
 // IsAboveMinVersion uses semver to check if `version` is >= minVersion
 func IsAboveMinVersion(version, minVersion string) bool {
+	version = formatVersionTag(version)
 	v, err := semver.NewVersion(version)
 	if err != nil {
 		return false
@@ -20,4 +29,14 @@ func IsAboveMinVersion(version, minVersion string) bool {
 	}
 
 	return c.Check(v)
+}
+
+// formatVersionTag checks if the version tag uses dashes in lieu of periods, and replaces the first two dashes if so.
+func formatVersionTag(versionTag string) string {
+	if versionWithDashesRx.FindString(versionTag) != "" {
+		versionTag = strings.Replace(versionTag, "-", ".", 2)
+	}
+
+	// Return versionTag if it matches with versionRx regex, or "".
+	return versionRx.FindString(versionTag)
 }

--- a/pkg/utils/version_test.go
+++ b/pkg/utils/version_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCompareVersion(t *testing.T) {
+func TestIsAboveMinVersion(t *testing.T) {
 	testCases := []struct {
 		version    string
 		minVersion string
@@ -62,10 +62,121 @@ func TestCompareVersion(t *testing.T) {
 			minVersion: "1.22-0",
 			expected:   true,
 		},
+		{
+			version:    "7.27.0-beta",
+			minVersion: "7.26.0-0",
+			expected:   true,
+		},
+		{
+			version:    "7.27.0-beta",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-beta",
+			minVersion: "7.26.0-0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-beta",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
+		{
+			version:    "7.27.0-rc-3-jmx",
+			minVersion: "7.26.0-0",
+			expected:   true,
+		},
+		{
+			version:    "7.27.0-rc-3-jmx",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-rc-3-jmx",
+			minVersion: "7.26.0-0",
+			expected:   false,
+		},
+		{
+			version:    "7.25.0-rc-3-jmx",
+			minVersion: "7.26.0",
+			expected:   false,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.version, func(t *testing.T) {
 			result := IsAboveMinVersion(test.version, test.minVersion)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func Test_formatVersionTag(t *testing.T) {
+	testCases := []struct {
+		version  string
+		expected string
+	}{
+		{
+			version:  "7.46.0",
+			expected: "7.46.0",
+		},
+		{
+			version:  "7.46.0-jmx",
+			expected: "7.46.0-jmx",
+		},
+		{
+			version:  "7.46.0-rc.3",
+			expected: "7.46.0-rc.3",
+		},
+		{
+			version:  "7.46.0-rc.3-jmx",
+			expected: "7.46.0-rc.3-jmx",
+		},
+		{
+			version:  "7.46.0-beta",
+			expected: "7.46.0-beta",
+		},
+		// dashes ("-") in lieu of periods (".")
+		{
+			version:  "7-46-0",
+			expected: "7.46.0",
+		},
+		{
+			version:  "7-46-0-jmx",
+			expected: "7.46.0-jmx",
+		},
+		{
+			version:  "7-46-0-rc-3-jmx",
+			expected: "7.46.0-rc-3-jmx",
+		},
+		{
+			version:  "7-46-0-rc.3.jmx",
+			expected: "7.46.0-rc.3.jmx",
+		},
+		{
+			version:  "7-46-0-beta",
+			expected: "7.46.0-beta",
+		},
+		{
+			version:  "customImage",
+			expected: "",
+		},
+		{
+			version:  "customImage",
+			expected: "",
+		},
+		{
+			version:  "custom-image",
+			expected: "",
+		},
+		{
+			version:  "custom-image-long-name",
+			expected: "",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.version, func(t *testing.T) {
+			result := formatVersionTag(test.version)
 			assert.Equal(t, test.expected, result)
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a format function in pkg/utils/version to support image tags that use dashes in lieu of periods.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Test a DatadogAgent CR with the node agent image override set to something like 7-46-0-jmx . Ensure that the KSMFeature RBACs and collectors are present as expected.