### PR TITLE
[CECO-721] Operator metrics forwarder : drop application key dependency

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -58,13 +58,13 @@ const (
 	featureEnabledFormat        = "%s.%s.feature.enabled"
 	datadogOperatorSourceType   = "datadog"
 	defaultbaseURL              = "https://api.datadoghq.com"
+	// We use an empty application key as solely the API key is necessary to send metrics and events
+	emptyAppKey = ""
 )
 
 var (
 	// ErrEmptyAPIKey empty APIKey error
 	ErrEmptyAPIKey = errors.New("empty api key")
-	// ErrEmptyAppKey empty AppKey error
-	ErrEmptyAppKey = errors.New("empty app key")
 	// errInitValue used to initialize lastReconcileErr
 	errInitValue = errors.New("last error init value")
 )
@@ -75,16 +75,14 @@ type delegatedAPI interface {
 	delegatedSendReconcileMetric(float64, []string) error
 	delegatedSendFeatureMetric(string) error
 	delegatedSendEvent(string, EventType) error
-	delegatedValidateCreds(string, string) (*api.Client, error)
+	delegatedValidateCreds(string) (*api.Client, error)
 }
 
 // hashKeys is used to detect if credentials have changed
 // hashKeys is NOT a security function
-func hashKeys(apiKey, appKey string) uint64 {
+func hashKeys(apiKey string) uint64 {
 	h := fnv.New64()
 	_, _ = h.Write([]byte(apiKey))
-	_, _ = h.Write([]byte(appKey))
-
 	return h.Sum64()
 }
 
@@ -99,7 +97,6 @@ type metricsForwarder struct {
 	v2Enabled    bool
 	platformInfo *kubernetes.PlatformInfo
 	apiKey       string
-	appKey       string
 	clusterName  string
 	labels       map[string]string
 	dsStatus     *commonv1.DaemonSetStatus
@@ -262,13 +259,12 @@ func (mf *metricsForwarder) setupV2() error {
 	mf.dcaStatus = status.ClusterAgent
 	mf.ccrStatus = status.ClusterChecksRunner
 
-	// set apiKey and appKey
-	apiKey, appKey, err := mf.getCredentialsV2(dda)
+	// set apiKey
+	apiKey, err := mf.getCredentialsV2(dda)
 	if err != nil {
 		return err
 	}
 	mf.apiKey = apiKey
-	mf.appKey = appKey
 	return nil
 }
 
@@ -290,13 +286,12 @@ func (mf *metricsForwarder) setup() error {
 	mf.dcaStatus = dda.Status.ClusterAgent
 	mf.ccrStatus = dda.Status.ClusterChecksRunner
 
-	// set apiKey and appKey
-	apiKey, appKey, err := mf.getCredentials(dda)
+	// set apiKey
+	apiKey, err := mf.getCredentials(dda)
 	if err != nil {
 		return err
 	}
 	mf.apiKey = apiKey
-	mf.appKey = appKey
 	return nil
 }
 
@@ -316,7 +311,7 @@ func (mf *metricsForwarder) connectToDatadogAPI() (bool, error) {
 		return false, nil
 	}
 	mf.logger.Info("Initializing Datadog metrics forwarder")
-	if err = mf.initAPIClient(mf.apiKey, mf.appKey); err != nil {
+	if err = mf.initAPIClient(mf.apiKey); err != nil {
 		mf.logger.Error(err, "cannot retrieve Datadog metrics forwarder to send deployment metrics, will retry later...")
 		return false, nil
 	}
@@ -340,7 +335,7 @@ func (mf *metricsForwarder) forwardMetrics() error {
 		mf.logger.Error(err, "cannot get Datadog credentials")
 		return err
 	}
-	if err = mf.updateCredsIfNeeded(mf.apiKey, mf.appKey); err != nil {
+	if err = mf.updateCredsIfNeeded(mf.apiKey); err != nil {
 		mf.logger.Error(err, "cannot update Datadog credentials")
 		return err
 	}
@@ -439,35 +434,35 @@ func (mf *metricsForwarder) setLastReconcileError(newErr error) {
 }
 
 // initAPIClient initializes and validates the Datadog API client
-func (mf *metricsForwarder) initAPIClient(apiKey, appKey string) error {
+func (mf *metricsForwarder) initAPIClient(apiKey string) error {
 	if mf.delegator == nil {
 		mf.delegator = mf
 	}
-	datadogClient, err := mf.validateCreds(apiKey, appKey)
+	datadogClient, err := mf.validateCreds(apiKey)
 	if err != nil {
 		return err
 	}
 	mf.datadogClient = datadogClient
-	mf.keysHash = hashKeys(apiKey, appKey)
+	mf.keysHash = hashKeys(apiKey)
 	return nil
 }
 
-// updateCredsIfNeeded used to update Datadog apiKey and appKey if they change
-func (mf *metricsForwarder) updateCredsIfNeeded(apiKey, appKey string) error {
-	if mf.keysHash != hashKeys(apiKey, appKey) {
-		return mf.initAPIClient(apiKey, appKey)
+// updateCredsIfNeeded used to update Datadog apiKey if it changes
+func (mf *metricsForwarder) updateCredsIfNeeded(apiKey string) error {
+	if mf.keysHash != hashKeys(apiKey) {
+		return mf.initAPIClient(apiKey)
 	}
 	return nil
 }
 
-// validateCreds returns validates the creds by querying the Datadog API
-func (mf *metricsForwarder) validateCreds(apiKey, appKey string) (*api.Client, error) {
-	return mf.delegator.delegatedValidateCreds(apiKey, appKey)
+// validateCreds returns validates the API key by querying the Datadog API
+func (mf *metricsForwarder) validateCreds(apiKey string) (*api.Client, error) {
+	return mf.delegator.delegatedValidateCreds(apiKey)
 }
 
 // delegatedValidateCreds is separated from validateCreds to facilitate mocking the Datadog API
-func (mf *metricsForwarder) delegatedValidateCreds(apiKey, appKey string) (*api.Client, error) {
-	datadogClient := api.NewClient(apiKey, appKey)
+func (mf *metricsForwarder) delegatedValidateCreds(apiKey string) (*api.Client, error) {
+	datadogClient := api.NewClient(apiKey, emptyAppKey)
 	datadogClient.SetBaseUrl(mf.baseURL)
 	valid, err := datadogClient.Validate()
 	if err != nil {
@@ -611,13 +606,14 @@ func (mf *metricsForwarder) getDatadogAgentV2() (*v2alpha1.DatadogAgent, error) 
 	return dda, err
 }
 
-func (mf *metricsForwarder) getCredentialsV2(dda *v2alpha1.DatadogAgent) (string, string, error) {
+// getCredentialsV2 retrieves the api key configured in the DatadogAgent
+func (mf *metricsForwarder) getCredentialsV2(dda *v2alpha1.DatadogAgent) (string, error) {
 	if dda.Spec.Global == nil || dda.Spec.Global.Credentials == nil {
-		return "", "", fmt.Errorf("credentials not configured in the DatadogAgent")
+		return "", fmt.Errorf("credentials not configured in the DatadogAgent")
 	}
 
 	var err error
-	apiKey, appKey := "", ""
+	apiKey := ""
 
 	defaultSecretName := v2alpha1.GetDefaultCredentialsSecretName(dda)
 
@@ -627,50 +623,36 @@ func (mf *metricsForwarder) getCredentialsV2(dda *v2alpha1.DatadogAgent) (string
 		_, secretName, secretKeyName := v2alpha1.GetAPIKeySecret(dda.Spec.Global.Credentials, defaultSecretName)
 		apiKey, err = mf.getKeyFromSecret(dda.Namespace, secretName, secretKeyName)
 		if err != nil {
-			return "", "", err
-		}
-	}
-
-	if dda.Spec.Global != nil && dda.Spec.Global.Credentials != nil && dda.Spec.Global.Credentials.AppKey != nil && *dda.Spec.Global.Credentials.AppKey != "" {
-		appKey = *dda.Spec.Global.Credentials.AppKey
-	} else {
-		_, secretName, secretKeyName := v2alpha1.GetAppKeySecret(dda.Spec.Global.Credentials, defaultSecretName)
-		appKey, err = mf.getKeyFromSecret(dda.Namespace, secretName, secretKeyName)
-		if err != nil {
-			return "", "", err
+			return "", err
 		}
 	}
 
 	if apiKey == "" {
-		return "", "", ErrEmptyAPIKey
+		return "", ErrEmptyAPIKey
 	}
 
-	if appKey == "" {
-		return "", "", ErrEmptyAppKey
-	}
-
-	return mf.resolveSecretsIfNeeded(apiKey, appKey)
+	return mf.resolveSecretsIfNeeded(apiKey)
 }
 
 // getCredentials returns the Datadog API Key and App Key, it returns an error if one key is missing
-func (mf *metricsForwarder) getCredentials(dda *v1alpha1.DatadogAgent) (string, string, error) {
-	apiKey, appKey, err := mf.getCredsFromDatadogAgent(dda)
+func (mf *metricsForwarder) getCredentials(dda *v1alpha1.DatadogAgent) (string, error) {
+	apiKey, err := mf.getCredsFromDatadogAgent(dda)
 	if err != nil {
-		if errors.Is(err, ErrEmptyAPIKey) || errors.Is(err, ErrEmptyAppKey) {
+		if errors.Is(err, ErrEmptyAPIKey) {
 			// Fallback to the operator config in this case
-			mf.logger.Info("API and/or App key aren't defined in the Custom Resource, getting credentials from the operator config")
+			mf.logger.Info("API key isn't defined in the Custom Resource, getting credentials from the operator config")
 			var creds config.Creds
 			creds, err = mf.credsManager.GetCredentials()
-			return creds.APIKey, creds.AppKey, err
+			return creds.APIKey, err
 		}
 	}
 
-	return apiKey, appKey, err
+	return apiKey, err
 }
 
-func (mf *metricsForwarder) getCredsFromDatadogAgent(dda *v1alpha1.DatadogAgent) (string, string, error) {
+func (mf *metricsForwarder) getCredsFromDatadogAgent(dda *v1alpha1.DatadogAgent) (string, error) {
 	var err error
-	apiKey, appKey := "", ""
+	apiKey := ""
 
 	if dda.Spec.Credentials.APIKey != "" {
 		apiKey = dda.Spec.Credentials.APIKey
@@ -678,70 +660,51 @@ func (mf *metricsForwarder) getCredsFromDatadogAgent(dda *v1alpha1.DatadogAgent)
 		_, secretName, secretKeyName := v1alpha1.GetAPIKeySecret(&dda.Spec.Credentials.DatadogCredentials, v1alpha1.GetDefaultCredentialsSecretName(dda))
 		apiKey, err = mf.getKeyFromSecret(dda.Namespace, secretName, secretKeyName)
 		if err != nil {
-			return "", "", err
-		}
-	}
-
-	if dda.Spec.Credentials.AppKey != "" {
-		appKey = dda.Spec.Credentials.AppKey
-	} else {
-		_, secretName, secretKeyName := v1alpha1.GetAppKeySecret(&dda.Spec.Credentials.DatadogCredentials, v1alpha1.GetDefaultCredentialsSecretName(dda))
-		appKey, err = mf.getKeyFromSecret(dda.Namespace, secretName, secretKeyName)
-		if err != nil {
-			return "", "", err
+			return "", err
 		}
 	}
 
 	if apiKey == "" {
-		return "", "", ErrEmptyAPIKey
+		return "", ErrEmptyAPIKey
 	}
 
-	if appKey == "" {
-		return "", "", ErrEmptyAppKey
-	}
-
-	return mf.resolveSecretsIfNeeded(apiKey, appKey)
+	return mf.resolveSecretsIfNeeded(apiKey)
 }
 
 // resolveSecretsIfNeeded calls the secret backend if creds are encrypted
-func (mf *metricsForwarder) resolveSecretsIfNeeded(apiKey, appKey string) (string, string, error) {
-	if !secrets.IsEnc(apiKey) && !secrets.IsEnc(appKey) {
+func (mf *metricsForwarder) resolveSecretsIfNeeded(apiKey string) (string, error) {
+	if !secrets.IsEnc(apiKey) {
 		// Credentials are not encrypted
-		return apiKey, appKey, nil
+		return apiKey, nil
 	}
 
 	// Try to get secrets from the local cache
-	if decAPIKey, decAppKey, cacheHit := mf.getSecretsFromCache(apiKey, appKey); cacheHit {
+	if decAPIKey, cacheHit := mf.getSecretsFromCache(apiKey); cacheHit {
 		// Creds are found in local cache
-		return decAPIKey, decAppKey, nil
+		return decAPIKey, nil
 	}
 
 	// Cache miss, call the secret decryptor
-	decrypted, err := mf.decryptor.Decrypt([]string{apiKey, appKey})
+	decrypted, err := mf.decryptor.Decrypt([]string{apiKey})
 	if err != nil {
 		mf.logger.Error(err, "cannot decrypt secrets")
-		return "", "", err
+		return "", err
 	}
 
 	// Update the local cache with the decrypted secrets
 	mf.resetSecretsCache(decrypted)
 
-	return decrypted[apiKey], decrypted[appKey], nil
+	return decrypted[apiKey], nil
 }
 
 // getSecretsFromCache returns the cached and decrypted values of encrypted creds
-func (mf *metricsForwarder) getSecretsFromCache(encAPIKey, encAppKey string) (string, string, bool) {
+func (mf *metricsForwarder) getSecretsFromCache(encAPIKey string) (string, bool) {
 	decAPIKey, found := mf.creds.Load(encAPIKey)
 	if !found {
-		return "", "", false
+		return "", false
 	}
 
-	decAppKey, found := mf.creds.Load(encAppKey)
-	if !found {
-		return "", "", false
-	}
-
-	return decAPIKey.(string), decAppKey.(string), true
+	return decAPIKey.(string), true
 }
 
 // resetSecretsCache updates the local secret cache with new secret values

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -58,9 +58,9 @@ func (c *fakeMetricsForwarder) delegatedSendFeatureMetric(feature string) error 
 	return nil
 }
 
-func (c *fakeMetricsForwarder) delegatedValidateCreds(apiKey, appKey string) (*api.Client, error) {
-	c.Called(apiKey, appKey)
-	if strings.Contains(apiKey, "invalid") || strings.Contains(appKey, "invalid") {
+func (c *fakeMetricsForwarder) delegatedValidateCreds(apiKey string) (*api.Client, error) {
+	c.Called(apiKey)
+	if strings.Contains(apiKey, "invalid") {
 		return nil, errors.New("invalid creds")
 	}
 	return &api.Client{}, nil
@@ -322,7 +322,6 @@ func TestMetricsForwarder_updateCredsIfNeeded(t *testing.T) {
 		name     string
 		loadFunc func() (*metricsForwarder, *fakeMetricsForwarder)
 		apiKey   string
-		appKey   string
 		wantErr  bool
 		wantFunc func(*metricsForwarder, *fakeMetricsForwarder) error
 	}{
@@ -332,14 +331,13 @@ func TestMetricsForwarder_updateCredsIfNeeded(t *testing.T) {
 				f := &fakeMetricsForwarder{}
 				return &metricsForwarder{
 					delegator: f,
-					keysHash:  hashKeys("sameApiKey", "sameAppKey"),
+					keysHash:  hashKeys("sameApiKey"),
 				}, f
 			},
 			apiKey:  "sameApiKey",
-			appKey:  "sameAppKey",
 			wantErr: false,
 			wantFunc: func(m *metricsForwarder, f *fakeMetricsForwarder) error {
-				if m.keysHash != hashKeys("sameApiKey", "sameAppKey") {
+				if m.keysHash != hashKeys("sameApiKey") {
 					return errors.New("Wrong hash update")
 				}
 				if !f.AssertNumberOfCalls(t, "delegatedValidateCreds", 0) {
@@ -352,40 +350,16 @@ func TestMetricsForwarder_updateCredsIfNeeded(t *testing.T) {
 			name: "new apiKey, update",
 			loadFunc: func() (*metricsForwarder, *fakeMetricsForwarder) {
 				f := &fakeMetricsForwarder{}
-				f.On("delegatedValidateCreds", "newApiKey", "sameAppKey")
+				f.On("delegatedValidateCreds", "newApiKey")
 				return &metricsForwarder{
 					delegator: f,
-					keysHash:  hashKeys("oldApiKey", "sameAppKey"),
+					keysHash:  hashKeys("oldApiKey"),
 				}, f
 			},
 			apiKey:  "newApiKey",
-			appKey:  "sameAppKey",
 			wantErr: false,
 			wantFunc: func(m *metricsForwarder, f *fakeMetricsForwarder) error {
-				if m.keysHash != hashKeys("newApiKey", "sameAppKey") {
-					return errors.New("Wrong hash update")
-				}
-				if !f.AssertNumberOfCalls(t, "delegatedValidateCreds", 1) {
-					return errors.New("Wrong number of calls")
-				}
-				return nil
-			},
-		},
-		{
-			name: "new appKey, update",
-			loadFunc: func() (*metricsForwarder, *fakeMetricsForwarder) {
-				f := &fakeMetricsForwarder{}
-				f.On("delegatedValidateCreds", "sameApiKey", "newAppKey")
-				return &metricsForwarder{
-					delegator: f,
-					keysHash:  hashKeys("sameApiKey", "oldAppKey"),
-				}, f
-			},
-			apiKey:  "sameApiKey",
-			appKey:  "newAppKey",
-			wantErr: false,
-			wantFunc: func(m *metricsForwarder, f *fakeMetricsForwarder) error {
-				if m.keysHash != hashKeys("sameApiKey", "newAppKey") {
+				if m.keysHash != hashKeys("newApiKey") {
 					return errors.New("Wrong hash update")
 				}
 				if !f.AssertNumberOfCalls(t, "delegatedValidateCreds", 1) {
@@ -398,17 +372,16 @@ func TestMetricsForwarder_updateCredsIfNeeded(t *testing.T) {
 			name: "invalid creds, no update",
 			loadFunc: func() (*metricsForwarder, *fakeMetricsForwarder) {
 				f := &fakeMetricsForwarder{}
-				f.On("delegatedValidateCreds", "invalidApiKey", "invalidAppKey")
+				f.On("delegatedValidateCreds", "invalidApiKey")
 				return &metricsForwarder{
 					delegator: f,
-					keysHash:  hashKeys("oldApiKey", "oldAppKey"),
+					keysHash:  hashKeys("oldApiKey"),
 				}, f
 			},
 			apiKey:  "invalidApiKey",
-			appKey:  "invalidAppKey",
 			wantErr: true,
 			wantFunc: func(m *metricsForwarder, f *fakeMetricsForwarder) error {
-				if m.keysHash != hashKeys("oldApiKey", "oldAppKey") {
+				if m.keysHash != hashKeys("oldApiKey") {
 					return errors.New("Wrong hash update")
 				}
 				if !f.AssertNumberOfCalls(t, "delegatedValidateCreds", 1) {
@@ -421,7 +394,7 @@ func TestMetricsForwarder_updateCredsIfNeeded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dd, f := tt.loadFunc()
-			if err := dd.updateCredsIfNeeded(tt.apiKey, tt.appKey); (err != nil) != tt.wantErr {
+			if err := dd.updateCredsIfNeeded(tt.apiKey); (err != nil) != tt.wantErr {
 				t.Errorf("metricsForwarder.updateCredsIfNeeded() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err := tt.wantFunc(dd, f); err != nil {
@@ -433,10 +406,8 @@ func TestMetricsForwarder_updateCredsIfNeeded(t *testing.T) {
 
 func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 	apiKey := "foundAPIKey"
-	appKey := "foundAppKey"
 
 	encAPIKey := "ENC[APIKey]"
-	encAppKey := "ENC[AppKey]"
 
 	type fields struct {
 		client client.Client
@@ -450,7 +421,6 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 		fields     fields
 		args       args
 		wantAPIKey string
-		wantAppKey string
 		wantErr    bool
 		wantFunc   func(*metricsForwarder, *secrets.DummyDecryptor) error
 	}{
@@ -463,29 +433,11 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 				dda: testV2.NewDatadogAgent("foo", "bar", &datadoghqv2alpha1.GlobalConfig{
 					Credentials: &datadoghqv2alpha1.DatadogCredentials{
 						APIKey: apiutils.NewStringPointer(apiKey),
-						AppKey: apiutils.NewStringPointer(appKey),
 					},
 				}),
 			},
 			wantAPIKey: "foundAPIKey",
-			wantAppKey: "foundAppKey",
 			wantErr:    false,
-		},
-		{
-			name: "appKey missing",
-			fields: fields{
-				client: fake.NewFakeClient(),
-			},
-			args: args{
-				dda: testV2.NewDatadogAgent("foo", "bar", &datadoghqv2alpha1.GlobalConfig{
-					Credentials: &datadoghqv2alpha1.DatadogCredentials{
-						APIKey: apiutils.NewStringPointer(apiKey),
-					},
-				}),
-			},
-			wantAPIKey: "",
-			wantAppKey: "",
-			wantErr:    true,
 		},
 		{
 			name: "creds found in secrets",
@@ -498,10 +450,6 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 						APISecret: &commonv1.SecretConfig{
 							SecretName: "datadog-creds-api",
 							KeyName:    "datadog_api_key",
-						},
-						AppSecret: &commonv1.SecretConfig{
-							SecretName: "datadog-creds-app",
-							KeyName:    "application_key",
 						},
 					},
 				}),
@@ -516,52 +464,9 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 						},
 					}
 					_ = m.k8sClient.Create(context.TODO(), secret)
-
-					secret = &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "datadog-creds-app",
-							Namespace: "foo",
-						},
-						Data: map[string][]byte{
-							"application_key": []byte(appKey),
-						},
-					}
-					_ = m.k8sClient.Create(context.TODO(), secret)
 				},
 			},
 			wantAPIKey: "foundAPIKey",
-			wantAppKey: "foundAppKey",
-			wantErr:    false,
-		},
-		{
-			name: "apiKey found in CR, appKey found in secret",
-			fields: fields{
-				client: fake.NewFakeClient(),
-			},
-			args: args{
-				dda: testV2.NewDatadogAgent("foo", "bar", &datadoghqv2alpha1.GlobalConfig{
-					Credentials: &datadoghqv2alpha1.DatadogCredentials{
-						APIKey: &apiKey,
-						AppSecret: &commonv1.SecretConfig{
-							SecretName: "datadog-creds",
-						},
-					},
-				}),
-				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
-					secret := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "datadog-creds",
-							Namespace: "foo",
-						},
-						Data: map[string][]byte{
-							"app_key": []byte(appKey),
-						},
-					}
-					_ = m.k8sClient.Create(context.TODO(), secret)
-				},
-			},
-			wantAPIKey: "foundAPIKey",
-			wantAppKey: "foundAppKey",
 			wantErr:    false,
 		},
 		{
@@ -573,17 +478,14 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 				dda: testV2.NewDatadogAgent("foo", "bar", &datadoghqv2alpha1.GlobalConfig{
 					Credentials: &datadoghqv2alpha1.DatadogCredentials{
 						APIKey: apiutils.NewStringPointer(encAPIKey),
-						AppKey: apiutils.NewStringPointer(encAppKey),
 					},
 				}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					m.cleanSecretsCache()
 					m.creds.Store(encAPIKey, "cachedAPIKey")
-					m.creds.Store(encAppKey, "cachedAppKey")
 				},
 			},
 			wantAPIKey: "cachedAPIKey",
-			wantAppKey: "cachedAppKey",
 			wantErr:    false,
 			wantFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) error {
 				if !d.AssertNumberOfCalls(t, "Decrypt", 0) {
@@ -602,25 +504,19 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 				dda: testV2.NewDatadogAgent("foo", "bar", &datadoghqv2alpha1.GlobalConfig{
 					Credentials: &datadoghqv2alpha1.DatadogCredentials{
 						APIKey: apiutils.NewStringPointer(encAPIKey),
-						AppKey: apiutils.NewStringPointer(encAppKey),
 					},
 				}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					m.cleanSecretsCache()
-					d.On("Decrypt", []string{encAPIKey, encAppKey}).Once()
+					d.On("Decrypt", []string{encAPIKey}).Once()
 				},
 			},
 			wantAPIKey: "DEC[ENC[APIKey]]",
-			wantAppKey: "DEC[ENC[AppKey]]",
 			wantErr:    false,
 			wantFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) error {
 				v, found := m.creds.Load(encAPIKey)
 				assert.True(t, found)
 				assert.Equal(t, "DEC[ENC[APIKey]]", v)
-
-				v, found = m.creds.Load(encAppKey)
-				assert.True(t, found)
-				assert.Equal(t, "DEC[ENC[AppKey]]", v)
 
 				d.AssertExpectations(t)
 				return nil
@@ -648,16 +544,13 @@ func TestReconcileDatadogAgent_getCredentialsV2(t *testing.T) {
 			if tt.args.loadFunc != nil {
 				tt.args.loadFunc(mf, d)
 			}
-			apiKey, appKey, err := mf.getCredentialsV2(tt.args.dda)
+			apiKey, err := mf.getCredentialsV2(tt.args.dda)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("metricsForwarder.getCredentialsV2() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if apiKey != tt.wantAPIKey {
 				t.Errorf("metricsForwarder.getCredentialsV2() apiKey = %v, want %v", apiKey, tt.wantAPIKey)
-			}
-			if appKey != tt.wantAppKey {
-				t.Errorf("metricsForwarder.getCredentialsV2() appKey = %v, want %v", appKey, tt.wantAppKey)
 			}
 			if tt.wantFunc != nil {
 				if err := tt.wantFunc(mf, d); err != nil {
@@ -681,7 +574,6 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 		fields     fields
 		args       args
 		wantAPIKey string
-		wantAPPKey string
 		wantErr    bool
 		wantFunc   func(*metricsForwarder, *secrets.DummyDecryptor) error
 	}{
@@ -696,35 +588,12 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 						Creds: &datadoghqv1alpha1.AgentCredentials{
 							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
 								APIKey: "foundApiKey",
-								AppKey: "foundAppKey",
 							},
 						},
 					}),
 			},
 			wantAPIKey: "foundApiKey",
-			wantAPPKey: "foundAppKey",
 			wantErr:    false,
-		},
-		{
-			name: "appKey missing",
-			fields: fields{
-				client: fake.NewFakeClient(),
-			},
-			args: args{
-				dda: test.NewDefaultedDatadogAgent(
-					"foo",
-					"bar",
-					&test.NewDatadogAgentOptions{
-						Creds: &datadoghqv1alpha1.AgentCredentials{
-							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
-								APIKey: "foundApiKey",
-							},
-						},
-					}),
-			},
-			wantAPIKey: "",
-			wantAPPKey: "",
-			wantErr:    true,
 		},
 		{
 			name: "creds found in secrets",
@@ -740,10 +609,6 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 									SecretName: "datadog-creds-api",
 									KeyName:    "datadog_api_key",
 								},
-								APPSecret: &commonv1.SecretConfig{
-									SecretName: "datadog-creds-app",
-									KeyName:    "application_key",
-								},
 							},
 						},
 					}),
@@ -758,21 +623,9 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 						},
 					}
 					_ = m.k8sClient.Create(context.TODO(), secret)
-
-					secret = &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "datadog-creds-app",
-							Namespace: "foo",
-						},
-						Data: map[string][]byte{
-							"application_key": []byte("foundAppKey"),
-						},
-					}
-					_ = m.k8sClient.Create(context.TODO(), secret)
 				},
 			},
 			wantAPIKey: "foundApiKey",
-			wantAPPKey: "foundAppKey",
 			wantErr:    false,
 		},
 		{
@@ -786,7 +639,6 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 						Creds: &datadoghqv1alpha1.AgentCredentials{
 							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
 								APIKeyExistingSecret: "datadog-creds",
-								AppKeyExistingSecret: "datadog-creds",
 							},
 						},
 					}),
@@ -798,80 +650,12 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 						},
 						Data: map[string][]byte{
 							"api_key": []byte("foundApiKey"),
-							"app_key": []byte("foundAppKey"),
 						},
 					}
 					_ = m.k8sClient.Create(context.TODO(), secret)
 				},
 			},
 			wantAPIKey: "foundApiKey",
-			wantAPPKey: "foundAppKey",
-			wantErr:    false,
-		},
-		{
-			name: "apiKey found in CR, appKey found in secret",
-			fields: fields{
-				client: fake.NewFakeClient(),
-			},
-			args: args{
-				dda: test.NewDefaultedDatadogAgent("foo", "bar",
-					&test.NewDatadogAgentOptions{
-						Creds: &datadoghqv1alpha1.AgentCredentials{
-							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
-								APIKey: "foundApiKey",
-								APPSecret: &commonv1.SecretConfig{
-									SecretName: "datadog-creds",
-								},
-							},
-						},
-					}),
-				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
-					secret := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "datadog-creds",
-							Namespace: "foo",
-						},
-						Data: map[string][]byte{
-							"app_key": []byte("foundAppKey"),
-						},
-					}
-					_ = m.k8sClient.Create(context.TODO(), secret)
-				},
-			},
-			wantAPIKey: "foundApiKey",
-			wantAPPKey: "foundAppKey",
-			wantErr:    false,
-		},
-		{
-			name: "apiKey found in CR, appKey found in deprecated secret",
-			fields: fields{
-				client: fake.NewFakeClient(),
-			},
-			args: args{
-				dda: test.NewDefaultedDatadogAgent("foo", "bar",
-					&test.NewDatadogAgentOptions{
-						Creds: &datadoghqv1alpha1.AgentCredentials{
-							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
-								APIKey:               "foundApiKey",
-								AppKeyExistingSecret: "datadog-creds",
-							},
-						},
-					}),
-				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
-					secret := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "datadog-creds",
-							Namespace: "foo",
-						},
-						Data: map[string][]byte{
-							"app_key": []byte("foundAppKey"),
-						},
-					}
-					_ = m.k8sClient.Create(context.TODO(), secret)
-				},
-			},
-			wantAPIKey: "foundApiKey",
-			wantAPPKey: "foundAppKey",
 			wantErr:    false,
 		},
 		{
@@ -885,18 +669,15 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 						Creds: &datadoghqv1alpha1.AgentCredentials{
 							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
 								APIKey: "ENC[ApiKey]",
-								AppKey: "ENC[AppKey]",
 							},
 						},
 					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					m.cleanSecretsCache()
 					m.creds.Store("ENC[ApiKey]", "cachedApiKey")
