### PR TITLE
[datadogmonitor] Recreate monitor if deleted in the UI

### DIFF
--- a/controllers/datadogmonitor/controller.go
+++ b/controllers/datadogmonitor/controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -145,10 +146,10 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 		} else if instance.Status.MonitorLastForceSyncTime == nil || (defaultForceSyncPeriod-now.Sub(instance.Status.MonitorLastForceSyncTime.Time)) <= 0 {
 			// Periodically force a sync with the API monitor to ensure parity
 			// Get monitor to make sure it exists before trying any updates. If it doesn't, set shouldCreate
-			m, err = r.get(logger, instance, now)
+			_, err = r.get(logger, instance, now)
 			if err != nil {
 				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
-				if apierrors.IsNotFound(err) {
+				if strings.Contains(err.Error(), "404 Not Found") {
 					shouldCreate = true
 				}
 			} else {
@@ -160,7 +161,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 			m, err = r.get(logger, instance, now)
 			if err != nil {
 				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
-				if apierrors.IsNotFound(err) {
+				if strings.Contains(err.Error(), "404 Not Found") {
 					shouldCreate = true
 				}
 			}


### PR DESCRIPTION
### What does this PR do?

Recreate a monitor if it is deleted in the UI

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
