### PR TITLE
Mount host files for proper os detection in SBOMs

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -156,6 +156,34 @@ const (
 	SystemProbeOSReleaseDirVolumePath = "/etc/os-release"
 	SystemProbeOSReleaseDirMountPath  = "/host/etc/os-release"
 
+	ApkDirVolumeName = "host-apk-dir"
+	ApkDirVolumePath = "/var/lib/apk"
+	ApkDirMountPath  = "/host/var/lib/apk"
+
+	DpkgDirVolumeName = "host-dpkg-dir"
+	DpkgDirVolumePath = "/var/lib/dpkg"
+	DpkgDirMountPath  = "/host/var/lib/dpkg"
+
+	RpmDirVolumeName = "host-rpm-dir"
+	RpmDirVolumePath = "/var/lib/rpm"
+	RpmDirMountPath  = "/host/var/lib/rpm"
+
+	RedhatReleaseVolumeName = "etc-redhat-release"
+	RedhatReleaseVolumePath = "/etc/redhat-release"
+	RedhatReleaseMountPath  = "/host/etc/redhat-release"
+
+	FedoraReleaseVolumeName = "etc-fedora-release"
+	FedoraReleaseVolumePath = "/etc/fedora-release"
+	FedoraReleaseMountPath  = "/host/etc/fedora-release"
+
+	LsbReleaseVolumeName = "etc-lsb-release"
+	LsbReleaseVolumePath = "/etc/lsb-release"
+	LsbReleaseMountPath  = "/host/etc/lsb-release"
+
+	SystemReleaseVolumeName = "etc-system-release"
+	SystemReleaseVolumePath = "/etc/system-release"
+	SystemReleaseMountPath  = "/host/etc/system-release"
+
 	SystemProbeSocketVolumeName = "sysprobe-socket-dir"
 	SystemProbeSocketVolumePath = "/var/run/sysprobe"
 

--- a/controllers/datadogagent/feature/sbom/feature.go
+++ b/controllers/datadogagent/feature/sbom/feature.go
@@ -20,6 +20,7 @@ import (
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/volume"
 )
 
 func init() {
@@ -133,6 +134,48 @@ func (f *sbomFeature) ManageNodeAgent(managers feature.PodTemplateManagers) erro
 			Name:  apicommon.DDSBOMHostAnalyzers,
 			Value: strings.Join(f.hostAnalyzers, " "),
 		})
+	}
+
+	if f.hostEnabled {
+		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
+			Name:  apicommon.DDHostRootEnvVar,
+			Value: "/host",
+		})
+
+		volMgr := managers.Volume()
+		volMountMgr := managers.VolumeMount()
+
+		osReleaseVol, osReleaseVolMount := volume.GetVolumes(apicommon.SystemProbeOSReleaseDirVolumeName, apicommon.SystemProbeOSReleaseDirVolumePath, apicommon.SystemProbeOSReleaseDirMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&osReleaseVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&osReleaseVol)
+
+		hostApkVol, hostApkVolMount := volume.GetVolumes(apicommon.ApkDirVolumeName, apicommon.ApkDirVolumePath, apicommon.ApkDirMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostApkVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostApkVol)
+
+		hostDpkgVol, hostDpkgVolMount := volume.GetVolumes(apicommon.DpkgDirVolumeName, apicommon.DpkgDirVolumePath, apicommon.DpkgDirMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostDpkgVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostDpkgVol)
+
+		hostRpmVol, hostRpmVolMount := volume.GetVolumes(apicommon.RpmDirVolumeName, apicommon.RpmDirVolumePath, apicommon.RpmDirMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostRpmVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostRpmVol)
+
+		hostRedhatReleaseVol, hostRedhatReleaseVolMount := volume.GetVolumes(apicommon.RedhatReleaseVolumeName, apicommon.RedhatReleaseVolumePath, apicommon.RedhatReleaseMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostRedhatReleaseVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostRedhatReleaseVol)
+
+		hostFedoraReleaseVol, hostFedoraReleaseVolMount := volume.GetVolumes(apicommon.FedoraReleaseVolumeName, apicommon.FedoraReleaseVolumePath, apicommon.FedoraReleaseMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostFedoraReleaseVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostFedoraReleaseVol)
+
+		hostLsbReleaseVol, hostLsbReleaseVolMount := volume.GetVolumes(apicommon.LsbReleaseVolumeName, apicommon.LsbReleaseVolumePath, apicommon.LsbReleaseMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostLsbReleaseVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostLsbReleaseVol)
+
+		hostSystemReleaseVol, hostSystemReleaseVolMount := volume.GetVolumes(apicommon.SystemReleaseVolumeName, apicommon.SystemReleaseVolumePath, apicommon.SystemReleaseMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostSystemReleaseVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostSystemReleaseVol)
 	}
 
 	return nil

--- a/controllers/datadogagent/feature/sbom/feature_test.go
+++ b/controllers/datadogagent/feature/sbom/feature_test.go
@@ -106,10 +106,130 @@ func Test_sbomFeature_Configure(t *testing.T) {
 				Name:  apicommon.DDSBOMHostEnabled,
 				Value: "true",
 			},
+			{
+				Name:  apicommon.DDHostRootEnvVar,
+				Value: "/host",
+			},
 		}
 
 		nodeAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
 		assert.True(t, apiutils.IsEqualStruct(nodeAgentEnvVars, wantEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeAgentEnvVars, wantEnvVars))
+
+		wantVolumeMounts := []corev1.VolumeMount{
+			{
+				Name:      apicommon.SystemProbeOSReleaseDirVolumeName,
+				MountPath: apicommon.SystemProbeOSReleaseDirMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      apicommon.ApkDirVolumeName,
+				MountPath: apicommon.ApkDirMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      apicommon.DpkgDirVolumeName,
+				MountPath: apicommon.DpkgDirMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      apicommon.RpmDirVolumeName,
+				MountPath: apicommon.RpmDirMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      apicommon.RedhatReleaseVolumeName,
+				MountPath: apicommon.RedhatReleaseMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      apicommon.FedoraReleaseVolumeName,
+				MountPath: apicommon.FedoraReleaseMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      apicommon.LsbReleaseVolumeName,
+				MountPath: apicommon.LsbReleaseMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      apicommon.SystemReleaseVolumeName,
+				MountPath: apicommon.SystemReleaseMountPath,
+				ReadOnly:  true,
+			},
+		}
+
+		agentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommonv1.CoreAgentContainerName]
+		assert.True(t, apiutils.IsEqualStruct(agentVolumeMounts, wantVolumeMounts), "Agent volume mounts \ndiff = %s", cmp.Diff(agentVolumeMounts, wantVolumeMounts))
+
+		wantVolumes := []corev1.Volume{
+			{
+				Name: apicommon.SystemProbeOSReleaseDirVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.SystemProbeOSReleaseDirVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.ApkDirVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.ApkDirVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.DpkgDirVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.DpkgDirVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.RpmDirVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.RpmDirVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.RedhatReleaseVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.RedhatReleaseVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.FedoraReleaseVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.FedoraReleaseVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.LsbReleaseVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.LsbReleaseVolumePath,
+					},
+				},
+			},
+			{
+				Name: apicommon.SystemReleaseVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: apicommon.SystemReleaseVolumePath,
+					},
+				},
+			},
+		}
+
+		volumes := mgr.VolumeMgr.Volumes
+		assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 	}
 
 	tests := test.FeatureTestSuite{


### PR DESCRIPTION
### What does this PR do?

This PR mounts the host files required for the agent to be able
to properly detection the host operating system.

### Motivation

Without this change, the SBOM generated is the one from the
agent container and not the one from the host.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
