### PR TITLE
Add registerEndpoint option to external metrics feature to allow disabling external metrics endpoint registration

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -535,6 +535,11 @@ type ExternalMetricsServerFeatureConfig struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// RegisterEndpoint registers the External Metrics endpoint as an APIService
+	// Default: true
+	// +optional
+	RegisterEndpoint *bool `json:"registerEndpoint,omitempty"`
+
 	// WPAController enables the informer and controller of the Watermark Pod Autoscaler.
 	// NOTE: The Watermark Pod Autoscaler controller needs to be installed.
 	// See also: https://github.com/DataDog/watermarkpodautoscaler.

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -8112,6 +8112,9 @@ spec:
                           description: 'Port specifies the metricsProvider External Metrics Server service port. Default: 8443'
                           format: int32
                           type: integer
+                        registerEndpoint:
+                          description: 'RegisterEndpoint registers the External Metrics endpoint as an APIService Default: true'
+                          type: boolean
                         useDatadogMetrics:
                           description: 'UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries). Default: true'
                           type: boolean

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -15662,6 +15662,9 @@ spec:
                           description: 'Port specifies the metricsProvider External Metrics Server service port. Default: 8443'
                           format: int32
                           type: integer
+                        registerEndpoint:
+                          description: 'RegisterEndpoint registers the External Metrics endpoint as an APIService Default: true'
+                          type: boolean
                         useDatadogMetrics:
                           description: 'UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries). Default: true'
                           type: boolean

