### PR TITLE
Add rule to allow agent role to curl `/metrics/slis`

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
 - nonResourceURLs:
   - /metrics
+  - /metrics/slis
   verbs:
   - get
 - apiGroups:

--- a/controllers/datadogagent/component/agent/rbac.go
+++ b/controllers/datadogagent/component/agent/rbac.go
@@ -31,8 +31,11 @@ func GetDefaultAgentClusterRolePolicyRules() []rbacv1.PolicyRule {
 
 func getMetricsEndpointPolicyRule() rbacv1.PolicyRule {
 	return rbacv1.PolicyRule{
-		NonResourceURLs: []string{rbac.MetricsURL},
-		Verbs:           []string{rbac.GetVerb},
+		NonResourceURLs: []string{
+			rbac.MetricsURL,
+			rbac.MetricsSLIsURL,
+		},
+		Verbs: []string{rbac.GetVerb},
 	}
 }
 

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -82,9 +82,10 @@ const (
 
 	// Non resource URLs
 
-	VersionURL = "/version"
-	HealthzURL = "/healthz"
-	MetricsURL = "/metrics"
+	VersionURL     = "/version"
+	HealthzURL     = "/healthz"
+	MetricsURL     = "/metrics"
+	MetricsSLIsURL = "/metrics/slis"
 
 	// Verbs
 


### PR DESCRIPTION
### What does this PR do?

This change updates the cluster role that the operator defines for the agent. This change corresponds to https://github.com/DataDog/helm-charts/pull/1155.

### Motivation

Kubernetes v1.26 exposed a new `/metrics/slis` endpoint (reference [here](https://kubernetes.io/docs/reference/instrumentation/slis/#sli-metrics)). This change is necessary to support the corresponding changes in https://github.com/DataDog/integrations-core/pull/15731

### Additional Notes
Is the milestone `1.2.0` set correctly?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
I followed the following steps (thanks @khewonc for the guidance!)
1. `make build`
2. `make docker-build`
3. `make deploy`
4. I then verified that the pod cluster role changes were applied appropriately

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
