### PR TITLE
[defaulting/images] Update agents to 7.50.1

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion correspond to the latest stable agent release
-	AgentLatestVersion = "7.49.1"
+	AgentLatestVersion = "7.50.1"
 	// ClusterAgentLatestVersion correspond to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.49.1"
+	ClusterAgentLatestVersion = "7.50.1"
 	// GCRContainerRegistry correspond to the datadoghq GCR registry
 	GCRContainerRegistry ContainerRegistry = "gcr.io/datadoghq"
 	// DockerHubContainerRegistry correspond to the datadoghq docker.io registry


### PR DESCRIPTION
### What does this PR do?

Deploys 7.50.1 by default

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
