### PR TITLE
Fix patch_bundle.sh `spec.replaces` formatting

### DIFF
--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -26,7 +26,7 @@ VERSION=$($YQ '.spec.version' bundle/manifests/datadog-operator.clusterserviceve
 $YQ -i ".metadata.annotations.\"olm.skipRange\" = \"<$VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Set spec.replaces to latest released version
-$YQ -i ".spec.\"replaces\" = \"$LATEST_VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
+$YQ -i ".spec.\"replaces\" = \"datadog-operator.v$LATEST_VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Add OpenShift version annotation (adding in main bundle as it's used for OpenShift Community)
 $YQ -i ".annotations.\"com.redhat.openshift.versions\" = \"v4.6\"" bundle/metadata/annotations.yaml


### PR DESCRIPTION
### What does this PR do?

Update how `spec.replaces` is formatted in the bundle CSV file. Correct formatting was suggested [here](https://github.com/redhat-openshift-ecosystem/certified-operators/pull/3288#discussion_r1433705281)

Result sample

```diff
@@ -1016,4 +1018,4 @@ spec:
   provider:
     name: Datadog
   version: 1.3.0
-  replaces: 1.2.1
+  replaces: datadog-operator.v1.2.1
diff --git a/hack/patch-bundle.sh b/hack/patch-bundle.sh
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
