### PR TITLE
Revert "[datadogmonitor] Return matching downtimes and show downtime status (#894)" (#932)

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -263,8 +263,8 @@ type DatadogMonitorTriggeredState struct {
 // DatadogMonitorDowntimeStatus represents the downtime status of a DatadogMonitor
 // +k8s:openapi-gen=true
 type DatadogMonitorDowntimeStatus struct {
-	IsDowntimed bool `json:"isDowntimed"`
-	DowntimeID  int  `json:"downtimeID,omitempty"`
+	IsDowntimed bool `json:"isDowntimed,omitempty"`
+	DowntimeID  int  `json:"downtimeId,omitempty"`
 }
 
 // DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
@@ -273,7 +273,6 @@ type DatadogMonitorDowntimeStatus struct {
 // +kubebuilder:resource:path=datadogmonitors,scope=Namespaced
 // +kubebuilder:printcolumn:name="id",type="string",JSONPath=".status.id"
 // +kubebuilder:printcolumn:name="monitor state",type="string",JSONPath=".status.monitorState"
-// +kubebuilder:printcolumn:name="is downtimed",type="boolean",JSONPath=".status.downtimeStatus.isDowntimed"
 // +kubebuilder:printcolumn:name="last state transition",type="string",JSONPath=".status.monitorStateLastTransitionTime"
 // +kubebuilder:printcolumn:name="last state sync",type="string",format="date",JSONPath=".status.monitorStateLastUpdateTime"
 // +kubebuilder:printcolumn:name="sync status",type="string",JSONPath=".status.syncStatus"

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -2068,19 +2068,17 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorDowntimeStatus(ref common.Ref
 				Properties: map[string]spec.Schema{
 					"isDowntimed": {
 						SchemaProps: spec.SchemaProps{
-							Default: false,
-							Type:    []string{"boolean"},
-							Format:  "",
+							Type:   []string{"boolean"},
+							Format: "",
 						},
 					},
-					"downtimeID": {
+					"downtimeId": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
 							Format: "int32",
 						},
 					},
 				},
-				Required: []string{"isDowntimed"},
 			},
 		},
 	}

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -23,9 +23,6 @@ spec:
         - jsonPath: .status.monitorState
           name: monitor state
           type: string
-        - jsonPath: .status.downtimeStatus.isDowntimed
-          name: is downtimed
-          type: boolean
         - jsonPath: .status.monitorStateLastTransitionTime
           name: last state transition
           type: string
@@ -217,12 +214,10 @@ spec:
                 downtimeStatus:
                   description: DowntimeStatus defines whether the monitor is downtimed
                   properties:
-                    downtimeID:
+                    downtimeId:
                       type: integer
                     isDowntimed:
                       type: boolean
-                  required:
-                    - isDowntimed
                   type: object
                 id:
                   description: ID is the monitor ID generated in Datadog

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -15,9 +15,6 @@ spec:
     - JSONPath: .status.monitorState
       name: monitor state
       type: string
-    - JSONPath: .status.downtimeStatus.isDowntimed
-      name: is downtimed
-      type: boolean
     - JSONPath: .status.monitorStateLastTransitionTime
       name: last state transition
       type: string
@@ -218,12 +215,10 @@ spec:
             downtimeStatus:
               description: DowntimeStatus defines whether the monitor is downtimed
               properties:
-                downtimeID:
+                downtimeId:
                   type: integer
                 isDowntimed:
                   type: boolean
-              required:
-                - isDowntimed
               type: object
             id:
               description: ID is the monitor ID generated in Datadog

