### PR TITLE
feat(dogstatsd): activate Origin Detection with UDP

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -56,6 +56,8 @@ const (
 	DefaultAdmissionControllerTargetPort = 8000
 	// DefaultAdmissionControllerWebhookName default admission controller webhook name
 	DefaultAdmissionControllerWebhookName string = "datadog-webhook"
+	// DefaultDogstatsdOriginDetection default Origin Detection
+	DefaultDogstatsdOriginDetection = "false"
 	// DefaultDogstatsdPort default dogstatsd port
 	DefaultDogstatsdPort = 8125
 	// DefaultDogstatsdPortName default dogstatsd port name

--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -48,6 +48,7 @@ const (
 	DDDogstatsdMapperProfiles                         = "DD_DOGSTATSD_MAPPER_PROFILES"
 	DDDogstatsdNonLocalTraffic                        = "DD_DOGSTATSD_NON_LOCAL_TRAFFIC"
 	DDDogstatsdOriginDetection                        = "DD_DOGSTATSD_ORIGIN_DETECTION"
+	DDDogstatsdOriginDetectionClient                  = "DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT"
 	DDDogstatsdTagCardinality                         = "DD_DOGSTATSD_TAG_CARDINALITY"
 	DDDogstatsdPort                                   = "DD_DOGSTATSD_PORT"
 	DDDogstatsdSocket                                 = "DD_DOGSTATSD_SOCKET"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -841,8 +841,12 @@ func defaultEnvVars(extraEnv map[string]string) []corev1.EnvVar {
 			Value: fmt.Sprintf("%s-leader-election", testDdaName),
 		},
 		{
-			Name:  "DD_DOGSTATSD_ORIGIN_DETECTION",
-			Value: "false",
+			Name:  apicommon.DDDogstatsdOriginDetection,
+			Value: apicommon.DefaultDogstatsdOriginDetection,
+		},
+		{
+			Name:  apicommon.DDDogstatsdOriginDetectionClient,
+			Value: apicommon.DefaultDogstatsdOriginDetection,
 		},
 		{
 			Name:  "DD_DOGSTATSD_SOCKET",
@@ -1931,8 +1935,12 @@ func customKubeletConfigPodSpec(kubeletConfig *commonv1.KubeletConfig) corev1.Po
 			Value: fmt.Sprintf("%s-leader-election", testDdaName),
 		},
 		{
-			Name:  "DD_DOGSTATSD_ORIGIN_DETECTION",
-			Value: "false",
+			Name:  apicommon.DDDogstatsdOriginDetection,
+			Value: apicommon.DefaultDogstatsdOriginDetection,
+		},
+		{
+			Name:  apicommon.DDDogstatsdOriginDetectionClient,
+			Value: apicommon.DefaultDogstatsdOriginDetection,
 		},
 		{
 			Name:  "DD_DOGSTATSD_SOCKET",

--- a/controllers/datadogagent/feature/dogstatsd/feature.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature.go
@@ -238,6 +238,10 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommonv1.AgentC
 			Name:  apicommon.DDDogstatsdOriginDetection,
 			Value: "true",
 		})
+		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+			Name:  apicommon.DDDogstatsdOriginDetectionClient,
+			Value: "true",
+		})
 		if f.udsEnabled {
 			managers.PodTemplateSpec().Spec.HostPID = true
 		}

--- a/controllers/datadogagent/feature/dogstatsd/feature_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_test.go
@@ -200,7 +200,7 @@ func Test_DogstatsdFeature_ConfigureV2(t *testing.T) {
 			WantConfigure: true,
 			Agent: test.NewDefaultComponentTest().WithWantFunc(
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
-					customEnvVars := append(getWantUDPEnvVars(), getOriginDetectionEnvVar())
+					customEnvVars := append(getWantUDPEnvVars(), getOriginDetectionEnvVar(), getOriginDetectionClientEnvVar())
 					assertWants(t, mgrInterface, "10", getWantVolumeMounts(), getWantVolumes(), customEnvVars, getWantUDSEnvVarsV2(), getWantHostPorts())
 				},
 			),
