### PR TITLE
Clean up cos_containerd provider name

### DIFF
--- a/controllers/datadogagent/controller_reconcile_agent_test.go
+++ b/controllers/datadogagent/controller_reconcile_agent_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const defaultProvider = kubernetes.DefaultProvider
-const gkeCosContainerdProvider = kubernetes.GKECloudProvider + "-" + kubernetes.GKECosContainerdType
+const gkeCosProvider = kubernetes.GKECloudProvider + "-" + kubernetes.GKECosType
 
 func Test_generateNodeAffinity(t *testing.T) {
 
@@ -47,7 +47,7 @@ func Test_generateNodeAffinity(t *testing.T) {
 			name: "nil affinity, gke cos containerd provider",
 			args: args{
 				affinity: nil,
-				provider: gkeCosContainerdProvider,
+				provider: gkeCosProvider,
 			},
 		},
 		{
@@ -61,7 +61,7 @@ func Test_generateNodeAffinity(t *testing.T) {
 			name: "existing affinity, but empty, gke cos containerd provider",
 			args: args{
 				affinity: &corev1.Affinity{},
-				provider: gkeCosContainerdProvider,
+				provider: gkeCosProvider,
 			},
 		},
 		{
@@ -101,7 +101,7 @@ func Test_generateNodeAffinity(t *testing.T) {
 						},
 					},
 				},
-				provider: gkeCosContainerdProvider,
+				provider: gkeCosProvider,
 			},
 		},
 		{
@@ -145,7 +145,7 @@ func Test_generateNodeAffinity(t *testing.T) {
 						},
 					},
 				},
-				provider: gkeCosContainerdProvider,
+				provider: gkeCosProvider,
 			},
 		},
 	}
@@ -254,8 +254,7 @@ func Test_updateProviderStore(t *testing.T) {
 				},
 			},
 			existingProviders: map[string]struct{}{
-				"gke-cos_containerd": {},
-				"default":            {},
+				"default": {},
 			},
 			wantedProviders: map[string]struct{}{
 				"gke-cos": {},
@@ -265,12 +264,12 @@ func Test_updateProviderStore(t *testing.T) {
 			name:  "empty node list",
 			nodes: []client.Object{},
 			existingProviders: map[string]struct{}{
-				"gke-cos_containerd": {},
-				"default":            {},
+				"gke-cos": {},
+				"default": {},
 			},
 			wantedProviders: map[string]struct{}{
-				"gke-cos_containerd": {},
-				"default":            {},
+				"gke-cos": {},
+				"default": {},
 			},
 		},
 	}
@@ -315,14 +314,14 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 						},
 					},
 				},
 			},
 			edsEnabled: false,
 			existingProviders: map[string]struct{}{
-				gkeCosContainerdProvider: {},
+				gkeCosProvider: {},
 			},
 			wantDS: &appsv1.DaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -334,7 +333,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							},
 							ResourceVersion: "999",
 						},
@@ -349,14 +348,14 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 						},
 					},
 				},
 			},
 			edsEnabled: true,
 			existingProviders: map[string]struct{}{
-				gkeCosContainerdProvider: {},
+				gkeCosProvider: {},
 			},
 			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -368,7 +367,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							},
 							ResourceVersion: "999",
 						},
@@ -383,7 +382,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 						},
 					},
 				},
@@ -407,7 +406,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 						},
 					},
 				},
@@ -429,7 +428,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents:     []client.Object{},
 			edsEnabled: false,
 			existingProviders: map[string]struct{}{
-				gkeCosContainerdProvider: {},
+				gkeCosProvider: {},
 			},
 			wantDS: &appsv1.DaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -444,7 +443,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 			agents:     []client.Object{},
 			edsEnabled: true,
 			existingProviders: map[string]struct{}{
-				gkeCosContainerdProvider: {},
+				gkeCosProvider: {},
 			},
 			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
 				TypeMeta: metav1.TypeMeta{
@@ -461,7 +460,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 						},
 					},
 				},
@@ -478,7 +477,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							},
 							ResourceVersion: "999",
 						},
@@ -493,7 +492,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "gke-cos-node",
 						Labels: map[string]string{
-							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+							apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 						},
 					},
 				},
@@ -510,7 +509,7 @@ func Test_cleanupDaemonSetsForProvidersThatNoLongerApply(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "gke-cos-node",
 							Labels: map[string]string{
-								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosContainerdProvider,
+								apicommon.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							},
 							ResourceVersion: "999",
 						},

--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -6,9 +6,10 @@
 package oomkill
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
@@ -96,7 +97,7 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers, p
 
 	// src volume mount
 	_, providerValue := kubernetes.GetProviderLabelKeyValue(provider)
