### PR TITLE
[cherry-pick] Update integrations_autodiscovery.md (#985)

### DIFF
--- a/docs/integrations_autodiscovery.md
+++ b/docs/integrations_autodiscovery.md
@@ -17,7 +17,7 @@ spec:
      apiKey: "<DATADOG_API_KEY>"
      appKey: "<DATADOG_APP_KEY>"
  override:
-  clusterAgent:
+  nodeAgent:
     extraConfd:
       configDataMap:
         http_check.yaml: |-


### PR DESCRIPTION
* Update integrations_autodiscovery.md

Noticed a mismatched https://a.cl.ly/qGuYnRqn

* Update integrations_autodiscovery.md

Updated the configuration to match the graph title "Use the spec.override.nodeAgent.extraConfd.configDataMap" -> "Use the spec.override.clusterAgent.extraConfd.configDataMap" apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
 global:
   credentials:
     apiKey: "<DATADOG_API_KEY>"
     appKey: "<DATADOG_APP_KEY>"
 override:
  nodeAgent:
    extraConfd:
      configDataMap:
        http_check.yaml: |-
          init_config:
          instances:
            - url: "http://%%host%%" name: "My service"

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
