### PR TITLE
Add local agent service selector

### DIFF
--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -353,11 +353,6 @@ func GetClusterAgentSCCName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultClusterAgentResourceSuffix)
 }
 
-// GetAgentServiceName return the Agent service name based on the DatadogAgent name
-func GetAgentServiceName(dda metav1.Object) string {
-	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
-}
-
 // GetAgentName return the Agent name based on the DatadogAgent info
 func GetAgentName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-%s", dda.GetName(), apicommon.DefaultAgentResourceSuffix)
@@ -566,25 +561,12 @@ func dcaServicePort() netv1.NetworkPolicyPort {
 	}
 }
 
-// BuildAgentLocalService creates a local service for the node agent
-func BuildAgentLocalService(dda metav1.Object, name string) (string, string, map[string]string, []corev1.ServicePort, *corev1.ServiceInternalTrafficPolicyType) {
-	if name == "" {
-		name = GetAgentServiceName(dda)
-	}
-	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-	selector := map[string]string{
+// GetAgentLocalServiceSelector creates the selector to be used for the agent local service
+func GetAgentLocalServiceSelector(dda metav1.Object) map[string]string {
+	return map[string]string{
 		apicommon.AgentDeploymentNameLabelKey:      dda.GetName(),
 		apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultAgentResourceSuffix,
 	}
-	ports := []corev1.ServicePort{
-		{
-			Protocol:   corev1.ProtocolUDP,
-			TargetPort: intstr.FromInt(apicommon.DefaultDogstatsdPort),
-			Port:       apicommon.DefaultDogstatsdPort,
-			Name:       apicommon.DefaultDogstatsdPortName,
-		},
-	}
-	return name, dda.GetNamespace(), selector, ports, &serviceInternalTrafficPolicy
 }
 
 // ShouldCreateAgentLocalService returns whether the node agent local service should be created based on the Kubernetes version

--- a/controllers/datadogagent/feature/apm/feature.go
+++ b/controllers/datadogagent/feature/apm/feature.go
@@ -167,7 +167,7 @@ func (f *apmFeature) ManageDependencies(managers feature.ResourceManagers, compo
 		}
 
 		serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-		if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), nil, []corev1.ServicePort{*apmPort}, &serviceInternalTrafficPolicy); err != nil {
+		if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), component.GetAgentLocalServiceSelector(f.owner), []corev1.ServicePort{*apmPort}, &serviceInternalTrafficPolicy); err != nil {
 			return err
 		}
 	}

--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -157,7 +157,7 @@ func (f *dogstatsdFeature) ManageDependencies(managers feature.ResourceManagers,
 			}
 		}
 		serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-		if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), nil, []corev1.ServicePort{*dsdPort}, &serviceInternalTrafficPolicy); err != nil {
+		if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), component.GetAgentLocalServiceSelector(f.owner), []corev1.ServicePort{*dsdPort}, &serviceInternalTrafficPolicy); err != nil {
 			return err
 		}
 	}

--- a/controllers/datadogagent/feature/otlp/feature.go
+++ b/controllers/datadogagent/feature/otlp/feature.go
@@ -173,7 +173,7 @@ func (f *otlpFeature) ManageDependencies(managers feature.ResourceManagers, comp
 				},
 			}
 			serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-			if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), nil, servicePort, &serviceInternalTrafficPolicy); err != nil {
+			if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), component.GetAgentLocalServiceSelector(f.owner), servicePort, &serviceInternalTrafficPolicy); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Adds back in the local agent service selector.

Agent service:
```
$ kubectl describe svc datadog-agent
Name:              datadog-agent
[...]
Selector:          agent.datadoghq.com/component=agent,agent.datadoghq.com/name=datadog
```

Logs from node tracer showing traces were sent to the local agent service:
```
Request to the agent: {"path":"/v0.4/traces","method":"PUT","headers":{"Content-Type":"application/msgpack","Datadog-Meta-Tracer-Version":"2.11.0","X-Datadog-Trace-Count":"1","Datadog-Meta-Lang":"nodejs","Datadog-Meta-Lang-Version":"v12.22.12","Datadog-Meta-Lang-Interpreter":"v8"},"protocol":"http:","hostname":"datadog-agent.system.svc.cluster.local","port":"8126"}
Response from the agent: {"rate_by_service":{"service:,env:":1}}
```

Logs from trace-agent showing the trace was received:
```
2023-09-08 18:36:10 UTC | TRACE | INFO | (run.go:269 in Infof) | [lang:nodejs lang_version:v12.22.12 interpreter:v8 tracer_version:2.11.0 endpoint_version:v0.4] -> traces received: 1, traces filtered: 0, traces amount: 474 bytes, events extracted: 0, events sampled: 0
```

### Motivation

Fixes https://github.com/DataDog/datadog-operator/issues/912

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Check that the agent local service uses the correct selector and that traces can be sent via local service

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
