### PR TITLE
update feature default values and tests

### DIFF
--- a/apis/datadoghq/v2alpha1/datadogagent_default.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default.go
@@ -11,7 +11,6 @@ import (
 )
 
 // Default configuration values. These are the recommended settings for monitoring with Datadog in Kubernetes.
-// Note: many default values are set in the Datadog Agent and deliberately not set by the Operator.
 const (
 	defaultSite       string = "datadoghq.com"
 	defaultEuropeSite string = "datadoghq.eu"
@@ -19,20 +18,21 @@ const (
 	defaultGovSite    string = "ddog-gov.com"
 	defaultLogLevel   string = "info"
 
-	// defaultLogCollectionEnabled          bool   = false
+	defaultLogCollectionEnabled          bool   = false
 	defaultLogContainerCollectUsingFiles bool   = true
 	defaultLogContainerLogsPath          string = "/var/lib/docker/containers"
 	defaultLogPodLogsPath                string = "/var/log/pods"
 	defaultLogContainerSymlinksPath      string = "/var/log/containers"
 	defaultLogTempStoragePath            string = "/var/lib/datadog-agent/logs"
 
-	// defaultLiveProcessCollectionEnabled   bool = false
+	defaultLiveProcessCollectionEnabled   bool = false
 	defaultLiveContainerCollectionEnabled bool = true
+	defaultProcessDiscoveryEnabled        bool = true
 
-	defaultProcessDiscoveryEnabled bool = true
+	defaultOOMKillEnabled        bool = false
+	defaultTCPQueueLengthEnabled bool = false
 
-	// defaultOOMKillEnabled        bool = false
-	// defaultTCPQueueLengthEnabled bool = false
+	defaultEBPFCheckEnabled bool = false
 
 	defaultAPMEnabled         bool   = true
 	defaultAPMHostPortEnabled bool   = false
@@ -40,17 +40,17 @@ const (
 	defaultAPMSocketEnabled   bool   = true
 	defaultAPMSocketHostPath  string = apicommon.DogstatsdAPMSocketHostPath + "/" + apicommon.APMSocketName
 
-	// defaultCSPMEnabled              bool = false
-	// defaultCWSEnabled               bool = false
+	defaultCSPMEnabled                bool = false
+	defaultCWSEnabled                 bool = false
 	defaultCWSSyscallMonitorEnabled   bool = false
 	defaultCWSNetworkEnabled          bool = true
 	defaultCWSSecurityProfilesEnabled bool = true
 
-	// defaultNPMEnabled         bool = false
+	defaultNPMEnabled         bool = false
 	defaultNPMEnableConntrack bool = true
 	defaultNPMCollectDNSStats bool = true
 
-	// defaultUSMEnabled bool = false
+	defaultUSMEnabled bool = false
 
 	defaultDogstatsdOriginDetectionEnabled bool   = false
 	defaultDogstatsdHostPortEnabled        bool   = false
@@ -74,9 +74,9 @@ const (
 	defaultOrchestratorExplorerEnabled         bool = true
 	defaultOrchestratorExplorerScrubContainers bool = true
 
-	// defaultExternalMetricsServerEnabled bool = false
-	defaultDatadogMetricsEnabled bool = true
-	defaultRegisterAPIService    bool = true
+	defaultExternalMetricsServerEnabled bool = false
+	defaultDatadogMetricsEnabled        bool = true
+	defaultRegisterAPIService           bool = true
 	// Cluster Agent versions < 1.20 should use 443
 	defaultMetricsProviderPort int32 = 8443
 
@@ -85,7 +85,7 @@ const (
 	defaultClusterChecksEnabled    bool = true
 	defaultUseClusterChecksRunners bool = false
 
-	// defaultPrometheusScrapeEnabled                bool = false
+	defaultPrometheusScrapeEnabled                bool = false
 	defaultPrometheusScrapeEnableServiceEndpoints bool = false
 	defaultPrometheusScrapeVersion                int  = 2
 
@@ -136,7 +136,12 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// LogsCollection Feature
-	if ddaSpec.Features.LogCollection != nil && ddaSpec.Features.LogCollection.Enabled != nil && *ddaSpec.Features.LogCollection.Enabled {
+	if ddaSpec.Features.LogCollection == nil {
+		ddaSpec.Features.LogCollection = &LogCollectionFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.LogCollection.Enabled, defaultLogCollectionEnabled)
+
+	if *ddaSpec.Features.LogCollection.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.LogCollection.ContainerCollectUsingFiles, defaultLogContainerCollectUsingFiles)
 
 		apiutils.DefaultStringIfUnset(&ddaSpec.Features.LogCollection.ContainerLogsPath, defaultLogContainerLogsPath)
@@ -149,24 +154,45 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// LiveContainerCollection Feature
-	if ddaSpec.Features.LiveContainerCollection == nil || apiutils.IsEqualStruct(*ddaSpec.Features.LiveContainerCollection, LiveContainerCollectionFeatureConfig{}) {
-		ddaSpec.Features.LiveContainerCollection = &LiveContainerCollectionFeatureConfig{
-			Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
-		}
+	if ddaSpec.Features.LiveContainerCollection == nil {
+		ddaSpec.Features.LiveContainerCollection = &LiveContainerCollectionFeatureConfig{}
 	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.LiveContainerCollection.Enabled, defaultLiveContainerCollectionEnabled)
+
+	// LiveProcessCollection Feature
+	if ddaSpec.Features.LiveProcessCollection == nil {
+		ddaSpec.Features.LiveProcessCollection = &LiveProcessCollectionFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.LiveProcessCollection.Enabled, defaultLiveProcessCollectionEnabled)
 
 	// ProcessDiscovery Feature
-	if ddaSpec.Features.ProcessDiscovery == nil || apiutils.IsEqualStruct(*ddaSpec.Features.ProcessDiscovery, ProcessDiscoveryFeatureConfig{}) {
-		ddaSpec.Features.ProcessDiscovery = &ProcessDiscoveryFeatureConfig{
-			Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
-		}
+	if ddaSpec.Features.ProcessDiscovery == nil {
+		ddaSpec.Features.ProcessDiscovery = &ProcessDiscoveryFeatureConfig{}
 	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ProcessDiscovery.Enabled, defaultProcessDiscoveryEnabled)
 
-	// APM is enabled by default
+	// OOMKill Feature
+	if ddaSpec.Features.OOMKill == nil {
+		ddaSpec.Features.OOMKill = &OOMKillFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OOMKill.Enabled, defaultOOMKillEnabled)
+
+	// TCPQueueLength Feature
+	if ddaSpec.Features.TCPQueueLength == nil {
+		ddaSpec.Features.TCPQueueLength = &TCPQueueLengthFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.TCPQueueLength.Enabled, defaultTCPQueueLengthEnabled)
+
+	// EBPFCheck Feature
+	if ddaSpec.Features.EBPFCheck == nil {
+		ddaSpec.Features.EBPFCheck = &EBPFCheckFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.EBPFCheck.Enabled, defaultEBPFCheckEnabled)
+
+	// APM Feature
 	if ddaSpec.Features.APM == nil {
 		ddaSpec.Features.APM = &APMFeatureConfig{}
 	}
-
 	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.APM.Enabled, defaultAPMEnabled)
 
 	if *ddaSpec.Features.APM.Enabled {
@@ -187,8 +213,19 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 		apiutils.DefaultStringIfUnset(&ddaSpec.Features.APM.UnixDomainSocketConfig.Path, defaultAPMSocketHostPath)
 	}
 
+	// CSPM (Cloud Security Posture Management) Feature
+	if ddaSpec.Features.CSPM == nil {
+		ddaSpec.Features.CSPM = &CSPMFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.CSPM.Enabled, defaultCSPMEnabled)
+
 	// CWS (Cloud Workload Security) Feature
-	if ddaSpec.Features.CWS != nil && ddaSpec.Features.CWS.Enabled != nil && *ddaSpec.Features.CWS.Enabled {
+	if ddaSpec.Features.CWS == nil {
+		ddaSpec.Features.CWS = &CWSFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.CWS.Enabled, defaultCWSEnabled)
+
+	if *ddaSpec.Features.CWS.Enabled {
 		if ddaSpec.Features.CWS.Network == nil {
 			ddaSpec.Features.CWS.Network = &CWSNetworkConfig{}
 		}
@@ -202,17 +239,26 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// NPM (Network Performance Monitoring) Feature
-	if ddaSpec.Features.NPM != nil && ddaSpec.Features.NPM.Enabled != nil && *ddaSpec.Features.NPM.Enabled {
-		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.NPM.EnableConntrack, defaultNPMEnableConntrack)
+	if ddaSpec.Features.NPM == nil {
+		ddaSpec.Features.NPM = &NPMFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.NPM.Enabled, defaultNPMEnabled)
 
+	if *ddaSpec.Features.NPM.Enabled {
+		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.NPM.EnableConntrack, defaultNPMEnableConntrack)
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.NPM.CollectDNSStats, defaultNPMCollectDNSStats)
 	}
 
-	// Dogstatd Feature
+	// USM (Universal Service Monitoring) Feature
+	if ddaSpec.Features.USM == nil {
+		ddaSpec.Features.USM = &USMFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.USM.Enabled, defaultUSMEnabled)
+
+	// Dogstatsd Feature
 	if ddaSpec.Features.Dogstatsd == nil {
 		ddaSpec.Features.Dogstatsd = &DogstatsdFeatureConfig{}
 	}
-
 	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.Dogstatsd.OriginDetectionEnabled, defaultDogstatsdOriginDetectionEnabled)
 
 	if ddaSpec.Features.Dogstatsd.HostPortConfig == nil {
@@ -260,49 +306,46 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	// Cluster-level features
 
 	// EventCollection Feature
-	if ddaSpec.Features.EventCollection == nil || apiutils.IsEqualStruct(*ddaSpec.Features.EventCollection, EventCollectionFeatureConfig{}) {
-		ddaSpec.Features.EventCollection = &EventCollectionFeatureConfig{
-			CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
-		}
+	if ddaSpec.Features.EventCollection == nil {
+		ddaSpec.Features.EventCollection = &EventCollectionFeatureConfig{}
 	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.EventCollection.CollectKubernetesEvents, defaultCollectKubernetesEvents)
 
 	// OrchestratorExplorer check Feature
-	if ddaSpec.Features.OrchestratorExplorer == nil || apiutils.IsEqualStruct(*ddaSpec.Features.OrchestratorExplorer, OrchestratorExplorerFeatureConfig{}) {
-		ddaSpec.Features.OrchestratorExplorer = &OrchestratorExplorerFeatureConfig{
-			Enabled: apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
-		}
+	if ddaSpec.Features.OrchestratorExplorer == nil {
+		ddaSpec.Features.OrchestratorExplorer = &OrchestratorExplorerFeatureConfig{}
 	}
-
-	if ddaSpec.Features.OrchestratorExplorer != nil {
-		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OrchestratorExplorer.Enabled, defaultOrchestratorExplorerEnabled)
-	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OrchestratorExplorer.Enabled, defaultOrchestratorExplorerEnabled)
 
 	if *ddaSpec.Features.OrchestratorExplorer.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.OrchestratorExplorer.ScrubContainers, defaultOrchestratorExplorerScrubContainers)
 	}
 
 	// KubeStateMetricsCore check Feature
-	if ddaSpec.Features.KubeStateMetricsCore == nil || apiutils.IsEqualStruct(*ddaSpec.Features.KubeStateMetricsCore, KubeStateMetricsCoreFeatureConfig{}) {
-		ddaSpec.Features.KubeStateMetricsCore = &KubeStateMetricsCoreFeatureConfig{
-			Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
-		}
+	if ddaSpec.Features.KubeStateMetricsCore == nil {
+		ddaSpec.Features.KubeStateMetricsCore = &KubeStateMetricsCoreFeatureConfig{}
 	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.KubeStateMetricsCore.Enabled, defaultKubeStateMetricsCoreEnabled)
 
 	// AdmissionController Feature
 	if ddaSpec.Features.AdmissionController == nil {
-		ddaSpec.Features.AdmissionController = &AdmissionControllerFeatureConfig{
-			Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerEnabled),
-		}
+		ddaSpec.Features.AdmissionController = &AdmissionControllerFeatureConfig{}
 	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.AdmissionController.Enabled, defaultAdmissionControllerEnabled)
 
-	if ddaSpec.Features.AdmissionController.Enabled == nil || *ddaSpec.Features.AdmissionController.Enabled {
+	if *ddaSpec.Features.AdmissionController.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.AdmissionController.Enabled, defaultAdmissionControllerEnabled)
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.AdmissionController.MutateUnlabelled, defaultAdmissionControllerMutateUnlabelled)
 		apiutils.DefaultStringIfUnset(&ddaSpec.Features.AdmissionController.ServiceName, defaultAdmissionServiceName)
 	}
 
 	// ExternalMetricsServer Feature
-	if ddaSpec.Features.ExternalMetricsServer != nil && ddaSpec.Features.ExternalMetricsServer.Enabled != nil && *ddaSpec.Features.ExternalMetricsServer.Enabled {
+	if ddaSpec.Features.ExternalMetricsServer == nil {
+		ddaSpec.Features.ExternalMetricsServer = &ExternalMetricsServerFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ExternalMetricsServer.Enabled, defaultExternalMetricsServerEnabled)
+
+	if *ddaSpec.Features.ExternalMetricsServer.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ExternalMetricsServer.UseDatadogMetrics, defaultDatadogMetricsEnabled)
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ExternalMetricsServer.RegisterAPIService, defaultRegisterAPIService)
 		apiutils.DefaultInt32IfUnset(&ddaSpec.Features.ExternalMetricsServer.Port, defaultMetricsProviderPort)
@@ -310,11 +353,8 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 
 	// ClusterChecks Feature
 	if ddaSpec.Features.ClusterChecks == nil {
-		ddaSpec.Features.ClusterChecks = &ClusterChecksFeatureConfig{
-			Enabled: apiutils.NewBoolPointer(defaultClusterChecksEnabled),
-		}
+		ddaSpec.Features.ClusterChecks = &ClusterChecksFeatureConfig{}
 	}
-
 	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.ClusterChecks.Enabled, defaultClusterChecksEnabled)
 
 	if *ddaSpec.Features.ClusterChecks.Enabled {
@@ -322,7 +362,12 @@ func defaultFeaturesConfig(ddaSpec *DatadogAgentSpec) {
 	}
 
 	// PrometheusScrape Feature
-	if ddaSpec.Features.PrometheusScrape != nil && ddaSpec.Features.PrometheusScrape.Enabled != nil && *ddaSpec.Features.PrometheusScrape.Enabled {
+	if ddaSpec.Features.PrometheusScrape == nil {
+		ddaSpec.Features.PrometheusScrape = &PrometheusScrapeFeatureConfig{}
+	}
+	apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.PrometheusScrape.Enabled, defaultPrometheusScrapeEnabled)
+
+	if *ddaSpec.Features.PrometheusScrape.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.PrometheusScrape.EnableServiceEndpoints, defaultPrometheusScrapeEnableServiceEndpoints)
 		apiutils.DefaultIntIfUnset(&ddaSpec.Features.PrometheusScrape.Version, defaultPrometheusScrapeVersion)
 	}

