### PR TITLE
update gitlab runner image to golang 1.19-bullseye

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/images/mirror/golang:1.18.6-bullseye
+image: registry.ddbuild.io/images/mirror/golang:1.19-bullseye
 variables:
   PROJECTNAME: "datadog-operator"
   PROJECTNAME_CHECK: "datadog-operator-check"


### PR DESCRIPTION
### What does this PR do?

Update runner image to use golang 1.19 due to issue following update of [setup-envtest](https://github.com/kubernetes-sigs/controller-runtime/issues/2537)

### Motivation

Fix CI failure

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
