### PR TITLE
[APMON-406] Set Datadog namespace env variable on Cluster Agent

### DIFF
--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -68,6 +68,7 @@ const (
 	DDKubeletCAPath                                   = "DD_KUBELET_CLIENT_CA"
 	DDKubeletHost                                     = "DD_KUBERNETES_KUBELET_HOST"
 	DDKubeletTLSVerify                                = "DD_KUBELET_TLS_VERIFY"
+	DDKubeResourcesNamespace                          = "DD_KUBE_RESOURCES_NAMESPACE"
 	DDKubeStateMetricsCoreConfigMap                   = "DD_KUBE_STATE_METRICS_CORE_CONFIGMAP_NAME"
 	DDKubeStateMetricsCoreEnabled                     = "DD_KUBE_STATE_METRICS_CORE_ENABLED"
 	DDLeaderElection                                  = "DD_LEADER_ELECTION"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	testDdaName     = "foo"
-	agentConfigFile = "/etc/datadog-agent/datadog.yaml"
+	testDdaName      = "foo"
+	testDdaNamespace = "bar"
+	agentConfigFile  = "/etc/datadog-agent/datadog.yaml"
 )
 
 func apiKeyValue() *corev1.EnvVarSource {

--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -529,6 +529,10 @@ func getEnvVarsForClusterAgent(logger logr.Logger, dda *datadoghqv1alpha1.Datado
 			Value: utils.GetDatadogLeaderElectionResourceName(dda),
 		},
 		{
+			Name:  apicommon.DDKubeResourcesNamespace,
+			Value: utils.GetDatadogAgentResourceNamespace(dda),
+		},
+		{
 			Name:  apicommon.DDComplianceConfigEnabled,
 			Value: strconv.FormatBool(complianceEnabled),
 		},

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -201,6 +201,10 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 			Name:  "DD_CLUSTER_AGENT_TOKEN_NAME",
 			Value: fmt.Sprintf("%stoken", testDdaName),
 		},
+		{
+			Name:  "DD_KUBE_RESOURCES_NAMESPACE",
+			Value: testDdaNamespace,
+		},
 	}
 }
 

--- a/pkg/controller/utils/shared_utils.go
+++ b/pkg/controller/utils/shared_utils.go
@@ -23,6 +23,11 @@ func GetDatadogLeaderElectionResourceName(dda metav1.Object) string {
 	return fmt.Sprintf("%s-leader-election", dda.GetName())
 }
 
+// GetDatadogAgentResourceNamespace returns the namespace of the Datadog Agent Resource
+func GetDatadogAgentResourceNamespace(dda metav1.Object) string {
+	return dda.GetNamespace()
+}
+
 // GetDatadogTokenResourceName returns the name of the ConfigMap used by the cluster agent to store token
 func GetDatadogTokenResourceName(dda metav1.Object) string {
 	return fmt.Sprintf("%stoken", dda.GetName())


### PR DESCRIPTION
### What does this PR do?

Sets an environment variable DD_KUBE_RESOURCES_NAMESPACE on Cluster Agent, indicating the Kubernetes namespace where Datadog is running at. This env variable is already set by Helm Charts and is used in Cluster Agent.

### Motivation

To move APM Instrumentation namespaces exclusion logic to Cluster Agent, Cluster Agent needs to know the namespace where it's running.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Updated Cluster Agent unit-tests in the Operator

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
