### PR TITLE
Add `createdAd`, `support` fields to bundle CSV file

### DIFF
--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 SCRIPTS_DIR="$(dirname "$0")"
+CREATED_AT="$(date -u +'%Y-%m-%d %H:%M:%S')"
 # Provides $OS,$ARCH,$PLAFORM,$ROOT variables
 source "$SCRIPTS_DIR/os-env.sh"
 
@@ -17,6 +18,8 @@ $YQ -i ".spec.install.spec.clusterPermissions += load(\"$ROOT/hack/patch-bundle-
 # Add annotation required for upstream publication
 IMAGE=$($YQ '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' bundle/manifests/datadog-operator.clusterserviceversion.yaml)
 $YQ -i ".metadata.annotations.containerImage = \"$IMAGE\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
+$YQ -i ".metadata.annotations.createAt = \"$CREATED_AT\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
+$YQ -i ".metadata.annotations.support = \"Datadog Inc.\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Add skipRange annotation to allow direct upgrades
 VERSION=$($YQ '.spec.version' bundle/manifests/datadog-operator.clusterserviceversion.yaml )

--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -19,7 +19,7 @@ $YQ -i ".spec.install.spec.clusterPermissions += load(\"$ROOT/hack/patch-bundle-
 IMAGE=$($YQ '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' bundle/manifests/datadog-operator.clusterserviceversion.yaml)
 $YQ -i ".metadata.annotations.containerImage = \"$IMAGE\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 $YQ -i ".metadata.annotations.createdAt = \"$CREATED_AT\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
-$YQ -i ".metadata.annotations.support = \"Datadog Inc.\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
+$YQ -i ".metadata.annotations.support = \"Datadog, Inc.\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Add skipRange annotation to allow direct upgrades
 VERSION=$($YQ '.spec.version' bundle/manifests/datadog-operator.clusterserviceversion.yaml )

--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -18,7 +18,7 @@ $YQ -i ".spec.install.spec.clusterPermissions += load(\"$ROOT/hack/patch-bundle-
 # Add annotation required for upstream publication
 IMAGE=$($YQ '.spec.install.spec.deployments[0].spec.template.spec.containers[0].image' bundle/manifests/datadog-operator.clusterserviceversion.yaml)
 $YQ -i ".metadata.annotations.containerImage = \"$IMAGE\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
-$YQ -i ".metadata.annotations.createAt = \"$CREATED_AT\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
+$YQ -i ".metadata.annotations.createdAt = \"$CREATED_AT\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 $YQ -i ".metadata.annotations.support = \"Datadog Inc.\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Add skipRange annotation to allow direct upgrades


### PR DESCRIPTION
### What does this PR do?

Fixes test failures in [community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod) publishing process, sample PR https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/3760.

Output after change
```diff
     repository: https://github.com/DataDog/datadog-operator
-    containerImage: gcr.io/datadoghq/operator:1.2.1
-    olm.skipRange: <1.2.1
-  name: datadog-operator.v1.2.1
+    containerImage: gcr.io/datadoghq/operator:1.3.0
+    createAt: "2023-12-19 17:44:43"
+    support: Datadog Inc.
+    olm.skipRange: <1.3.0
+  name: datadog-operator.v1.3.0
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
