### PR TITLE
lower log levels of a few log lines

### DIFF
--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -115,7 +115,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 
 	// Set up dependencies required by enabled features
 	for _, feat := range features {
-		logger.Info("Dependency ManageDependencies", "featureID", feat.ID())
+		logger.V(1).Info("Dependency ManageDependencies", "featureID", feat.ID())
 		if featErr := feat.ManageDependencies(resourceManagers, requiredComponents); featErr != nil {
 			errs = append(errs, featErr)
 		}

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -249,7 +249,7 @@ func (mf *metricsForwarder) setupV2() error {
 	}
 
 	mf.baseURL = getbaseURLV2(dda)
-	mf.logger.Info("Got site for DatadogAgent", "site", mf.baseURL)
+	mf.logger.V(1).Info("Got site for DatadogAgent", "site", mf.baseURL)
 
 	if dda.Spec.Global != nil && dda.Spec.Global.ClusterName != nil {
 		mf.clusterName = *dda.Spec.Global.ClusterName
@@ -345,7 +345,7 @@ func (mf *metricsForwarder) forwardMetrics() error {
 		return err
 	}
 
-	mf.logger.Info("Collecting metrics")
+	mf.logger.V(1).Info("Collecting metrics")
 	mf.updateTags(mf.clusterName, mf.labels)
 
 	// Send status-based metrics


### PR DESCRIPTION
### What does this PR do?

These log lines are rather noisy and noticed in the last release; lowering their log level so that they are not visible unless configured to be

### Motivation

Make it easier to view useful logs

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

N/A

### Describe your test plan

Deploy Datadog Operator and a DatadogAgent and ensure these log lines are not visible by default

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
