### PR TITLE
chore(golangci-lint): bump from v1.51.0 to v1.56.0

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -99,6 +99,10 @@
     "deadcode",
     "rowserrcheck",
     "sqlclosecheck",
+    "depguard",
+    "perfsprint",
+    "inamedparam",
+    "nakedret",
   ]
 
 [issues]

--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ bin/$(PLATFORM)/yq: Makefile
 	hack/install-yq.sh v4.31.2
 
 bin/$(PLATFORM)/golangci-lint: Makefile
-	hack/golangci-lint.sh -b "bin/$(PLATFORM)" v1.51.0
+	hack/golangci-lint.sh -b "bin/$(PLATFORM)" v1.56.0
 
 bin/$(PLATFORM)/operator-sdk: Makefile
 	hack/install-operator-sdk.sh v1.23.0


### PR DESCRIPTION
### What does this PR do?

Bump `golangci-lint` version from v1.51.0 to v1.56.0

### Motivation

The current version of `golangci-lint` has memory issues with some Go versions.

### Describe your test plan

```
➜  datadog-operator git:(wassim.dhif/bump-golangci-lint) ✗ make lint
hack/golangci-lint.sh -b "bin/darwin-arm64" v1.56.0
golangci/golangci-lint info checking GitHub for tag 'v1.56.0'
golangci/golangci-lint info found version: 1.56.0 for v1.56.0/darwin/arm64
golangci/golangci-lint info installed bin/darwin-arm64/golangci-lint
go fmt ./...
go vet ./...
bin/darwin-arm64/golangci-lint run ./...
pkg/config/config.go:12:2: import 'github.com/go-logr/logr' is not allowed from list 'Main' (depguard)
	"github.com/go-logr/logr"
	^
[...]
controllers/datadogagent/clusteragent.go:1459:18: fmt.Sprintf can be replaced with string addition (perfsprint)
			MatchPattern: fmt.Sprintf("*-app.agent.%s", site),
			              ^
make: *** [lint] Error 1
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
