### PR TITLE
[CECO-754][introspection] Clean up unused ds/eds

### DIFF
--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -73,31 +73,31 @@ type ReconcilerOptions struct {
 
 // Reconciler is the internal reconciler for Datadog Agent
 type Reconciler struct {
-	options      ReconcilerOptions
-	client       client.Client
-	versionInfo  *version.Info
-	platformInfo kubernetes.PlatformInfo
-	providers    *kubernetes.ProviderStore
-	scheme       *runtime.Scheme
-	log          logr.Logger
-	recorder     record.EventRecorder
-	forwarders   datadog.MetricForwardersManager
+	options       ReconcilerOptions
+	client        client.Client
+	versionInfo   *version.Info
+	platformInfo  kubernetes.PlatformInfo
+	providerStore *kubernetes.ProviderStore
+	scheme        *runtime.Scheme
+	log           logr.Logger
+	recorder      record.EventRecorder
+	forwarders    datadog.MetricForwardersManager
 }
 
 // NewReconciler returns a reconciler for DatadogAgent
 func NewReconciler(options ReconcilerOptions, client client.Client, versionInfo *version.Info, platformInfo kubernetes.PlatformInfo,
-	providers *kubernetes.ProviderStore, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder,
+	providerStore *kubernetes.ProviderStore, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder,
 	metricForwarder datadog.MetricForwardersManager) (*Reconciler, error) {
 	return &Reconciler{
-		options:      options,
-		client:       client,
-		versionInfo:  versionInfo,
-		platformInfo: platformInfo,
-		providers:    providers,
-		scheme:       scheme,
-		log:          log,
-		recorder:     recorder,
-		forwarders:   metricForwarder,
+		options:       options,
+		client:        client,
+		versionInfo:   versionInfo,
+		platformInfo:  platformInfo,
+		providerStore: providerStore,
+		scheme:        scheme,
+		log:           log,
+		recorder:      recorder,
+		forwarders:    metricForwarder,
 	}, nil
 }
 

--- a/controllers/datadogagent/controller_reconcile_agent_test.go
+++ b/controllers/datadogagent/controller_reconcile_agent_test.go
@@ -1,19 +1,29 @@
 package datadogagent
 
 import (
+	"context"
 	"testing"
 
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
+	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const defaultProvider = kubernetes.DefaultProvider
+const gcpCosContainerdProvider = kubernetes.GCPCloudProvider + "-" + kubernetes.GCPCosContainerdProviderValue
+
 func Test_generateNodeAffinity(t *testing.T) {
-	defaultProvider := kubernetes.DefaultProvider
-	gcpCosContainerdProvider := kubernetes.GCPCloudProvider + "-" + kubernetes.GCPCosContainerdProviderValue
 
 	type args struct {
 		affinity *corev1.Affinity
@@ -237,4 +247,335 @@ func getAffinityComponents(affinity *corev1.Affinity) (*corev1.NodeAffinity, *co
 		return nil, nil, nil
 	}
 	return affinity.NodeAffinity, affinity.PodAffinity, affinity.PodAntiAffinity
+}
+
+func Test_updateProviderStore(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name              string
+		nodes             []client.Object
+		existingProviders map[string]struct{}
+		wantedProviders   *map[string]struct{}
+	}{
+		{
+			name: "recompute all providers",
+			nodes: []client.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gcp-cos-node",
+						Labels: map[string]string{
+							kubernetes.GCPProviderLabel: kubernetes.GCPCosProviderValue,
+						},
+					},
+				},
+			},
+			existingProviders: map[string]struct{}{
+				"gcp-cos_containerd": {},
+				"default":            {},
+			},
+			wantedProviders: &map[string]struct{}{
+				"gcp-cos": {},
+			},
+		},
+		{
+			name:  "empty node list",
+			nodes: []client.Object{},
+			existingProviders: map[string]struct{}{
+				"gcp-cos_containerd": {},
+				"default":            {},
+			},
+			wantedProviders: &map[string]struct{}{
+				"gcp-cos_containerd": {},
+				"default":            {},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.nodes...).Build()
+			p := kubernetes.NewProviderStore(logf.Log.WithName("test_updateProviderStore"))
+			r := &Reconciler{
+				providers: &p,
+				client:    fakeClient,
+			}
+			r.providers.SetAllProviders(tt.existingProviders)
+
+			err := r.updateProviderStore(ctx)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantedProviders, r.providers.GetProviders())
+		})
+	}
+}
+
+func Test_cleanupUnusedProviders(t *testing.T) {
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	_ = edsdatadoghqv1alpha1.AddToScheme(sch)
+	ctx := context.Background()
+
+	testCases := []struct {
+		name              string
+		agents            []client.Object
+		edsEnabled        bool
+		existingProviders map[string]struct{}
+		wantDS            *appsv1.DaemonSetList
+		wantEDS           *edsdatadoghqv1alpha1.ExtendedDaemonSetList
+	}{
+		{
+			name: "no unused ds",
+			agents: []client.Object{
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gcp-cos-node",
+						Labels: map[string]string{
+							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+						},
+					},
+				},
+			},
+			edsEnabled: false,
+			existingProviders: map[string]struct{}{
+				gcpCosContainerdProvider: {},
+			},
+			wantDS: &appsv1.DaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DaemonSetList",
+					APIVersion: "apps/v1",
+				},
+				Items: []appsv1.DaemonSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gcp-cos-node",
+							Labels: map[string]string{
+								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							},
+							ResourceVersion: "999",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no unused eds",
+			agents: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gcp-cos-node",
+						Labels: map[string]string{
+							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+						},
+					},
+				},
+			},
+			edsEnabled: true,
+			existingProviders: map[string]struct{}{
+				gcpCosContainerdProvider: {},
+			},
+			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ExtendedDaemonSetList",
+					APIVersion: "datadoghq.com/v1alpha1",
+				},
+				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gcp-cos-node",
+							Labels: map[string]string{
+								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							},
+							ResourceVersion: "999",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unused ds",
+			agents: []client.Object{
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gcp-cos-node",
+						Labels: map[string]string{
+							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+						},
+					},
+				},
+			},
+			edsEnabled: false,
+			existingProviders: map[string]struct{}{
+				defaultProvider: {},
+			},
+			wantDS: &appsv1.DaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DaemonSetList",
+					APIVersion: "apps/v1",
+				},
+				Items: []appsv1.DaemonSet{},
+			},
+		},
+		{
+			name: "unused eds",
+			agents: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gcp-cos-node",
+						Labels: map[string]string{
+							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+						},
+					},
+				},
+			},
+			edsEnabled: true,
+			existingProviders: map[string]struct{}{
+				defaultProvider: {},
+			},
+			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ExtendedDaemonSetList",
+					APIVersion: "datadoghq.com/v1alpha1",
+				},
+				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{},
+			},
+		},
+		{
+			name:       "no ds to delete",
+			agents:     []client.Object{},
+			edsEnabled: false,
+			existingProviders: map[string]struct{}{
+				gcpCosContainerdProvider: {},
+			},
+			wantDS: &appsv1.DaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DaemonSetList",
+					APIVersion: "apps/v1",
+				},
+				Items: nil,
+			},
+		},
+		{
+			name:       "no eds to delete",
+			agents:     []client.Object{},
+			edsEnabled: true,
+			existingProviders: map[string]struct{}{
+				gcpCosContainerdProvider: {},
+			},
+			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ExtendedDaemonSetList",
+					APIVersion: "datadoghq.com/v1alpha1",
+				},
+				Items: nil,
+			},
+		},
+		{
+			name: "no providers for ds",
+			agents: []client.Object{
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gcp-cos-node",
+						Labels: map[string]string{
+							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+						},
+					},
+				},
+			},
+			edsEnabled:        false,
+			existingProviders: map[string]struct{}{},
+			wantDS: &appsv1.DaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DaemonSetList",
+					APIVersion: "apps/v1",
+				},
+				Items: []appsv1.DaemonSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gcp-cos-node",
+							Labels: map[string]string{
+								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							},
+							ResourceVersion: "999",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no providers for eds",
+			agents: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "gcp-cos-node",
+						Labels: map[string]string{
+							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+						},
+					},
+				},
+			},
+			edsEnabled:        true,
+			existingProviders: map[string]struct{}{},
+			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ExtendedDaemonSetList",
+					APIVersion: "datadoghq.com/v1alpha1",
+				},
+				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gcp-cos-node",
+							Labels: map[string]string{
+								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							},
+							ResourceVersion: "999",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(tt.agents...).Build()
+			p := kubernetes.NewProviderStore(logf.Log.WithName("test_cleanupUnusedProviders"))
+			r := &Reconciler{
+				providers: &p,
+				client:    fakeClient,
+				options: ReconcilerOptions{
+					ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+						Enabled: tt.edsEnabled,
+					},
+				},
+			}
+			r.providers.SetAllProviders(tt.existingProviders)
+
+			err := r.cleanupUnusedProviders(ctx)
+			assert.NoError(t, err)
+
+			kind := "daemonsets"
+			if tt.edsEnabled {
+				kind = "extendeddaemonsets"
+			}
+			objList := getObjectListFromKind(kind)
+			err = fakeClient.List(ctx, objList)
+			assert.NoError(t, err)
+
+			if tt.edsEnabled {
+				assert.Equal(t, tt.wantEDS, objList)
+			} else {
+				assert.Equal(t, tt.wantDS, objList)
+			}
+		})
+	}
+}
+
+func getObjectListFromKind(kind string) client.ObjectList {
+	switch kind {
+	case "daemonsets":
+		return &appsv1.DaemonSetList{}
+	case "extendeddaemonsets":
+		return &edsdatadoghqv1alpha1.ExtendedDaemonSetList{}
+	}
+	return nil
 }

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -143,11 +143,11 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	requiredContainers := requiredComponents.Agent.Containers
 
 	// for all providers, go through agent reconcile