--- a/controllers/datadogagent/feature/externalmetrics/feature.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature.go
@@ -57,6 +57,7 @@ type externalMetricsFeature struct {
 
 	createKubernetesNetworkPolicy bool
 	createCiliumNetworkPolicy     bool
+	registerEndpoint              bool
 }
 
 type secret struct {
@@ -76,6 +77,9 @@ func (f *externalMetricsFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 	em := dda.Spec.Features.ExternalMetricsServer
 
 	if em != nil && apiutils.BoolValue(em.Enabled) {
+		// By default, we register the external metrics endpoint
+		f.registerEndpoint = em.RegisterEndpoint == nil || apiutils.BoolValue(em.RegisterEndpoint)
+
 		f.useWPA = apiutils.BoolValue(em.WPAController)
 		f.useDDM = apiutils.BoolValue(em.UseDatadogMetrics)
 		f.port = *em.Port
@@ -230,44 +234,46 @@ func (f *externalMetricsFeature) ManageDependencies(managers feature.ResourceMan
 		return fmt.Errorf("error adding external metrics provider service to store: %w", err)
 	}
 
-	// apiservice
-	apiServiceSpec := apiregistrationv1.APIServiceSpec{
-		Service: &apiregistrationv1.ServiceReference{
-			Name:      serviceName,
-			Namespace: ns,
-			Port:      &f.port,
-		},
-		Version:               "v1beta1",
-		InsecureSkipTLSVerify: true,
-		Group:                 rbac.ExternalMetricsAPIGroup,
-		GroupPriorityMinimum:  100,
-		VersionPriority:       100,
-	}
-	if err := managers.APIServiceManager().AddAPIService(componentdca.GetMetricsServerAPIServiceName(), ns, apiServiceSpec); err != nil {
-		return fmt.Errorf("error adding external metrics provider apiservice to store: %w", err)
-	}
+	if f.registerEndpoint {
+		// apiservice
+		apiServiceSpec := apiregistrationv1.APIServiceSpec{
+			Service: &apiregistrationv1.ServiceReference{
+				Name:      serviceName,
+				Namespace: ns,
+				Port:      &f.port,
+			},
+			Version:               "v1beta1",
+			InsecureSkipTLSVerify: true,
+			Group:                 rbac.ExternalMetricsAPIGroup,
+			GroupPriorityMinimum:  100,
+			VersionPriority:       100,
+		}
+		if err := managers.APIServiceManager().AddAPIService(componentdca.GetMetricsServerAPIServiceName(), ns, apiServiceSpec); err != nil {
+			return fmt.Errorf("error adding external metrics provider apiservice to store: %w", err)
+		}
 
-	// credential secret
-	if len(f.keySecret) != 0 {
-		for idx, s := range f.keySecret {
-			if len(s.data) != 0 {
-				if err := managers.SecretManager().AddSecret(ns, componentdca.GetDefaultExternalMetricSecretName(f.owner), idx, string(s.data)); err != nil {
-					return fmt.Errorf("error adding external metrics provider credentials secret to store: %w", err)
+		// credential secret
+		if len(f.keySecret) != 0 {
+			for idx, s := range f.keySecret {
+				if len(s.data) != 0 {
+					if err := managers.SecretManager().AddSecret(ns, componentdca.GetDefaultExternalMetricSecretName(f.owner), idx, string(s.data)); err != nil {
+						return fmt.Errorf("error adding external metrics provider credentials secret to store: %w", err)
+					}
 				}
 			}
 		}
-	}
 
-	// rbac
-	rbacResourcesName := componentdca.GetClusterAgentRbacResourcesName(f.owner)
-	if err := managers.RBACManager().AddClusterPolicyRules(ns, rbacResourcesName, f.serviceAccountName, getDCAClusterPolicyRules(f.useDDM, f.useWPA)); err != nil {
-		return fmt.Errorf("error adding external metrics provider dca clusterrole and clusterrolebinding to store: %w", err)
-	}
-	if err := managers.RBACManager().AddClusterPolicyRules("kube-system", componentdca.GetExternalMetricsReaderClusterRoleName(f.owner, managers.Store().GetVersionInfo()), "horizontal-pod-autoscaler", getExternalMetricsReaderPolicyRules()); err != nil {
-		return fmt.Errorf("error adding external metrics provider external metrics reader clusterrole and clusterrolebinding to store: %w", err)
-	}
-	if err := managers.RBACManager().AddClusterRoleBinding(ns, componentdca.GetHPAClusterRoleBindingName(f.owner), f.serviceAccountName, getAuthDelegatorRoleRef()); err != nil {
-		return fmt.Errorf("error adding external metrics provider auth delegator clusterrolebinding to store: %w", err)
+		// rbac
+		rbacResourcesName := componentdca.GetClusterAgentRbacResourcesName(f.owner)
+		if err := managers.RBACManager().AddClusterPolicyRules(ns, rbacResourcesName, f.serviceAccountName, getDCAClusterPolicyRules(f.useDDM, f.useWPA)); err != nil {
+			return fmt.Errorf("error adding external metrics provider dca clusterrole and clusterrolebinding to store: %w", err)
+		}
+		if err := managers.RBACManager().AddClusterPolicyRules("kube-system", componentdca.GetExternalMetricsReaderClusterRoleName(f.owner, managers.Store().GetVersionInfo()), "horizontal-pod-autoscaler", getExternalMetricsReaderPolicyRules()); err != nil {
+			return fmt.Errorf("error adding external metrics provider external metrics reader clusterrole and clusterrolebinding to store: %w", err)
+		}
+		if err := managers.RBACManager().AddClusterRoleBinding(ns, componentdca.GetHPAClusterRoleBindingName(f.owner), f.serviceAccountName, getAuthDelegatorRoleRef()); err != nil {
+			return fmt.Errorf("error adding external metrics provider auth delegator clusterrolebinding to store: %w", err)
+		}
 	}
 
 	// network policies

--- a/controllers/datadogagent/feature/externalmetrics/feature_test.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature_test.go
@@ -85,30 +85,36 @@ func TestExternalMetricsFeature(t *testing.T) {
 		//////////////////////////
 		{
 			Name:          "v2alpha1 external metrics not enabled",
-			DDAv2:         newV2Agent(false, false, false, v2alpha1.DatadogCredentials{}),
+			DDAv2:         newV2Agent(false, true, false, false, v2alpha1.DatadogCredentials{}),
 			WantConfigure: false,
 		},
 		{
 			Name:          "v2alpha1 external metrics enabled",
-			DDAv2:         newV2Agent(true, true, false, v2alpha1.DatadogCredentials{}),
+			DDAv2:         newV2Agent(true, true, true, false, v2alpha1.DatadogCredentials{}),
 			WantConfigure: true,
 			ClusterAgent:  testDCAResources(true, false, false),
 		},
 		{
 			Name:          "v2alpha1 external metrics enabled, wpa controller enabled",
-			DDAv2:         newV2Agent(true, true, true, v2alpha1.DatadogCredentials{}),
+			DDAv2:         newV2Agent(true, true, true, true, v2alpha1.DatadogCredentials{}),
 			WantConfigure: true,
 			ClusterAgent:  testDCAResources(true, true, false),
 		},
 		{
 			Name:          "v2alpha1 external metrics enabled, ddm disabled",
-			DDAv2:         newV2Agent(true, false, false, v2alpha1.DatadogCredentials{}),
+			DDAv2:         newV2Agent(true, true, false, false, v2alpha1.DatadogCredentials{}),
 			WantConfigure: true,
 			ClusterAgent:  testDCAResources(false, false, false),
 		},
 		{
 			Name:          "v2alpha1 external metrics enabled, secrets set",
-			DDAv2:         newV2Agent(true, true, false, secretV2),
+			DDAv2:         newV2Agent(true, true, true, false, secretV2),
+			WantConfigure: true,
+			ClusterAgent:  testDCAResources(true, false, true),
+		},
+		{
+			Name:          "v2alpha1 external metrics enabled, secrets set, registerEndpoint disabled",
+			DDAv2:         newV2Agent(true, false, true, false, secretV2),
 			WantConfigure: true,
 			ClusterAgent:  testDCAResources(true, false, true),
 		},
@@ -135,12 +141,13 @@ func TestExternalMetricsFeature(t *testing.T) {
 // 	}
 // }
 
-func newV2Agent(enabled, useDDM, wpaController bool, secret v2alpha1.DatadogCredentials) *v2alpha1.DatadogAgent {
+func newV2Agent(enabled, registerEndpoint, useDDM, wpaController bool, secret v2alpha1.DatadogCredentials) *v2alpha1.DatadogAgent {
 	return &v2alpha1.DatadogAgent{
 		Spec: v2alpha1.DatadogAgentSpec{
 			Features: &v2alpha1.DatadogFeatures{
 				ExternalMetricsServer: &v2alpha1.ExternalMetricsServerFeatureConfig{
 					Enabled:           apiutils.NewBoolPointer(enabled),
+					RegisterEndpoint:  apiutils.NewBoolPointer(registerEndpoint),
 					WPAController:     apiutils.NewBoolPointer(wpaController),
 					UseDatadogMetrics: apiutils.NewBoolPointer(useDDM),
 					Port:              apiutils.NewInt32Pointer(8443),

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -81,6 +81,7 @@ spec:
 | features.externalMetricsServer.endpoint.credentials.appSecret.secretName | SecretName is the name of the secret. |
 | features.externalMetricsServer.endpoint.url | URL defines the endpoint URL. |
 | features.externalMetricsServer.port | Port specifies the metricsProvider External Metrics Server service port. Default: 8443 |
+| features.externalMetricsServer.registerEndpoint | RegisterEndpoint registers the External Metrics endpoint as an APIService Default: true |
 | features.externalMetricsServer.useDatadogMetrics | UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries). Default: true |
 | features.externalMetricsServer.wpaController | WPAController enables the informer and controller of the Watermark Pod Autoscaler. NOTE: The Watermark Pod Autoscaler controller needs to be installed. See also: https://github.com/DataDog/watermarkpodautoscaler. Default: false |
 | features.kubeStateMetricsCore.conf.configData | ConfigData corresponds to the configuration file content. |


### PR DESCRIPTION
### What does this PR do?

This PR allows the user to enable creating an external metrics server while still disabling registering the external metrics server as an APIService.

It allows this by adding the option `registerEndpoint` to the `externalMetrics` feature to allow the user to disable registering external-metrics server as an APIService

### Motivation

This allows the user to use other external-metrics providers (such as KEDA) in the cluster, but also use the datadog cluster-agent as a metrics proxy to datadog.

### Additional Notes

`registerEndpoint` is defaulted to true in `externalMetrics` feature for backward compatibility. By default we register the endpoint if the user enables external metrics server.


### Describe your test plan
We can test this by deploying the agent using the operator on a kind cluster locally.

Steps:
- Build and deploy the operator as described here:
    - Build the operator image `make IMG=test/operator:test docker-build`
    - Load the image into `kind` : `kind load docker-image test/operator:test`
    - Deploy the operator: `make IMG=test/operator:test deploy`
- Deploy the agent and cluster agent as described [here](https://github.com/DataDog/datadog-operator/blob/main/docs/how-to-contribute.md#deploy-a-basic-v2alpha1datadogagent-resource)
    - Instead of using the Datadog definition in `examples/datadogagent/v2alpha1/min.yaml` by the following definition
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  features:
    externalMetricsServer:
      enabled: true
      useDatadogMetrics: false
      registerEndpoint: true
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  override:
    clusterAgent:
      replicas: 2
    nodeAgent:
      tolerations:
        - operator: Exists
```
- Check if the endpoint is registered or not by running `kubectl get apiservices.apiregistration.k8s.io | grep external `. It should produce an empty output if the endpoint is not registered. If it is registered, the output should show the endpoint name with status being `True` (Example: `v1beta1.external.metrics.k8s.io        system/datadog-cluster-agent-metrics-server   True        12s` )

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
