### PR TITLE
[gitlab] Add nightly operator and operator_check jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -294,13 +294,14 @@ trigger_internal_operator_nightly_image:
     - when: never
   trigger:
     project: DataDog/images
-    branch: master
+    branch: celene/add_nightly_job
     strategy: depend
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    RELEASE_TAG: ${CI_COMMIT_TIMESTAMP:0:10}-main
+    BUILD_NIGHTLY: "true"
+    # RELEASE_TAG: ${CI_COMMIT_TIMESTAMP:0:10}-main
     BUILD_TAG: 20240109-main
     RELEASE_STAGING: "false"
     RELEASE_PROD: "false"
@@ -313,13 +314,14 @@ trigger_internal_operator_check_nightly_image:
     - when: never
   trigger:
     project: DataDog/images
-    branch: master
+    branch: celene/add_nightly_job
     strategy: depend
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME_CHECK
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    RELEASE_TAG: $(date -d "$CI_COMMIT_TIMESTAMP" +"%Y%m%d-main")
+    # RELEASE_TAG: $(date -d "$CI_COMMIT_TIMESTAMP" +"%Y%m%d-main")
+    BUILD_NIGHTLY: "true"
     BUILD_TAG: ${date +"%Y%m%d-main"}
     RELEASE_STAGING: "false"
     RELEASE_PROD: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -286,6 +286,44 @@ trigger_internal_operator_check_image:
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
+trigger_internal_operator_nightly_image:
+  stage: release
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "celene/gitlab_nightly_image"'
+      when: on_success
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v1
+    IMAGE_NAME: $PROJECTNAME
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: ${date +"%Y%m%d-main"}
+    BUILD_TAG: ${date +"%Y%m%d-main"}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "false"
+
+trigger_internal_operator_check_nightly_image:
+  stage: release
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "celene/gitlab_nightly_image"'
+      when: on_success
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v1
+    IMAGE_NAME: $PROJECTNAME_CHECK
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: ${date +"%Y%m%d-main"}
+    BUILD_TAG: ${date +"%Y%m%d-main"}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "false"
+
 trigger_custom_operator_image_staging:
   stage: release
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -300,9 +300,9 @@ trigger_internal_operator_nightly_image:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    RELEASE_TAG: ${date +"%Y%m%d-main"}
-    BUILD_TAG: ${date +"%Y%m%d-main"}
-    RELEASE_STAGING: "true"
+    RELEASE_TAG: ${CI_COMMIT_TIMESTAMP:0:10}-main
+    BUILD_TAG: 20240109-main
+    RELEASE_STAGING: "false"
     RELEASE_PROD: "false"
 
 trigger_internal_operator_check_nightly_image:
@@ -319,9 +319,9 @@ trigger_internal_operator_check_nightly_image:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME_CHECK
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    RELEASE_TAG: ${date +"%Y%m%d-main"}
+    RELEASE_TAG: $(date -d "$CI_COMMIT_TIMESTAMP" +"%Y%m%d-main")
     BUILD_TAG: ${date +"%Y%m%d-main"}
-    RELEASE_STAGING: "true"
+    RELEASE_STAGING: "false"
     RELEASE_PROD: "false"
 
 trigger_custom_operator_image_staging:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -289,41 +289,41 @@ trigger_internal_operator_check_image:
 trigger_internal_operator_nightly_image:
   stage: release
   rules:
-    - if: '$CI_COMMIT_BRANCH == "celene/gitlab_nightly_image"'
-      when: on_success
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      # Temporarily require manual build
+      when: manual
     - when: never
   trigger:
     project: DataDog/images
-    branch: celene/add_nightly_job
+    branch: master
     strategy: depend
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    # Trigger a nightly images build that sets the RELEASE_TAG and BUILD_TAG
     BUILD_NIGHTLY: "true"
-    # RELEASE_TAG: ${CI_COMMIT_TIMESTAMP:0:10}-main
-    BUILD_TAG: 20240109-main
-    RELEASE_STAGING: "false"
+    RELEASE_STAGING: "true"
     RELEASE_PROD: "false"
 
 trigger_internal_operator_check_nightly_image:
   stage: release
   rules:
-    - if: '$CI_COMMIT_BRANCH == "celene/gitlab_nightly_image"'
-      when: on_success
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      # Temporarily require manual build
+      when: manual
     - when: never
   trigger:
     project: DataDog/images
-    branch: celene/add_nightly_job
+    branch: master
     strategy: depend
   variables:
     IMAGE_VERSION: tmpl-v1
     IMAGE_NAME: $PROJECTNAME_CHECK
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
-    # RELEASE_TAG: $(date -d "$CI_COMMIT_TIMESTAMP" +"%Y%m%d-main")
+    # Trigger a nightly images build that sets the RELEASE_TAG and BUILD_TAG
     BUILD_NIGHTLY: "true"
-    BUILD_TAG: ${date +"%Y%m%d-main"}
-    RELEASE_STAGING: "false"
+    RELEASE_STAGING: "true"
     RELEASE_PROD: "false"
 
 trigger_custom_operator_image_staging:


### PR DESCRIPTION
### What does this PR do?

Adds nightly image build jobs. This will trigger a downstream job in the internal images tool.

Requires manual trigger for now.

### Motivation

Set up nightly Operator deploys

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
