### PR TITLE
[override/container] Fix container resources override with 0

### DIFF
--- a/controllers/datadogagent/override/container.go
+++ b/controllers/datadogagent/override/container.go
@@ -110,10 +110,6 @@ func overrideContainer(container *corev1.Container, override *v2alpha1.DatadogAg
 
 	if override.Resources != nil {
 		for resource, quantity := range override.Resources.Requests {
-			if quantity.IsZero() {
-				continue
-			}
-
 			if container.Resources.Requests == nil {
 				container.Resources.Requests = corev1.ResourceList{}
 			}
@@ -121,10 +117,6 @@ func overrideContainer(container *corev1.Container, override *v2alpha1.DatadogAg
 		}
 
 		for resource, quantity := range override.Resources.Limits {
-			if quantity.IsZero() {
-				continue
-			}
-
 			if container.Resources.Limits == nil {
 				container.Resources.Limits = corev1.ResourceList{}
 			}


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the function that overrides container resources. It was not overriding when the value was 0, but that's incorrect.


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
