### PR TITLE
Improve internal image tagging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,8 +216,11 @@ trigger_internal_operator_image:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_RELEASE_PROD: "true"
+        IMAGE_TAG: ${CI_COMMIT_REF_SLUG}
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
+      variables:
+        IMAGE_TAG: branch-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
     - when: never
   trigger:
     project: DataDog/images
@@ -226,8 +229,8 @@ trigger_internal_operator_image:
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: datadog-operator
-    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
-    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    RELEASE_TAG: ${IMAGE_TAG}
+    BUILD_TAG: ${IMAGE_TAG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: ${IMAGE_RELEASE_PROD}
@@ -238,8 +241,11 @@ trigger_internal_operator_check_image:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_RELEASE_PROD: "true"
+        IMAGE_TAG: ${CI_COMMIT_REF_SLUG}
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
+      variables:
+        IMAGE_TAG: branch-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
     - when: never
   trigger:
     project: DataDog/images
@@ -248,9 +254,9 @@ trigger_internal_operator_check_image:
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME_CHECK
-    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
-    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: ${IMAGE_TAG}
+    BUILD_TAG: ${IMAGE_TAG}
     RELEASE_STAGING: "true"
     RELEASE_PROD: ${IMAGE_RELEASE_PROD}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ variables:
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   PUSH_IMAGES_TO_STAGING:
     description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."
-  IMAGE_RELEASE_PROD: "false"
 
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}
@@ -214,38 +213,6 @@ trigger_internal_operator_image:
   stage: release
   rules:
     - if: $CI_COMMIT_TAG
-      variables:
-        IMAGE_RELEASE_PROD: "true"
-        IMAGE_TAG: $CI_COMMIT_REF_SLUG
-    - if: $PUSH_IMAGES_TO_STAGING == 'true'
-      when: manual
-      variables:
-        IMAGE_TAG: $CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-    - when: never
-  trigger:
-    project: DataDog/images
-    branch: master
-    strategy: depend
-  variables:
-    IMAGE_VERSION: tmpl-v1
-    IMAGE_NAME: datadog-operator
-    RELEASE_TAG: $IMAGE_TAG
-    BUILD_TAG: $IMAGE_TAG
-    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    RELEASE_STAGING: "true"
-    RELEASE_PROD: $IMAGE_RELEASE_PROD
-
-trigger_internal_operator_check_image:
-  stage: release
-  rules:
-    - if: $CI_COMMIT_TAG
-      variables:
-        IMAGE_RELEASE_PROD: "true"
-        IMAGE_TAG: $CI_COMMIT_REF_SLUG
-    - if: $PUSH_IMAGES_TO_STAGING == 'true'
-      when: manual
-      variables:
-        IMAGE_TAG: $CI_COMMIT_BRANCH-$CI_COMMIT_SHORT_SHA
     - when: never
   trigger:
     project: DataDog/images
@@ -255,10 +222,68 @@ trigger_internal_operator_check_image:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME_CHECK
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    RELEASE_TAG: $IMAGE_TAG
-    BUILD_TAG: $IMAGE_TAG
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
     RELEASE_STAGING: "true"
-    RELEASE_PROD: $IMAGE_RELEASE_PROD
+    RELEASE_PROD: "true"
+
+trigger_internal_operator_check_image:
+  stage: release
+  rules:
+    - if: $CI_COMMIT_TAG
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v1
+    IMAGE_NAME: $PROJECTNAME_CHECK
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"
+
+
+trigger_internal_staging_only_operator_image:
+  stage: release
+  rules:
+    - if: $PUSH_IMAGES_TO_STAGING == 'true'
+      when: manual
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v1
+    IMAGE_NAME: $PROJECTNAME_CHECK
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "false"
+
+trigger_internal_staging_only_operator_check_image:
+  stage: release
+  rules:
+    - if: $PUSH_IMAGES_TO_STAGING == 'true'
+      when: manual
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v1
+    IMAGE_NAME: $PROJECTNAME_CHECK
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "false"
+
 
 submit_preflight_redhat_public_tag:
   stage: post-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,11 +216,11 @@ trigger_internal_operator_image:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_RELEASE_PROD: "true"
