### PR TITLE
Fix hostport custom port settings

### DIFF
--- a/apis/datadoghq/v2alpha1/test/builder.go
+++ b/apis/datadoghq/v2alpha1/test/builder.go
@@ -83,7 +83,7 @@ func (builder *DatadogAgentBuilder) WithDogstatsdHostPortEnabled(enabled bool) *
 
 func (builder *DatadogAgentBuilder) WithDogstatsdHostPortConfig(port int32) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.HostPortConfig.Port = apiutils.NewInt32Pointer(1234)
+	builder.datadogAgent.Spec.Features.Dogstatsd.HostPortConfig.Port = apiutils.NewInt32Pointer(port)
 	return builder
 }
 
@@ -346,11 +346,13 @@ func (builder *DatadogAgentBuilder) WithAPMEnabled(enabled bool) *DatadogAgentBu
 	return builder
 }
 
-func (builder *DatadogAgentBuilder) WithAPMHostPortEnabled(enabled bool, port int32) *DatadogAgentBuilder {
+func (builder *DatadogAgentBuilder) WithAPMHostPortEnabled(enabled bool, port *int32) *DatadogAgentBuilder {
 	builder.initAPM()
 	builder.datadogAgent.Spec.Features.APM.HostPortConfig = &v2alpha1.HostPortConfig{
 		Enabled: apiutils.NewBoolPointer(enabled),
-		Port:    apiutils.NewInt32Pointer(port),
+	}
+	if port != nil {
+		builder.datadogAgent.Spec.Features.APM.HostPortConfig.Port = port
 	}
 	return builder
 }
@@ -500,6 +502,6 @@ func (builder *DatadogAgentBuilder) WithComponentOverride(componentName v2alpha1
 		builder.datadogAgent.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{}
 	}
 
-	builder.datadogAgent.Spec.Override[componentName] = &v2alpha1.DatadogAgentComponentOverride{}
+	builder.datadogAgent.Spec.Override[componentName] = &override
 	return builder
 }

--- a/controllers/datadogagent/feature/apm/feature.go
+++ b/controllers/datadogagent/feature/apm/feature.go
@@ -261,17 +261,19 @@ func (f *apmFeature) manageNodeAgent(agentContainerName apicommonv1.AgentContain
 	}
 	if f.hostPortEnabled {
 		apmPort.HostPort = f.hostPortHostPort
+		receiverPortEnvVarValue := apicommon.DefaultApmPort
 		// if using host network, host port should be set and needs to match container port
 		if f.useHostNetwork {
 			apmPort.ContainerPort = f.hostPortHostPort
+			receiverPortEnvVarValue = int(f.hostPortHostPort)
 		}
-		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-			Name:  apicommon.DDAPMReceiverPort,
-			Value: strconv.FormatInt(int64(f.hostPortHostPort), 10),
-		})
 		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
 			Name:  apicommon.DDAPMNonLocalTraffic,
 			Value: "true",
+		})
+		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+			Name:  apicommon.DDAPMReceiverPort,
+			Value: strconv.Itoa(receiverPortEnvVarValue),
 		})
 	}
 	managers.Port().AddPortToContainer(agentContainerName, apmPort)

--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -196,18 +196,20 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommonv1.AgentC
 	if f.hostPortEnabled {
 		// f.hostPortHostPort will be 0 if HostPort is not set in v1alpha1
 		// f.hostPortHostPort will default to 8125 in v2alpha1
+		dsdPortEnvVarValue := apicommon.DefaultDogstatsdPort
 		if f.hostPortHostPort != 0 {
 			dogstatsdPort.HostPort = f.hostPortHostPort
 			// if using host network, host port should be set and needs to match container port
 			if f.useHostNetwork {
 				dogstatsdPort.ContainerPort = f.hostPortHostPort
+				dsdPortEnvVarValue = int(f.hostPortHostPort)
 			}
-			managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-				// defaults to 8125 in datadog-agent code
-				Name:  apicommon.DDDogstatsdPort,
-				Value: strconv.FormatInt(int64(f.hostPortHostPort), 10),
-			})
 		}
+		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+			// defaults to 8125 in datadog-agent code
+			Name:  apicommon.DDDogstatsdPort,
+			Value: strconv.Itoa(dsdPortEnvVarValue),
+		})
 		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
 			Name:  apicommon.DDDogstatsdNonLocalTraffic,
 			Value: "true",

--- a/controllers/datadogagent/feature/dogstatsd/feature_v1alpha1_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_v1alpha1_test.go
@@ -80,7 +80,7 @@ func Test_DogstatsdFeature_ConfigureV1(t *testing.T) {
 	wantCustomUDPEnvVars := []*corev1.EnvVar{
 		{
 			Name:  apicommon.DDDogstatsdPort,
-			Value: "1234",
+			Value: "8125",
 		},
 		{
 			Name:  apicommon.DDDogstatsdNonLocalTraffic,


### PR DESCRIPTION
### What does this PR do?

Fix custom host port settings for APM and DSD. The current behavior changes the env vars for APM and DSD that tell the agent which ports to listen on so the agent could be listening on port #### when even though the custom host port is mapped to 8125 or 8126 in the container. Now, we only change the host port mapping so that custom host port #### will map to 8125 or 8126 in the container.

DatadogAgent manifest:
```yaml
    dogstatsd:
      hostPortConfig:
        enabled: true
        hostPort: 8128
    apm:
      hostPortConfig:
        enabled: true
        hostPort: 8129
```

Agent:
```yaml
    name: agent
    env:
    - name: DD_DOGSTATSD_PORT
      value: "8125"
    ports:
    - containerPort: 8125
      hostPort: 8128
      name: dogstatsdport
      protocol: UDP

    name: trace-agent
    env:
    - name: DD_APM_RECEIVER_PORT
      value: "8129"
    ports:
    - containerPort: 8126
      hostPort: 8129
      name: traceport
      protocol: TCP
```

Local service:
```yaml
  ports:
  - name: traceport
    port: 8129
    protocol: TCP
    targetPort: 8126
  - name: dogstatsdport
    port: 8128
    protocol: UDP
    targetPort: 8125
```


### Motivation

Support escalation

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

* Test custom host ports for dogstatsd and apm (see example above) and ensure metrics and traces are received
* Test `hostPortConfig.enabled:true` without setting `hostPortConfig.hostPort`, ensure the default host port value (8125 for dsd, 8126 for apm) is used and that metrics and traces are received

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
