### PR TITLE
Add(check-operator): patch-crd sub command

### DIFF
--- a/cmd/check-operator/patchcrd/patchcrd.go
+++ b/cmd/check-operator/patchcrd/patchcrd.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package patchcrd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/DataDog/datadog-operator/pkg/plugin/common"
+)
+
+// Options provides information required to manage the patch function.
+type Options struct {
+	genericclioptions.IOStreams
+	common.Options
+	args           []string
+	crdName        string
+	storedVersions []string
+}
+
+// NewOptions provides an instance of Options with default values.
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	opts := &Options{
+		IOStreams: streams,
+	}
+
+	opts.SetConfigFlags()
+
+	return opts
+}
+
+// NewCmdPatch provides a cobra command wrapping Options.
+func NewCmdPatch(streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:          "patch-crd <crd-name>",
+		Short:        "patch the CRD status to update storedVersions list",
+		Example:      "./check-operator patch-crd datadogagents.datadoghq.com",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+			if err := o.Validate(); err != nil {
+				return err
+			}
+
+			return o.Run()
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&o.storedVersions, "storedVersions", []string{}, "used to define the status.storedVersion field in the CRD")
+
+	o.ConfigFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// Complete sets all information required for processing the command.
+func (o *Options) Complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	if len(args) > 0 {
+		o.crdName = args[0]
+	}
+
+	return o.Init(cmd)
+}
+
+// Validate ensures that all required arguments and flag values are provided.
+func (o *Options) Validate() error {
+	if o.crdName == "" {
+		return fmt.Errorf("the CRD name is required")
+	}
+
+	if len(o.storedVersions) == 0 {
+		return fmt.Errorf("at least one storedVersion needs to be provided")
+	}
+
+	return nil
+}
+
+// Run use to run the command.
+func (o *Options) Run() error {
+	o.printOutf("Start checking patching CRD status")
+	crd, err := o.APIExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), o.crdName, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("unable to patch %s CRD, err: %w", o.crdName, err)
+		}
+		return fmt.Errorf("unknow error during CRD get, err: %w", err)
+	}
+
+	o.printOutf("Current storedVersions value: %s,", strings.Join(crd.Status.StoredVersions, ","))
+	crd.Status.StoredVersions = o.storedVersions
+
+	crd, err = o.APIExtClient.ApiextensionsV1().CustomResourceDefinitions().UpdateStatus(context.Background(), crd, v1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to update CRD, retry later, err: %w", err)
+	}
+	o.printOutf("Sucessful CRD update, new storedVersions values: %s", strings.Join(crd.Status.StoredVersions, ","))
+	return nil
+
+}
+
+func (o *Options) printOutf(format string, a ...interface{}) {
+	args := []interface{}{time.Now().UTC().Format("2006-01-02T15:04:05.999Z"), o.crdName}
+	args = append(args, a...)
+	_, _ = fmt.Fprintf(o.Out, "[%s] CRD '%s': "+format+"\n", args...)
+}

--- a/cmd/check-operator/patchcrd/patchcrd.go
+++ b/cmd/check-operator/patchcrd/patchcrd.go
@@ -90,15 +90,15 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-// Run use to run the command.
+// Run is used to run the command.
 func (o *Options) Run() error {
-	o.printOutf("Start checking patching CRD status")
+	o.printOutf("Start checking patched CRD status")
 	crd, err := o.APIExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), o.crdName, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return fmt.Errorf("unable to patch %s CRD, err: %w", o.crdName, err)
 		}
-		return fmt.Errorf("unknow error during CRD get, err: %w", err)
+		return fmt.Errorf("unknown error during CRD get, err: %w", err)
 	}
 
 	o.printOutf("Current storedVersions value: %s,", strings.Join(crd.Status.StoredVersions, ","))