--- a/apis/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -115,6 +115,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -126,11 +147,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -150,12 +177,18 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
 					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
 					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
@@ -169,8 +202,8 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -196,6 +229,9 @@ func Test_defaultFeatures(t *testing.T) {
 					},
 					TCPQueueLength: &TCPQueueLengthFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(valueFalse),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
 					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(valueFalse),
@@ -261,6 +297,9 @@ func Test_defaultFeatures(t *testing.T) {
 					},
 					TCPQueueLength: &TCPQueueLengthFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(valueFalse),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
 					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(valueFalse),
@@ -333,6 +372,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(valueTrue),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -344,15 +404,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(valueTrue),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						// The agent will automatically disable process discovery collection in this case
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -372,12 +434,18 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
 					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
 					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
@@ -391,8 +459,8 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -408,6 +476,32 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled:                    apiutils.NewBoolPointer(valueTrue),
+						ContainerCollectUsingFiles: apiutils.NewBoolPointer(defaultLogContainerCollectUsingFiles),
+						ContainerLogsPath:          apiutils.NewStringPointer(defaultLogContainerLogsPath),
+						PodLogsPath:                apiutils.NewStringPointer(defaultLogPodLogsPath),
+						ContainerSymlinksPath:      apiutils.NewStringPointer(defaultLogContainerSymlinksPath),
+						TempStoragePath:            apiutils.NewStringPointer(defaultLogTempStoragePath),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -419,19 +513,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LogCollection: &LogCollectionFeatureConfig{
-						Enabled:                    apiutils.NewBoolPointer(valueTrue),
-						ContainerCollectUsingFiles: apiutils.NewBoolPointer(defaultLogContainerCollectUsingFiles),
-						ContainerLogsPath:          apiutils.NewStringPointer(defaultLogContainerLogsPath),
-						PodLogsPath:                apiutils.NewStringPointer(defaultLogPodLogsPath),
-						ContainerSymlinksPath:      apiutils.NewStringPointer(defaultLogContainerSymlinksPath),
-						TempStoragePath:            apiutils.NewStringPointer(defaultLogTempStoragePath),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -451,12 +543,18 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
 					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
 					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
@@ -470,8 +568,8 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -487,22 +585,49 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
 					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
 					},
 					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
 					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(valueTrue),
 						HostPortConfig: &HostPortConfig{
-							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
 							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
 						},
 						UnixDomainSocketConfig: &UnixDomainSocketConfig{
 							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
+					},
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
+					},
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -522,12 +647,18 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
 					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
 					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
