### PR TITLE
feat: add NotificationPresetName to monitor options

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -68,6 +68,16 @@ const (
 	DatadogMonitorTypeComposite DatadogMonitorType = "composite"
 )
 
+// DatadogMonitorOptionsNotificationPresets Toggles the display of additional content sent in the monitor notification.
+type DatadogMonitorOptionsNotificationPresets string
+
+const (
+	DatadogMonitorOptionsNotificationPresetsShowAll     DatadogMonitorOptionsNotificationPresets = "show_all"
+	DatadogMonitorOptionsNotificationPresetsHideQuery   DatadogMonitorOptionsNotificationPresets = "hide_query"
+	DatadogMonitorOptionsNotificationPresetsHideHandles DatadogMonitorOptionsNotificationPresets = "hide_handles"
+	DatadogMonitorOptionsNotificationPresetsHideAll     DatadogMonitorOptionsNotificationPresets = "hide_all"
+)
+
 // DatadogMonitorOptions define the optional parameters of a monitor
 // +k8s:openapi-gen=true
 type DatadogMonitorOptions struct {
@@ -90,6 +100,8 @@ type DatadogMonitorOptions struct {
 	// monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
 	// is used for metric alerts, and 24 hours is used for service checks.
 	NoDataTimeframe *int64 `json:"noDataTimeframe,omitempty"`
+	// An enum for toggling the display of additional content sent in the monitor notification.
+	NotificationPresetName DatadogMonitorOptionsNotificationPresets `json:"notificationPresetName,omitempty"`
 	// A Boolean indicating whether tagged users are notified on changes to this monitor.
 	NotifyAudit *bool `json:"notifyAudit,omitempty"`
 	// A Boolean indicating whether this monitor notifies when data stops reporting.

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -2145,6 +2145,13 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorOptions(ref common.ReferenceC
 							Format:      "int64",
 						},
 					},
+					"notificationPresetName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "An enum for toggling the display of additional content sent in the monitor notification.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"notifyAudit": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A Boolean indicating whether tagged users are notified on changes to this monitor.",

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -92,6 +92,9 @@ spec:
                       description: The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.
                       format: int64
                       type: integer
+                    notificationPresetName:
+                      description: An enum for toggling the display of additional content sent in the monitor notification.
+                      type: string
                     notifyAudit:
                       description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                       type: boolean

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -93,6 +93,9 @@ spec:
                   description: The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.
                   format: int64
                   type: integer
+                notificationPresetName:
+                  description: An enum for toggling the display of additional content sent in the monitor notification.
+                  type: string
                 notifyAudit:
                   description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                   type: boolean

--- a/controllers/datadogmonitor/monitor.go
+++ b/controllers/datadogmonitor/monitor.go
@@ -145,6 +145,10 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 		o.SetTimeoutH(*options.TimeoutH)
 	}
 
+	if options.NotificationPresetName != "" {
+		o.SetNotificationPresetName(datadogV1.MonitorOptionsNotificationPresets(string(options.NotificationPresetName)))
+	}
+
 	m := datadogV1.NewMonitor(query, monitorType)
 	{
 		m.SetName(name)

--- a/controllers/datadogmonitor/monitor_test.go
+++ b/controllers/datadogmonitor/monitor_test.go
@@ -52,16 +52,17 @@ func Test_buildMonitor(t *testing.T) {
 				"kube_cluster:test.staging",
 			},
 			Options: datadoghqv1alpha1.DatadogMonitorOptions{
-				EnableLogsSample:  &valTrue,
-				EvaluationDelay:   &evalDelay,
-				EscalationMessage: &escalationMsg,
-				IncludeTags:       &valTrue,
-				Locked:            &valTrue,
-				NewGroupDelay:     &newGroupDelay,
-				NotifyNoData:      &valTrue,
-				NoDataTimeframe:   &noDataTimeframe,
-				RenotifyInterval:  &renotifyInterval,
-				TimeoutH:          &timeoutH,
+				EnableLogsSample:       &valTrue,
+				EvaluationDelay:        &evalDelay,
+				EscalationMessage:      &escalationMsg,
+				IncludeTags:            &valTrue,
+				Locked:                 &valTrue,
+				NewGroupDelay:          &newGroupDelay,
+				NoDataTimeframe:        &noDataTimeframe,
+				NotificationPresetName: "show_all",
+				NotifyNoData:           &valTrue,
+				RenotifyInterval:       &renotifyInterval,
+				TimeoutH:               &timeoutH,
 				Thresholds: &datadoghqv1alpha1.DatadogMonitorOptionsThresholds{
 					Critical: &critThreshold,
 					Warning:  &warnThreshold,
@@ -108,11 +109,14 @@ func Test_buildMonitor(t *testing.T) {
 	assert.Equal(t, *dm.Spec.Options.NewGroupDelay, monitor.Options.GetNewGroupDelay(), "discrepancy found in parameter: NewGroupDelay")
 	assert.Equal(t, *dm.Spec.Options.NewGroupDelay, monitorUR.Options.GetNewGroupDelay(), "discrepancy found in parameter: NewGroupDelay")
 
-	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitor.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
-	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitorUR.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
-
 	assert.Equal(t, *dm.Spec.Options.NoDataTimeframe, monitor.Options.GetNoDataTimeframe(), "discrepancy found in parameter: NoDataTimeframe")
 	assert.Equal(t, *dm.Spec.Options.NoDataTimeframe, monitorUR.Options.GetNoDataTimeframe(), "discrepancy found in parameter: NoDataTimeframe")
+
+	assert.Equal(t, string(dm.Spec.Options.NotificationPresetName), string(monitor.Options.GetNotificationPresetName()), "discrepancy found in parameter: NotificationPresetName")
+	assert.Equal(t, string(dm.Spec.Options.NotificationPresetName), string(monitorUR.Options.GetNotificationPresetName()), "discrepancy found in parameter: NotificationPresetName")
+
+	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitor.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
+	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitorUR.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
 
 	assert.Equal(t, *dm.Spec.Options.RenotifyInterval, monitor.Options.GetRenotifyInterval(), "discrepancy found in parameter: RenotifyInterval")
 	assert.Equal(t, *dm.Spec.Options.RenotifyInterval, monitorUR.Options.GetRenotifyInterval(), "discrepancy found in parameter: RenotifyInterval")


### PR DESCRIPTION
### What does this PR do?

In datadog, we have the possibility to toggle the "Content display in notification" for every monitor. This PR enables this.

More info in https://docs.datadoghq.com/monitors/notify/#toggle-additional-content

### Motivation

https://github.com/DataDog/datadog-operator/issues/815

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

Nop

### Describe your test plan

Write there any instructions and details you may have to test your PR.

You can try passing the option `notificationPresetName` with one of `show_all`, `hide_query`, `hide_handles`, `hide_all`. And it will set the right value in the field "Content display in notification" of the monitor.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
