### PR TITLE
Enabling APM by default (#1006) 

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -34,7 +34,7 @@ const (
 	// defaultOOMKillEnabled        bool = false
 	// defaultTCPQueueLengthEnabled bool = false
 
-	// defaultAPMEnabled         bool   = false
+	defaultAPMEnabled         bool   = true
 	defaultAPMHostPortEnabled bool   = false
 	defaultAPMHostPort        int32  = 8126
 	defaultAPMSocketEnabled   bool   = true
@@ -162,8 +162,14 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 		}
 	}
 
-	// APM Feature
-	if ddaSpec.Features.APM != nil && ddaSpec.Features.APM.Enabled != nil && *ddaSpec.Features.APM.Enabled {
+	// APM is enabled by default
+	if ddaSpec.Features.APM == nil {
+		ddaSpec.Features.APM = &APMFeatureConfig{}
+	}
+
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.APM.Enabled, defaultAPMEnabled)
+
+	if *ddaSpec.Features.APM.Enabled {
 		if ddaSpec.Features.APM.HostPortConfig == nil {
 			ddaSpec.Features.APM.HostPortConfig = &HostPortConfig{}
 		}

--- a/apis/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -115,6 +115,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
@@ -322,6 +333,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(valueTrue),
 					},
@@ -386,6 +408,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LogCollection: &LogCollectionFeatureConfig{
 						Enabled:                    apiutils.NewBoolPointer(valueTrue),
 						ContainerCollectUsingFiles: apiutils.NewBoolPointer(defaultLogContainerCollectUsingFiles),
@@ -525,6 +558,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
@@ -597,6 +641,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
@@ -657,6 +712,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
@@ -723,6 +789,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
@@ -784,6 +861,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
@@ -845,6 +933,17 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
@@ -929,9 +1028,19 @@ func Test_defaultFeatures(t *testing.T) {
 					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
 					},
-					OOMKill:               &OOMKillFeatureConfig{},
-					TCPQueueLength:        &TCPQueueLengthFeatureConfig{},
-					APM:                   &APMFeatureConfig{},
+					OOMKill:        &OOMKillFeatureConfig{},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{},
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
 					CSPM:                  &CSPMFeatureConfig{},
 					CWS:                   &CWSFeatureConfig{},
 					NPM:                   &NPMFeatureConfig{},

--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -102,7 +102,7 @@ type DatadogFeatures struct {
 // APM runs in the Trace Agent.
 type APMFeatureConfig struct {
 	// Enabled enables Application Performance Monitoring.
-	// Default: false
+	// Default: true
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -7826,7 +7826,7 @@ spec:
                       description: APM (Application Performance Monitoring) configuration.
                       properties:
                         enabled:
-                          description: 'Enabled enables Application Performance Monitoring. Default: false'
+                          description: 'Enabled enables Application Performance Monitoring. Default: true'
                           type: boolean
                         hostPortConfig:
                           description: 'HostPortConfig contains host port configuration. Enabled Default: false Port Default: 8126'

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -15376,7 +15376,7 @@ spec:
                       description: APM (Application Performance Monitoring) configuration.
                       properties:
                         enabled:
-                          description: 'Enabled enables Application Performance Monitoring. Default: false'
+                          description: 'Enabled enables Application Performance Monitoring. Default: true'
                           type: boolean
                         hostPortConfig:
                           description: 'HostPortConfig contains host port configuration. Enabled Default: false Port Default: 8126'

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -40,7 +40,7 @@ spec:
 | features.admissionController.mutateUnlabelled | MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled="true"'. Default: false |
 | features.admissionController.serviceName | ServiceName corresponds to the webhook service name. |
 | features.admissionController.webhookName | WebhookName is a custom name for the MutatingWebhookConfiguration. Default: "datadog-webhook" |
-| features.apm.enabled | Enabled enables Application Performance Monitoring. Default: false |
+| features.apm.enabled | Enabled enables Application Performance Monitoring. Default: true |
 | features.apm.hostPortConfig.enabled | Enabled enables host port configuration Default: false |
 | features.apm.hostPortConfig.hostPort | Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.) If HostNetwork is enabled, this value must match the ContainerPort. |
 | features.apm.unixDomainSocketConfig.enabled | Enabled enables Unix Domain Socket. Default: true |


### PR DESCRIPTION
### What does this PR do?

Breaking up https://github.com/DataDog/datadog-operator/pull/981 into 2 parts.

### Motivation

Unblock Release of 1.3.0.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