@@ -256,7 +256,7 @@ func Test_DogstatsdFeature_ConfigureV2(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					assert.True(t, mgr.Tpl.Spec.HostPID, "13. Host PID \ndiff = %s", cmp.Diff(mgr.Tpl.Spec.HostPID, true))
-					assertWants(t, mgrInterface, "13", getWantVolumeMounts(), getWantVolumes(), []*corev1.EnvVar{getOriginDetectionEnvVar()}, getWantUDSEnvVarsV2(), getWantContainerPorts())
+					assertWants(t, mgrInterface, "13", getWantVolumeMounts(), getWantVolumes(), []*corev1.EnvVar{getOriginDetectionEnvVar(), getOriginDetectionClientEnvVar()}, getWantUDSEnvVarsV2(), getWantContainerPorts())
 				},
 			),
 		},
@@ -289,7 +289,7 @@ func Test_DogstatsdFeature_ConfigureV2(t *testing.T) {
 						Name:  apicommon.DDDogstatsdTagCardinality,
 						Value: "orchestrator",
 					}
-					customEnvVars := append(getWantUDPEnvVars(), getOriginDetectionEnvVar(), &wantTagCardinalityEnvVar)
+					customEnvVars := append(getWantUDPEnvVars(), getOriginDetectionEnvVar(), getOriginDetectionClientEnvVar(), &wantTagCardinalityEnvVar)
 					assertWants(t, mgrInterface, "15", getWantVolumeMounts(), getWantVolumes(), customEnvVars, getWantUDSEnvVarsV2(), getWantHostPorts())
 				},
 			),
@@ -333,6 +333,14 @@ func getOriginDetectionEnvVar() *corev1.EnvVar {
 		Value: "true",
 	}
 	return &originDetectionEnvVar
+}
+
+func getOriginDetectionClientEnvVar() *corev1.EnvVar {
+	originDetectionClientEnvVar := corev1.EnvVar{
+		Name:  apicommon.DDDogstatsdOriginDetectionClient,
+		Value: "true",
+	}
+	return &originDetectionClientEnvVar
 }
 
 func getCustomEnvVar() []*corev1.EnvVar {

--- a/controllers/datadogagent/feature/dogstatsd/feature_v1alpha1_test.go
+++ b/controllers/datadogagent/feature/dogstatsd/feature_v1alpha1_test.go
@@ -110,6 +110,12 @@ func Test_DogstatsdFeature_ConfigureV1(t *testing.T) {
 		Value: "true",
 	}
 
+	// origin detection client envvar
+	originDetectionClientEnvVar := corev1.EnvVar{
+		Name:  apicommon.DDDogstatsdOriginDetectionClient,
+		Value: "true",
+	}
+
 	// mapper profiles envvar
 	mapperProfilesEnvVar := corev1.EnvVar{
 		Name:  apicommon.DDDogstatsdMapperProfiles,
@@ -191,7 +197,7 @@ func Test_DogstatsdFeature_ConfigureV1(t *testing.T) {
 					volumes := mgr.VolumeMgr.Volumes
 					assert.True(t, apiutils.IsEqualStruct(volumes, []*corev1.Volume{}), "3. Volumes \ndiff = %s", cmp.Diff(volumes, []*corev1.Volume{}))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					customEnvVars := append([]*corev1.EnvVar{}, &originDetectionEnvVar)
+					customEnvVars := []*corev1.EnvVar{&originDetectionEnvVar, &originDetectionClientEnvVar}
 					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, customEnvVars), "3. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, customEnvVars))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]
 					assert.True(t, apiutils.IsEqualStruct(coreAgentPorts, wantContainerPorts), "3. Agent ports \ndiff = %s", cmp.Diff(coreAgentPorts, wantContainerPorts))
@@ -265,7 +271,7 @@ func Test_DogstatsdFeature_ConfigureV1(t *testing.T) {
 					volumes := mgr.VolumeMgr.Volumes
 					assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumesV1), "6. Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumesV1))
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
-					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar}), "6. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar}))
+					assert.True(t, apiutils.IsEqualStruct(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar, &originDetectionClientEnvVar}), "6. Agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, []*corev1.EnvVar{&originDetectionEnvVar}))
 					allEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
 					assert.True(t, apiutils.IsEqualStruct(allEnvVars, wantUDSEnvVarsV1), "6. All Containers envvars \ndiff = %s", cmp.Diff(agentEnvVars, wantUDSEnvVarsV2))
 					coreAgentPorts := mgr.PortMgr.PortsByC[apicommonv1.CoreAgentContainerName]

