### PR TITLE
Correct a malformed example command in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -166,7 +166,7 @@ After deploying the Datadog Operator, create the `DatadogAgent` resource that tr
 
 1. Deploy the Datadog Agent with the above configuration file:
    ```shell
-   kubectl apply -f agent_spec=/path/to/your/datadog-agent.yaml
+   kubectl apply -f /path/to/your/datadog-agent.yaml
    ```
 
 In a cluster with two worker nodes, you should see the Agent Pods created on each node.


### PR DESCRIPTION
One of the `kubectl` commands in this installation guide passed a non-path parameter to `kubectl apply -f`. I'm not sure what the `agent_spec=` prefix is supposed to do, but `kubectl` rejects it on my cluster.
