### PR TITLE
[profiles] Add pod anti-affinity to agent pods

### DIFF
--- a/controllers/datadogagent_controller_v2_profiles_test.go
+++ b/controllers/datadogagent_controller_v2_profiles_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
@@ -170,6 +171,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -273,6 +275,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -381,6 +384,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -534,6 +538,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -564,6 +569,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -712,6 +718,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -848,6 +855,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -967,6 +975,7 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 							},
 						},
 					},
+					PodAntiAffinity: podAntiAffinityForAgents(),
 				},
 				containerResources: map[common.AgentContainerName]v1.ResourceRequirements{
 					common.CoreAgentContainerName: {
@@ -1140,6 +1149,26 @@ func affinityForDefaultProfile() *v1.Affinity {
 						},
 					},
 				},
+			},
+		},
+		PodAntiAffinity: podAntiAffinityForAgents(),
+	}
+}
+
+func podAntiAffinityForAgents() *v1.PodAntiAffinity {
+	return &v1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      apicommon.AgentDeploymentComponentLabelKey,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"agent"},
+						},
+					},
+				},
+				TopologyKey: v1.LabelHostname,
 			},
 		},
 	}

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
@@ -393,6 +394,24 @@ func TestComponentOverrideFromProfile(t *testing.T) {
 				Labels: map[string]string{
 					"agent.datadoghq.com/profile": fmt.Sprintf("%s-%s", "default", "example"),
 				},
+				Affinity: &v1.Affinity{
+					PodAntiAffinity: &v1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      apicommon.AgentDeploymentComponentLabelKey,
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"agent"},
+										},
+									},
+								},
+								TopologyKey: v1.LabelHostname,
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -413,6 +432,22 @@ func TestComponentOverrideFromProfile(t *testing.T) {
 										},
 									},
 								},
+							},
+						},
+					},
+					PodAntiAffinity: &v1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      apicommon.AgentDeploymentComponentLabelKey,
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"agent"},
+										},
+									},
+								},
+								TopologyKey: v1.LabelHostname,
 							},
 						},
 					},


### PR DESCRIPTION
### What does this PR do?

Adds pod anti-affinity to agent pods to avoid scheduling multiple agent pods of different profiles on the same node during rollouts.

I've marked this as draft because this PR contains the commits from #1002. It needs to be merged before this one.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
