### PR TITLE
Add SLI metrics URL to clc rbac

### DIFF
--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -182,8 +182,11 @@ func GetDefaultClusterChecksRunnerClusterRolePolicyRules(dda metav1.Object, excl
 
 	if !excludeNonResourceRules {
 		policyRule = append(policyRule, rbacv1.PolicyRule{
-			NonResourceURLs: []string{rbac.MetricsURL},
-			Verbs:           []string{rbac.GetVerb},
+			NonResourceURLs: []string{
+				rbac.MetricsURL,
+				rbac.MetricsSLIsURL,
+			},
+			Verbs: []string{rbac.GetVerb},
 		})
 	}
 


### PR DESCRIPTION
### What does this PR do?

As a follow-up to https://github.com/DataDog/datadog-operator/pull/910, we want to be able to query the SLI metrics URL from cluster check runners as well.

### Motivation

This change is necessary to support the corresponding changes to the control plane checks to support SLI metrics.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. `make build`
2. `make docker-build`
3. `make deploy`
4. I then applied a manifest with cluster check workers enabled, and verified that the datadog-cluster-checks-runner cluster role changes were applied appropriately


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
