### PR TITLE
[datadogmonitor] reduce number of reconcile requeues

### DIFF
--- a/controllers/datadogmonitor/controller_test.go
+++ b/controllers/datadogmonitor/controller_test.go
@@ -75,7 +75,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 					_ = c.Create(context.TODO(), genericDatadogMonitor())
 				},
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, dm); err != nil {
@@ -94,7 +94,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				},
 				firstReconcileCount: 3,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, dm); err != nil {
@@ -113,7 +113,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				},
 				firstReconcileCount: 2,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, dm); err != nil {
@@ -152,7 +152,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				},
 				secondReconcileCount: 2,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, dm); err != nil {
@@ -178,7 +178,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 					assert.NoError(t, err)
 				},
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    true,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -197,7 +197,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				},
 				firstReconcileCount: 2,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -218,7 +218,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -239,7 +239,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -260,7 +260,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -281,7 +281,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -302,7 +302,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -323,7 +323,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -344,7 +344,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -365,7 +365,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -386,7 +386,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -421,7 +421,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				},
 				firstReconcileCount: 2,
 			},
-			wantResult: reconcile.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}

--- a/controllers/datadogmonitor/finalizer.go
+++ b/controllers/datadogmonitor/finalizer.go
@@ -30,21 +30,21 @@ func (r *Reconciler) handleFinalizer(logger logr.Logger, dm *datadoghqv1alpha1.D
 			dm.SetFinalizers(utils.RemoveString(dm.GetFinalizers(), datadogMonitorFinalizer))
 			err := r.client.Update(context.TODO(), dm)
 			if err != nil {
-				return ctrl.Result{Requeue: true, RequeueAfter: defaultErrRequeuePeriod}, err
+				return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
 			}
 		}
 
 		// Requeue until the object was properly deleted by Kuberentes
-		return ctrl.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod}, nil
+		return ctrl.Result{RequeueAfter: defaultRequeuePeriod}, nil
 	}
 
 	// Add finalizer for this resource if it doesn't already exist.
 	if !utils.ContainsString(dm.GetFinalizers(), datadogMonitorFinalizer) {
 		if err := r.addFinalizer(logger, dm); err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: defaultErrRequeuePeriod}, err
+			return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
 		}
 
-		return ctrl.Result{Requeue: true, RequeueAfter: defaultRequeuePeriod}, nil
+		return ctrl.Result{RequeueAfter: defaultRequeuePeriod}, nil
 	}
 
 	// Proceed in reconcile loop.

--- a/pkg/controller/utils/condition/datadogmonitor.go
+++ b/pkg/controller/utils/condition/datadogmonitor.go
@@ -45,9 +45,12 @@ func SetDatadogMonitorCondition(condition *datadoghqv1alpha1.DatadogMonitorCondi
 	if condition.Status != conditionStatus {
 		condition.LastTransitionTime = now
 		condition.Status = conditionStatus
+		condition.LastUpdateTime = now
+		condition.Message = desc
+	} else if condition.Message != desc {
+		condition.LastUpdateTime = now
+		condition.Message = desc
 	}
-	condition.LastUpdateTime = now
-	condition.Message = desc
 
 	return condition
 }


### PR DESCRIPTION
### What does this PR do?

Reduce the high number of requeues of a datadogmonitor instance to lighten load of operator. The primary change is to only update a status condition if the status condition status has changed, or the message has changed.
Remove `result.Requeue: true` if `result.RequeueAfter` is set (this is implied)


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

The most effective way to test this change is to examine a cluster that is reconciling many DatadogMonitor objects. The test cluster we used had ~90. Check that the reconcile count per monitor is not more than a couple per minute.