--- a/controllers/datadogmonitor/controller.go
+++ b/controllers/datadogmonitor/controller.go
@@ -146,7 +146,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 		} else if instance.Status.MonitorLastForceSyncTime == nil || (defaultForceSyncPeriod-now.Sub(instance.Status.MonitorLastForceSyncTime.Time)) <= 0 {
 			// Periodically force a sync with the API monitor to ensure parity
 			// Get monitor to make sure it exists before trying any updates. If it doesn't, set shouldCreate
-			_, err = r.get(logger, instance, now)
+			m, err = r.get(instance, newStatus)
 			if err != nil {
 				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
 				if strings.Contains(err.Error(), "404 Not Found") {
@@ -158,14 +158,14 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 		} else if instance.Status.MonitorStateLastUpdateTime == nil || (defaultRequeuePeriod-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
 			// If other conditions aren't met, and we have passed the defaultRequeuePeriod, then update monitor state
 			// Get monitor to make sure it exists before trying any updates. If it doesn't, set shouldCreate
-			m, err = r.get(logger, instance, now)
+			m, err = r.get(instance, newStatus)
 			if err != nil {
 				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
 				if strings.Contains(err.Error(), "404 Not Found") {
 					shouldCreate = true
 				}
 			}
-			updateMonitorStateAndDowntime(m, now, newStatus, err)
+			updateMonitorState(m, now, newStatus)
 		}
 	}
 
@@ -265,42 +265,20 @@ func (r *Reconciler) update(logger logr.Logger, datadogMonitor *datadoghqv1alpha
 	return nil
 }
 
-func (r *Reconciler) get(logger logr.Logger, datadogMonitor *datadoghqv1alpha1.DatadogMonitor, now metav1.Time) (datadogV1.Monitor, error) {
-	// Get monitor from Datadog
-	return getMonitor(r.datadogAuth, r.datadogClient, datadogMonitor.Status.ID)
-}
-
-func updateMonitorStateAndDowntime(m datadogV1.Monitor, now metav1.Time, status *datadoghqv1alpha1.DatadogMonitorStatus, err error) {
+func (r *Reconciler) get(datadogMonitor *datadoghqv1alpha1.DatadogMonitor, status *datadoghqv1alpha1.DatadogMonitorStatus) (datadogV1.Monitor, error) {
+	// Get monitor from Datadog and update resource status if needed
+	m, err := getMonitor(r.datadogAuth, r.datadogClient, datadogMonitor.Status.ID)
 	if err != nil {
 		status.MonitorStateSyncStatus = datadoghqv1alpha1.MonitorStateSyncStatusGetError
-		return
+		return m, err
 	}
+	return m, nil
+}
 
+func updateMonitorState(m datadogV1.Monitor, now metav1.Time, status *datadoghqv1alpha1.DatadogMonitorStatus) {
 	convertStateToStatus(m, status, now)
 	status.MonitorStateLastUpdateTime = &now
 	status.MonitorStateSyncStatus = datadoghqv1alpha1.MonitorStateSyncStatusOK
-
-	if len(m.MatchingDowntimes) > 0 {
-		matchingDowntimes := []datadogV1.MatchingDowntime{}
-		_ = copy(matchingDowntimes, m.MatchingDowntimes)
-		setDowntimeStatus(matchingDowntimes, status)
-	}
-}
-
-func setDowntimeStatus(matchingDowntimes []datadogV1.MatchingDowntime, status *datadoghqv1alpha1.DatadogMonitorStatus) {
-	if len(matchingDowntimes) > 0 {
-		// Sort so that displayed Downtime is consistent
-		sort.SliceStable(matchingDowntimes, func(i, j int) bool { return *matchingDowntimes[i].Start < *matchingDowntimes[j].Start })
-
-		status.DowntimeStatus = datadoghqv1alpha1.DatadogMonitorDowntimeStatus{
-			IsDowntimed: true,
-			// Only show ID of first Downtime in the list
-			DowntimeID: int(matchingDowntimes[0].Id),
-		}
-	} else {
-		// Reset DowntimeStatus
-		status.DowntimeStatus = datadoghqv1alpha1.DatadogMonitorDowntimeStatus{IsDowntimed: false}
-	}
 }
 
 func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, datadogMonitor *datadoghqv1alpha1.DatadogMonitor, now metav1.Time, status *datadoghqv1alpha1.DatadogMonitorStatus, currentErr error, result ctrl.Result) (ctrl.Result, error) {
@@ -404,6 +382,8 @@ func convertStateToStatus(monitor datadogV1.Monitor, newStatus *datadoghqv1alpha
 	if newStatus.MonitorState != oldMonitorState {
 		newStatus.MonitorStateLastTransitionTime = &now
 	}
+	// TODO Updating this requires having the API client also return any matching downtime objects
+	newStatus.DowntimeStatus = datadoghqv1alpha1.DatadogMonitorDowntimeStatus{}
 }
 
 func isSupportedMonitorType(monitorType datadoghqv1alpha1.DatadogMonitorType) bool {

--- a/controllers/datadogmonitor/controller_test.go
+++ b/controllers/datadogmonitor/controller_test.go
@@ -510,61 +510,6 @@ func newRequest(ns, name string) reconcile.Request {
 	}
 }
 
-func Test_setDowntimeStatus(t *testing.T) {
-	mockNow := int64(1612244495)
-	mockNowAfterFive := mockNow + 5
-	mockNowAfterFifty := mockNow + 50
-
-	tests := []struct {
-		name              string
-		matchingDowntimes []datadogV1.MatchingDowntime
-		status            *datadoghqv1alpha1.DatadogMonitorStatus
-		wantStatus        *datadoghqv1alpha1.DatadogMonitorStatus
-	}{
-		{
-			name: "three different downtimes",
-			matchingDowntimes: []datadogV1.MatchingDowntime{
-				{
-					Id:    678,
-					Start: &mockNow,
-				},
-				{
-					Id:    45678,
-					Start: &mockNowAfterFive,
-				},
-				{
-					Id:    5678,
-					Start: &mockNowAfterFifty,
-				},
-			},
-			status: &datadoghqv1alpha1.DatadogMonitorStatus{},
-			wantStatus: &datadoghqv1alpha1.DatadogMonitorStatus{
-				DowntimeStatus: datadoghqv1alpha1.DatadogMonitorDowntimeStatus{
-					IsDowntimed: true,
-					DowntimeID:  678,
-				},
-			},
-		},
-		{
-			name:              "no downtimes",
-			matchingDowntimes: []datadogV1.MatchingDowntime{},
-			status:            &datadoghqv1alpha1.DatadogMonitorStatus{},
-			wantStatus: &datadoghqv1alpha1.DatadogMonitorStatus{
-				DowntimeStatus: datadoghqv1alpha1.DatadogMonitorDowntimeStatus{
-					IsDowntimed: false,
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setDowntimeStatus(tt.matchingDowntimes, tt.status)
-
-			assert.Equal(t, tt.wantStatus.DowntimeStatus, tt.status.DowntimeStatus)
-		})
-	}
-}
-
 func Test_convertStateToStatus(t *testing.T) {
 	triggerTs := int64(1612244495)
 	secondTriggerTs := triggerTs + 300

--- a/controllers/datadogmonitor/monitor.go
+++ b/controllers/datadogmonitor/monitor.go
@@ -174,10 +174,8 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 
 func getMonitor(auth context.Context, client *datadogV1.MonitorsApi, monitorID int) (datadogV1.Monitor, error) {
 	groupStates := "all"
-	withDowntimes := true
 	optionalParams := datadogV1.GetMonitorOptionalParameters{
-		GroupStates:   &groupStates,
-		WithDowntimes: &withDowntimes,
+		GroupStates: &groupStates,
 	}
 	m, _, err := client.GetMonitor(auth, int64(monitorID), optionalParams)
 	if err != nil {

--- a/controllers/datadogmonitor/monitor_test.go
+++ b/controllers/datadogmonitor/monitor_test.go
@@ -156,9 +156,6 @@ func Test_getMonitor(t *testing.T) {
 	val, err := getMonitor(testAuth, client, mID)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedMonitor, val)
-
-	// Check MatchingDowntime is correct
-	assert.Equal(t, int64(6789), val.MatchingDowntimes[0].Id)
 }
 
 func Test_validateMonitor(t *testing.T) {
@@ -309,11 +306,6 @@ func genericMonitor(mID int) datadogV1.Monitor {
 		Query:    query,
 		Tags:     tags,
 		Type:     mType,
-		MatchingDowntimes: []datadogV1.MatchingDowntime{
-			{
-				Id: 6789,
-			},
-		},
 	}
 }
 


### PR DESCRIPTION

* Revert "[datadogmonitor] Return matching downtimes and show downtime status (#894)"

This reverts commit b044ce7135e0dbe682f8dca0f4b1af9009c0c75d.

* re-add openapi-gen tags

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
