### PR TITLE
Update OpenShift install docs and example for proper DCA behaviour

### DIFF
--- a/docs/install-openshift.md
+++ b/docs/install-openshift.md
@@ -80,6 +80,10 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
       clusterAgent:
         serviceAccountName: datadog-agent-scc
         replicas: 2
+        containers:
+          cluster-agent:
+            securityContext:
+              readOnlyRootFilesystem: false
   ```
 
 Setting the `serviceAccountName` in the `nodeAgent` and `clusterAgent` `override` section ensures that these pods are associated with the necessary `SecurityContextConstraints` and RBACs.

--- a/examples/datadogagent/v2alpha1/datadog-agent-openshift.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-openshift.yaml
@@ -36,3 +36,7 @@ spec:
     clusterAgent:
       serviceAccountName: datadog-agent-scc
       replicas: 2
+      containers:
+        cluster-agent:
+          securityContext:
+            readOnlyRootFilesystem: false


### PR DESCRIPTION
### What does this PR do?
* Updates the OpenShift documentation to include the SC override for the DCA so it can run `agent ...` commands (thanks to the `auth_token` in `/etc/datadog-agent/`) and use cluster checks from files

### Motivation
* Detailed context is available in the Github original PR : https://github.com/DataDog/datadog-operator/pull/897

### Additional Notes
* This is a "band-aid" while the DCA is not able to properly run for now with `readOnlyRootFilesystem: true` (not specifically in OpenShift, but this is where notably we can see the consequences)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
