### PR TITLE
Check CRD status for reconcile errors in upgrade hook

### DIFF
--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -162,7 +162,8 @@ func isReconcileError(conditions []metav1.Condition) bool {
 	for _, condition := range conditions {
 		if (condition.Type == "DatadogAgentReconcileError" && condition.Status == metav1.ConditionTrue) ||
 			(condition.Type == "AgentReconcile" && condition.Status == metav1.ConditionFalse) ||
-			(condition.Type == "ClusterAgentReconcile" && condition.Status == metav1.ConditionFalse) {
+			(condition.Type == "ClusterAgentReconcile" && condition.Status == metav1.ConditionFalse) ||
+			(condition.Type == "ClusterChecksRunnerReconcile" && condition.Status == metav1.ConditionFalse) {
 			return true
 		}
 	}

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -160,7 +160,9 @@ func (o *Options) getV2Status() (common.StatusWrapper, error) {
 
 func isReconcileError(conditions []metav1.Condition) bool {
 	for _, condition := range conditions {
-		if (condition.Type == "DatadogAgentReconcileError" && condition.Status == metav1.ConditionTrue) || (condition.Type == "AgentReconcile" && condition.Status == metav1.ConditionTrue) || (condition.Type == "ClusterAgentReconcile" && condition.Status == metav1.ConditionTrue) {
+		if (condition.Type == "DatadogAgentReconcileError" && condition.Status == metav1.ConditionTrue) ||
+			(condition.Type == "AgentReconcile" && condition.Status == metav1.ConditionFalse) ||
+			(condition.Type == "ClusterAgentReconcile" && condition.Status == metav1.ConditionFalse) {
 			return true
 		}
 	}
@@ -193,7 +195,7 @@ func (o *Options) Run() error {
 		}
 
 		if isReconcileError(status.GetStatusCondition()) {
-			return false, fmt.Errorf("Got reconcile error.")
+			return false, fmt.Errorf("got reconcile error")
 		}
 
 		if !agentDone {

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/pkg/plugin/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Options provides information required to manage canary.
@@ -157,6 +158,15 @@ func (o *Options) getV2Status() (common.StatusWrapper, error) {
 	return common.NewV2StatusWrapper(datadogAgent), nil
 }
 
+func isReconcileError(conditions []metav1.Condition) bool {
+	for _, condition := range conditions {
+		if (condition.Type == "DatadogAgentReconcileError" && condition.Status == metav1.ConditionTrue) || (condition.Type == "AgentReconcile" && condition.Status == metav1.ConditionTrue) || (condition.Type == "ClusterAgentReconcile" && condition.Status == metav1.ConditionTrue) {
+			return true
+		}
+	}
+	return false
+}
+
 // Run use to run the command.
 func (o *Options) Run() error {
 	o.printOutf("Start checking rolling-update status")
@@ -180,6 +190,10 @@ func (o *Options) Run() error {
 			return true, nil
 		} else if err != nil {
 			return false, fmt.Errorf("unable to get the DatadogAgent.status, err:%w", err)
+		}
+
+		if isReconcileError(status.GetStatusCondition()) {
+			return false, fmt.Errorf("Got reconcile error.")
 		}
 
 		if !agentDone {


### PR DESCRIPTION
### What does this PR do?

Check for agent reconciliation errors in the upgrade hook, and report an error status as appropriate.

### Motivation

There are instances where a reconciliation error occurs in the agent/cluster agent, but the upgrade hook hangs until it times out as it does not detect these errors earlier.

### Additional Notes

Questions: 
1. Should more information be provided in the error that is returned?
2. When testing there was a case where `AgentReconcile` was `false` but `DatadogAgentReconcileError` was `false` as well. To ensure all conditions are covered, the hook currently checks the value of `DatadogAgentReconcileError`, `AgentReconcile` and `ClusterAgentReconcile`, and errors out if any indicate an error state. Is this case valid, or should this be investigated further?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Set up the operator to deploy the agent
2. Build the `check-operator` CLI: `cd /cmd/check-operator && go build .` 
4. Verify that when there are no issues with deployment, no error is reported by the upgrade hook `./check-operator upgrade datadog` 
5. Try to deploy the agent in a way that will cause a reconciliation error e.g. having a label that is too long
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  override:
    nodeAgent:
      labels:
        too-long: sdfjkhsdjfhkjsdhfljkhsdkjfhgkshfjkhwejkfhjkwehflkwehkjfskjhfgkjshfkhskjdghfkjsdhgkjsdhlgkjlksjfgkjsdklgjsdlkjgfdjslkdsjfkljsdklfjlkdsjflksdjfklsjdklfjsdlkfjlksdjf
  features:
    apm:
      enabled: true
    logCollection:
      enabled: true
```
6. Verify that when running the upgrade hook, an error is reported (`got reconcile error`)

I couldn't find existing tests for the hook, but if I had missed it happy to add unit tests to cover these changes!!

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