-					m.creds.Store("ENC[AppKey]", "cachedAppKey")
 				},
 			},
 			wantAPIKey: "cachedApiKey",
-			wantAPPKey: "cachedAppKey",
 			wantErr:    false,
 			wantFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) error {
 				if !d.AssertNumberOfCalls(t, "Decrypt", 0) {
@@ -917,26 +698,20 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 						Creds: &datadoghqv1alpha1.AgentCredentials{
 							DatadogCredentials: datadoghqv1alpha1.DatadogCredentials{
 								APIKey: "ENC[ApiKey]",
-								AppKey: "ENC[AppKey]",
 							},
 						},
 					}),
 				loadFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) {
 					m.cleanSecretsCache()
-					d.On("Decrypt", []string{"ENC[ApiKey]", "ENC[AppKey]"}).Once()
+					d.On("Decrypt", []string{"ENC[ApiKey]"}).Once()
 				},
 			},
 			wantAPIKey: "DEC[ENC[ApiKey]]",
-			wantAPPKey: "DEC[ENC[AppKey]]",
 			wantErr:    false,
 			wantFunc: func(m *metricsForwarder, d *secrets.DummyDecryptor) error {
 				v, found := m.creds.Load("ENC[ApiKey]")
 				assert.True(t, found)
 				assert.Equal(t, "DEC[ENC[ApiKey]]", v)
-
-				v, found = m.creds.Load("ENC[AppKey]")
-				assert.True(t, found)
-				assert.Equal(t, "DEC[ENC[AppKey]]", v)
 
 				d.AssertExpectations(t)
 				return nil
@@ -954,16 +729,13 @@ func TestReconcileDatadogAgent_getCredsFromDatadogAgent(t *testing.T) {
 			if tt.args.loadFunc != nil {
 				tt.args.loadFunc(mf, d)
 			}
-			apiKey, appKey, err := mf.getCredsFromDatadogAgent(tt.args.dda)
+			apiKey, err := mf.getCredsFromDatadogAgent(tt.args.dda)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("metricsForwarder.getCredsFromDatadogAgent() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if apiKey != tt.wantAPIKey {
 				t.Errorf("metricsForwarder.getCredsFromDatadogAgent() apiKey = %v, want %v", apiKey, tt.wantAPIKey)
-			}
-			if appKey != tt.wantAPPKey {
-				t.Errorf("metricsForwarder.getCredsFromDatadogAgent() appKey = %v, want %v", appKey, tt.wantAPPKey)
 			}
 			if tt.wantFunc != nil {
 				if err := tt.wantFunc(mf, d); err != nil {
@@ -1216,14 +988,10 @@ func Test_metricsForwarder_cleanSecretsCache(t *testing.T) {
 	}
 
 	mf.creds.Store("k", "v")
-	mf.creds.Store("kk", "vv")
 
 	mf.cleanSecretsCache()
 
 	_, found := mf.creds.Load("k")
-	assert.False(t, found)
-
-	_, found = mf.creds.Load("kk")
 	assert.False(t, found)
 
 	mf.creds.Range(func(k, v interface{}) bool {
@@ -1265,66 +1033,44 @@ func Test_metricsForwarder_resetSecretsCache(t *testing.T) {
 func Test_metricsForwarder_getSecretsFromCache(t *testing.T) {
 	type args struct {
 		encAPIKey string
-		encAPPKey string
 	}
 	tests := []struct {
 		name   string
 		cached map[string]string
 		args   args
 		want   string
-		want1  string
-		want2  bool
+		want1  bool
 	}{
 		{
 			name: "cache hit",
 			cached: map[string]string{
 				"apiKey": "decApiKey",
-				"appKey": "decAppKey",
 			},
 			args: args{
 				encAPIKey: "apiKey",
-				encAPPKey: "appKey",
 			},
 			want:  "decApiKey",
-			want1: "decAppKey",
-			want2: true,
+			want1: true,
 		},
 		{
 			name: "apiKey cache miss",
 			cached: map[string]string{
-				"appKey": "decAppKey",
+				"foo": "bar",
 			},
 			args: args{
 				encAPIKey: "apiKey",
-				encAPPKey: "appKey",
 			},
 			want:  "",
-			want1: "",
-			want2: false,
-		},
-		{
-			name: "appKey cache miss",
-			cached: map[string]string{
-				"apiKey": "decApiKey",
-			},
-			args: args{
-				encAPIKey: "apiKey",
-				encAPPKey: "appKey",
-			},
-			want:  "",
-			want1: "",
-			want2: false,
+			want1: false,
 		},
 		{
 			name:   "total cache miss",
 			cached: map[string]string{},
 			args: args{
 				encAPIKey: "apiKey",
-				encAPPKey: "appKey",
 			},
 			want:  "",
-			want1: "",
-			want2: false,
+			want1: false,
 		},
 	}
 	for _, tt := range tests {
@@ -1335,15 +1081,12 @@ func Test_metricsForwarder_getSecretsFromCache(t *testing.T) {
 			for k, v := range tt.cached {
 				mf.creds.Store(k, v)
 			}
-			got, got1, got2 := mf.getSecretsFromCache(tt.args.encAPIKey, tt.args.encAPPKey)
+			got, got1 := mf.getSecretsFromCache(tt.args.encAPIKey)
 			if got != tt.want {
 				t.Errorf("metricsForwarder.getSecretsFromCache() got = %v, want %v", got, tt.want)
 			}
 			if got1 != tt.want1 {
-				t.Errorf("metricsForwarder.getSecretsFromCache() got1 = %v, want %v", got1, tt.want1)
-			}
-			if got2 != tt.want2 {
-				t.Errorf("metricsForwarder.getSecretsFromCache() got2 = %v, want %v", got2, tt.want2)
+				t.Errorf("metricsForwarder.getSecretsFromCache() got2 = %v, want %v", got1, tt.want1)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

* This PR removes the requirement of setting an application key in order for the metrics forwarder of the operator (responsible to send metrics such as `datadog.operator.<feature>.enabled` and events) to be initialized

### Motivation

* [CECO-721] : Datadog intake solely requires API key for data submission. Dropping the application key is beneficial as it reduces the privileges of the API client and the number of secrets the operator needs

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Create a secret with your api key : `k create secret generic datadog-secret --from-literal api-key=$DD_API_KEY`
* Install the custom operator build without setting any credentials : `helm install my-datadog-operator datadog/datadog-operator --set logLevel="debug" --set image.repository=<REPLACE_ME>/operator --set image.tag=<REPLACE_ME>`
* Use a CR without an app key : 
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    clusterName: kind
    kubelet:
      tlsVerify: false
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
  features:
    apm:
      enabled: false
    logCollection:
      enabled: true
      containerCollectAll: true
```
* Review the operator logs to ensure the metrics forwarder was init properly : `kubectl logs <operator pod> | grep metrics` and assert the client starts, and metrics collection is working : 
```
{"level":"INFO","ts":"2023-10-21T07:29:44Z","logger":"DatadogMetricForwarders","msg":"New Datadog metrics forwarder registered","ID":"default/datadog"}
{"level":"INFO","ts":"2023-10-21T07:29:44Z","logger":"DatadogMetricForwarders","msg":"Starting Datadog metrics forwarder","CustomResource.Namespace":"default","CustomResource.Name":"datadog"}
{"level":"INFO","ts":"2023-10-21T07:29:44Z","logger":"DatadogMetricForwarders","msg":"Initializing Datadog metrics forwarder","CustomResource.Namespace":"default","CustomResource.Name":"datadog"}
{"level":"INFO","ts":"2023-10-21T07:29:44Z","logger":"DatadogMetricForwarders","msg":"Datadog metrics forwarder initialized successfully","CustomResource.Namespace":"default","CustomResource.Name":"datadog"}
{"level":"DEBUG","ts":"2023-10-21T07:29:59Z","logger":"DatadogMetricForwarders","msg":"Collecting metrics","CustomResource.Namespace":"default","CustomResource.Name":"datadog"}
```
* Ensure `datadog.operator.default.feature.enabled` is present in your account with proper tags `cr_name` and `cr_namespace`
* Ensure operator events are present in your account `source:datadog cr_name:datadog cr_namespace:default`

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label


[CECO-721]: https://datadoghq.atlassian.net/browse/CECO-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