### PR TITLE
[profiles] Create default profile with a node anti affinity

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -86,6 +86,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -7,13 +7,16 @@ package datadogagent
 
 import (
 	"context"
+	"fmt"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/override"
+	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -24,7 +27,7 @@ const (
 	datadogAgentFinalizer = "finalizer.agent.datadoghq.com"
 )
 
-type finalizerDadFunc func(reqLogger logr.Logger, dda client.Object)
+type finalizerDadFunc func(reqLogger logr.Logger, dda client.Object) error
 
 func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, dda client.Object, finalizerDad finalizerDadFunc) (reconcile.Result, error) {
 	// Check if the DatadogAgent instance is marked to be deleted, which is
@@ -35,7 +38,9 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, dda client.Object, f
 			// Run finalization logic for datadogAgentFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
-			finalizerDad(reqLogger, dda)
+			if err := finalizerDad(reqLogger, dda); err != nil {
+				return reconcile.Result{}, err
+			}
 
 			// Remove datadogAgentFinalizer. Once all finalizers have been
 			// removed, the object will be deleted.
@@ -59,7 +64,7 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, dda client.Object, f
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) finalizeDadV1(reqLogger logr.Logger, obj client.Object) {
+func (r *Reconciler) finalizeDadV1(reqLogger logr.Logger, obj client.Object) error {
 	dda := obj.(*datadoghqv1alpha1.DatadogAgent)
 	_, err := r.cleanupMetricsServerAPIService(reqLogger, dda)
 	if err != nil {
@@ -78,9 +83,10 @@ func (r *Reconciler) finalizeDadV1(reqLogger logr.Logger, obj client.Object) {
 
 	r.forwarders.Unregister(dda)
 	reqLogger.Info("Successfully finalized DatadogAgent")
+	return nil
 }
 
-func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) {
+func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) error {
 	// We need to apply the defaults to be able to delete the resources
 	// associated with those defaults.
 	dda := obj.(*datadoghqv2alpha1.DatadogAgent).DeepCopy()
@@ -119,18 +125,20 @@ func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) {
 	errs = append(errs, override.Dependencies(reqLogger, resourceManagers, dda)...)
 
 	if len(errs) > 0 {
-		reqLogger.Info("Errors calculating dependencies while finalizing the DatadogAgent", "errors", errs)
+		return fmt.Errorf("errors calculating dependencies while finalizing the DatadogAgent: %v", errs)
 	}
 
 	deleteErrs := depsStore.DeleteAll(context.TODO(), r.client)
-
-	if len(deleteErrs) == 0 {
-		reqLogger.Info("Successfully finalized DatadogAgent")
-	} else {
-		for _, deleteErr := range deleteErrs {
-			reqLogger.Error(deleteErr, "Error deleting dependencies while finalizing the DatadogAgent")
-		}
+	if len(deleteErrs) > 0 {
+		return fmt.Errorf("error deleting dependencies while finalizing the DatadogAgent: %v", deleteErrs)
 	}
+
+	if err := r.profilesCleanup(); err != nil {
+		return err
+	}
+
+	reqLogger.Info("Successfully finalized DatadogAgent")
+	return nil
 }
 
 func (r *Reconciler) addFinalizer(reqLogger logr.Logger, dda client.Object) error {
@@ -143,5 +151,26 @@ func (r *Reconciler) addFinalizer(reqLogger logr.Logger, dda client.Object) erro
 		reqLogger.Error(err, "Failed to update DatadogAgent with finalizer")
 		return err
 	}
+	return nil
+}
+
+// profilesCleanup performs the cleanups required for the profiles feature. The
+// only thing that we need to do is to ensure that no nodes are left with the
+// profile label.
+func (r *Reconciler) profilesCleanup() error {
+	nodeList := corev1.NodeList{}
+	if err := r.client.List(context.TODO(), &nodeList); err != nil {
+		return err
+	}
+
+	for _, node := range nodeList.Items {
+		if _, profileLabelExists := node.Labels[agentprofile.ProfileLabelKey]; profileLabelExists {
+			delete(node.Labels, agentprofile.ProfileLabelKey)
+			if err := r.client.Update(context.TODO(), &node); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }

--- a/controllers/datadogagent/testutils/client_utils.go
+++ b/controllers/datadogagent/testutils/client_utils.go
@@ -28,6 +28,7 @@ func TestScheme(isV2 bool) *runtime.Scheme {
 	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Secret{})
 	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ServiceAccount{})
 	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ConfigMap{})
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Node{})
 	s.AddKnownTypes(rbacv1.SchemeGroupVersion, &rbacv1.ClusterRoleBinding{})
 	s.AddKnownTypes(rbacv1.SchemeGroupVersion, &rbacv1.ClusterRole{})
 	s.AddKnownTypes(rbacv1.SchemeGroupVersion, &rbacv1.Role{})

--- a/controllers/datadogagent_controller_v2_profiles_test.go
+++ b/controllers/datadogagent_controller_v2_profiles_test.go
@@ -9,6 +9,7 @@
 package controllers
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"time"
@@ -59,7 +60,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
 			defaultDaemonSetNamespacedName(namespace, &agent): {
-				affinity: nil,
+				affinity: affinityForDefaultProfile(),
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName:    {},
 					common.ProcessAgentContainerName: {},
@@ -67,7 +68,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 			},
 		}
 
