### PR TITLE
fix parsing of EDS flag options

### DIFF
--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -109,6 +109,6 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 }
 
 func newIntOrStringPointer(str string) *intstr.IntOrString {
-	val := intstr.FromString(str)
+	val := intstr.Parse(str)
 	return &val
 }

--- a/controllers/datadogagent/component/agent/new_test.go
+++ b/controllers/datadogagent/component/agent/new_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+
+func Test_newIntOrStringPointer(t *testing.T) {
+	tests := []struct{
+		input string
+		want intstr.IntOrString
+	}{
+		{
+			input: "15",
+			want: intstr.FromInt(15),
+		},
+		{
+			input: "15%",
+			want: intstr.FromString("15%"),
+		},
+		{
+			input: "0",
+			want: intstr.FromInt(0),
+		},
+		{
+			input: "help",
+			want: intstr.FromString("help"),
+		},
+		
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			output := newIntOrStringPointer(tt.input)
+			if tt.want != *output {
+				t.Errorf("newIntOrStringPointer() result is %v but want %v", *output, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fix parsing of flags that should be treated as IntOrString values (and not just strings).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

N/A

### Describe your test plan

Test the operator with different inputs for `--edsCanaryReplicas`, for instance:

```
args:
        - --enable-leader-election
        - --pprof
        - --supportExtendedDaemonset=true
        - --edsMaxPodUnavailable=5%
        - --edsCanaryReplicas=15
 ```

```
args:
        - --enable-leader-election
        - --pprof
        - --supportExtendedDaemonset=true
        - --edsMaxPodUnavailable=5%
        - --edsCanaryReplicas=15%
 ```

and make sure that the resulting ExtendedDaemonset resource has the spec value types set as expected. (`kubectl get eds -oyaml`).


### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
