### PR TITLE
Add a startup log for V2APIEnabled flag deprecation

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,7 +178,6 @@ func main() {
 // run allow to use defer func() paradigm properly.
 // do not use `os.Exit()` in this function
 func run(opts *options) error {
-
 	// Logging setup
 	if err := customSetupLogging(*opts.logLevel, opts.logEncoder); err != nil {
 		return setupErrorf(setupLog, err, "Unable to setup the logger")
@@ -190,6 +189,12 @@ func run(opts *options) error {
 		return nil
 	}
 	version.PrintVersionLogs(setupLog)
+
+	if !opts.v2APIEnabled {
+		setupLog.Info("V2APIEnabled flag is deprecated in v1.2.0+ and will be removed in the future releases. " +
+			"Once removed Operator can't be configured to reconcile DatadogAgent CRD v1alpha1. " +
+			"You will still be able to apply v1alpha1 with conversion webhook enabled.")
+	}
 
 	if opts.profilingEnabled {
 		setupLog.Info("Starting datadog profiler")

--- a/main.go
+++ b/main.go
@@ -191,9 +191,9 @@ func run(opts *options) error {
 	version.PrintVersionLogs(setupLog)
 
 	if !opts.v2APIEnabled {
-		setupLog.Info("V2APIEnabled flag is deprecated in v1.2.0+ and will be removed in the future releases. " +
-			"Once removed Operator can't be configured to reconcile DatadogAgent CRD v1alpha1. " +
-			"You will still be able to apply v1alpha1 with conversion webhook enabled.")
+		setupLog.Info("The `v2APIEnabled` flag is deprecated in v1.2.0+ and will be removed in a future release." +
+			"Once removed, the Datadog Operator cannot be configured to reconcile the v1alpha1 DatadogAgent CRD." +
+			"You will still be able to apply v1alpha1 with the conversion webhook enabled (`webhookEnabled`).")
 	}
 
 	if opts.profilingEnabled {


### PR DESCRIPTION
### What does this PR do?

Log `V2APIEnabled` deprecation notice. Output when flag is set to `false`:

`{"level":"INFO","ts":"2023-09-08T17:29:10Z","logger":"setup","msg":"V2APIEnabled flag is deprecated in v1.2.0+ and will be removed in the future releases. Once removed Operator can't be configured to reconcile DatadogAgent CRD v1alpha1. You will still be able to apply v1alpha1 with conversion webhook enabled."}`

### Motivation

Cleaning up v1 controller in later versions.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
