### PR TITLE
[introspection] Change gcp to gke

### DIFF
--- a/controllers/datadogagent/controller_reconcile_agent_test.go
+++ b/controllers/datadogagent/controller_reconcile_agent_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const defaultProvider = kubernetes.DefaultProvider
-const gcpCosContainerdProvider = kubernetes.GCPCloudProvider + "-" + kubernetes.GCPCosContainerdType
+const gkeCosContainerdProvider = kubernetes.GKECloudProvider + "-" + kubernetes.GKECosContainerdType
 
 func Test_generateNodeAffinity(t *testing.T) {
 
@@ -44,10 +44,10 @@ func Test_generateNodeAffinity(t *testing.T) {
 			},
 		},
 		{
-			name: "nil affinity, gcp cos containerd provider",
+			name: "nil affinity, gke cos containerd provider",
 			args: args{
 				affinity: nil,
-				provider: gcpCosContainerdProvider,
+				provider: gkeCosContainerdProvider,
 			},
 		},
 		{
@@ -58,10 +58,10 @@ func Test_generateNodeAffinity(t *testing.T) {
 			},
 		},
 		{
-			name: "existing affinity, but empty, gcp cos containerd provider",
+			name: "existing affinity, but empty, gke cos containerd provider",
 			args: args{
 				affinity: &corev1.Affinity{},
-				provider: gcpCosContainerdProvider,
+				provider: gkeCosContainerdProvider,
 			},
 		},
 		{
@@ -101,7 +101,7 @@ func Test_generateNodeAffinity(t *testing.T) {
 						},
 					},
 				},
-				provider: gcpCosContainerdProvider,
+				provider: gkeCosContainerdProvider,
 			},
 		},
 		{
@@ -145,7 +145,7 @@ func Test_generateNodeAffinity(t *testing.T) {
 						},
 					},
 				},
-				provider: gcpCosContainerdProvider,
+				provider: gkeCosContainerdProvider,
 			},
 		},
 	}
@@ -156,7 +156,7 @@ func Test_generateNodeAffinity(t *testing.T) {
 				providerStore: &p,
 			}
 			existingProviders := map[string]struct{}{
-				"gcp-cos": {},
+				"gke-cos": {},
 				"default": {},
 			}
 			r.providerStore.Reset(existingProviders)
@@ -177,9 +177,9 @@ func generateWantedAffinity(provider string, na *corev1.NodeAffinity, pa *corev1
 				{
 					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
-							Key:      kubernetes.GCPProviderLabel,
+							Key:      kubernetes.GKEProviderLabel,
 							Operator: corev1.NodeSelectorOpNotIn,
-							Values:   []string{kubernetes.GCPCosType},
+							Values:   []string{kubernetes.GKECosType},
 						},
 					},
 				},
@@ -246,30 +246,30 @@ func Test_updateProviderStore(t *testing.T) {
 			nodes: []client.Object{
 				&corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gcp-cos-node",
+						Name: "gke-cos-node",
 						Labels: map[string]string{
-							kubernetes.GCPProviderLabel: kubernetes.GCPCosType,
+							kubernetes.GKEProviderLabel: kubernetes.GKECosType,
 						},
 					},
 				},
 			},
 			existingProviders: map[string]struct{}{
-				"gcp-cos_containerd": {},
+				"gke-cos_containerd": {},
 				"default":            {},
 			},
 			wantedProviders: map[string]struct{}{
-				"gcp-cos": {},
+				"gke-cos": {},
 			},
 		},
 		{
 			name:  "empty node list",
 			nodes: []client.Object{},
 			existingProviders: map[string]struct{}{
-				"gcp-cos_containerd": {},
+				"gke-cos_containerd": {},
 				"default":            {},
 			},
 			wantedProviders: map[string]struct{}{
-				"gcp-cos_containerd": {},
+				"gke-cos_containerd": {},
 				"default":            {},
 			},
 		},
@@ -313,16 +313,16 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents: []client.Object{
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gcp-cos-node",
+						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 						},
 					},
 				},
 			},
 			edsEnabled: false,
 			existingProviders: map[string]struct{}{
-				gcpCosContainerdProvider: {},
+				gkeCosContainerdProvider: {},
 			},
 			wantDS: &appsv1.DaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -332,9 +332,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 				Items: []appsv1.DaemonSet{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "gcp-cos-node",
+							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 							},
 							ResourceVersion: "999",
 						},
@@ -347,16 +347,16 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents: []client.Object{
 				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gcp-cos-node",
+						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 						},
 					},
 				},
 			},
 			edsEnabled: true,
 			existingProviders: map[string]struct{}{
-				gcpCosContainerdProvider: {},
+				gkeCosContainerdProvider: {},
 			},
 			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -366,9 +366,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "gcp-cos-node",
+							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 							},
 							ResourceVersion: "999",
 						},
@@ -381,9 +381,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents: []client.Object{
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gcp-cos-node",
+						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 						},
 					},
 				},
@@ -405,9 +405,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents: []client.Object{
 				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gcp-cos-node",
+						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 						},
 					},
 				},
@@ -429,7 +429,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents:     []client.Object{},
 			edsEnabled: false,
 			existingProviders: map[string]struct{}{
-				gcpCosContainerdProvider: {},
+				gkeCosContainerdProvider: {},
 			},
 			wantDS: &appsv1.DaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -444,7 +444,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents:     []client.Object{},
 			edsEnabled: true,
 			existingProviders: map[string]struct{}{
-				gcpCosContainerdProvider: {},
+				gkeCosContainerdProvider: {},
 			},
 			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -459,9 +459,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents: []client.Object{
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gcp-cos-node",
+						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 						},
 					},
 				},
@@ -476,9 +476,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 				Items: []appsv1.DaemonSet{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "gcp-cos-node",
+							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 							},
 							ResourceVersion: "999",
 						},
@@ -491,9 +491,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents: []client.Object{
 				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gcp-cos-node",
+						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 						},
 					},
 				},
@@ -508,9 +508,9 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "gcp-cos-node",
+							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gcpCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
 							},
 							ResourceVersion: "999",
 						},

--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -96,7 +96,7 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers, p
 
 	// src volume mount
 	_, providerValue := kubernetes.GetProviderLabelKeyValue(provider)
-	if providerValue != kubernetes.GCPCosContainerdType && providerValue != kubernetes.GCPCosType {
+	if providerValue != kubernetes.GKECosContainerdType && providerValue != kubernetes.GKECosType {
 		srcVol, srcVolMount := volume.GetVolumes(apicommon.SrcVolumeName, apicommon.SrcVolumePath, apicommon.SrcVolumePath, true)
 		managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommonv1.SystemProbeContainerName)
 		managers.Volume().AddVolume(&srcVol)

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -99,7 +99,7 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 
 	// src volume mount
 	_, providerValue := kubernetes.GetProviderLabelKeyValue(provider)
-	if providerValue != kubernetes.GCPCosContainerdType && providerValue != kubernetes.GCPCosType {
+	if providerValue != kubernetes.GKECosContainerdType && providerValue != kubernetes.GKECosType {
 		srcVol, srcVolMount := volume.GetVolumes(apicommon.SrcVolumeName, apicommon.SrcVolumePath, apicommon.SrcVolumePath, true)
 		managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommonv1.SystemProbeContainerName)
 		managers.Volume().AddVolume(&srcVol)

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -25,21 +25,21 @@ type ProviderStore struct {
 const (
 	LegacyProvider  = ""
 	DefaultProvider = "default"
-	// GCP provider values https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images
-	GCPCosContainerdType = "cos_containerd"
-	GCPCosType           = "cos"
+	// GKE provider values https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images
+	GKECosContainerdType = "cos_containerd"
+	GKECosType           = "cos"
 
 	// CloudProvider
-	GCPCloudProvider = "gcp"
+	GKECloudProvider = "gke"
 
 	// ProviderLabel
-	GCPProviderLabel = "cloud.google.com/gke-os-distribution"
+	GKEProviderLabel = "cloud.google.com/gke-os-distribution"
 )
 
 // ProviderValue allowlist
 var providerValueAllowlist = map[string]struct{}{
-	GCPCosContainerdType: {},
-	GCPCosType:           {},
+	GKECosContainerdType: {},
+	GKECosType:           {},
 }
 
 // NewProviderStore generates an empty ProviderStore instance
@@ -53,9 +53,9 @@ func NewProviderStore(log logr.Logger) ProviderStore {
 // DetermineProvider creates a Provider based on a map of labels
 func DetermineProvider(labels map[string]string) string {
 	if len(labels) > 0 {
-		// GCP
-		if val, ok := labels[GCPProviderLabel]; ok {
-			if provider := generateValidProviderName(GCPCloudProvider, val); provider != "" {
+		// GKE
+		if val, ok := labels[GKEProviderLabel]; ok {
+			if provider := generateValidProviderName(GKECloudProvider, val); provider != "" {
 				return provider
 			}
 		}
@@ -135,7 +135,7 @@ func isProviderValueAllowed(value string) bool {
 func GetProviderLabelKeyValue(provider string) (string, string) {
 	// cloud provider to label mapping
 	providerMapping := map[string]string{
-		GCPCloudProvider: GCPProviderLabel,
+		GKECloudProvider: GKEProviderLabel,
 	}
 
 	cp, value := splitProviderSuffix(provider)

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -18,8 +18,8 @@ import (
 
 var (
 	defaultProvider          = DefaultProvider
-	gcpCosContainerdProvider = generateValidProviderName(GCPCloudProvider, GCPCosContainerdType)
-	gcpCosProvider           = generateValidProviderName(GCPCloudProvider, GCPCosType)
+	gkeCosContainerdProvider = generateValidProviderName(GKECloudProvider, GKECosContainerdType)
+	gkeCosProvider           = generateValidProviderName(GKECloudProvider, GKECosType)
 )
 
 func Test_determineProvider(t *testing.T) {
@@ -41,20 +41,20 @@ func Test_determineProvider(t *testing.T) {
 			provider: defaultProvider,
 		},
 		{
-			name: "gcp provider",
+			name: "gke provider",
 			labels: map[string]string{
 				"foo":            "bar",
-				GCPProviderLabel: GCPCosType,
+				GKEProviderLabel: GKECosType,
 			},
-			provider: generateValidProviderName(GCPCloudProvider, GCPCosType),
+			provider: generateValidProviderName(GKECloudProvider, GKECosType),
 		},
 		{
-			name: "gcp provider, underscore",
+			name: "gke provider, underscore",
 			labels: map[string]string{
 				"foo":            "bar",
-				GCPProviderLabel: GCPCosContainerdType,
+				GKEProviderLabel: GKECosContainerdType,
 			},
-			provider: generateValidProviderName(GCPCloudProvider, GCPCosContainerdType),
+			provider: generateValidProviderName(GKECloudProvider, GKECosContainerdType),
 		},
 	}
 
@@ -74,7 +74,7 @@ func Test_isProviderValueAllowed(t *testing.T) {
 	}{
 		{
 			name:  "valid value",
-			value: GCPCosContainerdType,
+			value: GKECosContainerdType,
 			want:  true,
 		},
 		{
@@ -111,14 +111,14 @@ func Test_sortProviders(t *testing.T) {
 		{
 			name: "one provider",
 			existingProviders: map[string]struct{}{
-				gcpCosProvider: {},
+				gkeCosProvider: {},
 			},
-			wantSortedProviders: []string{gcpCosProvider},
+			wantSortedProviders: []string{gkeCosProvider},
 		},
 		{
 			name: "multiple providers",
 			existingProviders: map[string]struct{}{
-				gcpCosProvider: {},
+				gkeCosProvider: {},
 				"abcde":        {},
 				"zyxwv":        {},
 				"12345":        {},
@@ -126,7 +126,7 @@ func Test_sortProviders(t *testing.T) {
 			wantSortedProviders: []string{
 				"12345",
 				"abcde",
-				gcpCosProvider,
+				gkeCosProvider,
 				"zyxwv",
 			},
 		},
@@ -162,15 +162,15 @@ func Test_GenerateProviderNodeAffinity(t *testing.T) {
 		{
 			name: "one existing provider, default provider",
 			existingProviders: map[string]struct{}{
-				gcpCosProvider: {},
+				gkeCosProvider: {},
 			},
 			provider: defaultProvider,
 			wantNSR: []corev1.NodeSelectorRequirement{
 				{
-					Key:      GCPProviderLabel,
+					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpNotIn,
 					Values: []string{
-						GCPCosType,
+						GKECosType,
 					},
 				},
 			},
@@ -178,15 +178,15 @@ func Test_GenerateProviderNodeAffinity(t *testing.T) {
 		{
 			name: "one existing provider, ubuntu provider",
 			existingProviders: map[string]struct{}{
-				gcpCosProvider: {},
+				gkeCosProvider: {},
 			},
-			provider: gcpCosContainerdProvider,
+			provider: gkeCosContainerdProvider,
 			wantNSR: []corev1.NodeSelectorRequirement{
 				{
-					Key:      GCPProviderLabel,
+					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpIn,
 					Values: []string{
-						GCPCosContainerdType,
+						GKECosContainerdType,
 					},
 				},
 			},
@@ -194,28 +194,28 @@ func Test_GenerateProviderNodeAffinity(t *testing.T) {
 		{
 			name: "multiple providers, default provider",
 			existingProviders: map[string]struct{}{
-				gcpCosProvider: {},
-				"gcp-abcde":    {},
-				"gcp-zyxwv":    {},
+				gkeCosProvider: {},
+				"gke-abcde":    {},
+				"gke-zyxwv":    {},
 			},
 			provider: defaultProvider,
 			wantNSR: []corev1.NodeSelectorRequirement{
 				{
-					Key:      GCPProviderLabel,
+					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpNotIn,
 					Values: []string{
 						"abcde",
 					},
 				},
 				{
-					Key:      GCPProviderLabel,
+					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpNotIn,
 					Values: []string{
-						GCPCosType,
+						GKECosType,
 					},
 				},
 				{
-					Key:      GCPProviderLabel,
+					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpNotIn,
 					Values: []string{
 						"zyxwv",
@@ -226,17 +226,17 @@ func Test_GenerateProviderNodeAffinity(t *testing.T) {
 		{
 			name: "multiple providers, ubuntu provider",
 			existingProviders: map[string]struct{}{
-				gcpCosProvider: {},
+				gkeCosProvider: {},
 				"abcdef":       {},
 				"lmnop":        {},
 			},
-			provider: gcpCosContainerdProvider,
+			provider: gkeCosContainerdProvider,
 			wantNSR: []corev1.NodeSelectorRequirement{
 				{
-					Key:      GCPProviderLabel,
+					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpIn,
 					Values: []string{
-						GCPCosContainerdType,
+						GKECosContainerdType,
 					},
 				},
 			},
@@ -295,10 +295,10 @@ func Test_GetProviderLabelKeyValue(t *testing.T) {
 			wantValue: "",
 		},
 		{
-			name:      "gcp cos provider",
-			provider:  gcpCosProvider,
-			wantLabel: GCPProviderLabel,
-			wantValue: GCPCosType,
+			name:      "gke cos provider",
+			provider:  gkeCosProvider,
+			wantLabel: GKEProviderLabel,
+			wantValue: GKECosType,
 		},
 	}
 
@@ -321,13 +321,13 @@ func Test_Reset(t *testing.T) {
 		{
 			name: "replace empty providers",
 			newProviders: map[string]struct{}{
-				gcpCosProvider:  {},
+				gkeCosProvider:  {},
 				defaultProvider: {},
 			},
 			existingProviders: nil,
 			wantProviders: &ProviderStore{
 				providers: map[string]struct{}{
-					gcpCosProvider:  {},
+					gkeCosProvider:  {},
 					defaultProvider: {},
 				},
 			},
@@ -335,7 +335,7 @@ func Test_Reset(t *testing.T) {
 		{
 			name: "replace existing providers",
 			newProviders: map[string]struct{}{
-				gcpCosProvider:  {},
+				gkeCosProvider:  {},
 				defaultProvider: {},
 			},
 			existingProviders: &ProviderStore{
@@ -345,7 +345,7 @@ func Test_Reset(t *testing.T) {
 			},
 			wantProviders: &ProviderStore{
 				providers: map[string]struct{}{
-					gcpCosProvider:  {},
+					gkeCosProvider:  {},
 					defaultProvider: {},
 				},
 			},
@@ -355,12 +355,12 @@ func Test_Reset(t *testing.T) {
 			newProviders: map[string]struct{}{},
 			existingProviders: &ProviderStore{
 				providers: map[string]struct{}{
-					gcpCosProvider: {},
+					gkeCosProvider: {},
 				},
 			},
 			wantProviders: &ProviderStore{
 				providers: map[string]struct{}{
-					gcpCosProvider: {},
+					gkeCosProvider: {},
 				},
 			},
 		},
@@ -392,7 +392,7 @@ func Test_IsPresent(t *testing.T) {
 			provider: defaultProvider,
 			existingProviders: &ProviderStore{
 				providers: map[string]struct{}{
-					gcpCosProvider:  {},
+					gkeCosProvider:  {},
 					defaultProvider: {},
 				},
 			},
@@ -403,7 +403,7 @@ func Test_IsPresent(t *testing.T) {
 			provider: defaultProvider,
 			existingProviders: &ProviderStore{
 				providers: map[string]struct{}{
-					gcpCosProvider: {},
+					gkeCosProvider: {},
 				},
 			},
 			want: false,
@@ -413,7 +413,7 @@ func Test_IsPresent(t *testing.T) {
 			provider: "",
 			existingProviders: &ProviderStore{
 				providers: map[string]struct{}{
-					gcpCosProvider: {},
+					gkeCosProvider: {},
 				},
 			},
 			want: false,


### PR DESCRIPTION
### What does this PR do?

Change introspection cloud provider from `gcp` to `gke` to match what we have in helm: https://github.com/DataDog/helm-charts/blob/716fc5c56344d64ddf9a1841e9d70d96a7a8fd94/charts/datadog/values.yaml#L2017

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
