### PR TITLE
[CECO-836] DCA namespace resources env var added for V2

### DIFF
--- a/controllers/datadogagent/clusteragent.go
+++ b/controllers/datadogagent/clusteragent.go
@@ -529,10 +529,6 @@ func getEnvVarsForClusterAgent(logger logr.Logger, dda *datadoghqv1alpha1.Datado
 			Value: utils.GetDatadogLeaderElectionResourceName(dda),
 		},
 		{
-			Name:  apicommon.DDKubeResourcesNamespace,
-			Value: utils.GetDatadogAgentResourceNamespace(dda),
-		},
-		{
 			Name:  apicommon.DDComplianceConfigEnabled,
 			Value: strconv.FormatBool(complianceEnabled),
 		},

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -133,6 +133,10 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 			Value: GetClusterAgentServiceName(dda),
 		},
 		{
+			Name:  apicommon.DDKubeResourcesNamespace,
+			Value: utils.GetDatadogAgentResourceNamespace(dda),
+		},
+		{
 			Name:  apicommon.DDLeaderElection,
 			Value: "true",
 		},


### PR DESCRIPTION
### What does this PR do?

DCA namespace resources env var added for V2

### Motivation

CECO-836

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent: N/A

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
