### PR TITLE
fix(rbac): enable PodSecurityPolicy rules only when supported

### DIFF
--- a/controllers/datadogagent/feature/cspm/feature.go
+++ b/controllers/datadogagent/feature/cspm/feature.go
@@ -190,7 +190,9 @@ func (f *cspmFeature) ManageDependencies(managers feature.ResourceManagers, comp
 	// Manage RBAC
 	rbacName := getRBACResourceName(f.owner)
 
-	return managers.RBACManager().AddClusterPolicyRules(f.owner.GetNamespace(), rbacName, f.serviceAccountName, getRBACPolicyRules())
+	pi := managers.Store().GetPlatformInfo()
+
+	return managers.RBACManager().AddClusterPolicyRules(f.owner.GetNamespace(), rbacName, f.serviceAccountName, getRBACPolicyRules(pi.IsResourceSupported("PodSecurityPolicy")))
 }
 
 // ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec

--- a/controllers/datadogagent/feature/cspm/rbac.go
+++ b/controllers/datadogagent/feature/cspm/rbac.go
@@ -12,7 +12,8 @@ import (
 )
 
 // getRBACRules generates the cluster role required for CSPM
-func getRBACPolicyRules() []rbacv1.PolicyRule {
+func getRBACPolicyRules(supportsPSP bool) []rbacv1.PolicyRule {
+
 	rbacRules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{rbac.CoreAPIGroup},
@@ -21,13 +22,6 @@ func getRBACPolicyRules() []rbacv1.PolicyRule {
 				rbac.ServiceAccountResource,
 			},
 			Verbs: []string{rbac.ListVerb},
-		},
-		{
-			APIGroups: []string{rbac.PolicyAPIGroup},
-			Resources: []string{
-				rbac.PodSecurityPolicyResource,
-			},
-			Verbs: []string{rbac.GetVerb, rbac.ListVerb, rbac.WatchVerb},
 		},
 		{
 			APIGroups: []string{rbac.RbacAPIGroup},
@@ -44,6 +38,17 @@ func getRBACPolicyRules() []rbacv1.PolicyRule {
 			},
 			Verbs: []string{rbac.ListVerb},
 		},
+	}
+
+	if supportsPSP {
+		pspRule := rbacv1.PolicyRule{
+			APIGroups: []string{rbac.PolicyAPIGroup},
+			Resources: []string{
+				rbac.PodSecurityPolicyResource,
+			},
+			Verbs: []string{rbac.GetVerb, rbac.ListVerb, rbac.WatchVerb},
+		}
+		rbacRules = append(rbacRules[:1], append([]rbacv1.PolicyRule{pspRule}, rbacRules[1:]...)...)
 	}
 
 	return rbacRules

--- a/controllers/datadogagent/feature/cspm/rbac_test.go
+++ b/controllers/datadogagent/feature/cspm/rbac_test.go
@@ -1,0 +1,100 @@
+package cspm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
+)
+
+func Test_getRBACPolicyRules(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		supportsPSP bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want []rbacv1.PolicyRule
+	}{
+		{
+			name: "when supportsPSP is true",
+			args: args{
+				supportsPSP: true,
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{rbac.CoreAPIGroup},
+					Resources: []string{
+						rbac.NamespaceResource,
+						rbac.ServiceAccountResource,
+					},
+					Verbs: []string{rbac.ListVerb},
+				},
+				{
+					APIGroups: []string{rbac.PolicyAPIGroup},
+					Resources: []string{
+						rbac.PodSecurityPolicyResource,
+					},
+					Verbs: []string{rbac.GetVerb, rbac.ListVerb, rbac.WatchVerb},
+				},
+				{
+					APIGroups: []string{rbac.RbacAPIGroup},
+					Resources: []string{
+						rbac.ClusterRoleBindingResource,
+						rbac.RoleBindingResource,
+					},
+					Verbs: []string{rbac.ListVerb},
+				},
+				{
+					APIGroups: []string{rbac.NetworkingAPIGroup},
+					Resources: []string{
+						rbac.NetworkPolicyResource,
+					},
+					Verbs: []string{rbac.ListVerb},
+				},
+			},
+		},
+		{
+			name: "when supportsPSP is false",
+			args: args{
+				supportsPSP: false,
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{rbac.CoreAPIGroup},
+					Resources: []string{
+						rbac.NamespaceResource,
+						rbac.ServiceAccountResource,
+					},
+					Verbs: []string{rbac.ListVerb},
+				},
+				{
+					APIGroups: []string{rbac.RbacAPIGroup},
+					Resources: []string{
+						rbac.ClusterRoleBindingResource,
+						rbac.RoleBindingResource,
+					},
+					Verbs: []string{rbac.ListVerb},
+				},
+				{
+					APIGroups: []string{rbac.NetworkingAPIGroup},
+					Resources: []string{
+						rbac.NetworkPolicyResource,
+					},
+					Verbs: []string{rbac.ListVerb},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, getRBACPolicyRules(tt.args.supportsPSP))
+		})
+	}
+}


### PR DESCRIPTION
fix https://github.com/DataDog/datadog-operator/issues/975

### What does this PR do?

This PR updates the RBAC policy rule generation logic to conditionally include support for the `PodSecurityPolicy` resource based on a support flag. This change is in response to the deprecation and removal of the `api: policy/v1beta1` PodSecurityPolicy resource in Kubernetes 1.25.

### Motivation

Kubernetes 1.25 has removed the `api: policy/v1beta1` PodSecurityPolicy resource, which necessitates changes in our RBAC policy rule generation to ensure our application remains compatible with the latest Kubernetes API changes. This PR introduces a flag that, when set, includes the necessary rules for `PodSecurityPolicy` only if the cluster supports it, thus maintaining backward compatibility while respecting the latest Kubernetes version's API.

### Additional Notes

While this change primarily targets compatibility with Kubernetes 1.25, it's implemented in a manner that ensures backward compatibility with earlier versions of Kubernetes that still support `PodSecurityPolicy`. As a result, this update should not impact any existing deployments on older Kubernetes versions.

### Minimum Agent Versions

To accommodate the changes in Kubernetes API, the minimum versions of the Datadog Agent and the Cluster Agent are specified as follows:

* Agent: vX.Y.Z (Please specify the minimum version that includes the updated RBAC logic)
* Cluster Agent: vX.Y.Z (Please specify the minimum version that includes the updated RBAC logic)

### Describe your test plan

Testing this PR should include the following scenarios:

1. Deploying on a Kubernetes cluster version 1.25 and verifying that no `PodSecurityPolicy` rules are generated when the support flag is disabled.
2. Deploying on a Kubernetes cluster version < 1.25 with the support flag enabled and verifying that `PodSecurityPolicy` rules are correctly generated and applied.
3. Ensuring that enabling the support flag on a Kubernetes 1.25 cluster doesn't cause any issues, given that the resource is no longer supported in this version.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
