### PR TITLE
Fix Admission Controller default value doc/comment

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -482,7 +482,7 @@ type KubeStateMetricsCoreFeatureConfig struct {
 // The Admission Controller runs in the Cluster Agent.
 type AdmissionControllerFeatureConfig struct {
 	// Enabled enables the Admission Controller.
-	// Default: false
+	// Default: true
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -7807,7 +7807,7 @@ spec:
                           description: AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent. It can be "hostip", "service", or "socket".
                           type: string
                         enabled:
-                          description: 'Enabled enables the Admission Controller. Default: false'
+                          description: 'Enabled enables the Admission Controller. Default: true'
                           type: boolean
                         failurePolicy:
                           description: FailurePolicy determines how unrecognized and timeout errors are handled.

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -15357,7 +15357,7 @@ spec:
                           description: AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent. It can be "hostip", "service", or "socket".
                           type: string
                         enabled:
-                          description: 'Enabled enables the Admission Controller. Default: false'
+                          description: 'Enabled enables the Admission Controller. Default: true'
                           type: boolean
                         failurePolicy:
                           description: FailurePolicy determines how unrecognized and timeout errors are handled.

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -35,7 +35,7 @@ spec:
 | Parameter | Description |
 | --------- | ----------- |
 | features.admissionController.agentCommunicationMode | AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent. It can be "hostip", "service", or "socket". |
-| features.admissionController.enabled | Enabled enables the Admission Controller. Default: false |
+| features.admissionController.enabled | Enabled enables the Admission Controller. Default: true |
 | features.admissionController.failurePolicy | FailurePolicy determines how unrecognized and timeout errors are handled. |
 | features.admissionController.mutateUnlabelled | MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled="true"'. Default: false |
 | features.admissionController.serviceName | ServiceName corresponds to the webhook service name. |


### PR DESCRIPTION
### What does this PR do?

Admission controller is [enabled by default](https://github.com/DataDog/datadog-operator/blob/main/apis/datadoghq/v2alpha1/datadogagent_default.go#L66) but CRD doc/comment says otherwise.

### Motivation

fix doc

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
