### PR TITLE
update default liveness and readiness probes

### DIFF
--- a/apis/datadoghq/common/common.go
+++ b/apis/datadoghq/common/common.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// GetDefaultLivenessProbe creates a all defaulted LivenessProbe
+// GetDefaultLivenessProbe creates a defaulted LivenessProbe
 func GetDefaultLivenessProbe() *corev1.Probe {
 	livenessProbe := &corev1.Probe{
 		InitialDelaySeconds: DefaultLivenessProbeInitialDelaySeconds,
@@ -30,7 +30,7 @@ func GetDefaultLivenessProbe() *corev1.Probe {
 	return livenessProbe
 }
 
-// GetDefaultReadinessProbe creates a all defaulted ReadynessProbe
+// GetDefaultReadinessProbe creates a defaulted ReadinessProbe
 func GetDefaultReadinessProbe() *corev1.Probe {
 	readinessProbe := &corev1.Probe{
 		InitialDelaySeconds: DefaultReadinessProbeInitialDelaySeconds,
@@ -46,6 +46,21 @@ func GetDefaultReadinessProbe() *corev1.Probe {
 		},
 	}
 	return readinessProbe
+}
+
+// GetDefaultTraceAgentProbe creates a defaulted liveness/readiness probe for the Trace Agent
+func GetDefaultTraceAgentProbe() *corev1.Probe {
+	probe := &corev1.Probe{
+		InitialDelaySeconds: DefaultLivenessProbeInitialDelaySeconds,
+		PeriodSeconds:       DefaultLivenessProbePeriodSeconds,
+		TimeoutSeconds:      DefaultLivenessProbeTimeoutSeconds,
+	}
+	probe.TCPSocket = &corev1.TCPSocketAction{
+		Port: intstr.IntOrString{
+			IntVal: DefaultApmPort,
+		},
+	}
+	return probe
 }
 
 // GetImage builds the image string based on ImageConfig and the registry configuration.

--- a/apis/datadoghq/v1alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default.go
@@ -551,7 +551,7 @@ func DefaultDatadogAgentSpecAgentApm(agent *DatadogAgentSpecAgentSpec) *APMSpec 
 	}
 
 	if agent.Apm.LivenessProbe == nil {
-		agent.Apm.LivenessProbe = getDefaultAPMAgentLivenessProbe()
+		agent.Apm.LivenessProbe = apicommon.GetDefaultTraceAgentProbe()
 		apmOverride.LivenessProbe = agent.Apm.LivenessProbe
 	}
 
@@ -560,20 +560,6 @@ func DefaultDatadogAgentSpecAgentApm(agent *DatadogAgentSpecAgentSpec) *APMSpec 
 	}
 
 	return apmOverride
-}
-
-func getDefaultAPMAgentLivenessProbe() *corev1.Probe {
-	livenessProbe := &corev1.Probe{
-		InitialDelaySeconds: apicommon.DefaultLivenessProbeInitialDelaySeconds,
-		PeriodSeconds:       apicommon.DefaultLivenessProbePeriodSeconds,
-		TimeoutSeconds:      apicommon.DefaultLivenessProbeTimeoutSeconds,
-	}
-	livenessProbe.TCPSocket = &corev1.TCPSocketAction{
-		Port: intstr.IntOrString{
-			IntVal: defaultApmHostPort,
-		},
-	}
-	return livenessProbe
 }
 
 // DefaultDatadogAgentSpecAgentApmUDS used to default APMUnixDomainSocketSpec

--- a/apis/datadoghq/v1alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_default_test.go
@@ -1034,7 +1034,7 @@ func TestDefaultDatadogAgentSpecAgentApm(t *testing.T) {
 			want: &APMSpec{
 				HostPort:         apiutils.NewInt32Pointer(8126),
 				UnixDomainSocket: &APMUnixDomainSocketSpec{Enabled: apiutils.NewBoolPointer(false)},
-				LivenessProbe:    getDefaultAPMAgentLivenessProbe(),
+				LivenessProbe:    apicommon.GetDefaultTraceAgentProbe(),
 			},
 		},
 	}

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -142,8 +142,8 @@ func traceAgentContainer(dda metav1.Object) corev1.Container {
 		},
 		Env:            commonEnvVars(dda),
 		VolumeMounts:   volumeMountsForTraceAgent(),
-		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+		LivenessProbe:  apicommon.GetDefaultTraceAgentProbe(),
+		ReadinessProbe: apicommon.GetDefaultTraceAgentProbe(),
 	}
 }
 
@@ -155,10 +155,8 @@ func processAgentContainer(dda metav1.Object) corev1.Container {
 			"process-agent", fmt.Sprintf("--config=%s", apicommon.AgentCustomConfigVolumePath),
 			fmt.Sprintf("--sysprobe-config=%s", apicommon.SystemProbeConfigVolumePath),
 		},
-		Env:            commonEnvVars(dda),
-		VolumeMounts:   volumeMountsForProcessAgent(),
-		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+		Env:          commonEnvVars(dda),
+		VolumeMounts: volumeMountsForProcessAgent(),
 	}
 }
 
@@ -170,10 +168,8 @@ func securityAgentContainer(dda metav1.Object) corev1.Container {
 			"security-agent",
 			"start", fmt.Sprintf("-c=%s", apicommon.AgentCustomConfigVolumePath),
 		},
-		Env:            envVarsForSecurityAgent(dda),
-		VolumeMounts:   volumeMountsForSecurityAgent(),
-		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+		Env:          envVarsForSecurityAgent(dda),
+		VolumeMounts: volumeMountsForSecurityAgent(),
 	}
 }
 
@@ -185,10 +181,8 @@ func systemProbeContainer(dda metav1.Object) corev1.Container {
 			"system-probe",
 			fmt.Sprintf("--config=%s", apicommon.SystemProbeConfigVolumePath),
 		},
-		Env:            commonEnvVars(dda),
-		VolumeMounts:   volumeMountsForSystemProbe(),
-		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+		Env:          commonEnvVars(dda),
+		VolumeMounts: volumeMountsForSystemProbe(),
 		SecurityContext: &corev1.SecurityContext{
 			SeccompProfile: &corev1.SeccompProfile{
 				Type:             corev1.SeccompProfileTypeLocalhost,

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -140,10 +140,9 @@ func traceAgentContainer(dda metav1.Object) corev1.Container {
 			"trace-agent",
 			fmt.Sprintf("--config=%s", apicommon.AgentCustomConfigVolumePath),
 		},
-		Env:            commonEnvVars(dda),
-		VolumeMounts:   volumeMountsForTraceAgent(),
-		LivenessProbe:  apicommon.GetDefaultTraceAgentProbe(),
-		ReadinessProbe: apicommon.GetDefaultTraceAgentProbe(),
+		Env:           commonEnvVars(dda),
+		VolumeMounts:  volumeMountsForTraceAgent(),
+		LivenessProbe: apicommon.GetDefaultTraceAgentProbe(),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

- Remove the default liveness and readiness probes from all agent containers besides the core agent
- Add a different default probe (same for liveness and readiness) for the trace agent container

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