@@ -541,8 +672,8 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -558,6 +689,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -569,16 +721,19 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
 					},
 					NPM: &NPMFeatureConfig{
 						Enabled:         apiutils.NewBoolPointer(valueTrue),
 						EnableConntrack: apiutils.NewBoolPointer(defaultNPMEnableConntrack),
 						CollectDNSStats: apiutils.NewBoolPointer(defaultNPMCollectDNSStats),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -598,12 +753,18 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
 					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
 					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
@@ -617,8 +778,8 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -641,6 +802,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -652,11 +834,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -668,20 +856,26 @@ func Test_defaultFeatures(t *testing.T) {
 					},
 					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
 						GRPC: &OTLPGRPCConfig{
-							Enabled:  apiutils.NewBoolPointer(true),
+							Enabled:  apiutils.NewBoolPointer(valueTrue),
 							Endpoint: apiutils.NewStringPointer(defaultOTLPGRPCEndpoint),
 						},
 						HTTP: &OTLPHTTPConfig{
-							Enabled:  apiutils.NewBoolPointer(true),
+							Enabled:  apiutils.NewBoolPointer(valueTrue),
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
 					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
 					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
@@ -695,8 +889,8 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -712,6 +906,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -723,11 +938,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -747,6 +968,9 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
@@ -754,14 +978,14 @@ func Test_defaultFeatures(t *testing.T) {
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
 					},
-					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
-					},
 					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
 						Enabled:            apiutils.NewBoolPointer(valueTrue),
 						RegisterAPIService: apiutils.NewBoolPointer(defaultRegisterAPIService),
 						UseDatadogMetrics:  apiutils.NewBoolPointer(defaultDatadogMetricsEnabled),
 						Port:               apiutils.NewInt32Pointer(defaultMetricsProviderPort),
+					},
+					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
 					},
 					ClusterChecks: &ClusterChecksFeatureConfig{
 						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
@@ -772,8 +996,8 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -789,6 +1013,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -800,11 +1045,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -824,6 +1075,9 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
@@ -831,20 +1085,23 @@ func Test_defaultFeatures(t *testing.T) {
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
 					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
+					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
 					},
 					ClusterChecks: &ClusterChecksFeatureConfig{
 						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
-						UseClusterChecksRunners: apiutils.NewBoolPointer(false),
+						UseClusterChecksRunners: apiutils.NewBoolPointer(valueFalse),
 					},
 					AdmissionController: &AdmissionControllerFeatureConfig{
 						Enabled:          apiutils.NewBoolPointer(defaultAdmissionControllerEnabled),
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -861,6 +1118,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -872,11 +1150,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -896,6 +1180,9 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
@@ -903,21 +1190,24 @@ func Test_defaultFeatures(t *testing.T) {
 						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
 					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
+					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
 					},
 					ClusterChecks: &ClusterChecksFeatureConfig{
 						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
-						UseClusterChecksRunners: apiutils.NewBoolPointer(false),
+						UseClusterChecksRunners: apiutils.NewBoolPointer(defaultUseClusterChecksRunners),
 					},
 					AdmissionController: &AdmissionControllerFeatureConfig{
-						Enabled:                apiutils.NewBoolPointer(true),
-						MutateUnlabelled:       apiutils.NewBoolPointer(true),
+						Enabled:                apiutils.NewBoolPointer(valueTrue),
+						MutateUnlabelled:       apiutils.NewBoolPointer(valueTrue),
 						ServiceName:            apiutils.NewStringPointer(defaultAdmissionServiceName),
 						AgentCommunicationMode: apiutils.NewStringPointer("socket"),
 					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},
@@ -933,6 +1223,27 @@ func Test_defaultFeatures(t *testing.T) {
 			},
 			want: &DatadogAgentSpec{
 				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
 					APM: &APMFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
 						HostPortConfig: &HostPortConfig{
@@ -944,11 +1255,17 @@ func Test_defaultFeatures(t *testing.T) {
 							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
 						},
 					},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
 					},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
 					},
 					Dogstatsd: &DogstatsdFeatureConfig{
 						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
@@ -968,6 +1285,9 @@ func Test_defaultFeatures(t *testing.T) {
 							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
 						},
 					}}},
+					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
 					EventCollection: &EventCollectionFeatureConfig{
 						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
 					},
@@ -976,105 +1296,8 @@ func Test_defaultFeatures(t *testing.T) {
 						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
 						CustomResources: []string{"datadoghq.com/v1alpha1/datadogmetrics"},
 					},
-					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
-					},
-					ClusterChecks: &ClusterChecksFeatureConfig{
-						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
-						UseClusterChecksRunners: apiutils.NewBoolPointer(false),
-					},
-					AdmissionController: &AdmissionControllerFeatureConfig{
-						Enabled:          apiutils.NewBoolPointer(defaultAdmissionControllerEnabled),
-						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
-					},
-					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
-					},
-				},
-			},
-		},
-		{
-			// This test sets same defaults as the one with `Features: nil`; and leaves other configs as empty structs.
-			name: "all feature configs are empty structs, configures defaults where applicable, leaves others empty",
-			ddaSpec: &DatadogAgentSpec{
-				Features: &DatadogFeatures{
-					LogCollection:           &LogCollectionFeatureConfig{},
-					LiveProcessCollection:   &LiveProcessCollectionFeatureConfig{},
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{},
-					ProcessDiscovery:        &ProcessDiscoveryFeatureConfig{},
-					OOMKill:                 &OOMKillFeatureConfig{},
-					TCPQueueLength:          &TCPQueueLengthFeatureConfig{},
-					APM:                     &APMFeatureConfig{},
-					CSPM:                    &CSPMFeatureConfig{},
-					CWS:                     &CWSFeatureConfig{},
-					NPM:                     &NPMFeatureConfig{},
-					USM:                     &USMFeatureConfig{},
-					OTLP:                    &OTLPFeatureConfig{},
-					EventCollection:         &EventCollectionFeatureConfig{},
-					OrchestratorExplorer:    &OrchestratorExplorerFeatureConfig{},
-					KubeStateMetricsCore:    &KubeStateMetricsCoreFeatureConfig{},
-					AdmissionController:     &AdmissionControllerFeatureConfig{},
-					ExternalMetricsServer:   &ExternalMetricsServerFeatureConfig{},
-					ClusterChecks:           &ClusterChecksFeatureConfig{},
-					PrometheusScrape:        &PrometheusScrapeFeatureConfig{},
-					RemoteConfiguration:     &RemoteConfigurationFeatureConfig{},
-				},
-			},
-			want: &DatadogAgentSpec{
-				Features: &DatadogFeatures{
-					LogCollection:         &LogCollectionFeatureConfig{},
-					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{},
-					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
-					},
-					OOMKill:        &OOMKillFeatureConfig{},
-					TCPQueueLength: &TCPQueueLengthFeatureConfig{},
-					APM: &APMFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
-						HostPortConfig: &HostPortConfig{
-							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
-							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
-						},
-						UnixDomainSocketConfig: &UnixDomainSocketConfig{
-							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
-						},
-					},
-					CSPM:                  &CSPMFeatureConfig{},
-					CWS:                   &CWSFeatureConfig{},
-					NPM:                   &NPMFeatureConfig{},
-					USM:                   &USMFeatureConfig{},
-					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{},
-					PrometheusScrape:      &PrometheusScrapeFeatureConfig{},
-
-					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
-						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
-					},
-					Dogstatsd: &DogstatsdFeatureConfig{
-						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
-						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
-						UnixDomainSocketConfig: &UnixDomainSocketConfig{
-							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
-							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
-						},
-					},
-					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
-						GRPC: &OTLPGRPCConfig{
-							Enabled:  apiutils.NewBoolPointer(defaultOTLPGRPCEnabled),
-							Endpoint: apiutils.NewStringPointer(defaultOTLPGRPCEndpoint),
-						},
-						HTTP: &OTLPHTTPConfig{
-							Enabled:  apiutils.NewBoolPointer(defaultOTLPHTTPEnabled),
-							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
-						},
-					}}},
-					EventCollection: &EventCollectionFeatureConfig{
-						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
-					},
-					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
-						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
-						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
 					},
 					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
@@ -1088,8 +1311,131 @@ func Test_defaultFeatures(t *testing.T) {
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
 						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 					},
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
+					},
+				},
+			},
+		},
+		{
+			// This test sets same defaults as the one with `Features: nil`; and leaves other configs as empty structs.
+			name: "all feature configs are empty structs, configures defaults where applicable, leaves others empty",
+			ddaSpec: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					LogCollection:           &LogCollectionFeatureConfig{},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{},
+					LiveProcessCollection:   &LiveProcessCollectionFeatureConfig{},
+					ProcessDiscovery:        &ProcessDiscoveryFeatureConfig{},
+					OOMKill:                 &OOMKillFeatureConfig{},
+					TCPQueueLength:          &TCPQueueLengthFeatureConfig{},
+					EBPFCheck:               &EBPFCheckFeatureConfig{},
+					APM:                     &APMFeatureConfig{},
+					CSPM:                    &CSPMFeatureConfig{},
+					CWS:                     &CWSFeatureConfig{},
+					NPM:                     &NPMFeatureConfig{},
+					USM:                     &USMFeatureConfig{},
+					OTLP:                    &OTLPFeatureConfig{},
+					RemoteConfiguration:     &RemoteConfigurationFeatureConfig{},
+					EventCollection:         &EventCollectionFeatureConfig{},
+					OrchestratorExplorer:    &OrchestratorExplorerFeatureConfig{},
+					KubeStateMetricsCore:    &KubeStateMetricsCoreFeatureConfig{},
+					AdmissionController:     &AdmissionControllerFeatureConfig{},
+					ExternalMetricsServer:   &ExternalMetricsServerFeatureConfig{},
+					ClusterChecks:           &ClusterChecksFeatureConfig{},
+					PrometheusScrape:        &PrometheusScrapeFeatureConfig{},
+				},
+			},
+			want: &DatadogAgentSpec{
+				Features: &DatadogFeatures{
+					LogCollection: &LogCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLogCollectionEnabled),
+					},
+					LiveProcessCollection: &LiveProcessCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveProcessCollectionEnabled),
+					},
+					LiveContainerCollection: &LiveContainerCollectionFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultLiveContainerCollectionEnabled),
+					},
+					ProcessDiscovery: &ProcessDiscoveryFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultProcessDiscoveryEnabled),
+					},
+					OOMKill: &OOMKillFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultOOMKillEnabled),
+					},
+					TCPQueueLength: &TCPQueueLengthFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultTCPQueueLengthEnabled),
+					},
+					EBPFCheck: &EBPFCheckFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultEBPFCheckEnabled),
+					},
+					APM: &APMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultAPMEnabled),
+						HostPortConfig: &HostPortConfig{
+							Port:    apiutils.NewInt32Pointer(defaultAPMHostPort),
+							Enabled: apiutils.NewBoolPointer(defaultAPMHostPortEnabled),
+						},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultAPMSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultAPMSocketHostPath),
+						},
+					},
+					CSPM: &CSPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCSPMEnabled),
+					},
+					CWS: &CWSFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultCWSEnabled),
+					},
+					NPM: &NPMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultNPMEnabled),
+					},
+					USM: &USMFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultUSMEnabled),
+					},
+					Dogstatsd: &DogstatsdFeatureConfig{
+						OriginDetectionEnabled: apiutils.NewBoolPointer(defaultDogstatsdOriginDetectionEnabled),
+						HostPortConfig:         &HostPortConfig{Enabled: apiutils.NewBoolPointer(defaultDogstatsdHostPortEnabled)},
+						UnixDomainSocketConfig: &UnixDomainSocketConfig{
+							Enabled: apiutils.NewBoolPointer(defaultDogstatsdSocketEnabled),
+							Path:    apiutils.NewStringPointer(defaultDogstatsdHostSocketPath),
+						},
+					},
+					OTLP: &OTLPFeatureConfig{Receiver: OTLPReceiverConfig{Protocols: OTLPProtocolsConfig{
+						GRPC: &OTLPGRPCConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPGRPCEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPGRPCEndpoint),
+						},
+						HTTP: &OTLPHTTPConfig{
+							Enabled:  apiutils.NewBoolPointer(defaultOTLPHTTPEnabled),
+							Endpoint: apiutils.NewStringPointer(defaultOTLPHTTPEndpoint),
+						},
+					}}},
 					RemoteConfiguration: &RemoteConfigurationFeatureConfig{
 						Enabled: apiutils.NewBoolPointer(defaultRemoteConfigurationEnabled),
+					},
+					EventCollection: &EventCollectionFeatureConfig{
+						CollectKubernetesEvents: apiutils.NewBoolPointer(defaultCollectKubernetesEvents),
+					},
+					OrchestratorExplorer: &OrchestratorExplorerFeatureConfig{
+						Enabled:         apiutils.NewBoolPointer(defaultOrchestratorExplorerEnabled),
+						ScrubContainers: apiutils.NewBoolPointer(defaultOrchestratorExplorerScrubContainers),
+					},
+					ExternalMetricsServer: &ExternalMetricsServerFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultExternalMetricsServerEnabled),
+					},
+					KubeStateMetricsCore: &KubeStateMetricsCoreFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultKubeStateMetricsCoreEnabled),
+					},
+					ClusterChecks: &ClusterChecksFeatureConfig{
+						Enabled:                 apiutils.NewBoolPointer(defaultClusterChecksEnabled),
+						UseClusterChecksRunners: apiutils.NewBoolPointer(defaultUseClusterChecksRunners),
+					},
+					AdmissionController: &AdmissionControllerFeatureConfig{
+						Enabled:          apiutils.NewBoolPointer(defaultAdmissionControllerEnabled),
+						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
+						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
+					},
+					PrometheusScrape: &PrometheusScrapeFeatureConfig{
+						Enabled: apiutils.NewBoolPointer(defaultPrometheusScrapeEnabled),
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

- Set explicit default `Enabled` values for all features
- Add default value for EBPFCheck
- Update tests accordingly

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

The effect of this PR should be noop. 

Build Operator and apply a minimal DatadogAgent. Check that LogCollection, LiveProcessCollection, OOMKill, TCPQueueLength, CSPM, CWS, NPM, USM, ExternalMetricsServer, and PrometheusScraped are all disabled by default.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
