### PR TITLE
Remove ksm `telemetry` parameter

### DIFF
--- a/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
@@ -51,8 +51,7 @@ func ksmCheckConfig(clusterCheck bool, collectorOpts collectorOptions) string {
 cluster_check: %s
 init_config:
 instances:
-  - telemetry: true
-    skip_leader_election: %s
+  - skip_leader_election: %s
     collectors:
     - pods
     - replicationcontrollers

--- a/docs/kubernetes_state_metrics.md
+++ b/docs/kubernetes_state_metrics.md
@@ -117,7 +117,7 @@ data:
           label_app: app
 ``` 
 
-The above example will create 2 separate Cluster Level Checks, using different collectors and features (label joins, telemetry, remapping...).
+The above example will create 2 separate Cluster Level Checks, using different collectors and features (label joins, remapping...).
 Once you have created the ConfigMap (in the same namespace as the operator), make sure you reference the name in the DatadogAgent Spec, in this case:
 
 You can also reference the configuration in the specification of the DatadogAgent spec as follows:

--- a/docs/kubernetes_state_metrics.md
+++ b/docs/kubernetes_state_metrics.md
@@ -91,7 +91,6 @@ data:
           label_chart_name: chart_name
           label_chart_version: chart_version
           label_team: team
-        telemetry: true
       - collectors:
           - deployments
           - daemonsets
@@ -116,7 +115,6 @@ data:
         labels_mapper:
           label_service: service
           label_app: app
-        telemetry: true
 ``` 
 
 The above example will create 2 separate Cluster Level Checks, using different collectors and features (label joins, telemetry, remapping...).
@@ -137,7 +135,6 @@ spec:
               - collectors:
                   - pods
                   - nodes
-            telemetry: true
 ```
 
 The above will have the operator create and maintain a ConfigMap for you with this config. It will run a single Kubernetes State Metrics Core check with the pods and nodes collectors enabled.


### PR DESCRIPTION
### What does this PR do?

This PR removes the ksm telemetry parameter which should be disabled by default.

### Motivation

This parameter was initially added for internal QA. Moreover, it can cause tag corruption, adding `resource_name` tag to every ksm metric.

### Additional Notes

N/A

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

N/A

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