--- a/controllers/datadogagent/utils.go
+++ b/controllers/datadogagent/utils.go
@@ -884,12 +884,16 @@ func getEnvVarsForAgent(logger logr.Logger, dda *datadoghqv1alpha1.DatadogAgent)
 	envVars = append(envVars, commonEnvVars...)
 
 	if isDogstatsdConfigured(&spec) {
-		envVars = append(envVars,
-			corev1.EnvVar{
+		envVars = append(envVars, []corev1.EnvVar{
+			{
 				Name:  apicommon.DDDogstatsdOriginDetection,
 				Value: strconv.FormatBool(*spec.Agent.Config.Dogstatsd.DogstatsdOriginDetection),
 			},
-		)
+			{
+				Name:  apicommon.DDDogstatsdOriginDetectionClient,
+				Value: strconv.FormatBool(*spec.Agent.Config.Dogstatsd.DogstatsdOriginDetection),
+			},
+		}...)
 		// Always add DD_DOGSTATSD_SOCKET env var, to allow JMX-Fetch to use it inside pod's containers.
 		envVars = append(envVars, getEnvVarDogstatsdSocket(dda))
 


### PR DESCRIPTION
### What does this PR do?

Adds the setting needed to activate Origin Detection with DogStatsD and UDP.

### Motivation

We would like for our customer to use Origin Detection more easily without having to set custom environment variables manually.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Build and deploy the operator to a Kubernetes cluster
```
make build
make IMG=test/operator:test IMG_CHECK=test/operator-check:test docker-build
make IMG=test/operator:test IMG_CHECK=test/operator-check:test docker-push
make IMG=test/operator:test IMG_CHECK=test/operator-check:test deploy
```

Create a `datadog-secret`
```
kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY --from-literal app-key=$DD_APP_KEY --namespace system
```

Apply a manifest with the following (you need an agent running version `7.51.0`)
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  override:
    nodeAgent:
      image:
        name: agent
        tag: 7.51.0-rc.6-jmx
        pullPolicy: Always
      containers:
        agent:
          env:
          - name: "DD_AGENT_HOST"
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
  global:
    clusterName: wdhif
    kubelet:
      tlsVerify: false
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  features:
    dogstatsd:
      originDetectionEnabled: true
      tagCardinality: "high"
      hostPortConfig:
        enabled: true
```
```
kubectl apply --namespace system -f datadog-operator.yaml
```

You will also need a compatible workload

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-dsd-app-go
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-dsd-app-go
  template:
    metadata:
      labels:
        app: dummy-dsd-app-go
        admission.datadoghq.com/enabled: "false"
    spec:
      containers:
      - name: dummy-dsd-app-go
        image: docker.io/alidatadog/dummy-dsd-app:0.2.0
        imagePullPolicy: Always
        env:
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
```
```
kubectl apply --namespace system -f dummy-dsd-app-go.yaml
```

After that you will be able to see the `page.views` metric and it will be tagged with both `container_id` and `container_name`.

<img width="908" alt="image" src="https://github.com/DataDog/datadog-operator/assets/5231539/da58ced4-6481-4cce-9245-dc08d4040ea8">

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
