### PR TITLE
fix spaces after periods and small wording tweak

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,9 +191,9 @@ func run(opts *options) error {
 	version.PrintVersionLogs(setupLog)
 
 	if !opts.v2APIEnabled {
-		setupLog.Info("The `v2APIEnabled` flag is deprecated in v1.2.0+ and will be removed in a future release." +
-			"Once removed, the Datadog Operator cannot be configured to reconcile the v1alpha1 DatadogAgent CRD." +
-			"You will still be able to apply v1alpha1 with the conversion webhook enabled (`webhookEnabled`).")
+		setupLog.Info("The 'v2APIEnabled' flag is deprecated in v1.2.0+ and will be removed in a future release. " +
+			"Once removed, the Datadog Operator cannot be configured to reconcile the v1alpha1 DatadogAgent CRD. " +
+			"However, you will still be able to apply a v1alpha1 manifest with the conversion webhook enabled (using the flag 'webhookEnabled').")
 	}
 
 	if opts.profilingEnabled {


### PR DESCRIPTION
### What does this PR do?

Follow up go #915 ; small fixes including spaces after the periods and a small update to wording.

```
{"level":"INFO","ts":"2023-09-18T17:23:11Z","logger":"setup","msg":"The 'v2APIEnabled' flag is deprecated in v1.2.0+ and will be removed in a future release. Once removed, the Datadog Operator cannot be configured to reconcile the v1alpha1 DatadogAgent CRD. However, you will still be able to apply a v1alpha1 manifest with the conversion webhook enabled (using the flag 'webhookEnabled')."}
```

### Motivation

Fix formatting and make message clearer

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
