### PR TITLE
Use Agent default for kubelet client CA and move CA logic to override/global.go

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -7,7 +7,6 @@ package v2alpha1
 
 import (
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
-	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 )
 
@@ -86,8 +85,8 @@ const (
 	defaultPrometheusScrapeEnableServiceEndpoints bool = false
 	defaultPrometheusScrapeVersion                int  = 2
 
-	defaultKubeletAgentCAPath            = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	defaultKubeletAgentCAPathHostPathSet = "/var/run/host-kubelet-ca.crt"
+	// defaultKubeletAgentCAPath            = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	// defaultKubeletAgentCAPathHostPathSet = "/var/run/host-kubelet-ca.crt"
 )
 
 // DefaultDatadogAgent defaults the DatadogAgentSpec GlobalConfig and Features.
@@ -113,18 +112,6 @@ func defaultGlobalConfig(ddaSpec *DatadogAgentSpec) {
 
 	if ddaSpec.Global.LogLevel == nil {
 		ddaSpec.Global.LogLevel = apiutils.NewStringPointer(defaultLogLevel)
-	}
-
-	if ddaSpec.Global.Kubelet == nil {
-		ddaSpec.Global.Kubelet = &commonv1.KubeletConfig{
-			AgentCAPath: defaultKubeletAgentCAPath,
-		}
-	} else if ddaSpec.Global.Kubelet.AgentCAPath == "" {
-		if ddaSpec.Global.Kubelet.HostCAPath != "" {
-			ddaSpec.Global.Kubelet.AgentCAPath = defaultKubeletAgentCAPathHostPathSet
-		} else {
-			ddaSpec.Global.Kubelet.AgentCAPath = defaultKubeletAgentCAPath
-		}
 	}
 }
 

--- a/controllers/datadogagent/override/global.go
+++ b/controllers/datadogagent/override/global.go
@@ -211,7 +211,7 @@ func ApplyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 				// The environment variable `DD_KUBELET_CLIENT_CA` is necessary, as the Agent defaults to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` otherwise.
 				manager.EnvVar().AddEnvVar(&corev1.EnvVar{
 					Name:  apicommon.DDKubeletCAPath,
-					Value: config.Kubelet.AgentCAPath,
+					Value: agentCAPath,
 				})
 			}
 		}

--- a/controllers/datadogagent/override/global.go
+++ b/controllers/datadogagent/override/global.go
@@ -208,7 +208,7 @@ func ApplyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 					},
 				)
 				manager.Volume().AddVolume(&kubeletVol)
-				// The environment variable `DD_KUBELET_CLIENT_CA` is necessary, as the Agent defaults to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` otherwise.
+				// If the HostCAPath is overridden, set the environment variable `DD_KUBELET_CLIENT_CA`. The default value in the Agent is `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
 				manager.EnvVar().AddEnvVar(&corev1.EnvVar{
 					Name:  apicommon.DDKubeletCAPath,
 					Value: agentCAPath,


### PR DESCRIPTION
### What does this PR do?

* Moves logic checking for user-defined settings (from `spec.global`) to `controllers/datadogagent/override/global.go/ApplyGlobalSettings` function regarding the Kubelet client CA used by the Agent when a user-provided host location is mounted.
* Simplifies the logic by : 
    * setting `DD_KUBELET_CLIENT_CA` if and only if the user provides the host location instead of setting it to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` since this is already the Agent default : https://github.com/DataDog/datadog-agent/blob/2fa6b7b721c8605d67d85d3d6b1cc867eee1a1d0/pkg/util/kubernetes/kubelet/kubelet_client.go#L64-L66
    * When there is no user-provided host, avoid re-setting the kubelet host "default" `status.hostIP` as it is already defined in the default daemonset template spec thanks to https://github.com/DataDog/datadog-operator/blob/8983ac236f4d559317c082ace7a2c2aa31d44074/controllers/datadogagent/component/agent/default.go#L261-L266

### Motivation

* Let the Agent default as much as possible instead of having the Operator take the "decision"

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
* Use the scenarios below in 3 different CRs, exec inside the node Agent and run `agent config | egrep kubelet_host\|kubelet_client_ca`
* Scenarios to check : 
    1. No kubelet config provided by the user. **Assertion** : ensure kubelet host is set to status.hostIP and kubelet client ca is empty (this is expected, in `config.go` in the Agent, it defaults to empty string, then the `kubelet_client.go` sets the default)
    2. user provides a host CA location by setting `spec.global.kubelet.HostCAPath` but no `AgentCAPath` and no kubelet host. **Assertion**: ensure kubelet host is set to status.hostIP, the host certificate is mounted at `/var/run/host-kubelet-ca.crt` and kubelet client ca is set to the "default" `/var/run/host-kubelet-ca.crt`
    3. user provides a kubelet host `spec.global.kubelet.host.fieldRef.fieldPath: spec.nodeName`, a host CA path and a custom Agent CA path. **Assertion** : ensure kubelet host is set to node name, host cert is mounted at user-desired location and Agent uses it

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
