### PR TITLE
[cherry-pick][introspection] Fix override name combining (#1049)

### DIFF
--- a/apis/datadoghq/v2alpha1/test/builder.go
+++ b/apis/datadoghq/v2alpha1/test/builder.go
@@ -494,3 +494,14 @@ func (builder *DatadogAgentBuilder) WithCredentials(apiKey, appKey string) *Data
 	}
 	return builder
 }
+
+// Override
+
+func (builder *DatadogAgentBuilder) WithComponentOverride(componentName v2alpha1.ComponentName, override v2alpha1.DatadogAgentComponentOverride) *DatadogAgentBuilder {
+	if builder.datadogAgent.Spec.Override == nil {
+		builder.datadogAgent.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{}
+	}
+
+	builder.datadogAgent.Spec.Override[componentName] = &v2alpha1.DatadogAgentComponentOverride{}
+	return builder
+}

--- a/controllers/datadogagent/controller_v2_test.go
+++ b/controllers/datadogagent/controller_v2_test.go
@@ -13,7 +13,9 @@ import (
 	"testing"
 	"time"
 
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	v2alpha1test "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1/test"
 	testutils "github.com/DataDog/datadog-operator/controllers/datadogagent/testutils"
 	assert "github.com/stretchr/testify/require"
@@ -24,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +38,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+type fields struct {
+	client       client.Client
+	scheme       *runtime.Scheme
+	platformInfo kubernetes.PlatformInfo
+	recorder     record.EventRecorder
+}
+type args struct {
+	request  reconcile.Request
+	loadFunc func(c client.Client)
+}
 
 func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 	const resourcesName = "foo"
@@ -51,17 +65,6 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 	s := testutils.TestScheme(true)
 
 	defaultRequeueDuration := 15 * time.Second
-
-	type fields struct {
-		client       client.Client
-		scheme       *runtime.Scheme
-		platformInfo kubernetes.PlatformInfo
-		recorder     record.EventRecorder
-	}
-	type args struct {
-		request  reconcile.Request
-		loadFunc func(c client.Client)
-	}
 
 	tests := []struct {
 		name     string
@@ -375,6 +378,123 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 	}
 }
 
+func Test_Introspection(t *testing.T) {
+	const resourcesName = "foo"
+	const resourcesNamespace = "bar"
+	const dsName = "foo-agent"
+
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileDatadogAgent_Reconcile"})
+	forwarders := dummyManager{}
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	// Register operator types with the runtime scheme.
+	s := testutils.TestScheme(true)
+
+	defaultRequeueDuration := 15 * time.Second
+
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		want     reconcile.Result
+		wantErr  bool
+		wantFunc func(t *testing.T, c client.Client) error
+	}{
+		{
+			name: "[introspection] Daemonset names with affinity override",
+			fields: fields{
+				client:   fake.NewFakeClient(),
+				scheme:   s,
+				recorder: recorder,
+			},
+			args: args{
+				request: newRequest(resourcesNamespace, resourcesName),
+				loadFunc: func(c client.Client) {
+					dda := v2alpha1test.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+						WithComponentOverride(v2alpha1.NodeAgentComponentName, v2alpha1.DatadogAgentComponentOverride{
+							Affinity: &corev1.Affinity{
+								PodAntiAffinity: &corev1.PodAntiAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+										{
+											LabelSelector: &metav1.LabelSelector{
+												MatchLabels: map[string]string{
+													"foo": "bar",
+												},
+											},
+											TopologyKey: "baz",
+										},
+									},
+								},
+							},
+						}).
+						Build()
+					_ = c.Create(context.TODO(), dda)
+				},
+			},
+			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
+			wantErr: false,
+			wantFunc: func(t *testing.T, c client.Client) error {
+				expectedDaemonsets := []string{
+					string("foo-agent-provider1"),
+					string("foo-agent-provider2"),
+					string("foo-agent-provider3"),
+				}
+
+				return verifyDaemonsetNames(t, c, resourcesNamespace, dsName, expectedDaemonsets)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				client:       tt.fields.client,
+				scheme:       tt.fields.scheme,
+				platformInfo: tt.fields.platformInfo,
+				recorder:     recorder,
+				log:          logf.Log.WithName(tt.name),
+				forwarders:   forwarders,
+				options: ReconcilerOptions{
+					ExtendedDaemonsetOptions: componentagent.ExtendedDaemonsetOptions{
+						Enabled: false,
+					},
+					SupportCilium:        false,
+					V2Enabled:            true,
+					IntrospectionEnabled: true,
+				},
+			}
+
+			p := kubernetes.NewProviderStore(logf.Log.WithName("test_generateNodeAffinity"))
+			r.providerStore = &p
+			existingProviders := map[string]struct{}{
+				"provider1": {},
+				"provider2": {},
+				"provider3": {},
+			}
+			r.providerStore.Reset(existingProviders)
+
+			if tt.args.loadFunc != nil {
+				tt.args.loadFunc(r.client)
+			}
+			got, err := r.Reconcile(context.TODO(), tt.args.request)
+			if tt.wantErr {
+				assert.Error(t, err, "ReconcileDatadogAgent.Reconcile() expected an error")
+			} else {
+				assert.NoError(t, err, "ReconcileDatadogAgent.Reconcile() unexpected error: %v", err)
+			}
+
+			assert.Equal(t, tt.want, got, "ReconcileDatadogAgent.Reconcile() unexpected result")
+
+			if tt.wantFunc != nil {
+				err := tt.wantFunc(t, r.client)
+				assert.NoError(t, err, "ReconcileDatadogAgent.Reconcile() wantFunc validation error: %v", err)
+			}
+		})
+	}
+}
+
 func verifyDaemonsetContainers(c client.Client, resourcesNamespace, dsName string, expectedContainers []string) error {
 	ds := &appsv1.DaemonSet{}
 	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, ds); err != nil {
@@ -392,4 +512,20 @@ func verifyDaemonsetContainers(c client.Client, resourcesNamespace, dsName strin
 	} else {
 		return fmt.Errorf("Container don't match, expected %s, actual %s", expectedContainers, dsContainers)
 	}
+}
+
+func verifyDaemonsetNames(t *testing.T, c client.Client, resourcesNamespace, dsName string, expectedDSNames []string) error {
+	daemonSetList := appsv1.DaemonSetList{}
+	if err := c.List(context.TODO(), &daemonSetList, client.HasLabels{apicommon.MD5AgentDeploymentProviderLabelKey}); err != nil {
+		return err
+	}
+
+	actualDSNames := []string{}
+	for _, ds := range daemonSetList.Items {
+		actualDSNames = append(actualDSNames, ds.Name)
+	}
+	sort.Strings(actualDSNames)
+	sort.Strings(expectedDSNames)
+	assert.Equal(t, expectedDSNames, actualDSNames)
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Cherry pick of https://github.com/DataDog/datadog-operator/pull/1049

> When overrides were set with multiple providers, the node agent names were being combined:
```
datadog-agent-agent-default
datadog-agent-agent-default-gcp-cos
datadog-agent-agent-gcp-cos
datadog-agent-agent-gcp-cos-default
```
> This PR should prevent that from happening:
```
NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   5         5         3       5            3           <none>          6m36s
datadog-agent-gke-cos   5         5         0       5            0           <none>          6m36s
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
