### PR TITLE
fix(remoteConfig): Fix documentation on default behaviour

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -312,7 +312,7 @@ type CWSRemoteConfigurationConfig struct {
 // RC runs in the Agent.
 type RemoteConfigurationFeatureConfig struct {
 	// Enable this option to activate Remote Configuration.
-	// Default: false
+	// Default: true
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 }

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -8353,7 +8353,7 @@ spec:
                       description: Remote Configuration configuration.
                       properties:
                         enabled:
-                          description: 'Enable this option to activate Remote Configuration. Default: false'
+                          description: 'Enable this option to activate Remote Configuration. Default: true'
                           type: boolean
                       type: object
                     tcpQueueLength:

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -15903,7 +15903,7 @@ spec:
                       description: Remote Configuration configuration.
                       properties:
                         enabled:
-                          description: 'Enable this option to activate Remote Configuration. Default: false'
+                          description: 'Enable this option to activate Remote Configuration. Default: true'
                           type: boolean
                       type: object
                     tcpQueueLength:

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -176,7 +176,7 @@ spec:
 
 The table below lists parameters that can be used to override default or global settings. Maps and arrays have a type annotation in the table; properties that are configured as map values contain a `[key]` element which should be replaced by the actual map key. `override` itself is a map with the following possible keys: `nodeAgent`, `clusterAgent`, or `clusterChecksRunner`. Other keys can be added, but they do not have any effect.
 
-For example, the manifest below can be used to override the node Agent image, tag, and the resource limits of the system probe container.
+For example, the manifest below can be used to override the node Agent image, tag, and the resource limits of the system probe container. 
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -120,7 +120,7 @@ spec:
 | features.prometheusScrape.enableServiceEndpoints | EnableServiceEndpoints enables generating dedicated checks for service endpoints. Default: false |
 | features.prometheusScrape.enabled | Enable autodiscovery of pods and services exposing Prometheus metrics. Default: false |
 | features.prometheusScrape.version | Version specifies the version of the OpenMetrics check. Default: 2 |
-| features.remoteConfiguration.enabled | Enable this option to activate Remote Configuration. Default: false |
+| features.remoteConfiguration.enabled | Enable this option to activate Remote Configuration. Default: true |
 | features.tcpQueueLength.enabled | Enables the TCP queue length eBPF-based check. Default: false |
 | features.usm.enabled | Enabled enables Universal Service Monitoring. Default: false |
 | global.clusterAgentToken | ClusterAgentToken is the token for communication between the NodeAgent and ClusterAgent. |
@@ -176,7 +176,7 @@ spec:
 
 The table below lists parameters that can be used to override default or global settings. Maps and arrays have a type annotation in the table; properties that are configured as map values contain a `[key]` element which should be replaced by the actual map key. `override` itself is a map with the following possible keys: `nodeAgent`, `clusterAgent`, or `clusterChecksRunner`. Other keys can be added, but they do not have any effect.
 
-For example, the manifest below can be used to override the node Agent image, tag, and the resource limits of the system probe container. 
+For example, the manifest below can be used to override the node Agent image, tag, and the resource limits of the system probe container.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1


### PR DESCRIPTION
### What does this PR do?
Fixes Remote Config doc on RC being enabled by default

### Motivation
Clean docs

### Additional Notes


### Minimum Agent Versions


### Describe your test plan

Just docs

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
