### PR TITLE
feat: add OnMissingData to monitor options

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -78,6 +78,16 @@ const (
 	DatadogMonitorOptionsNotificationPresetHideAll     DatadogMonitorOptionsNotificationPreset = "hide_all"
 )
 
+// DatadogMonitorOptionsOnMissingData controls how groups or monitors are treated if an evaluation does not return any data points
+type DatadogMonitorOptionsOnMissingData string
+
+const (
+	DatadogMonitorOptionsOnMissingDataShowNoData          DatadogMonitorOptionsOnMissingData = "show_no_data"
+	DatadogMonitorOptionsOnMissingDataShowAndNotifyNoData DatadogMonitorOptionsOnMissingData = "show_and_notify_no_data"
+	DatadogMonitorOptionsOnMissingDataResolve             DatadogMonitorOptionsOnMissingData = "resolve"
+	DatadogMonitorOptionsOnMissingDataDefault             DatadogMonitorOptionsOnMissingData = "default"
+)
+
 // DatadogMonitorOptions define the optional parameters of a monitor
 // +k8s:openapi-gen=true
 type DatadogMonitorOptions struct {
@@ -106,6 +116,12 @@ type DatadogMonitorOptions struct {
 	NotifyAudit *bool `json:"notifyAudit,omitempty"`
 	// A Boolean indicating whether this monitor notifies when data stops reporting.
 	NotifyNoData *bool `json:"notifyNoData,omitempty"`
+	// An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+	// The default option results in different behavior depending on the monitor query type.
+	// For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+	// For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+	// This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+	OnMissingData DatadogMonitorOptionsOnMissingData `json:"onMissingData,omitempty"`
 	// The number of minutes after the last notification before a monitor re-notifies on the current status.
 	// It only re-notifies if it’s not resolved.
 	RenotifyInterval *int64 `json:"renotifyInterval,omitempty"`

--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -78,16 +78,6 @@ const (
 	DatadogMonitorOptionsNotificationPresetHideAll     DatadogMonitorOptionsNotificationPreset = "hide_all"
 )
 
-// DatadogMonitorOptionsOnMissingData controls how groups or monitors are treated if an evaluation does not return any data points
-type DatadogMonitorOptionsOnMissingData string
-
-const (
-	DatadogMonitorOptionsOnMissingDataShowNoData          DatadogMonitorOptionsOnMissingData = "show_no_data"
-	DatadogMonitorOptionsOnMissingDataShowAndNotifyNoData DatadogMonitorOptionsOnMissingData = "show_and_notify_no_data"
-	DatadogMonitorOptionsOnMissingDataResolve             DatadogMonitorOptionsOnMissingData = "resolve"
-	DatadogMonitorOptionsOnMissingDataDefault             DatadogMonitorOptionsOnMissingData = "default"
-)
-
 // DatadogMonitorOptions define the optional parameters of a monitor
 // +k8s:openapi-gen=true
 type DatadogMonitorOptions struct {
@@ -262,6 +252,16 @@ const (
 	DatadogMonitorStateIgnored DatadogMonitorState = "Ignored"
 	// DatadogMonitorStateUnknown means the DatadogMonitor is in an unknown state
 	DatadogMonitorStateUnknown DatadogMonitorState = "Unknown"
+)
+
+// DatadogMonitorOptionsOnMissingData controls how groups or monitors are treated if an evaluation does not return any data points
+type DatadogMonitorOptionsOnMissingData string
+
+const (
+	DatadogMonitorOptionsOnMissingDataShowNoData          DatadogMonitorOptionsOnMissingData = "show_no_data"
+	DatadogMonitorOptionsOnMissingDataShowAndNotifyNoData DatadogMonitorOptionsOnMissingData = "show_and_notify_no_data"
+	DatadogMonitorOptionsOnMissingDataResolve             DatadogMonitorOptionsOnMissingData = "resolve"
+	DatadogMonitorOptionsOnMissingDataDefault             DatadogMonitorOptionsOnMissingData = "default"
 )
 
 // MonitorStateSyncStatusMessage is the message reflecting the health of monitor state syncs to Datadog

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -2166,6 +2166,13 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorOptions(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"onMissingData": {
+						SchemaProps: spec.SchemaProps{
+							Description: "An enum that controls how groups or monitors are treated if an evaluation does not return data points. The default option results in different behavior depending on the monitor query type. For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions. For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status. This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"renotifyInterval": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it’s not resolved.",

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -101,6 +101,9 @@ spec:
                     notifyNoData:
                       description: A Boolean indicating whether this monitor notifies when data stops reporting.
                       type: boolean
+                    onMissingData:
+                      description: An enum that controls how groups or monitors are treated if an evaluation does not return data points. The default option results in different behavior depending on the monitor query type. For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions. For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status. This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                      type: string
                     renotifyInterval:
                       description: The number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it’s not resolved.
                       format: int64

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -102,6 +102,9 @@ spec:
                 notifyNoData:
                   description: A Boolean indicating whether this monitor notifies when data stops reporting.
                   type: boolean
+                onMissingData:
+                  description: An enum that controls how groups or monitors are treated if an evaluation does not return data points. The default option results in different behavior depending on the monitor query type. For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions. For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status. This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                  type: string
                 renotifyInterval:
                   description: The number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it’s not resolved.
                   format: int64

--- a/controllers/datadogmonitor/monitor.go
+++ b/controllers/datadogmonitor/monitor.go
@@ -149,6 +149,10 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 		o.SetNotificationPresetName(datadogV1.MonitorOptionsNotificationPresets(string(options.NotificationPresetName)))
 	}
 
+	if options.OnMissingData != "" {
+		o.SetOnMissingData(datadogV1.OnMissingDataOption(string(options.OnMissingData)))
+	}
+
 	m := datadogV1.NewMonitor(query, monitorType)
 	{
 		m.SetName(name)

--- a/controllers/datadogmonitor/monitor_test.go
+++ b/controllers/datadogmonitor/monitor_test.go
@@ -61,6 +61,7 @@ func Test_buildMonitor(t *testing.T) {
 				NoDataTimeframe:        &noDataTimeframe,
 				NotificationPresetName: "show_all",
 				NotifyNoData:           &valTrue,
+				OnMissingData:          "default",
 				RenotifyInterval:       &renotifyInterval,
 				TimeoutH:               &timeoutH,
 				Thresholds: &datadoghqv1alpha1.DatadogMonitorOptionsThresholds{
@@ -117,6 +118,9 @@ func Test_buildMonitor(t *testing.T) {
 
 	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitor.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
 	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitorUR.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
+
+	assert.Equal(t, string(dm.Spec.Options.OnMissingData), string(monitor.Options.GetOnMissingData()), "discrepancy found in parameter: OnMissingData")
+	assert.Equal(t, string(dm.Spec.Options.OnMissingData), string(monitorUR.Options.GetOnMissingData()), "discrepancy found in parameter: OnMissingData")
 
 	assert.Equal(t, *dm.Spec.Options.RenotifyInterval, monitor.Options.GetRenotifyInterval(), "discrepancy found in parameter: RenotifyInterval")
 	assert.Equal(t, *dm.Spec.Options.RenotifyInterval, monitorUR.Options.GetRenotifyInterval(), "discrepancy found in parameter: RenotifyInterval")


### PR DESCRIPTION
### What does this PR do?

* Provides the `on_missing_data` monitor option https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#on_missing_data

### Motivation

* Closes https://github.com/DataDog/datadog-operator/issues/1045

### Additional Notes

The `on_missing_data` option is only available in certain monitors and while some options are not configured (e.g. can't combine `no_data_timeframe` and `on_missing_data`. The unit test in `monitor_test.go` only tests the monitor can be built and passed to the API go client, ultimately the validation is handled by the API go client, returning a `4xx` if invalid.

### Minimum Agent Versions

N/A

### Describe your test plan

1. Apply new CRD `k apply -f config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml`
2. Install custom image with Helm, enabling monitors controller :
```yaml
apiKeyExistingSecret: datadog-secret
appKeyExistingSecret: datadog-secret
image:
  tag: "1"
  repository: tbdatadog/operator
  pullPolicy: Never
logLevel: "debug"
datadogAgent:
  enabled: false
datadogMonitor:
  enabled: true
installCRDs: false
```
3. Apply a log monitor using this option : 
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMonitor
metadata:
  name: datadog-log-alert-test
  namespace: default
spec:
  query: "logs(\"source:nagios AND status:error\").index(\"main\").rollup(\"count\").last(\"1h\") > 5"
  type: "log alert"
  name: "Test log alert made from DatadogMonitor"
  message: "1-2-3 testing"
  tags:
    - "test:datadog"
  priority: 5
  options:
    onMissingData: "abc"
    enableLogsSample: true
    evaluationDelay: 300
    includeTags: true
    locked: false
    notifyNoData: false
    renotifyInterval: 1440
```
4. Since `onMissingData` is `abc`, ensure you get a `400` and the monitor is not created.
<img width="1555" alt="image" src="https://github.com/DataDog/datadog-operator/assets/97530782/767c8ef8-8537-4d19-b47b-e9c2c94f71a2">

5. Update `onMissingData` to `show_no_data`
6. Ensure the monitor gets created in your account with said option 
<img width="619" alt="image" src="https://github.com/DataDog/datadog-operator/assets/97530782/7d1d1761-7a1d-4a8f-bed1-59ca881f4b6f">

7. Verify update operation by using `resolve` for `onMissingData`
<img width="327" alt="image" src="https://github.com/DataDog/datadog-operator/assets/97530782/20081a04-6309-4eb7-b106-bdeabfcce5b9">

8. Verify delete operation

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