--- a/cmd/check-operator/patchcrd/patchcrd.go
+++ b/cmd/check-operator/patchcrd/patchcrd.go
@@ -23,7 +23,6 @@ import (
 type Options struct {
 	genericclioptions.IOStreams
 	common.Options
-	args           []string
 	crdName        string
 	storedVersions []string
 }
@@ -69,7 +68,6 @@ func NewCmdPatch(streams genericclioptions.IOStreams) *cobra.Command {
 
 // Complete sets all information required for processing the command.
 func (o *Options) Complete(cmd *cobra.Command, args []string) error {
-	o.args = args
 	if len(args) > 0 {
 		o.crdName = args[0]
 	}

--- a/cmd/check-operator/root/root.go
+++ b/cmd/check-operator/root/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/DataDog/datadog-operator/cmd/check-operator/patchcrd"
 	"github.com/DataDog/datadog-operator/cmd/check-operator/upgrade"
 )
 
@@ -35,6 +36,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 
 	o.configFlags.AddFlags(cmd.Flags())
 	cmd.AddCommand(upgrade.NewCmdUpgrade(streams))
+	cmd.AddCommand(patchcrd.NewCmdPatch(streams))
 
 	return cmd
 }

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -167,13 +167,18 @@ func (o *Options) Run() error {
 	checkFunc := func() (bool, error) {
 		v2Available, err := common.IsV2Available(o.Clientset)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("unable to detect if CRD v2 is available, err:%w", err)
 		}
 		var status common.StatusWrapper
 		if v2Available {
+			o.printOutf("v2alpha1 available")
 			status, err = o.getV2Status()
 		} else {
+			o.printOutf("Only v1alpha1 available")
 			status, err = o.getV1Status()
+		}
+		if err != nil {
+			return false, fmt.Errorf("unable to get the DatadogAgent.status, err:%w", err)
 		}
 
 		if !agentDone {

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -135,8 +135,6 @@ func (o *Options) getV1Status() (common.StatusWrapper, error) {
 	err := o.Client.Get(context.TODO(), client.ObjectKey{Namespace: o.UserNamespace, Name: o.datadogAgentName}, datadogAgent)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			o.printOutf("Got a not found error while getting %s/%s. Assuming this DatadogAgent CR has never been deployed in this environment", o.UserNamespace, o.datadogAgentName)
-
 			return nil, err
 		}
 
@@ -150,7 +148,6 @@ func (o *Options) getV2Status() (common.StatusWrapper, error) {
 	err := o.Client.Get(context.TODO(), client.ObjectKey{Namespace: o.UserNamespace, Name: o.datadogAgentName}, datadogAgent)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			o.printOutf("Got a not found error while getting %s/%s. Assuming this DatadogAgent CR has never been deployed in this environment", o.UserNamespace, o.datadogAgentName)
 
 			return nil, err
 		}
@@ -177,7 +174,11 @@ func (o *Options) Run() error {
 			o.printOutf("Only v1alpha1 is available")
 			status, err = o.getV1Status()
 		}
-		if err != nil {
+
+		if errors.IsNotFound(err) {
+			o.printOutf("Got a not found error while getting %s/%s. Assuming this DatadogAgent CR has never been deployed in this environment", o.UserNamespace, o.datadogAgentName)
+			return true, nil
+		} else if err != nil {
 			return false, fmt.Errorf("unable to get the DatadogAgent.status, err:%w", err)
 		}
 

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -171,10 +171,10 @@ func (o *Options) Run() error {
 		}
 		var status common.StatusWrapper
 		if v2Available {
-			o.printOutf("v2alpha1 available")
+			o.printOutf("v2alpha1 is available")
 			status, err = o.getV2Status()
 		} else {
-			o.printOutf("Only v1alpha1 available")
+			o.printOutf("Only v1alpha1 is available")
 			status, err = o.getV1Status()
 		}
 		if err != nil {

--- a/pkg/plugin/common/options.go
+++ b/pkg/plugin/common/options.go
@@ -55,7 +55,7 @@ func (o *Options) Init(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("unable to create APIExtensionClient, err:%w", err)
 	}
-	o.SetApiExtentionClient(apiextClient)
+	o.SetApiExtensionClient(apiextClient)
 
 	nsConfig, _, err := clientConfig.Namespace()
 	if err != nil {
@@ -90,8 +90,8 @@ func (o *Options) SetClientset(clientset *kubernetes.Clientset) {
 	o.Clientset = clientset
 }
 
-// SetApiExtentionClient configures the APIExtClient
-func (o *Options) SetApiExtentionClient(client *apiextensionclient.Clientset) {
+// SetApiExtensionClient configures the APIExtClient
+func (o *Options) SetApiExtensionClient(client *apiextensionclient.Clientset) {
 	o.APIExtClient = client
 }
 

--- a/pkg/plugin/common/options.go
+++ b/pkg/plugin/common/options.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	apiextensionclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -17,9 +18,11 @@ import (
 
 // Options encapsulates the common fields of command options
 type Options struct {
-	ConfigFlags   *genericclioptions.ConfigFlags
-	Client        client.Client
-	Clientset     *kubernetes.Clientset
+	ConfigFlags  *genericclioptions.ConfigFlags
+	Client       client.Client
+	Clientset    *kubernetes.Clientset
+	APIExtClient *apiextensionclient.Clientset
+
 	isV2Available bool
 	UserNamespace string
 }
@@ -43,6 +46,16 @@ func (o *Options) Init(cmd *cobra.Command) error {
 	if o.isV2Available, err = IsV2Available(o.Clientset); err != nil {
 		return err
 	}
+
+	restConfig, err := o.ConfigFlags.ToRESTConfig()
+	if err != nil {
+		return fmt.Errorf("unable to create restConfig for APIExtensionClient, err:%w", err)
+	}
+	apiextClient, err := apiextensionclient.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("unable to create APIExtensionClient, err:%w", err)
+	}
+	o.SetApiExtentionClient(apiextClient)
 
 	nsConfig, _, err := clientConfig.Namespace()
 	if err != nil {
@@ -75,6 +88,11 @@ func (o *Options) SetClient(client client.Client) {
 // SetClientset configures the clientset
 func (o *Options) SetClientset(clientset *kubernetes.Clientset) {
 	o.Clientset = clientset
+}
+
+// SetApiExtentionClient configures the APIExtClient
+func (o *Options) SetApiExtentionClient(client *apiextensionclient.Clientset) {
+	o.APIExtClient = client
 }
 
 // GetClientConfig returns the client config


### PR DESCRIPTION
### What does this PR do?

The new `patch-crd` check-operator's sub-command allows to update
CRD `status.storedVersions` field to remove deprecated version.

For the Operator, it will allow to remove the `v1Alpha1` version
of the `datadogagents.datadoghq.com` CRD.

### Motivation

To be able to remove a deprecated version in a CRD `spec`, it can be needed to patch the `crd.status.storedVersions` to removes reference to the deprecated version before trying to remove the version from the `spec`. (see [public Kubernetes doc](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#upgrade-existing-objects-to-a-new-stored-version)

### Additional Notes

The idea is to use this command in a `pre-upgrade` helm hook.
Maybe we can also add this sub-command into the `kubectl datadog` plugin.

### Describe your test plan

Write there any instructions and details you may have to test your PR.
