### PR TITLE
Add GCR EU and Asia registries with auto defaulting

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -96,6 +96,9 @@ const (
 	DefaultAgentImageName        string = "agent"
 	DefaultClusterAgentImageName string = "cluster-agent"
 	DefaultImageRegistry         string = "gcr.io/datadoghq"
+	DefaultEuropeImageRegistry   string = "eu.gcr.io/datadoghq"
+	DefaultAsiaImageRegistry     string = "asia.gcr.io/datadoghq"
+	DefaultGovImageRegistry      string = "public.ecr.aws/datadog"
 
 	// ExtendedDaemonset defaulting
 	DefaultRollingUpdateMaxUnavailable                  = "10%"

--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -13,8 +13,11 @@ import (
 // Default configuration values. These are the recommended settings for monitoring with Datadog in Kubernetes.
 // Note: many default values are set in the Datadog Agent and deliberately not set by the Operator.
 const (
-	defaultSite     string = "datadoghq.com"
-	defaultLogLevel string = "info"
+	defaultSite       string = "datadoghq.com"
+	defaultEuropeSite string = "datadoghq.eu"
+	defaultAsiaSite   string = "ap1.datadoghq.com"
+	defaultGovSite    string = "ddog-gov.com"
+	defaultLogLevel   string = "info"
 
 	// defaultLogCollectionEnabled          bool   = false
 	defaultLogContainerCollectUsingFiles bool   = true
@@ -108,7 +111,16 @@ func defaultGlobalConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	if ddaSpec.Global.Registry == nil {
-		ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultImageRegistry)
+		switch *ddaSpec.Global.Site {
+		case defaultEuropeSite:
+			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultEuropeImageRegistry)
+		case defaultAsiaSite:
+			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultAsiaImageRegistry)
+		case defaultGovSite:
+			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultGovImageRegistry)
+		default:
+			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultImageRegistry)
+		}
 	}
 
 	if ddaSpec.Global.LogLevel == nil {

--- a/apis/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -39,6 +39,51 @@ func Test_defaultGlobal(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test registry defaulting based on site - EU",
+			ddaSpec: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site: apiutils.NewStringPointer(defaultEuropeSite),
+				},
+			},
+			want: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site:     apiutils.NewStringPointer(defaultEuropeSite),
+					Registry: apiutils.NewStringPointer(apicommon.DefaultEuropeImageRegistry),
+					LogLevel: apiutils.NewStringPointer(defaultLogLevel),
+				},
+			},
+		},
+		{
+			name: "test registry defaulting based on site - Asia",
+			ddaSpec: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site: apiutils.NewStringPointer(defaultAsiaSite),
+				},
+			},
+			want: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site:     apiutils.NewStringPointer(defaultAsiaSite),
+					Registry: apiutils.NewStringPointer(apicommon.DefaultAsiaImageRegistry),
+					LogLevel: apiutils.NewStringPointer(defaultLogLevel),
+				},
+			},
+		},
+		{
+			name: "test registry defaulting based on site - Gov",
+			ddaSpec: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site: apiutils.NewStringPointer(defaultGovSite),
+				},
+			},
+			want: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site:     apiutils.NewStringPointer(defaultGovSite),
+					Registry: apiutils.NewStringPointer(apicommon.DefaultGovImageRegistry),
+					LogLevel: apiutils.NewStringPointer(defaultLogLevel),
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -707,7 +707,12 @@ type GlobalConfig struct {
 	ClusterName *string `json:"clusterName,omitempty"`
 
 	// Site is the Datadog intake site Agent data are sent to.
+	// Set to 'datadoghq.com' to send data to the US1 site (default).
 	// Set to 'datadoghq.eu' to send data to the EU site.
+	// Set to 'us3.datadoghq.com' to send data to the US3 site.
+	// Set to 'us5.datadoghq.com' to send data to the US5 site.
+	// Set to 'ddog-gov.com' to send data to the US1-FED site.
+	// Set to 'ap1.datadoghq.com' to send data to the AP1 site.
 	// Default: 'datadoghq.com'
 	// +optional
 	Site *string `json:"site,omitempty"`

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -8668,7 +8668,7 @@ spec:
                       description: 'Registry is the image registry to use for all Agent images. Use ''public.ecr.aws/datadog'' for AWS ECR. Use ''docker.io/datadog'' for DockerHub. Default: ''gcr.io/datadoghq'''
                       type: string
                     site:
-                      description: 'Site is the Datadog intake site Agent data are sent to. Set to ''datadoghq.eu'' to send data to the EU site. Default: ''datadoghq.com'''
+                      description: 'Site is the Datadog intake site Agent data are sent to. Set to ''datadoghq.com'' to send data to the US1 site (default). Set to ''datadoghq.eu'' to send data to the EU site. Set to ''us3.datadoghq.com'' to send data to the US3 site. Set to ''us5.datadoghq.com'' to send data to the US5 site. Set to ''ddog-gov.com'' to send data to the US1-FED site. Set to ''ap1.datadoghq.com'' to send data to the AP1 site. Default: ''datadoghq.com'''
                       type: string
                     tags:
                       description: 'Tags contains a list of tags to attach to every metric, event and service check collected. Learn more about tagging: https://docs.datadoghq.com/tagging/'

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -16218,7 +16218,7 @@ spec:
                       description: 'Registry is the image registry to use for all Agent images. Use ''public.ecr.aws/datadog'' for AWS ECR. Use ''docker.io/datadog'' for DockerHub. Default: ''gcr.io/datadoghq'''
                       type: string
                     site:
-                      description: 'Site is the Datadog intake site Agent data are sent to. Set to ''datadoghq.eu'' to send data to the EU site. Default: ''datadoghq.com'''
+                      description: 'Site is the Datadog intake site Agent data are sent to. Set to ''datadoghq.com'' to send data to the US1 site (default). Set to ''datadoghq.eu'' to send data to the EU site. Set to ''us3.datadoghq.com'' to send data to the US3 site. Set to ''us5.datadoghq.com'' to send data to the US5 site. Set to ''ddog-gov.com'' to send data to the US1-FED site. Set to ''ap1.datadoghq.com'' to send data to the AP1 site. Default: ''datadoghq.com'''
                       type: string
                     tags:
                       description: 'Tags contains a list of tags to attach to every metric, event and service check collected. Learn more about tagging: https://docs.datadoghq.com/tagging/'

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -173,7 +173,7 @@ spec:
 | global.podAnnotationsAsTags | Provide a mapping of Kubernetes Annotations to Datadog Tags. <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY> |
 | global.podLabelsAsTags | Provide a mapping of Kubernetes Labels to Datadog Tags. <KUBERNETES_LABEL>: <DATADOG_TAG_KEY> |
 | global.registry | Registry is the image registry to use for all Agent images. Use 'public.ecr.aws/datadog' for AWS ECR. Use 'docker.io/datadog' for DockerHub. Default: 'gcr.io/datadoghq' |
-| global.site | Site is the Datadog intake site Agent data are sent to. Set to 'datadoghq.eu' to send data to the EU site. Default: 'datadoghq.com' |
+| global.site | Site is the Datadog intake site Agent data are sent to. Set to 'datadoghq.com' to send data to the US1 site (default). Set to 'datadoghq.eu' to send data to the EU site. Set to 'us3.datadoghq.com' to send data to the US3 site. Set to 'us5.datadoghq.com' to send data to the US5 site. Set to 'ddog-gov.com' to send data to the US1-FED site. Set to 'ap1.datadoghq.com' to send data to the AP1 site. Default: 'datadoghq.com' |
 | global.tags | Tags contains a list of tags to attach to every metric, event and service check collected. Learn more about tagging: https://docs.datadoghq.com/tagging/ |
 | override | Override the default configurations of the agents |
 <br>


### PR DESCRIPTION
### What does this PR do?

Add GCR EU and Asia registries with auto defaulting based on site.

### Motivation

### Additional Notes

### Minimum Agent Versions

### Describe your test plan

Create a `DatadogAgent` with europe or asia site, the registry should be defaulted to `eu.gcr.io` or `asia.gcr.io`.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