-		testProfilesFunc(nil, &agent, nodes, expectedDaemonSets, false)()
+		testProfilesFunc(nil, &agent, nodes, expectedDaemonSets, nil, false)()
 	})
 
 	Context("with a profile that does not apply to any node", func() {
@@ -124,23 +125,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
 			defaultDaemonSetNamespacedName(namespace, &agent): {
-				affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchExpressions: []v1.NodeSelectorRequirement{
-										{
-											Key:      "some-label",
-											Operator: v1.NodeSelectorOpNotIn,
-											Values:   []string{"3"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				affinity: affinityForDefaultProfile(),
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName:    {},
 					common.ProcessAgentContainerName: {},
@@ -178,7 +163,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 			},
 		}
 
-		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, false)()
+		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, nil, false)()
 	})
 
 	Context("with a profile that applies to all nodes", func() {
@@ -235,23 +220,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
 			defaultDaemonSetNamespacedName(namespace, &agent): {
-				affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchExpressions: []v1.NodeSelectorRequirement{
-										{
-											Key:      "some-label",
-											Operator: v1.NodeSelectorOpNotIn,
-											Values:   []string{"1", "2"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				affinity: affinityForDefaultProfile(),
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName:    {},
 					common.ProcessAgentContainerName: {},
@@ -289,7 +258,12 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 			},
 		}
 
-		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, false)()
+		expectedLabeledNodes := map[string]bool{
+			"test-profiles-node-1": true,
+			"test-profiles-node-2": true,
+		}
+
+		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, expectedLabeledNodes, false)()
 	})
 
 	Context("with a profile that applies to some nodes", func() {
@@ -346,23 +320,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
 			defaultDaemonSetNamespacedName(namespace, &agent): {
-				affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchExpressions: []v1.NodeSelectorRequirement{
-										{
-											Key:      "some-label",
-											Operator: v1.NodeSelectorOpNotIn,
-											Values:   []string{"1"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				affinity: affinityForDefaultProfile(),
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName:    {},
 					common.ProcessAgentContainerName: {},
@@ -400,7 +358,11 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 			},
 		}
 
-		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, false)()
+		expectedLabeledNodes := map[string]bool{
+			"test-profiles-node-1": true,
+		}
+
+		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, expectedLabeledNodes, false)()
 	})
 
 	Context("with several profiles that don't conflict between them", func() {
@@ -503,28 +465,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
 			defaultDaemonSetNamespacedName(namespace, &agent): {
-				affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchExpressions: []v1.NodeSelectorRequirement{
-										{
-											Key:      "some-label",
-											Operator: v1.NodeSelectorOpNotIn,
-											Values:   []string{"1"},
-										},
-										{
-											Key:      "some-label",
-											Operator: v1.NodeSelectorOpNotIn,
-											Values:   []string{"2"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				affinity: affinityForDefaultProfile(),
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName:    {},
 					common.ProcessAgentContainerName: {},
@@ -592,7 +533,12 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 			},
 		}
 
-		testProfilesFunc(profiles, &agent, nodes, expectedDaemonSets, false)()
+		expectedLabeledNodes := map[string]bool{
+			"test-profiles-node-1": true,
+			"test-profiles-node-2": true,
+		}
+
+		testProfilesFunc(profiles, &agent, nodes, expectedDaemonSets, expectedLabeledNodes, false)()
 	})
 
 	Context("with several profiles that conflict between them", func() {
@@ -689,23 +635,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
 			defaultDaemonSetNamespacedName(namespace, &agent): {
-				affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchExpressions: []v1.NodeSelectorRequirement{
-										{
-											Key:      "some-label",
-											Operator: v1.NodeSelectorOpNotIn,
-											Values:   []string{"1"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				affinity: affinityForDefaultProfile(),
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName:    {},
 					common.ProcessAgentContainerName: {},
@@ -744,7 +674,11 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 			// Don't expect a DaemonSet for the conflicting profile
 		}
 
-		testProfilesFunc(profiles, &agent, nodes, expectedDaemonSets, true)()
+		expectedLabeledNodes := map[string]bool{
+			"test-profiles-node-1": true,
+		}
+
+		testProfilesFunc(profiles, &agent, nodes, expectedDaemonSets, expectedLabeledNodes, true)()
 	})
 
 	Context("with a profile that applies and an agent with some resource overrides", func() {
@@ -819,23 +753,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
 			defaultDaemonSetNamespacedName(namespace, &agent): {
-				affinity: &v1.Affinity{
-					NodeAffinity: &v1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-							NodeSelectorTerms: []v1.NodeSelectorTerm{
-								{
-									MatchExpressions: []v1.NodeSelectorRequirement{
-										{
-											Key:      "some-label",
-											Operator: v1.NodeSelectorOpNotIn,
-											Values:   []string{"1"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				affinity: affinityForDefaultProfile(),
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
 						Limits: map[v1.ResourceName]resource.Quantity{
@@ -884,17 +802,124 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 			},
 		}
 
-		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, false)()
+		expectedLabeledNodes := map[string]bool{
+			"test-profiles-node-1": true,
+		}
+
+		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, expectedLabeledNodes, false)()
 	})
 
-	// TODO: marked this one as pending because the current approach of
-	// generating the "opposite" affinity for the default profile does not work
-	// in this case.
-	PContext("with a profile that has more than one node selector requirement", func() {
+	Context("with a profile that has more than one node selector requirement", func() {
+		nodes := []*v1.Node{
+			testutils.NewNode("test-profiles-node-1", map[string]string{"a": "1", "b": "2"}),
+			testutils.NewNode("test-profiles-node-2", map[string]string{"a": "1"}),
+		}
+
+		profile := &v1alpha1.DatadogAgentProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomKubernetesObjectName(),
+				Namespace: namespace,
+			},
+			Spec: v1alpha1.DatadogAgentProfileSpec{
+				ProfileAffinity: &v1alpha1.ProfileAffinity{
+					ProfileNodeAffinity: []v1.NodeSelectorRequirement{ // Applies only to the first node
+						{
+							Key:      "a",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"1"},
+						},
+						{
+							Key:      "b",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"2"},
+						},
+					},
+				},
+				Config: &v1alpha1.Config{
+					Override: map[v1alpha1.ComponentName]*v1alpha1.Override{
+						v1alpha1.NodeAgentComponentName: {
+							Containers: map[common.AgentContainerName]*v1alpha1.Container{
+								common.CoreAgentContainerName: {
+									Resources: &v1.ResourceRequirements{
+										Limits: map[v1.ResourceName]resource.Quantity{
+											v1.ResourceCPU: resource.MustParse("2"),
+										},
+										Requests: map[v1.ResourceName]resource.Quantity{
+											v1.ResourceCPU: resource.MustParse("1"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		agent := testutils.NewDatadogAgentWithoutFeatures(namespace, randomKubernetesObjectName())
+
+		profileDaemonSetName := types.NamespacedName{
+			Namespace: namespace,
+			Name: agentprofile.DaemonSetName(types.NamespacedName{
+				Namespace: profile.Namespace,
+				Name:      profile.Name,
+			}),
+		}
+
+		expectedDaemonSets := map[types.NamespacedName]daemonSetExpectations{
+			defaultDaemonSetNamespacedName(namespace, &agent): {
+				affinity: affinityForDefaultProfile(),
+				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
+					common.CoreAgentContainerName:    {},
+					common.ProcessAgentContainerName: {},
+				},
+			},
+			profileDaemonSetName: {
+				affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      "a",
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"1"},
+										},
+										{
+											Key:      "b",
+											Operator: v1.NodeSelectorOpIn,
+											Values:   []string{"2"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
+					common.CoreAgentContainerName: {
+						Limits: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU: resource.MustParse("2"),
+						},
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+					common.ProcessAgentContainerName: {},
+				},
+			},
+		}
+
+		expectedLabeledNodes := map[string]bool{
+			"test-profiles-node-1": true,
+		}
+
+		testProfilesFunc([]*v1alpha1.DatadogAgentProfile{profile}, &agent, nodes, expectedDaemonSets, expectedLabeledNodes, false)()
 	})
 })
 
-func testProfilesFunc(profiles []*v1alpha1.DatadogAgentProfile, agent *v2alpha1.DatadogAgent, nodes []*v1.Node, expectedDaemonSets map[types.NamespacedName]daemonSetExpectations, waitBetweenProfiles bool) func() {
+func testProfilesFunc(profiles []*v1alpha1.DatadogAgentProfile, agent *v2alpha1.DatadogAgent, nodes []*v1.Node, expectedDaemonSets map[types.NamespacedName]daemonSetExpectations, expectedLabeledNodes map[string]bool, waitBetweenProfiles bool) func() {
 	return func() {
 		BeforeEach(func() {
 			for _, node := range nodes {
@@ -929,7 +954,7 @@ func testProfilesFunc(profiles []*v1alpha1.DatadogAgentProfile, agent *v2alpha1.
 			}
 		})
 
-		It("should create the expected DaemonSets", func() {
+		It("should create the expected DaemonSets and label nodes with profiles", func() {
 			for namespacedName, expectedDaemonSet := range expectedDaemonSets {
 				storedDaemonSet := &appsv1.DaemonSet{}
 
@@ -961,8 +986,23 @@ func testProfilesFunc(profiles []*v1alpha1.DatadogAgentProfile, agent *v2alpha1.
 					}
 				}
 			}
+
+			// Check that only the nodes with profiles are labeled
+			nodeList := v1.NodeList{}
+			err := k8sClient.List(context.TODO(), &nodeList)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, node := range nodeList.Items {
+				_, expectLabel := expectedLabeledNodes[node.Name]
+				if expectLabel {
+					Expect(node.Labels[agentprofile.ProfileLabelKey]).To(Equal("true"))
+				} else {
+					Expect(node.Labels[agentprofile.ProfileLabelKey]).To(Equal(""))
+				}
+			}
 		})
 	}
+
 }
 
 func randomKubernetesObjectName() string {
@@ -1010,4 +1050,23 @@ func sortAffinityRequirements(affinity *v1.Affinity) {
 	sort.Slice(nodeSelectorTerms, func(i, j int) bool {
 		return nodeSelectorTerms[i].String() < nodeSelectorTerms[j].String()
 	})
+}
+
+func affinityForDefaultProfile() *v1.Affinity {
+	return &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      agentprofile.ProfileLabelKey,
+								Operator: v1.NodeSelectorOpDoesNotExist,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Changes the strategy used to create the default profile (the one that applies to nodes where none of the profiles defined apply).

We were creating the default profile by generating the opposite selector requirements of all the others. The downside of this approach is that it redeploys everything when the profile changes. Also, we did not implement support for profiles with multiple selector requirements which is not so easy to do with this approach.

The new approach tags adds a specific label whenever a profile is applied to them and defines the default profile's node affinity so that it excludes nodes with this label. This change fixes the issues mentioned above.


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