-	providersList, err := r.handleProviders(ctx)
+	providersList, err := r.handleProviders(ctx, instance)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	for provider := range *providersList {
+	for provider := range providersList {
 		result, err = r.reconcileV2Agent(logger, requiredComponents, features, instance, resourceManagers, newStatus, requiredContainers, provider)
 		if utils.ShouldReturn(result, err) {
 			return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err)

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -143,10 +143,10 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	requiredContainers := requiredComponents.Agent.Containers
 
 	// for all providers, go through agent reconcile
-	if err = r.handleProviders(ctx); err != nil {
+	providersList, err := r.handleProviders(ctx)
+	if err != nil {
 		errs = append(errs, err)
 	}
-	providersList := r.providers.GetProviders()
 	for provider := range *providersList {
 		result, err = r.reconcileV2Agent(logger, requiredComponents, features, instance, resourceManagers, newStatus, requiredContainers, provider)
 		if utils.ShouldReturn(result, err) {

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -143,6 +143,9 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	requiredContainers := requiredComponents.Agent.Containers
 
 	// for all providers, go through agent reconcile
+	if err = r.handleProviders(ctx); err != nil {
+		errs = append(errs, err)
+	}
 	providersList := r.providers.GetProviders()
 	for provider := range *providersList {
 		result, err = r.reconcileV2Agent(logger, requiredComponents, features, instance, resourceManagers, newStatus, requiredContainers, provider)

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -40,14 +40,14 @@ import (
 // DatadogAgentReconciler reconciles a DatadogAgent object.
 type DatadogAgentReconciler struct {
 	client.Client
-	VersionInfo  *version.Info
-	PlatformInfo kubernetes.PlatformInfo
-	Providers    *kubernetes.ProviderStore
-	Log          logr.Logger
-	Scheme       *runtime.Scheme
-	Recorder     record.EventRecorder
-	Options      datadogagent.ReconcilerOptions
-	internal     *datadogagent.Reconciler
+	VersionInfo   *version.Info
+	PlatformInfo  kubernetes.PlatformInfo
+	ProviderStore *kubernetes.ProviderStore
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	Recorder      record.EventRecorder
+	Options       datadogagent.ReconcilerOptions
+	internal      *datadogagent.Reconciler
 }
 
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadogagents,verbs=get;list;watch;create;update;patch;delete
@@ -198,12 +198,6 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder.Watches(&source.Kind{Type: &rbacv1.ClusterRole{}}, handlerEnqueue)
 	builder.Watches(&source.Kind{Type: &rbacv1.ClusterRoleBinding{}}, handlerEnqueue)
 
-	// node informer for introspection
-	builder.Watches(&source.Kind{Type: &corev1.Node{}}, handler.EnqueueRequestsFromMapFunc(func(obj client.Object) (reqs []reconcile.Request) {
-		r.Providers.SetProvider(obj)
-		return
-	}))
-
 	if r.Options.ExtendedDaemonsetOptions.Enabled {
 		builder = builder.Owns(&edsdatadoghqv1alpha1.ExtendedDaemonSet{})
 	}
@@ -241,7 +235,7 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 
-	internal, err := datadogagent.NewReconciler(r.Options, r.Client, r.VersionInfo, r.PlatformInfo, r.Providers, r.Scheme, r.Log, r.Recorder, metricForwarder)
+	internal, err := datadogagent.NewReconciler(r.Options, r.Client, r.VersionInfo, r.PlatformInfo, r.ProviderStore, r.Scheme, r.Log, r.Recorder, metricForwarder)
 	if err != nil {
 		return err
 	}

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -86,10 +86,10 @@ func SetupControllers(logger logr.Logger, mgr manager.Manager, options SetupOpti
 	}
 	platformInfo := kubernetes.NewPlatformInfo(versionInfo, groups, resources)
 
-	providers := kubernetes.NewProviderStore(logger)
+	providerStore := kubernetes.NewProviderStore(logger)
 
 	for controller, starter := range controllerStarters {
-		if err := starter(logger, mgr, versionInfo, platformInfo, &providers, options); err != nil {
+		if err := starter(logger, mgr, versionInfo, platformInfo, &providerStore, options); err != nil {
 			logger.Error(err, "Couldn't start controller", "controller", controller)
 		}
 	}
@@ -108,7 +108,7 @@ func getServerGroupsAndResources(log logr.Logger, discoveryClient *discovery.Dis
 	return groups, resources, nil
 }
 
-func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, pInfo kubernetes.PlatformInfo, providers *kubernetes.ProviderStore, options SetupOptions) error {
+func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, pInfo kubernetes.PlatformInfo, providerStore *kubernetes.ProviderStore, options SetupOptions) error {
 	if !options.DatadogAgentEnabled {
 		logger.Info("Feature disabled, not starting the controller", "controller", agentControllerName)
 
@@ -116,13 +116,13 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 	}
 
 	return (&DatadogAgentReconciler{
-		Client:       mgr.GetClient(),
-		VersionInfo:  vInfo,
-		PlatformInfo: pInfo,
-		Providers:    providers,
-		Log:          ctrl.Log.WithName("controllers").WithName(agentControllerName),
-		Scheme:       mgr.GetScheme(),
-		Recorder:     mgr.GetEventRecorderFor(agentControllerName),
+		Client:        mgr.GetClient(),
+		VersionInfo:   vInfo,
+		PlatformInfo:  pInfo,
+		ProviderStore: providerStore,
+		Log:           ctrl.Log.WithName("controllers").WithName(agentControllerName),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorderFor(agentControllerName),
 		Options: datadogagent.ReconcilerOptions{
 			ExtendedDaemonsetOptions: componentagent.ExtendedDaemonsetOptions{
 				Enabled:                    options.SupportExtendedDaemonset.Enabled,
@@ -142,7 +142,7 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 	}).SetupWithManager(mgr)
 }
 
-func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, pInfo kubernetes.PlatformInfo, providers *kubernetes.ProviderStore, options SetupOptions) error {
+func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, pInfo kubernetes.PlatformInfo, providerStore *kubernetes.ProviderStore, options SetupOptions) error {
 	if !options.DatadogMonitorEnabled {
 		logger.Info("Feature disabled, not starting the controller", "controller", monitorControllerName)
 
@@ -164,7 +164,7 @@ func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, vInfo *version
 	}).SetupWithManager(mgr)
 }
 
-func startDatadogSLO(logger logr.Logger, mgr manager.Manager, info *version.Info, pInfo kubernetes.PlatformInfo, providers *kubernetes.ProviderStore, options SetupOptions) error {
+func startDatadogSLO(logger logr.Logger, mgr manager.Manager, info *version.Info, pInfo kubernetes.PlatformInfo, providerStore *kubernetes.ProviderStore, options SetupOptions) error {
 	if !options.DatadogSLOEnabled {
 		logger.Info("Feature disabled, not starting the controller", "controller", sloControllerName)
 		return nil

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ProviderStore struct {
@@ -53,20 +52,6 @@ func DetermineProvider(labels map[string]string) string {
 	}
 
 	return DefaultProvider
-}
-
-// SetProvider creates a provider entry for a new provider if needed
-func (p *ProviderStore) SetProvider(obj client.Object) {
-	labels := obj.GetLabels()
-	objProvider := DetermineProvider(labels)
-
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	// add a new provider
-	if _, ok := p.providers[objProvider]; !ok {
-		p.providers[objProvider] = struct{}{}
-		p.log.Info("New provider detected", "provider", objProvider)
-	}
 }
 
 // GetProviders gets a list of providers
@@ -156,8 +141,8 @@ func sortProviders(providers map[string]struct{}) []string {
 	return sortedProviders
 }
 
-// SetAllProviders overwrites all providers in the provider store given a list of providers
-func (p *ProviderStore) SetAllProviders(providersList map[string]struct{}) {
+// Reset overwrites all providers in the provider store given a list of providers
+func (p *ProviderStore) Reset(providersList map[string]struct{}) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -166,8 +151,8 @@ func (p *ProviderStore) SetAllProviders(providersList map[string]struct{}) {
 	}
 }
 
-// IsProviderInProviderStore returns whether the given provider exists in the provider store
-func (p *ProviderStore) IsProviderInProviderStore(provider string) bool {
+// IsPresent returns whether the given provider exists in the provider store
+func (p *ProviderStore) IsPresent(provider string) bool {
 	if provider == "" {
 		return false
 	}

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -142,13 +142,15 @@ func sortProviders(providers map[string]struct{}) []string {
 }
 
 // Reset overwrites all providers in the provider store given a list of providers
-func (p *ProviderStore) Reset(providersList map[string]struct{}) {
+func (p *ProviderStore) Reset(providersList map[string]struct{}) map[string]struct{} {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	if len(providersList) > 0 {
 		p.providers = providersList
 	}
+
+	return p.providers
 }
 
 // IsPresent returns whether the given provider exists in the provider store

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -10,20 +10,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
-	gcpCosNode = corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "bar",
-			Name:      "node1",
-			Labels: map[string]string{
-				GCPProviderLabel: GCPCosProviderValue,
-			},
-		},
-	}
 	defaultProvider          = DefaultProvider
 	gcpCosContainerdProvider = generateProviderName(GCPCloudProvider, GCPCosContainerdProviderValue)
 	gcpCosProvider           = generateProviderName(GCPCloudProvider, GCPCosProviderValue)

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -72,67 +72,6 @@ func Test_determineProvider(t *testing.T) {
 		})
 	}
 }
-func Test_SetProvider(t *testing.T) {
-	tests := []struct {
-		name              string
-		obj               corev1.Node
-		existingProviders *ProviderStore
-		wantProviders     *ProviderStore
-	}{
-		{
-			name:              "add new provider",
-			obj:               gcpCosNode,
-			existingProviders: nil,
-			wantProviders: &ProviderStore{
-				providers: map[string]struct{}{
-					gcpCosProvider: {},
-				},
-			},
-		},
-		{
-			name: "add new provider with existing provider",
-			obj:  gcpCosNode,
-			existingProviders: &ProviderStore{
-				providers: map[string]struct{}{
-					"test": {},
-				},
-			},
-			wantProviders: &ProviderStore{
-				providers: map[string]struct{}{
-					"test":         {},
-					gcpCosProvider: {},
-				},
-			},
-		},
-		{
-			name: "add new node name to existing provider",
-			obj:  gcpCosNode,
-			existingProviders: &ProviderStore{
-				providers: map[string]struct{}{
-					gcpCosProvider: {},
-				},
-			},
-			wantProviders: &ProviderStore{
-				providers: map[string]struct{}{
-					gcpCosProvider: {},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			logger := logf.Log.WithName(t.Name())
-			profile := NewProviderStore(logger)
-			if tt.existingProviders != nil && tt.existingProviders.providers != nil {
-				profile.providers = tt.existingProviders.providers
-			}
-
-			profile.SetProvider(&tt.obj)
-			assert.Equal(t, tt.wantProviders.providers, profile.providers)
-		})
-	}
-}
 
 func Test_sortProviders(t *testing.T) {
 	tests := []struct {
@@ -348,7 +287,7 @@ func Test_GetProviderLabelKeyValue(t *testing.T) {
 	}
 }
 
-func Test_SetAllProviders(t *testing.T) {
+func Test_Reset(t *testing.T) {
 	tests := []struct {
 		name              string
 		newProviders      map[string]struct{}
@@ -411,13 +350,13 @@ func Test_SetAllProviders(t *testing.T) {
 				providerStore.providers = tt.existingProviders.providers
 			}
 
-			providerStore.SetAllProviders(tt.newProviders)
+			providerStore.Reset(tt.newProviders)
 			assert.Equal(t, tt.wantProviders.providers, providerStore.providers)
 		})
 	}
 }
 
-func Test_IsProviderInProviderStore(t *testing.T) {
+func Test_IsPresent(t *testing.T) {
 	tests := []struct {
 		name              string
 		provider          string
@@ -471,7 +410,7 @@ func Test_IsProviderInProviderStore(t *testing.T) {
 				providerStore.providers = tt.existingProviders.providers
 			}
 
-			assert.Equal(t, tt.want, providerStore.IsProviderInProviderStore(tt.provider))
+			assert.Equal(t, tt.want, providerStore.IsPresent(tt.provider))
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Cleans up unused DS/EDSs. In a cluster with cos and ubuntu node pools, we start with 2 DS:
```
$ kubectl get pods
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-gcp-cos-bp9hj                  3/3     Running   0          5m46s
datadog-agent-gcp-cos-rp5jl                  3/3     Running   0          5m46s
datadog-agent-gcp-ubuntu-h8d95               3/3     Running   0          2m
datadog-agent-gcp-ubuntu-mkfbq               3/3     Running   0          2m
datadog-cluster-agent-54cbb867bc-jhvw5       1/1     Running   0          5m46s
operator-datadog-operator-5c965d787d-2zxh8   1/1     Running   0          10m
$ kubectl get ds
NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-gcp-cos      2         2         2       2            2           <none>          5m52s
datadog-agent-gcp-ubuntu   2         2         2       2            2           <none>          2m6s
$ kubectl get dd
NAME      AGENT             CLUSTER-AGENT     CLUSTER-CHECKS-RUNNER   AGE
datadog   Running (4/4/4)   Running (1/1/1)                           5m55s
```

After deleting the ubuntu node pool, only cos nodes are left so only the `datadog-agent-gcp-cos` DS is needed:
```
$ kubectl get ds
NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-gcp-cos   2         2         2       2            2           <none>          9m32s
$ kubectl get pods
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-gcp-cos-bp9hj                  3/3     Running   0          9m33s
datadog-agent-gcp-cos-rp5jl                  3/3     Running   0          9m33s
datadog-cluster-agent-54cbb867bc-jhvw5       1/1     Running   0          9m33s
operator-datadog-operator-5c965d787d-2zxh8   1/1     Running   0          14m
$ kubectl get dd
NAME      AGENT             CLUSTER-AGENT     CLUSTER-CHECKS-RUNNER   AGE
datadog   Running (2/2/2)   Running (1/1/1)                           31m
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

1. Spin up node pools with multiple providers (e.g. cos and ubuntu) so that multiple DS/EDSs are created
2. Delete some node pools so that there are fewer providers than before
3. Ensure that DS/EDSs that do not spin up agent pods are deleted

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
