### PR TITLE
Enable by default container-image collection

### DIFF
--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -105,6 +105,7 @@ const (
 	DDRuntimeSecurityConfigNetworkEnabled             = "DD_RUNTIME_SECURITY_CONFIG_NETWORK_ENABLED"
 	DDRuntimeSecurityConfigActivityDumpEnabled        = "DD_RUNTIME_SECURITY_CONFIG_ACTIVITY_DUMP_ENABLED"
 	DDRuntimeSecurityConfigRemoteConfigurationEnabled = "DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED"
+	DDContainerImageEnabled                           = "DD_CONTAINER_IMAGE_ENABLED"
 	DDSBOMEnabled                                     = "DD_SBOM_ENABLED"
 	DDSBOMContainerImageEnabled                       = "DD_SBOM_CONTAINER_IMAGE_ENABLED"
 	DDSBOMContainerImageAnalyzers                     = "DD_SBOM_CONTAINER_IMAGE_ANALYZERS"
@@ -136,4 +137,7 @@ const (
 	KubernetesEnvVar = "KUBERNETES"
 
 	ClusterChecksConfigProvider = "clusterchecks"
+
+	EnvVarTrueValue  = "true"
+	EnvVarFalseValue = "false"
 )

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -268,7 +268,13 @@ func envVarsForCoreAgent(dda metav1.Object) []corev1.EnvVar {
 		},
 		{
 			Name:  apicommon.DDLeaderElection,
-			Value: "true",
+			Value: apicommon.EnvVarTrueValue,
+		},
+		{
+			// we want to default it in 7.49.0
+			// but in 7.50.0 it will be already defaulted in the agent process.
+			Name:  apicommon.DDContainerImageEnabled,
+			Value: apicommon.EnvVarTrueValue,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

This commit set the envvar DD_CONTAINER_IMAGE_ENABLED=true by default
in the NodeAgent's "agent" container.

This PR is needed for the other PR https://github.com/DataDog/datadog-operator/pull/836 to work with agent 7.49.0

### Motivation

We want to enabled container-image collection by default. it will
be the case from agent 7.50.0. But in Operator 1.3.0, the Agent is
defaulted to 7.49.0 since 7.50.0 is not yet released.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.48.0
* Cluster Agent: N/A

### Describe your test plan

Deploy the agent with the operator. The container images should appears in the new beta [container image page](https://app.datadoghq.com/containers/images)

Another way to validate that the PR works, is to exec in a running NodeAgent pod and run the `agent config` command to check if the `container_image.enabled` option is set to true.

```
$ kubectl exec -it <node-name-pod-name> -- agent config | grep -A2 container_image
container_image:
  enabled: true
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
