### PR TITLE
[CECO-849][introspection] Remove unused ds status

### DIFF
--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -297,7 +297,7 @@ func (r *Reconciler) cleanupDaemonSetsForProvidersThatNoLongerApply(ctx context.
 				event := buildEventInfo(eds.Name, eds.Namespace, extendedDaemonSetKind, datadog.DeletionEvent)
 				r.recordEvent(dda, event)
 
-				removeDaemonSetStatus(ddaStatus, eds.Name)
+				removeStaleStatus(ddaStatus, eds.Name)
 			}
 		}
 
@@ -319,16 +319,16 @@ func (r *Reconciler) cleanupDaemonSetsForProvidersThatNoLongerApply(ctx context.
 			event := buildEventInfo(ds.Name, ds.Namespace, daemonSetKind, datadog.DeletionEvent)
 			r.recordEvent(dda, event)
 
-			removeDaemonSetStatus(ddaStatus, ds.Name)
+			removeStaleStatus(ddaStatus, ds.Name)
 		}
 	}
 
 	return nil
 }
 
-// removeDaemonSetStatus removes a DaemonSet's status from a DatadogAgent's
+// removeStaleStatus removes a DaemonSet's status from a DatadogAgent's
 // status based on the DaemonSet's name
-func removeDaemonSetStatus(ddaStatus *datadoghqv2alpha1.DatadogAgentStatus, name string) {
+func removeStaleStatus(ddaStatus *datadoghqv2alpha1.DatadogAgentStatus, name string) {
 	if ddaStatus != nil {
 		for i, dsStatus := range ddaStatus.Agent {
 			if dsStatus.DaemonsetName == name {

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -241,13 +241,13 @@ func (r *Reconciler) generateNodeAffinity(p string, affinity *corev1.Affinity) *
 	return affinity
 }
 
-func (r *Reconciler) handleProviders(ctx context.Context, dda *datadoghqv2alpha1.DatadogAgent) (map[string]struct{}, error) {
+func (r *Reconciler) handleProviders(ctx context.Context, dda *datadoghqv2alpha1.DatadogAgent, ddaStatus *datadoghqv2alpha1.DatadogAgentStatus) (map[string]struct{}, error) {
 	providerList, err := r.updateProviderStore(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := r.cleanupDaemonSetsForProvidersThatNoLongerApply(ctx, dda); err != nil {
+	if err := r.cleanupDaemonSetsForProvidersThatNoLongerApply(ctx, dda, ddaStatus); err != nil {
 		return nil, err
 	}
 
@@ -280,7 +280,7 @@ func (r *Reconciler) updateProviderStore(ctx context.Context) (map[string]struct
 // that are not present in the provider store. If there are no providers in the
 // provider store, do not delete any ds/eds since that would delete all node
 // agents.
-func (r *Reconciler) cleanupDaemonSetsForProvidersThatNoLongerApply(ctx context.Context, dda *datadoghqv2alpha1.DatadogAgent) error {
+func (r *Reconciler) cleanupDaemonSetsForProvidersThatNoLongerApply(ctx context.Context, dda *datadoghqv2alpha1.DatadogAgent, ddaStatus *datadoghqv2alpha1.DatadogAgentStatus) error {
 	if r.options.ExtendedDaemonsetOptions.Enabled {
 		edsList := edsv1alpha1.ExtendedDaemonSetList{}
 		if err := r.client.List(ctx, &edsList, client.HasLabels{apicommon.MD5AgentDeploymentProviderLabelKey}); err != nil {
@@ -296,6 +296,8 @@ func (r *Reconciler) cleanupDaemonSetsForProvidersThatNoLongerApply(ctx context.
 				r.log.Info("Deleted ExtendedDaemonSet", "extendedDaemonSet.Namespace", eds.Namespace, "extendedDaemonSet.Name", eds.Name)
 				event := buildEventInfo(eds.Name, eds.Namespace, extendedDaemonSetKind, datadog.DeletionEvent)
 				r.recordEvent(dda, event)
+
+				removeDaemonSetStatus(ddaStatus, eds.Name)
 			}
 		}
 
@@ -316,8 +318,24 @@ func (r *Reconciler) cleanupDaemonSetsForProvidersThatNoLongerApply(ctx context.
 			r.log.Info("Deleted DaemonSet", "daemonSet.Namespace", ds.Namespace, "daemonSet.Name", ds.Name)
 			event := buildEventInfo(ds.Name, ds.Namespace, daemonSetKind, datadog.DeletionEvent)
 			r.recordEvent(dda, event)
+
+			removeDaemonSetStatus(ddaStatus, ds.Name)
 		}
 	}
 
 	return nil
+}
+
+// removeDaemonSetStatus removes a DaemonSet's status from a DatadogAgent's
+// status based on the DaemonSet's name
+func removeDaemonSetStatus(ddaStatus *datadoghqv2alpha1.DatadogAgentStatus, name string) {
+	if ddaStatus != nil {
+		for i, dsStatus := range ddaStatus.Agent {
+			if dsStatus.DaemonsetName == name {
+				newStatus := make([]*common.DaemonSetStatus, 0, len(ddaStatus.Agent)-1)
+				newStatus = append(newStatus, ddaStatus.Agent[:i]...)
+				ddaStatus.Agent = append(newStatus, ddaStatus.Agent[i+1:]...)
+			}
+		}
+	}
 }

--- a/controllers/datadogagent/controller_reconcile_agent_test.go
+++ b/controllers/datadogagent/controller_reconcile_agent_test.go
@@ -574,7 +574,7 @@ func getObjectListFromKind(kind string) client.ObjectList {
 	return nil
 }
 
-func Test_removeDaemonSetStatus(t *testing.T) {
+func Test_removeStaleStatus(t *testing.T) {
 	testCases := []struct {
 		name       string
 		ddaStatus  *datadoghqv2alpha1.DatadogAgentStatus
@@ -686,7 +686,7 @@ func Test_removeDaemonSetStatus(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			removeDaemonSetStatus(tt.ddaStatus, tt.dsName)
+			removeStaleStatus(tt.ddaStatus, tt.dsName)
 			assert.Equal(t, tt.wantStatus, tt.ddaStatus)
 		})
 	}

--- a/controllers/datadogagent/controller_reconcile_agent_test.go
+++ b/controllers/datadogagent/controller_reconcile_agent_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
-	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
+	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
@@ -540,9 +541,10 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			}
 			r.providerStore.Reset(tt.existingProviders)
 
-			dda := v2alpha1.DatadogAgent{}
+			dda := datadoghqv2alpha1.DatadogAgent{}
+			ddaStatus := datadoghqv2alpha1.DatadogAgentStatus{}
 
-			err := r.cleanupDaemonSetsForProvidersThatNoLongerApply(ctx, &dda)
+			err := r.cleanupDaemonSetsForProvidersThatNoLongerApply(ctx, &dda, &ddaStatus)
 			assert.NoError(t, err)
 
 			kind := "daemonsets"
@@ -570,4 +572,122 @@ func getObjectListFromKind(kind string) client.ObjectList {
 		return &edsdatadoghqv1alpha1.ExtendedDaemonSetList{}
 	}
 	return nil
+}
+
+func Test_removeDaemonSetStatus(t *testing.T) {
+	testCases := []struct {
+		name       string
+		ddaStatus  *datadoghqv2alpha1.DatadogAgentStatus
+		dsName     string
+		wantStatus *datadoghqv2alpha1.DatadogAgentStatus
+	}{
+		{
+			name: "no status to delete",
+			ddaStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{
+					{
+						Desired:       1,
+						Current:       1,
+						Ready:         1,
+						Available:     1,
+						DaemonsetName: "foo",
+					},
+				},
+			},
+			dsName: "bar",
+			wantStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{
+					{
+						Desired:       1,
+						Current:       1,
+						Ready:         1,
+						Available:     1,
+						DaemonsetName: "foo",
+					},
+				},
+			},
+		},
+		{
+			name: "delete status",
+			ddaStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{
+					{
+						Desired:       1,
+						Current:       1,
+						Ready:         1,
+						Available:     1,
+						DaemonsetName: "foo",
+					},
+					{
+						Desired:       2,
+						Current:       2,
+						Ready:         1,
+						Available:     1,
+						UpToDate:      1,
+						DaemonsetName: "bar",
+					},
+				},
+			},
+			dsName: "bar",
+			wantStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{
+					{
+						Desired:       1,
+						Current:       1,
+						Ready:         1,
+						Available:     1,
+						DaemonsetName: "foo",
+					},
+				},
+			},
+		},
+		{
+			name: "delete only status",
+			ddaStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{
+					{
+						Desired:       2,
+						Current:       2,
+						Ready:         1,
+						Available:     1,
+						UpToDate:      1,
+						DaemonsetName: "bar",
+					},
+				},
+			},
+			dsName: "bar",
+			wantStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{},
+			},
+		},
+		{
+			name: "agent status is empty",
+			ddaStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{},
+			},
+			dsName: "bar",
+			wantStatus: &datadoghqv2alpha1.DatadogAgentStatus{
+				Agent: []*common.DaemonSetStatus{},
+			},
+		},
+		{
+			name:       "dda status is empty",
+			ddaStatus:  &datadoghqv2alpha1.DatadogAgentStatus{},
+			dsName:     "bar",
+			wantStatus: &datadoghqv2alpha1.DatadogAgentStatus{},
+		},
+		{
+			name:       "status is nil",
+			ddaStatus:  nil,
+			dsName:     "bar",
+			wantStatus: nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			removeDaemonSetStatus(tt.ddaStatus, tt.dsName)
+			assert.Equal(t, tt.wantStatus, tt.ddaStatus)
+		})
+	}
 }

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -143,7 +143,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	requiredContainers := requiredComponents.Agent.Containers
 
 	// for all providers, go through agent reconcile
-	providersList, err := r.handleProviders(ctx, instance)
+	providersList, err := r.handleProviders(ctx, instance, newStatus)
 	if err != nil {
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
### What does this PR do?

Remove deleted DS/EDS status from DDA status.

Current `kubectl describe dd datadog`:
```
Status:
  Agent:
    Available:       2
    Current:         2
    Current Hash:    1c5c7b21c84b6a4462eda5060f919f0a
    Daemonset Name:  datadog-agent-gcp-cos
    Desired:         2
    Last Update:     2023-12-21T21:59:49Z
    Ready:           2
    State:           Running
    Status:          Running (2/2/2)
    Up To Date:      2
    Available:       0
    Current:         0
    Current Hash:    4e4dfa99925563393b45a2dec1e8ac3b
    Daemonset Name:  datadog-agent-default
    Desired:         0
    Last Update:     2023-12-21T21:59:18Z
    Ready:           0
    State:           Running
    Status:          Running (0/0/0)
    Up To Date:      0
```

New behavior `kubectl describe dd datadog`:
```
Status:
  Agent:
    Available:       2
    Current:         2
    Current Hash:    1c5c7b21c84b6a4462eda5060f919f0a
    Daemonset Name:  datadog-agent-gcp-cos
    Desired:         2
    Last Update:     2023-12-22T20:32:41Z
    Ready:           2
    State:           Running
    Status:          Running (2/2/2)
    Up To Date:      2
```

### Motivation

Stale DS status in DDA status

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

In a cluster using multiple providers (e.g. 2 gke nodepools: 1 cos, 1 ubuntu), delete a nodepool so that there is only 1 provider. The `kubectl describe dd <dda-name>` output shouldn't contain statuses for DS/EDSs that don't exist anymore.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
