### PR TITLE
Decrease log verbosity level

### DIFF
--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -192,7 +192,7 @@ func (r *Reconciler) reconcileInstance(ctx context.Context, logger logr.Logger, 
 	// Now create/update dependencies
 	errs = append(errs, depsStore.Apply(ctx, r.client)...)
 	if len(errs) > 0 {
-		logger.V(2).Info("Dependencies apply error", "errs", errs)
+		logger.V(1).Info("Dependencies apply error", "errs", errs)
 		return result, errors.NewAggregate(errs)
 	}
 	// -----------------------

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -156,7 +156,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	// ------------------------------
 	errs = append(errs, depsStore.Apply(ctx, r.client)...)
 	if len(errs) > 0 {
-		logger.V(2).Info("Dependencies apply error", "errs", errs)
+		logger.V(1).Info("Dependencies apply error", "errs", errs)
 		return result, errors.NewAggregate(errs)
 	}
 

--- a/controllers/datadogagent/dependencies/store.go
+++ b/controllers/datadogagent/dependencies/store.go
@@ -210,7 +210,7 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 			objAPIServer := kubernetes.ObjectFromKind(kind, ds.platformInfo)
 			err := k8sClient.Get(ctx, objNSName, objAPIServer)
 			if err != nil && apierrors.IsNotFound(err) {
-				ds.logger.V(2).Info("dependencies.store Add object to create", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
+				ds.logger.V(1).Info("dependencies.store Add object to create", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
 				objsToCreate = append(objsToCreate, objStore)
 				continue
 			} else if err != nil {
@@ -230,14 +230,14 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 			}
 
 			if !equality.IsEqualObject(kind, objStore, objAPIServer) {
-				ds.logger.V(2).Info("dependencies.store Add object to update", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
+				ds.logger.V(1).Info("dependencies.store Add object to update", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
 				objsToUpdate = append(objsToUpdate, objStore)
 				continue
 			}
 		}
 	}
 
-	ds.logger.V(2).Info("dependencies.store objsToCreate", "nb", len(objsToCreate))
+	ds.logger.V(1).Info("dependencies.store objsToCreate", "nb", len(objsToCreate))
 	for _, obj := range objsToCreate {
 		if err := k8sClient.Create(ctx, obj); err != nil {
 			ds.logger.Error(err, "dependencies.store Create", "obj.namespace", obj.GetNamespace(), "obj.name", obj.GetName())
@@ -245,7 +245,7 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 		}
 	}
 
-	ds.logger.V(2).Info("dependencies.store objsToUpdate", "nb", len(objsToUpdate))
+	ds.logger.V(1).Info("dependencies.store objsToUpdate", "nb", len(objsToUpdate))
 	for _, obj := range objsToUpdate {
 		if err := k8sClient.Update(ctx, obj); err != nil {
 			ds.logger.Error(err, "dependencies.store Update", "obj.namespace", obj.GetNamespace(), "obj.name", obj.GetName())

--- a/controllers/datadogagent/feature/clusterchecks/feature.go
+++ b/controllers/datadogagent/feature/clusterchecks/feature.go
@@ -248,7 +248,7 @@ func (f *clusterChecksFeature) updateConfigHash(dda *v2alpha1.DatadogAgent) {
 	if err != nil {
 		f.logger.Error(err, "couldn't generate hash for cluster checks config")
 	} else {
-		f.logger.V(2).Info("created cluster checks", "hash", hash)
+		f.logger.V(1).Info("created cluster checks", "hash", hash)
 	}
 	f.customConfigAnnotationValue = hash
 	f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.ClusterChecksIDType)

--- a/controllers/datadogagent/feature/cspm/feature.go
+++ b/controllers/datadogagent/feature/cspm/feature.go
@@ -81,7 +81,7 @@ func (f *cspmFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Req
 			if err != nil {
 				f.logger.Error(err, "couldn't generate hash for cspm custom benchmarks config")
 			} else {
-				f.logger.V(2).Info("built cspm custom benchmarks from custom config", "hash", hash)
+				f.logger.V(1).Info("built cspm custom benchmarks from custom config", "hash", hash)
 			}
 			f.customConfigAnnotationValue = hash
 			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.CSPMIDType)

--- a/controllers/datadogagent/feature/cws/feature.go
+++ b/controllers/datadogagent/feature/cws/feature.go
@@ -79,7 +79,7 @@ func (f *cwsFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requ
 			if err != nil {
 				f.logger.Error(err, "couldn't generate hash for cws custom policies config")
 			} else {
-				f.logger.V(2).Info("built cws custom policies from custom config", "hash", hash)
+				f.logger.V(1).Info("built cws custom policies from custom config", "hash", hash)
 			}
 			f.customConfigAnnotationValue = hash
 			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.CWSIDType)

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -172,7 +172,7 @@ func (f *defaultFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredC
 		if err != nil {
 			f.logger.Error(err, "couldn't generate hash for Cluster Agent token hash")
 		} else {
-			f.logger.V(2).Info("built Cluster Agent token hash", "hash", hash)
+			f.logger.V(1).Info("built Cluster Agent token hash", "hash", hash)
 		}
 		f.customConfigAnnotationValue = hash
 		f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(string(feature.DefaultIDType))

--- a/controllers/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/feature.go
@@ -115,7 +115,7 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 			if err != nil {
 				f.logger.Error(err, "couldn't generate hash for ksm core custom config")
 			} else {
-				f.logger.V(2).Info("built ksm core from custom config", "hash", hash)
+				f.logger.V(1).Info("built ksm core from custom config", "hash", hash)
 			}
 			f.customConfigAnnotationValue = hash
 			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.KubernetesStateCoreIDType)

--- a/controllers/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/controllers/datadogagent/feature/orchestratorexplorer/feature.go
@@ -85,7 +85,7 @@ func (f *orchestratorExplorerFeature) Configure(dda *v2alpha1.DatadogAgent) (req
 			if err != nil {
 				f.logger.Error(err, "couldn't generate hash for orchestrator explorer custom config")
 			} else {
-				f.logger.V(2).Info("built orchestrator explorer from custom config", "hash", hash)
+				f.logger.V(1).Info("built orchestrator explorer from custom config", "hash", hash)
 			}
 			f.customConfigAnnotationValue = hash
 			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.OrchestratorExplorerIDType)

--- a/controllers/datadogagent/override/podtemplatespec.go
+++ b/controllers/datadogagent/override/podtemplatespec.go
@@ -77,7 +77,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		if err != nil {
 			logger.Error(err, "couldn't generate hash for extra confd custom config")
 		} else {
-			logger.V(2).Info("built extra confd from custom config", "hash", hash)
+			logger.V(1).Info("built extra confd from custom config", "hash", hash)
 		}
 		annotationKey := object.GetChecksumAnnotationKey(cmName)
 		manager.Annotation().AddAnnotation(annotationKey, hash)
@@ -94,7 +94,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		if err != nil {
 			logger.Error(err, "couldn't generate hash for extra checksd custom config")
 		} else {
-			logger.V(2).Info("built extra checksd from custom config", "hash", hash)
+			logger.V(1).Info("built extra checksd from custom config", "hash", hash)
 		}
 		annotationKey := object.GetChecksumAnnotationKey(cmName)
 		manager.Annotation().AddAnnotation(annotationKey, hash)
@@ -187,7 +187,7 @@ func overrideCustomConfigVolumes(logger logr.Logger, manager feature.PodTemplate
 		if err != nil {
 			logger.Error(err, "couldn't generate hash for custom config", "filename", fileName)
 		} else {
-			logger.V(2).Info("built file from custom config", "filename", fileName, "hash", hash)
+			logger.V(1).Info("built file from custom config", "filename", fileName, "hash", hash)
 		}
 		annotationKey := object.GetChecksumAnnotationKey(string(fileName))
 		manager.Annotation().AddAnnotation(annotationKey, hash)

--- a/main.go
+++ b/main.go
@@ -302,7 +302,7 @@ func customSetupLogging(logLevel zapcore.Level, logEncoder string) error {
 	case "json":
 		encoder = zapcore.NewJSONEncoder(encoderConfig)
 	default:
-		return fmt.Errorf("unknow log encoder: %s", logEncoder)
+		return fmt.Errorf("unknown log encoder: %s", logEncoder)
 	}
 
 	ctrl.SetLogger(ctrlzap.New(


### PR DESCRIPTION
### What does this PR do?

Decreases the log verbosity level for some logs

### Motivation

Debugging purposes. When using semantically named logging levels, the most verbose we can get with zapr is `debug` which is equivalent to `V(1)` in logr. Moving some logging in the operator from `V(2)` to `V(1)` will allow more verbose operator logs when using `loglevel=debug` without having to create new numbered levels as described in https://pkg.go.dev/github.com/go-logr/zapr#readme-increasing-verbosity.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Spin up the operator using the helm chart with `--set logLevel="debug"`. After applying up a DatadogAgent, the operator should print out `DEBUG` log lines such as `{"level":"DEBUG","ts":"2023-12-28T22:03:14Z","logger":"controllers.DatadogAgent","msg":"dependencies.store Add object to update","datadogagent":"default/datadog","obj.namespace":"default","obj.name":"datadog-cluster-agent","obj.kind":"services"}` that was changed in this PR. When the operator is spun up without `--set logLevel="debug"`, the operator logs shouldn't show any `DEBUG` log lines.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
