### PR TITLE
[CECO-841] Add DAP validation before applying profiles

### DIFF
--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -145,7 +145,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 
 	requiredContainers := requiredComponents.Agent.Containers
 
-	profiles, profilesByNode, err := r.profilesToApply(ctx)
+	profiles, profilesByNode, err := r.profilesToApply(ctx, logger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -268,7 +268,7 @@ func (r *Reconciler) updateMetricsForwardersFeatures(dda *datadoghqv2alpha1.Data
 	// }
 }
 
-func (r *Reconciler) profilesToApply(ctx context.Context) ([]datadoghqv1alpha1.DatadogAgentProfile, map[string]types.NamespacedName, error) {
+func (r *Reconciler) profilesToApply(ctx context.Context, logger logr.Logger) ([]datadoghqv1alpha1.DatadogAgentProfile, map[string]types.NamespacedName, error) {
 	profilesList := datadoghqv1alpha1.DatadogAgentProfileList{}
 	err := r.client.List(ctx, &profilesList)
 	if err != nil {
@@ -281,5 +281,5 @@ func (r *Reconciler) profilesToApply(ctx context.Context) ([]datadoghqv1alpha1.D
 		return nil, nil, err
 	}
 
-	return agentprofile.ProfilesToApply(profilesList.Items, nodeList.Items)
+	return agentprofile.ProfilesToApply(profilesList.Items, nodeList.Items, logger)
 }

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -360,11 +361,99 @@ func TestProfilesToApply(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "invalid profile",
+			profiles: []v1alpha1.DatadogAgentProfile{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      "invalid",
+					},
+					Spec: v1alpha1.DatadogAgentProfileSpec{
+						Config: configWithCPURequestOverrideForCoreAgent("100m"),
+					},
+				},
+			},
+			nodes: []v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"os": "linux",
+						},
+					},
+				},
+			},
+			expectedProfiles: []v1alpha1.DatadogAgentProfile{
+				defaultProfile(),
+			},
+			expectedProfilesAppliedPerNode: map[string]types.NamespacedName{
+				"node1": {
+					Namespace: "",
+					Name:      "default",
+				},
+			},
+		},
+		{
+			name: "invalid profiles + valid profiles",
+			profiles: []v1alpha1.DatadogAgentProfile{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      "invalid-no-affinity",
+					},
+					Spec: v1alpha1.DatadogAgentProfileSpec{
+						Config: configWithCPURequestOverrideForCoreAgent("100m"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      "invalid-no-config",
+					},
+					Spec: v1alpha1.DatadogAgentProfileSpec{
+						ProfileAffinity: &v1alpha1.ProfileAffinity{
+							ProfileNodeAffinity: []v1.NodeSelectorRequirement{
+								{
+									Key:      "os",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"linux"},
+								},
+							},
+						},
+					},
+				},
+				exampleProfileForLinux(),
+				exampleProfileForWindows(),
+			},
+			nodes: []v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"os": "linux",
+						},
+					},
+				},
+			},
+			expectedProfiles: []v1alpha1.DatadogAgentProfile{
+				exampleProfileForLinux(),
+				exampleProfileForWindows(),
+				defaultProfile(),
+			},
+			expectedProfilesAppliedPerNode: map[string]types.NamespacedName{
+				"node1": {
+					Namespace: testNamespace,
+					Name:      "linux",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			profilesToApply, profileAppliedPerNode, err := ProfilesToApply(test.profiles, test.nodes)
+			testLogger := zap.New(zap.UseDevMode(true))
+			profilesToApply, profileAppliedPerNode, err := ProfilesToApply(test.profiles, test.nodes, testLogger)
 			require.NoError(t, err)
 			assert.ElementsMatch(t, test.expectedProfiles, profilesToApply)
 			assert.Equal(t, test.expectedProfilesAppliedPerNode, profileAppliedPerNode)


### PR DESCRIPTION
### What does this PR do?

Adds validation of DAP to ensure they are not missing any required configs like `ProfileAffinity` or a resource override

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