-	if providerValue != kubernetes.GKECosContainerdType && providerValue != kubernetes.GKECosType {
+	if providerValue != kubernetes.GKECosType {
 		srcVol, srcVolMount := volume.GetVolumes(apicommon.SrcVolumeName, apicommon.SrcVolumePath, apicommon.SrcVolumePath, true)
 		managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommonv1.SystemProbeContainerName)
 		managers.Volume().AddVolume(&srcVol)

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -6,9 +6,10 @@
 package tcpqueuelength
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
@@ -99,7 +100,7 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 
 	// src volume mount
 	_, providerValue := kubernetes.GetProviderLabelKeyValue(provider)
-	if providerValue != kubernetes.GKECosContainerdType && providerValue != kubernetes.GKECosType {
+	if providerValue != kubernetes.GKECosType {
 		srcVol, srcVolMount := volume.GetVolumes(apicommon.SrcVolumeName, apicommon.SrcVolumePath, apicommon.SrcVolumePath, true)
 		managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommonv1.SystemProbeContainerName)
 		managers.Volume().AddVolume(&srcVol)

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 )
 
 type ProviderStore struct {
@@ -23,23 +24,25 @@ type ProviderStore struct {
 }
 
 const (
-	LegacyProvider  = ""
+	// LegacyProvider Legacy Provider (empty name)
+	LegacyProvider = ""
+	// DefaultProvider Default provider name
 	DefaultProvider = "default"
-	// GKE provider values https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images
-	GKECosContainerdType = "cos_containerd"
-	GKECosType           = "cos"
 
-	// CloudProvider
+	// GKECosType GKE provider types: https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images
+	// Default "cos" node runtime is cos_containerd in GKE v1.24+
+	GKECosType = "cos"
+
+	// GKECloudProvider GKE CloudProvider name
 	GKECloudProvider = "gke"
 
-	// ProviderLabel
+	// GKEProviderLabel GKE ProviderLabel
 	GKEProviderLabel = "cloud.google.com/gke-os-distribution"
 )
 
 // ProviderValue allowlist
 var providerValueAllowlist = map[string]struct{}{
-	GKECosContainerdType: {},
-	GKECosType:           {},
+	GKECosType: {},
 }
 
 // NewProviderStore generates an empty ProviderStore instance

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -17,9 +17,8 @@ import (
 )
 
 var (
-	defaultProvider          = DefaultProvider
-	gkeCosContainerdProvider = generateValidProviderName(GKECloudProvider, GKECosContainerdType)
-	gkeCosProvider           = generateValidProviderName(GKECloudProvider, GKECosType)
+	defaultProvider = DefaultProvider
+	gkeCosProvider  = generateValidProviderName(GKECloudProvider, GKECosType)
 )
 
 func Test_determineProvider(t *testing.T) {
@@ -48,14 +47,6 @@ func Test_determineProvider(t *testing.T) {
 			},
 			provider: generateValidProviderName(GKECloudProvider, GKECosType),
 		},
-		{
-			name: "gke provider, underscore",
-			labels: map[string]string{
-				"foo":            "bar",
-				GKEProviderLabel: GKECosContainerdType,
-			},
-			provider: generateValidProviderName(GKECloudProvider, GKECosContainerdType),
-		},
 	}
 
 	for _, tt := range tests {
@@ -74,7 +65,7 @@ func Test_isProviderValueAllowed(t *testing.T) {
 	}{
 		{
 			name:  "valid value",
-			value: GKECosContainerdType,
+			value: GKECosType,
 			want:  true,
 		},
 		{
@@ -160,7 +151,7 @@ func Test_GenerateProviderNodeAffinity(t *testing.T) {
 			wantNSR:           []corev1.NodeSelectorRequirement{},
 		},
 		{
-			name: "one existing provider, default provider",
+			name: "one existing provider, new default provider",
 			existingProviders: map[string]struct{}{
 				gkeCosProvider: {},
 			},
@@ -180,13 +171,13 @@ func Test_GenerateProviderNodeAffinity(t *testing.T) {
 			existingProviders: map[string]struct{}{
 				gkeCosProvider: {},
 			},
-			provider: gkeCosContainerdProvider,
+			provider: gkeCosProvider,
 			wantNSR: []corev1.NodeSelectorRequirement{
 				{
 					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpIn,
 					Values: []string{
-						GKECosContainerdType,
+						GKECosType,
 					},
 				},
 			},
@@ -230,13 +221,13 @@ func Test_GenerateProviderNodeAffinity(t *testing.T) {
 				"abcdef":       {},
 				"lmnop":        {},
 			},
-			provider: gkeCosContainerdProvider,
+			provider: gkeCosProvider,
 			wantNSR: []corev1.NodeSelectorRequirement{
 				{
 					Key:      GKEProviderLabel,
 					Operator: corev1.NodeSelectorOpIn,
 					Values: []string{
-						GKECosContainerdType,
+						GKECosType,
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Clean up redundant `cos_containerd` provider name from introspection logic. 

### Motivation

`cos_containerd` node images are the default images in GKE v1.24+ and they are labeled `cloud.google.com/gke-os-distribution=cos"`, not `cos_containerd`. 

Docker-based nodes have been deprecated starting with GKE v1.24+: https://cloud.google.com/kubernetes-engine/docs/deprecations/docker-containerd 


### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