-        IMAGE_TAG: ${CI_COMMIT_REF_SLUG}
+        IMAGE_TAG: $CI_COMMIT_REF_SLUG
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
       variables:
-        IMAGE_TAG: ${CI_COMMIT_BRANCH}-${CI_COMMIT_SHORT_SHA}
+        IMAGE_TAG: $CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
     - when: never
   trigger:
     project: DataDog/images
@@ -229,11 +229,11 @@ trigger_internal_operator_image:
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: datadog-operator
-    RELEASE_TAG: ${IMAGE_TAG}
-    BUILD_TAG: ${IMAGE_TAG}
+    RELEASE_TAG: $IMAGE_TAG
+    BUILD_TAG: $IMAGE_TAG
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
-    RELEASE_PROD: ${IMAGE_RELEASE_PROD}
+    RELEASE_PROD: $IMAGE_RELEASE_PROD
 
 trigger_internal_operator_check_image:
   stage: release
@@ -241,11 +241,11 @@ trigger_internal_operator_check_image:
     - if: $CI_COMMIT_TAG
       variables:
         IMAGE_RELEASE_PROD: "true"
-        IMAGE_TAG: ${CI_COMMIT_REF_SLUG}
+        IMAGE_TAG: $CI_COMMIT_REF_SLUG
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
       variables:
-        IMAGE_TAG: ${CI_COMMIT_BRANCH}-${CI_COMMIT_SHORT_SHA}
+        IMAGE_TAG: $CI_COMMIT_BRANCH-$CI_COMMIT_SHORT_SHA
     - when: never
   trigger:
     project: DataDog/images
@@ -255,10 +255,10 @@ trigger_internal_operator_check_image:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME_CHECK
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    RELEASE_TAG: ${IMAGE_TAG}
-    BUILD_TAG: ${IMAGE_TAG}
+    RELEASE_TAG: $IMAGE_TAG
+    BUILD_TAG: $IMAGE_TAG
     RELEASE_STAGING: "true"
-    RELEASE_PROD: ${IMAGE_RELEASE_PROD}
+    RELEASE_PROD: $IMAGE_RELEASE_PROD
 
 submit_preflight_redhat_public_tag:
   stage: post-release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -246,7 +246,7 @@ trigger_internal_operator_check_image:
     RELEASE_PROD: "true"
 
 
-trigger_internal_staging_only_operator_image:
+trigger_custom_operator_image_staging:
   stage: release
   rules:
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
@@ -265,7 +265,7 @@ trigger_internal_staging_only_operator_image:
     RELEASE_STAGING: "true"
     RELEASE_PROD: "false"
 
-trigger_internal_staging_only_operator_check_image:
+trigger_custom_operator_check_image_staging:
   stage: release
   rules:
     - if: $PUSH_IMAGES_TO_STAGING == 'true'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -220,7 +220,7 @@ trigger_internal_operator_image:
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
       variables:
-        IMAGE_TAG: branch-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
+        IMAGE_TAG: ${CI_COMMIT_BRANCH}-${CI_COMMIT_SHORT_SHA}
     - when: never
   trigger:
     project: DataDog/images
@@ -245,7 +245,7 @@ trigger_internal_operator_check_image:
     - if: $PUSH_IMAGES_TO_STAGING == 'true'
       when: manual
       variables:
-        IMAGE_TAG: branch-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}
+        IMAGE_TAG: ${CI_COMMIT_BRANCH}-${CI_COMMIT_SHORT_SHA}
     - when: never
   trigger:
     project: DataDog/images


### PR DESCRIPTION
### What does this PR do?

Add a `commit sha` in the internal image tag, if the build is triggered manually

### Motivation

simply internal testing. Adding the commit sha in the image tag allow to push several image from the same branch without overriding the previous version. It can be usefull if the image was already replicated in some registry. Or to compare two versions

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
