### PR TITLE
[tooling] Add more descriptive error message

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -19,4 +19,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - if: github.event.pull_request.milestone == null && !contains(toJson(github.event.pull_request.labels.*.name), 'qa/skip-qa')
-        run: exit 1
+        run: echo "::error::Missing milestone or \`qa/skip-qa\` label" && exit 1


### PR DESCRIPTION
### What does this PR do?

Adds a more descriptive error message to the github workflow.

Before:
```
Run exit 1
Error: Process completed with exit code 1.
```

After:
```
Run echo "::error::Missing milestone or \`qa/skip-qa\` label" && exit 1
Error: Missing milestone or `qa/skip-qa` label
Error: Process completed with exit code 1.
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
