### PR TITLE
[ci] update publish_redhat_public_tag job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,14 +195,13 @@ publish_redhat_public_tag:
     # Docker login to pull build image
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - echo "docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64"
     - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
     - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
     # Docker login to push image to Redhat
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
     - docker push $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
 
-  # Save for future use.
+  # Save for future use with public-images.
   # trigger:
   #   project: DataDog/public-images
   #   branch: main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,8 @@ variables:
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
-  RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY: redhat_operator_token
+  # RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY: redhat_operator_token
+  RH_PARTNER_REGISTRY_SSM_KEY: redhat_registry_key
   RH_PARTNER_SCAN_REGISTRY: quay.io/redhat-isv-containers
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   PUSH_IMAGES_TO_STAGING:
@@ -197,7 +198,7 @@ publish_redhat_public_tag:
     - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
     - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
     # Docker login to push image to Redhat
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot quay.io --password-stdin
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot quay.io --password-stdin
     - docker push ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
   # Save for future use.
   # trigger:
@@ -225,6 +226,30 @@ publish_public_latest:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:latest
     IMG_SIGNING: "false"
+
+# RedHat does not support multi-arch images. Use docker commands in lieu of DataDog/public-images until they do.
+publish_redhat_public_latest:
+  stage: release
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: manual
+    - when: never
+  needs:
+    - "preflight_redhat_image_amd64"
+  tags: ["runner:docker", "size:large"]
+  image: $JOB_DOCKER_IMAGE
+  variables:
+    RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
+  script:
+    - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
+    # Docker login to pull build image
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
+    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
+    # Docker login to push image to Redhat
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot quay.io --password-stdin
+    - docker push ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
 
 trigger_internal_operator_image:
   stage: release
@@ -316,7 +341,7 @@ submit_preflight_redhat_public_tag:
     RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "unused" --password-stdin "$RH_PARTNER_SCAN_REGISTRY"
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "unused" --password-stdin "$RH_PARTNER_SCAN_REGISTRY"
     - RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - IMG=${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
     - make preflight-redhat-container-submit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,9 @@ build:
     - mkdir -p .cache
     - make install-tools
   script:
+    - echo "TEST"
+    - echo ${CI_COMMIT_TAG:1}
+    - echo $CI_COMMIT_TAG
     - make build
 
 unit_tests:
@@ -192,13 +195,14 @@ publish_redhat_public_tag:
   image: $JOB_DOCKER_IMAGE
   variables:
     SOURCE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    DEST_IMAGE: ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    DEST_IMAGE: $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     # Docker login to pull build image
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - docker pull --platform linux/amd64 $SOURCE_IMAGE
+    - echo $DEST_IMAGE
     - docker tag $SOURCE_IMAGE $DEST_IMAGE
     # Docker login to push image to Redhat
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
@@ -244,7 +248,7 @@ publish_redhat_public_latest:
   image: $JOB_DOCKER_IMAGE
   variables:
     SOURCE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    DEST_IMAGE: ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
+    DEST_IMAGE: $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:latest
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     # Docker login to pull build image
@@ -342,7 +346,7 @@ submit_preflight_redhat_public_tag:
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
   variables:
-    IMG: ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    IMG: $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -339,6 +339,7 @@ submit_preflight_redhat_public_tag:
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
-    - RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-    - make preflight-redhat-container-submit
+    - |
+      RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+      IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
+      make preflight-redhat-container-submit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,9 @@ variables:
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
-  RH_PARTNER_REGISTRY: quay.io/redhat-isv-containers
-  RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
-  RH_PARTNER_REGISTRY_USER: redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot
+  RH_PARTNER_REGISTRY: "quay.io/redhat-isv-containers"
+  RH_PARTNER_PROJECT_ID: "5e7c8ebc1c86a3163d1a69be"
+  RH_PARTNER_REGISTRY_USER: "redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot"
   RH_PARTNER_REGISTRY_KEY_SSM_KEY: redhat_registry_key
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   PUSH_IMAGES_TO_STAGING:
@@ -37,9 +37,6 @@ build:
     - mkdir -p .cache
     - make install-tools
   script:
-    - echo "TEST"
-    - echo ${CI_COMMIT_TAG:1}
-    - echo $CI_COMMIT_TAG
     - make build
 
 unit_tests:
@@ -193,20 +190,17 @@ publish_redhat_public_tag:
     - "preflight_redhat_image_amd64"
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
-  variables:
-    SOURCE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    DEST_IMAGE: $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     # Docker login to pull build image
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - docker pull --platform linux/amd64 $SOURCE_IMAGE
-    - echo $DEST_IMAGE
-    - docker tag $SOURCE_IMAGE $DEST_IMAGE
+    - echo "docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64"
+    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
+    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
     # Docker login to push image to Redhat
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
-    - docker push $DEST_IMAGE
+    - docker push $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
 
   # Save for future use.
   # trigger:
@@ -246,19 +240,16 @@ publish_redhat_public_latest:
     - "preflight_redhat_image_amd64"
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
-  variables:
-    SOURCE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    DEST_IMAGE: $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:latest
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     # Docker login to pull build image
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - docker pull --platform linux/amd64 $SOURCE_IMAGE
-    - docker tag $SOURCE_IMAGE $DEST_IMAGE
+    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
+    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:latest
     # Docker login to push image to Redhat
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
-    - docker push $DEST_IMAGE
+    - docker push $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:latest
 
 trigger_internal_operator_image:
   stage: release
@@ -345,10 +336,9 @@ submit_preflight_redhat_public_tag:
     - "publish_redhat_public_tag"
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
-  variables:
-    IMG: $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
     - make preflight-redhat-container-submit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,9 @@ variables:
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
-  # RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY: redhat_operator_token
-  RH_PARTNER_REGISTRY_SSM_KEY: redhat_registry_key
-  RH_PARTNER_SCAN_REGISTRY: quay.io/redhat-isv-containers
+  RH_PARTNER_REGISTRY: quay.io/redhat-isv-containers
+  RH_PARTNER_REGISTRY_USER: redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot
+  RH_PARTNER_REGISTRY_KEY_SSM_KEY: redhat_registry_key
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   PUSH_IMAGES_TO_STAGING:
     description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."
@@ -145,6 +145,7 @@ preflight_redhat_image_amd64:
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - IMG=$TARGET_IMAGE make preflight-redhat-container
 
+
 publish_public_main:
   stage: release
   rules:
@@ -196,10 +197,10 @@ publish_redhat_public_tag:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
     # Docker login to push image to Redhat
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot quay.io --password-stdin
-    - docker push ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
+    - docker push ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
   # Save for future use.
   # trigger:
   #   project: DataDog/public-images
@@ -246,10 +247,10 @@ publish_redhat_public_latest:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
+    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
     # Docker login to push image to Redhat
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot quay.io --password-stdin
-    - docker push ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
+    - docker push ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
 
 trigger_internal_operator_image:
   stage: release
@@ -286,7 +287,6 @@ trigger_internal_operator_check_image:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
-
 
 trigger_custom_operator_image_staging:
   stage: release
@@ -341,7 +341,7 @@ submit_preflight_redhat_public_tag:
     RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "unused" --password-stdin "$RH_PARTNER_SCAN_REGISTRY"
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - IMG=${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    - IMG=${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
     - make preflight-redhat-container-submit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -339,7 +339,6 @@ submit_preflight_redhat_public_tag:
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
-    - |
-      RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-      IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-      make preflight-redhat-container-submit
+    - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
+    - make preflight-redhat-container-submit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
   RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY: redhat_operator_token
-  RH_PARTNER_SCAN_REGISTRY: scan.connect.redhat.com
+  RH_PARTNER_SCAN_REGISTRY: quay.io/redhat-isv-containers
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   PUSH_IMAGES_TO_STAGING:
     description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."
@@ -176,23 +176,40 @@ publish_public_tag:
     IMG_DESTINATIONS_REGEX_REPL: ':'
     IMG_SIGNING: "false"
 
-# RedHat does not support multi-arch images
+# RedHat does not support multi-arch images. Use docker commands in lieu of DataDog/public-images until they do.
 publish_redhat_public_tag:
   stage: release
   rules:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  needs:
+    - "preflight_redhat_image_amd64"
+  tags: ["runner:docker", "size:large"]
+  image: $JOB_DOCKER_IMAGE
   variables:
-    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    IMG_DESTINATIONS: operator:$CI_COMMIT_TAG
-    IMG_DESTINATIONS_REGEX: ':v'
-    IMG_DESTINATIONS_REGEX_REPL: ':'
-    IMG_REGISTRIES: redhat-operator
+    RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
+  script:
+    - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
+    # Docker login to pull build image
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
+    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    # Docker login to push image to Redhat
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot quay.io --password-stdin
+    - docker push ${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+  # Save for future use.
+  # trigger:
+  #   project: DataDog/public-images
+  #   branch: main
+  #   strategy: depend
+  # variables:
+  #   IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
+  #   IMG_DESTINATIONS: operator:$CI_COMMIT_TAG
+  #   IMG_DESTINATIONS_REGEX: ':v'
+  #   IMG_DESTINATIONS_REGEX_REPL: ':'
+  #   IMG_REGISTRIES: redhat-operator
 
 publish_public_latest:
   stage: release
@@ -297,10 +314,9 @@ submit_preflight_redhat_public_tag:
   image: $JOB_DOCKER_IMAGE
   variables:
     RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
-    RH_PARTNER_SCAN_REGISTRY_PATH: /ospid-e18c96b6-0524-4c5c-8ada-ce2fca845c8c/operator
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_SCAN_OPERATOR_TOKEN_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "unused" --password-stdin "$RH_PARTNER_SCAN_REGISTRY"
     - RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - IMG=${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_SCAN_REGISTRY_PATH}:${CI_COMMIT_TAG:1}
+    - IMG=${RH_PARTNER_SCAN_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
     - make preflight-redhat-container-submit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ variables:
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
   RH_PARTNER_REGISTRY: quay.io/redhat-isv-containers
+  RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
   RH_PARTNER_REGISTRY_USER: redhat-isv-containers+5e7c8ebc1c86a3163d1a69be-robot
   RH_PARTNER_REGISTRY_KEY_SSM_KEY: redhat_registry_key
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
@@ -138,12 +139,12 @@ preflight_redhat_image_amd64:
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
   variables:
-    TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - IMG=$TARGET_IMAGE make preflight-redhat-container
+    - make preflight-redhat-container
 
 
 publish_public_main:
@@ -190,17 +191,19 @@ publish_redhat_public_tag:
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
   variables:
-    RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
+    SOURCE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
+    DEST_IMAGE: ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     # Docker login to pull build image
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    - docker pull --platform linux/amd64 $SOURCE_IMAGE
+    - docker tag $SOURCE_IMAGE $DEST_IMAGE
     # Docker login to push image to Redhat
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
-    - docker push ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
+    - docker push $DEST_IMAGE
+
   # Save for future use.
   # trigger:
   #   project: DataDog/public-images
@@ -240,17 +243,18 @@ publish_redhat_public_latest:
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
   variables:
-    RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
+    SOURCE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
+    DEST_IMAGE: ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     # Docker login to pull build image
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
+    - docker pull --platform linux/amd64 $SOURCE_IMAGE
+    - docker tag $SOURCE_IMAGE $DEST_IMAGE
     # Docker login to push image to Redhat
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
-    - docker push ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:latest
+    - docker push $DEST_IMAGE
 
 trigger_internal_operator_image:
   stage: release
@@ -338,10 +342,9 @@ submit_preflight_redhat_public_tag:
   tags: ["runner:docker", "size:large"]
   image: $JOB_DOCKER_IMAGE
   variables:
-    RH_PARTNER_PROJECT_ID: 5e7c8ebc1c86a3163d1a69be
+    IMG: ${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
   script:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - IMG=${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:${CI_COMMIT_TAG:1}
     - make preflight-redhat-container-submit


### PR DESCRIPTION
### What does this PR do?

Update Redhat registry and `publish_redhat_public_tag` job to not depend on internal PaaS service.

### Motivation

More automation; the image push job has been broken for some time now

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
