### PR TITLE
Fix publish-community-bundles script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -401,7 +401,7 @@ publish_community_operators:
     - make install-tools
   script:
     # Set version
-    - VERSION=${CI_COMMIT_TAG:1} # vX.Y.Z => X.Y.Z
+    - export VERSION=${CI_COMMIT_TAG:1} # vX.Y.Z => X.Y.Z
     # Install github-cli and skopeo deps
     - curl -fsSL "https://cli.github.com/packages/githubcli-archive-keyring.gpg" -o /usr/share/keyrings/githubcli-archive-keyring.gpg
     - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
@@ -428,4 +428,4 @@ publish_community_operators:
     - gh auth login --with-token < git-token.txt
     - gh auth setup-git
     # create pull request for each marketplace repo
-    - make publish-community-bundles $VERSION community-operators community-operators-prod certified-operators redhat-marketplace-operators
+    - make publish-community-bundles

--- a/hack/publish-community-bundles.sh
+++ b/hack/publish-community-bundles.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-VERSION="$1" # 1st argument passed to script is the operator version
-shift
-REPOS=("$@") # Make an array of repos with the remaining arguments passed to script
+if [ -z "$VERSION" ]; then
+    echo "Missing operator version"
+    exit 1
+fi
 
 OPERATOR_SUBPATH="datadog-operator"
 BUNDLE_NAME="bundle"
 WORKING_DIR=$PWD
 PR_BRANCH_NAME="datadog-operator-$VERSION"
+REPOS=("community-operators" "community-operators-prod" "certified-operators" "redhat-marketplace-operators")
 
 mkdir tmp
 


### PR DESCRIPTION
### What does this PR do?

Fix/simplify `hack/publish-community-bundles.sh` script to properly invoke make target from gitlab job. 

### Motivation

Broken make syntax in ci

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
