### PR TITLE
[profiles] Reduce mem usage in pods cleanup

### DIFF
--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -157,7 +157,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 		}
 	}
 
-	if err = r.handleProfiles(ctx, profiles, profilesByNode); err != nil {
+	if err = r.handleProfiles(ctx, profiles, profilesByNode, instance.Namespace); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"reflect"
 
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -183,10 +184,18 @@ func (r *DatadogAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 // SetupWithManager creates a new DatadogAgent controller.
 func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// This is for the agent profiles feature. We need to be able to get the
-	// agent pod running on a node.
+	// This is for the agent profiles feature. To delete the pods of profiles
+	// that no longer apply, we need to be able to get the agent pods of a
+	// specific node.
+	// Notice that only node agent pods are indexed.
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, "spec.nodeName", func(rawObj client.Object) []string {
 		pod := rawObj.(*corev1.Pod)
+
+		// Don't store the pod if it's not a node agent pod
+		if pod.Labels[apicommon.AgentDeploymentComponentLabelKey] != apicommon.DefaultAgentResourceSuffix {
+			return nil
+		}
+
 		return []string{pod.Spec.NodeName}
 	}); err != nil {
 		return err


### PR DESCRIPTION
### What does this PR do?

 Reduces the memory usage of the `cleanupPodsForProfilesThatNoLongerApply`.

This PR configures the cache so that only node agent pods are stored and only the information that we need (labels and nodeName).

This PR depends on my previous one: #1064 (only the last commit is new)

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
