### PR TITLE
[OpenShift] Defaults readonlyrootfs to false for the DCA

### DIFF
--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -63,7 +63,7 @@ func clusterAgentDefaultPodSpec() v1.PodSpec {
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
 				SecurityContext: &v1.SecurityContext{
-					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(true),
+					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(false),
 					AllowPrivilegeEscalation: apiutils.NewBoolPointer(false),
 				},
 			},

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -105,7 +105,7 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				Command:      nil,
 				Args:         nil,
 				SecurityContext: &corev1.SecurityContext{
-					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(true),
+					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(false),
 					AllowPrivilegeEscalation: apiutils.NewBoolPointer(false),
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

* Changes the default securitycontext of the `cluster-agent` container to set `readonlyrootfilesystem` to `false`

**Note** : this aligns with the default SCC from our Helm chart : https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/cluster-agent-scc.yaml#L24

### Motivation
* Testing in OpenShift to replicate a customer issue, with the default CRD from https://docs.datadoghq.com/containers/kubernetes/distributions?tab=operator#Openshift, some features are not available : 
    * `agent` commands that rely on `/etc/datadog-agent/auth_token` are not available since the `auth_token` does not get written : 
![image](https://github.com/DataDog/datadog-operator/assets/97530782/36065465-55ea-4981-a14f-77f317a3c73f)
    * cluster checks files coming from `spec.override.clusterAgent.extraConfd.configDataMap` cannot be written in `/etc/datadog-agent/conf.d` thus preventing cluster checks from being dispatched (N.B. : service annotations still work as a workaround in the meantime) with a log : 
```cannot create regular file '/etc/datadog-agent/conf.d/http_check.yaml': Read-only file system```

The workaround in `1.1.0` is to override the default value with : 
```
  override:
    clusterAgent:
      containers:
        cluster-agent:
          securityContext:
            readOnlyRootFilesystem: false
```
* https://datadoghq.atlassian.net/browse/CONTECO-178

### Minimum Agent Versions

_Are there minimum versions of the Datadog Agent and/or Cluster Agent required?_
I do not believe so, but all tests were done with `7.46.0`.

### Describe your test plan

CRD to use : 
```
kind: DatadogAgent
apiVersion: datadoghq.com/v2alpha1
metadata:
  name: datadog
spec:
  features:
    clusterChecks:
      useClusterChecksRunners: true
    apm:
      enabled: false
    cspm:
      enabled: false
    cws:
      enabled: false
    npm:
      enabled: false
    admissionController:
      enabled: false
    externalMetricsServer:
      enabled: false
      useDatadogMetrics: false
      port: 8443
  global:
    logLevel: 'debug'
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
    clusterName: local-openshift
    kubelet:
      tlsVerify: false
    criSocketPath: /var/run/crio/crio.sock
  override:
    clusterChecksRunner:
      image:
        name: gcr.io/datadoghq/agent:latest
      replicas: 1
    clusterAgent:
      image:
        name: gcr.io/datadoghq/cluster-agent:latest
      extraConfd:
        configDataMap:
          http_check.yaml: |-
            cluster_check: true
            init_config:
            instances:
            - name: "Google"
              url: "https://google.com"
    nodeAgent:
      serviceAccountName: datadog-agent-scc
      image:
        name: gcr.io/datadoghq/agent:latest
      tolerations:
        - key: node-role.kubernetes.io/master
          operator: Exists
          effect: NoSchedule
        - key: node-role.kubernetes.io/infra
          operator: Exists
          effect: NoSchedule
```

1. Install the Red Hat Certified Datadog operator in an OpenShift cluster
2. Switch to `openshift-operators` namespace and apply the above CR `k apply -f above.yaml -n openshift-operators`
3. Check that `auth_token` is missing from `/etc/datadog-agent/` and `http_check.yaml` from `/etc/datadog-agent/conf.d/` inside the DCA pod
4. Within the OpenShift console, edit the YAML to reference the "fixed" custom operator image at `spec.install.spec.deployments[0].spec.template.spec.containers[0].image` : 
<img width="2552" alt="Image 2023-08-24 at 4 11 18 PM" src="https://github.com/DataDog/datadog-operator/assets/97530782/9be29ad6-9e36-41fa-9344-41c8e902577c">.
Alternative is to directly edit the `ClusterServiceVersion` from `operators.coreos.com/v1alpha1` : `k edit csv datadog-operator.v1.1.0` <img width="1531" alt="Image 2023-08-24 at 4 39 22 PM" src="https://github.com/DataDog/datadog-operator/assets/97530782/5037e93d-a0cc-43cb-9c8c-59b2c4d1b2b0">

5. Save and reload the operator
6. After a short time, a new operator manager pod should spun up
7. Un-install and re-deploy the CR 
8. Check that `auth_token` and `http_check.yaml` are written inside the DCA
9. Ensure `agent clusterchecks` command works

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
