### PR TITLE
Allow manual push to staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -215,7 +215,7 @@ trigger_internal_operator_image:
   rules:
     - if: $CI_COMMIT_TAG
       variables:
-        IMAGE_RELEASE_PROD: "true
+        IMAGE_RELEASE_PROD: "true"
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
     - when: never
@@ -237,7 +237,7 @@ trigger_internal_operator_check_image:
   rules:
     - if: $CI_COMMIT_TAG
       variables:
-        IMAGE_RELEASE_PROD: "true
+        IMAGE_RELEASE_PROD: "true"
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ variables:
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   PUSH_IMAGES_TO_STAGING:
     description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."
+  IMAGE_RELEASE_PROD: "false"
 
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}
@@ -213,6 +214,8 @@ trigger_internal_operator_image:
   stage: release
   rules:
     - if: $CI_COMMIT_TAG
+      variables:
+        IMAGE_RELEASE_PROD: "true
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
     - when: never
@@ -227,12 +230,14 @@ trigger_internal_operator_image:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
-    RELEASE_PROD: "true"
+    RELEASE_PROD: ${IMAGE_RELEASE_PROD}
 
 trigger_internal_operator_check_image:
   stage: release
   rules:
     - if: $CI_COMMIT_TAG
+      variables:
+        IMAGE_RELEASE_PROD: "true
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
     - when: never
@@ -247,7 +252,7 @@ trigger_internal_operator_check_image:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
-    RELEASE_PROD: "true"
+    RELEASE_PROD: ${IMAGE_RELEASE_PROD}
 
 submit_preflight_redhat_public_tag:
   stage: post-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,8 @@ variables:
   RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY: redhat_operator_token
   RH_PARTNER_SCAN_REGISTRY: scan.connect.redhat.com
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
+  PUSH_IMAGES_TO_STAGING:
+    description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry.
 
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}
@@ -211,6 +213,8 @@ trigger_internal_operator_image:
   stage: release
   rules:
     - if: $CI_COMMIT_TAG
+    - if: $PUSH_IMAGES_TO_STAGING == 'true'
+      when: manual
     - when: never
   trigger:
     project: DataDog/images
@@ -229,6 +233,8 @@ trigger_internal_operator_check_image:
   stage: release
   rules:
     - if: $CI_COMMIT_TAG
+    - if: $PUSH_IMAGES_TO_STAGING == 'true'
+      when: manual
     - when: never
   trigger:
     project: DataDog/images

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ variables:
   RH_PARTNER_SCAN_REGISTRY: scan.connect.redhat.com
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   PUSH_IMAGES_TO_STAGING:
-    description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry.
+    description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."
 
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}


### PR DESCRIPTION
### What does this PR do?

Add the possibility to push manually  on internal staging registry `operator` and `operator-check` images, without the need of a tag.

### Motivation

Ease testing custom operator build

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
