### PR TITLE
fix(clusterchecksrunner): Disable Remote Config

### DIFF
--- a/controllers/datadogagent/clusterchecksrunner.go
+++ b/controllers/datadogagent/clusterchecksrunner.go
@@ -368,6 +368,10 @@ func getEnvVarsForClusterChecksRunner(dda *datadoghqv1alpha1.DatadogAgent) []cor
 			Value: "true",
 		},
 		{
+			Name:  apicommon.DDRemoteConfigurationEnabled,
+			Value: "false",
+		},
+		{
 			Name: apicommon.DDClcRunnerHost,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{

--- a/controllers/datadogagent/clusterchecksrunner_test.go
+++ b/controllers/datadogagent/clusterchecksrunner_test.go
@@ -178,6 +178,10 @@ func clusterChecksRunnerDefaultEnvVars() []corev1.EnvVar {
 			Value: "false",
 		},
 		{
+			Name:  "DD_REMOTE_CONFIGURATION_ENABLED",
+			Value: "false",
+		},
+		{
 			Name:  "DD_LOG_LEVEL",
 			Value: "INFO",
 		},


### PR DESCRIPTION
### What does this PR do?
Disables Remote Config on the cluster checks runner

### Motivation
Error logs during QA

### Additional Notes
N/A

### Minimum Agent Versions
This bug only triggers after agent 7.47.0

### Describe your test plan
Run the cluster checks runner, see there is no error log for Remote Config

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
