### PR TITLE
update patch-bundle script to include spec.replaces field in bundle

### DIFF
--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -22,8 +22,8 @@ $YQ -i ".metadata.annotations.containerImage = \"$IMAGE\"" bundle/manifests/data
 VERSION=$($YQ '.spec.version' bundle/manifests/datadog-operator.clusterserviceversion.yaml )
 $YQ -i ".metadata.annotations.\"olm.skipRange\" = \"<$VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
-# Delete replaces
-$YQ -i 'del(.spec.replaces)' bundle/manifests/datadog-operator.clusterserviceversion.yaml
+# Set spec.replaces to latest released version
+$YQ -i ".spec.\"replaces\" = \"$LATEST_VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Add OpenShift version annotation (adding in main bundle as it's used for OpenShift Community)
 $YQ -i ".annotations.\"com.redhat.openshift.versions\" = \"v4.6\"" bundle/metadata/annotations.yaml


### PR DESCRIPTION
### What does this PR do?

Updates script that updates bundle/ClusterServiceVersion file following notice from Redhat that, if using `olm.skipRange`, we also need to include `spec.replaces`.

Note that this will require setting `LATEST_VERSION` when running the make bundle command.

### Motivation

Redhat notice

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
