### PR TITLE
upgrade(remote-config): Create cluster agent volume when Remote Config is enabled

### DIFF
--- a/controllers/datadogagent/feature/remoteconfig/feature.go
+++ b/controllers/datadogagent/feature/remoteconfig/feature.go
@@ -119,7 +119,7 @@ func (f *rcFeature) ManageClusterAgent(managers feature.PodTemplateManagers) err
 
 	if f.enabled {
 		// Volume to create the Remote Config Database
-		// Mandatory as the cluster agent root FS is by default read only
+		// Mandatory as the cluster agent root FS is read only by default 
 		managers.Volume().AddVolume(rcVolume)
 		managers.VolumeMount().AddVolumeMount(rcVolumeMount)
 	}

--- a/controllers/datadogagent/feature/remoteconfig/feature.go
+++ b/controllers/datadogagent/feature/remoteconfig/feature.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	rcDBVolumeName = "remote-config"
+	rcDBVolumeName = "datadogrun"
 	rcDBVolumePath = "/opt/datadog-agent/run/"
 )
 
@@ -119,7 +119,7 @@ func (f *rcFeature) ManageClusterAgent(managers feature.PodTemplateManagers) err
 
 	if f.enabled {
 		// Volume to create the Remote Config Database
-		// Mandatory as the cluster agent root FS is read only by default 
+		// Mandatory as the cluster agent root FS is read only by default
 		managers.Volume().AddVolume(rcVolume)
 		managers.VolumeMount().AddVolumeMount(rcVolumeMount)
 	}

--- a/controllers/datadogagent/feature/remoteconfig/feature.go
+++ b/controllers/datadogagent/feature/remoteconfig/feature.go
@@ -20,6 +20,24 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 )
 
+const (
+	rcDBVolumeName = "remote-config"
+	rcDBVolumePath = "/opt/datadog-agent/run/"
+)
+
+var (
+	rcVolume = &corev1.Volume{
+		Name: rcDBVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	rcVolumeMount = &corev1.VolumeMount{
+		Name:      rcDBVolumeName,
+		MountPath: rcDBVolumePath,
+	}
+)
+
 func init() {
 	err := feature.Register(feature.RemoteConfigurationIDType, buildRCFeature)
 	if err != nil {
@@ -68,6 +86,12 @@ func (f *rcFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requi
 				apicommonv1.CoreAgentContainerName,
 			},
 		},
+		ClusterAgent: feature.RequiredComponent{
+			IsRequired: apiutils.NewBoolPointer(f.enabled),
+			Containers: []apicommonv1.AgentContainerName{
+				apicommonv1.ClusterAgentContainerName,
+			},
+		},
 	}
 
 	return reqComp
@@ -92,6 +116,13 @@ func (f *rcFeature) ManageClusterAgent(managers feature.PodTemplateManagers) err
 		Value: apiutils.BoolToString(&f.enabled),
 	}
 	managers.EnvVar().AddEnvVar(enabledEnvVar)
+
+	if f.enabled {
+		// Volume to create the Remote Config Database
+		// Mandatory as the cluster agent root FS is by default read only
+		managers.Volume().AddVolume(rcVolume)
+		managers.VolumeMount().AddVolumeMount(rcVolumeMount)
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
Remote Config needs access to `/opt/datadog-agent/run` in order to create its local database where configurations & their metadata are stored. By default, the cluster agent has the `readOnlyRootFilesystem` parameter set to true for security reasons. To circumvent this, we create an EmptyDir volume on the required path so that the agent can create the Remote Config database.

Current workaround is to create the volume at agent creation or disable the `readOnlyRootFilesystem` parameter. This doesn't impact many users currently as no product using Remote Config on the cluster agent is GA.

### Motivation
Fixing bugs

### Additional Notes
N/A

### Minimum Agent Versions
No

### Describe your test plan
Create a cluster agent and check in the logs it is able to start Remote Config properly
Error: `Failed to start remote-configuration: unable to create remote-config service: failed to create rc db dir`
Success: `

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
