### PR TITLE
[CECO-755][introspection] Limit provider values using allowlist

### DIFF
--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -54,7 +54,7 @@ func determineProvider(labels map[string]string) string {
 	if len(labels) > 0 {
 		// GCP
 		if val, ok := labels[GCPProviderLabel]; ok {
-			if provider := generateProviderName(GCPCloudProvider, val); provider != "" {
+			if provider := generateValidProviderName(GCPCloudProvider, val); provider != "" {
 				return provider
 			}
 		}
@@ -124,10 +124,10 @@ func (p *ProviderStore) GenerateProviderNodeAffinity(provider string) []corev1.N
 	return nsrList
 }
 
-// generateProviderName creates a provider name from the cloud provider and
-// provider value. NOTE: this should not be used to create a resource name as
-// it may contain underscores
-func generateProviderName(cloudProvider, providerValue string) string {
+// generateValidProviderName creates a provider name from the cloud provider
+// and provider value. NOTE: this should not be used to create a resource name
+// as it may contain underscores
+func generateValidProviderName(cloudProvider, providerValue string) string {
 	if isProviderValueAllowed(providerValue) {
 		return cloudProvider + "-" + providerValue
 	}

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -134,6 +134,37 @@ func Test_SetProvider(t *testing.T) {
 	}
 }
 
+func Test_isProviderValueAllowed(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{
+			name:  "valid value",
+			value: GCPCosContainerdProviderValue,
+			want:  true,
+		},
+		{
+			name:  "invalid value",
+			value: "foo",
+			want:  false,
+		},
+		{
+			name:  "empty value",
+			value: "",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed := isProviderValueAllowed(tt.value)
+			assert.Equal(t, tt.want, allowed)
+		})
+	}
+}
+
 func Test_sortProviders(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -25,8 +25,8 @@ var (
 		},
 	}
 	defaultProvider          = DefaultProvider
-	gcpCosContainerdProvider = generateProviderName(GCPCloudProvider, GCPCosContainerdProviderValue)
-	gcpCosProvider           = generateProviderName(GCPCloudProvider, GCPCosProviderValue)
+	gcpCosContainerdProvider = generateValidProviderName(GCPCloudProvider, GCPCosContainerdProviderValue)
+	gcpCosProvider           = generateValidProviderName(GCPCloudProvider, GCPCosProviderValue)
 )
 
 func Test_determineProvider(t *testing.T) {
@@ -53,7 +53,7 @@ func Test_determineProvider(t *testing.T) {
 				"foo":            "bar",
 				GCPProviderLabel: GCPCosProviderValue,
 			},
-			provider: generateProviderName(GCPCloudProvider, GCPCosProviderValue),
+			provider: generateValidProviderName(GCPCloudProvider, GCPCosProviderValue),
 		},
 		{
 			name: "gcp provider, underscore",
@@ -61,7 +61,7 @@ func Test_determineProvider(t *testing.T) {
 				"foo":            "bar",
 				GCPProviderLabel: GCPCosContainerdProviderValue,
 			},
-			provider: generateProviderName(GCPCloudProvider, GCPCosContainerdProviderValue),
+			provider: generateValidProviderName(GCPCloudProvider, GCPCosContainerdProviderValue),
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds an allowlist for provider values. Currently, we only check for a valid label key so any label value will become a provider even if the operator code doesn't fully support the provider. For example, `cloud.google.com/gke-os-distribution:foo` would create a provider `foo` whether or not we had the necessary changes in agent configuration to support provider `foo`. With this PR, a provider must be allowlisted or it will automatically fall under the `default` provider.

Current behavior when adding an ubuntu nodepool:
```
$ kubectl get ds
NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-gcp-cos      2         2         2       2            2           <none>          5m52s
datadog-agent-gcp-ubuntu   2         2         2       2            2           <none>          2m6s
```
New behavior when adding an ubuntu nodepool:
```
$ kubectl get ds
NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   2         2         0       2            0           <none>          35s
datadog-agent-gcp-cos   2         2         2       2            2           <none>          5m22s
```

### Motivation

Reduce confusion on which providers may be supported in the operator

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
