### PR TITLE
[profiles] Change node labels to use dap ns-name format

### DIFF
--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -291,7 +291,7 @@ func (r *Reconciler) labelNodesWithProfiles(ctx context.Context, profilesByNode 
 			for label, value := range node.Labels {
 				newLabels[label] = value
 			}
-			newLabels[agentprofile.ProfileLabelKey] = "true"
+			newLabels[agentprofile.ProfileLabelKey] = fmt.Sprintf("%s-%s", profileNamespacedName.Namespace, profileNamespacedName.Name)
 		}
 
 		if len(newLabels) == 0 {

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -2891,16 +2891,18 @@ func Test_LabelNodesWithProfiles(t *testing.T) {
 		name               string
 		nodes              []corev1.Node
 		profilesByNode     map[string]types.NamespacedName
-		expectProfileLabel map[string]bool
+		expectProfileLabel map[string]string
 	}{
 		{
 			name: "All nodes match profiles",
 			profilesByNode: map[string]types.NamespacedName{
 				"node-1": {
-					Name: "profile-1",
+					Name:      "profile-1",
+					Namespace: "ns-1",
 				},
 				"node-2": {
-					Name: "profile-2",
+					Name:      "profile-2",
+					Namespace: "ns-2",
 				},
 			},
 			nodes: []corev1.Node{
@@ -2921,16 +2923,17 @@ func Test_LabelNodesWithProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectProfileLabel: map[string]bool{
-				"node-1": true,
-				"node-2": true,
+			expectProfileLabel: map[string]string{
+				"node-1": "ns-1-profile-1",
+				"node-2": "ns-2-profile-2",
 			},
 		},
 		{
 			name: "Some nodes match profiles",
 			profilesByNode: map[string]types.NamespacedName{
 				"node-2": {
-					Name: "profile-2",
+					Name:      "profile-2",
+					Namespace: "ns-2",
 				},
 			},
 			nodes: []corev1.Node{
@@ -2951,9 +2954,9 @@ func Test_LabelNodesWithProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectProfileLabel: map[string]bool{
-				"node-1": false,
-				"node-2": true,
+			expectProfileLabel: map[string]string{
+				"node-1": "",
+				"node-2": "ns-2-profile-2",
 			},
 		},
 		{
@@ -2977,9 +2980,9 @@ func Test_LabelNodesWithProfiles(t *testing.T) {
 					},
 				},
 			},
-			expectProfileLabel: map[string]bool{
-				"node-1": false,
-				"node-2": false,
+			expectProfileLabel: map[string]string{
+				"node-1": "",
+				"node-2": "",
 			},
 		},
 	}
@@ -3004,10 +3007,8 @@ func Test_LabelNodesWithProfiles(t *testing.T) {
 			require.NoError(t, err, "Node with matching profile label not found")
 
 			for _, node := range gotNodes.Items {
-				if val, ok := tt.expectProfileLabel[node.Name]; ok {
-					if val {
-						assert.Equal(t, node.Labels[agentprofile.ProfileLabelKey], "true")
-					}
+				if val, ok := tt.expectProfileLabel[node.Name]; ok && val != "" {
+					assert.Equal(t, node.Labels[agentprofile.ProfileLabelKey], val)
 				} else {
 					assert.NotContains(t, node.Labels, agentprofile.ProfileLabelKey)
 				}


### PR DESCRIPTION
### What does this PR do?

Use `<profile-namespace>-<profile-name>` as the node label value instead of `true` for better tracking. 

Example: When adding a profile `dap-test` in the `default` ns targeting node `xx-worker2`, the node is labeled with `agent.datadoghq.com/profile=default-dap-test`:

```console
$ kubectl get node --show-labels
NAME               STATUS   ROLES           AGE    VERSION   LABELS
xx-control-plane   Ready    control-plane   7d3h   v1.28.0   beta.kubernetes.io/arch=arm64,beta.kubernetes.io/os=linux,kubernetes.io/arch=arm64,kubernetes.io/hostname=xx-control-plane,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node.kubernetes.io/exclude-from-external-load-balancers=
xx-worker          Ready    <none>          7d3h   v1.28.0   beta.kubernetes.io/arch=arm64,beta.kubernetes.io/os=linux,kubernetes.io/arch=arm64,kubernetes.io/hostname=xx-worker,kubernetes.io/os=linux
xx-worker2         Ready    <none>          7d3h   v1.28.0   agent.datadoghq.com/profile=default-dap-test,beta.kubernetes.io/arch=arm64,beta.kubernetes.io/os=linux,kubernetes.io/arch=arm64,kubernetes.io/hostname=xx-worker2,kubernetes.io/os=linux
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
