### PR TITLE
Overwrite dogstatsd port only when hostnetwork is used

### DIFF
--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -201,12 +201,12 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommonv1.AgentC
 			// if using host network, host port should be set and needs to match container port
 			if f.useHostNetwork {
 				dogstatsdPort.ContainerPort = f.hostPortHostPort
+				managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+					// defaults to 8125 in datadog-agent code
+					Name:  apicommon.DDDogstatsdPort,
+					Value: strconv.FormatInt(int64(f.hostPortHostPort), 10),
+				})
 			}
-			managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-				// defaults to 8125 in datadog-agent code
-				Name:  apicommon.DDDogstatsdPort,
-				Value: strconv.FormatInt(int64(f.hostPortHostPort), 10),
-			})
 		}
 		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
 			Name:  apicommon.DDDogstatsdNonLocalTraffic,


### PR DESCRIPTION
When features.dogstatsd.hostPortConfig.hostPort is set
- And hostNetwork is true Overwrite container port and DD_DOGSTATSD_PORT

- And hostNetwork is false Not overwrite container port and DD_DOGSTATSD_PORT, so both have the same value

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
