### PR TITLE
[profiles] Add support for EDS

### DIFF
--- a/controllers/datadogagent/testutils/client_utils.go
+++ b/controllers/datadogagent/testutils/client_utils.go
@@ -23,6 +23,7 @@ import (
 func TestScheme(isV2 bool) *runtime.Scheme {
 	s := scheme.Scheme
 	s.AddKnownTypes(edsdatadoghqv1alpha1.GroupVersion, &edsdatadoghqv1alpha1.ExtendedDaemonSet{})
+	s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.DatadogAgentProfile{})
 	s.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DaemonSet{})
 	s.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
 	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Secret{})


### PR DESCRIPTION
### What does this PR do?

Adds support for EDS when using profiles.

When EDS is enabled and there are profiles defined, we only create an EDS for the default profile, for the other profiles we create DaemonSets. This is to make deployments simpler. With multiple EDS there would be multiple canaries, etc.


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
