### PR TITLE
[profiles][CECO-925] Add flag to enable DAP

### DIFF
--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -65,11 +65,12 @@ const (
 
 // ReconcilerOptions provides options read from command line
 type ReconcilerOptions struct {
-	ExtendedDaemonsetOptions componentagent.ExtendedDaemonsetOptions
-	SupportCilium            bool
-	OperatorMetricsEnabled   bool
-	V2Enabled                bool
-	IntrospectionEnabled     bool
+	ExtendedDaemonsetOptions   componentagent.ExtendedDaemonsetOptions
+	SupportCilium              bool
+	OperatorMetricsEnabled     bool
+	V2Enabled                  bool
+	IntrospectionEnabled       bool
+	DatadogAgentProfileEnabled bool
 }
 
 // Reconciler is the internal reconciler for Datadog Agent

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -54,7 +54,8 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 	// DaemonSets.
 	// This is to make deployments simpler. With multiple EDS there would be
 	// multiple canaries, etc.
-	if r.options.ExtendedDaemonsetOptions.Enabled && agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
+	if (r.options.ExtendedDaemonsetOptions.Enabled && !r.options.DatadogAgentProfileEnabled) || (r.options.ExtendedDaemonsetOptions.Enabled &&
+		r.options.DatadogAgentProfileEnabled && agentprofile.IsDefaultProfile(profile.Namespace, profile.Name)) {
 		// Start by creating the Default Agent extendeddaemonset
 		eds = componentagent.NewDefaultAgentExtendedDaemonset(dda, &r.options.ExtendedDaemonsetOptions, requiredComponents.Agent)
 		podManagers = feature.NewPodTemplateManagers(&eds.Spec.Template)
@@ -75,9 +76,11 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 			componentOverrides = append(componentOverrides, componentOverride)
 		}
 
-		// Apply overrides from profiles after override from manifest, so they can override what's defined in the DDA.
-		overrideFromProfile := agentprofile.ComponentOverrideFromProfile(profile)
-		componentOverrides = append(componentOverrides, &overrideFromProfile)
+		if r.options.DatadogAgentProfileEnabled {
+			// Apply overrides from profiles after override from manifest, so they can override what's defined in the DDA.
+			overrideFromProfile := agentprofile.ComponentOverrideFromProfile(profile)
+			componentOverrides = append(componentOverrides, &overrideFromProfile)
+		}
 
 		if r.options.IntrospectionEnabled {
 			// use the last name override in the list to generate a provider-specific name
@@ -144,9 +147,11 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 		componentOverrides = append(componentOverrides, componentOverride)
 	}
 
-	// Apply overrides from profiles after override from manifest, so they can override what's defined in the DDA.
-	overrideFromProfile := agentprofile.ComponentOverrideFromProfile(profile)
-	componentOverrides = append(componentOverrides, &overrideFromProfile)
+	if r.options.DatadogAgentProfileEnabled {
+		// Apply overrides from profiles after override from manifest, so they can override what's defined in the DDA.
+		overrideFromProfile := agentprofile.ComponentOverrideFromProfile(profile)
+		componentOverrides = append(componentOverrides, &overrideFromProfile)
+	}
 
 	if r.options.IntrospectionEnabled {
 		// use the last name override in the list to generate a provider-specific name

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -212,10 +212,12 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(r.PlatformInfo.CreatePDBObject()).
 		Owns(&networkingv1.NetworkPolicy{})
 
-	builder.Watches(
-		&source.Kind{Type: &datadoghqv1alpha1.DatadogAgentProfile{}},
-		handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForAllDDAs()),
-	)
+	if r.Options.DatadogAgentProfileEnabled {
+		builder.Watches(
+			&source.Kind{Type: &datadoghqv1alpha1.DatadogAgentProfile{}},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForAllDDAs()),
+		)
+	}
 
 	// Watch nodes and reconcile all DatadogAgents for node creation, node deletion, and node label change events
 	if r.Options.V2Enabled {

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -34,15 +34,16 @@ const (
 
 // SetupOptions defines options for setting up controllers to ease testing
 type SetupOptions struct {
-	SupportExtendedDaemonset ExtendedDaemonsetOptions
-	SupportCilium            bool
-	Creds                    config.Creds
-	DatadogAgentEnabled      bool
-	DatadogMonitorEnabled    bool
-	DatadogSLOEnabled        bool
-	OperatorMetricsEnabled   bool
-	V2APIEnabled             bool
-	IntrospectionEnabled     bool
+	SupportExtendedDaemonset   ExtendedDaemonsetOptions
+	SupportCilium              bool
+	Creds                      config.Creds
+	DatadogAgentEnabled        bool
+	DatadogMonitorEnabled      bool
+	DatadogSLOEnabled          bool
+	OperatorMetricsEnabled     bool
+	V2APIEnabled               bool
+	IntrospectionEnabled       bool
+	DatadogAgentProfileEnabled bool
 }
 
 // ExtendedDaemonsetOptions defines ExtendedDaemonset options
@@ -137,10 +138,11 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 				CanaryAutoFailEnabled:               options.SupportExtendedDaemonset.CanaryAutoFailEnabled,
 				CanaryAutoFailMaxRestarts:           int32(options.SupportExtendedDaemonset.CanaryAutoFailMaxRestarts),
 			},
-			SupportCilium:          options.SupportCilium,
-			OperatorMetricsEnabled: options.OperatorMetricsEnabled,
-			V2Enabled:              options.V2APIEnabled,
-			IntrospectionEnabled:   options.IntrospectionEnabled,
+			SupportCilium:              options.SupportCilium,
+			OperatorMetricsEnabled:     options.OperatorMetricsEnabled,
+			V2Enabled:                  options.V2APIEnabled,
+			IntrospectionEnabled:       options.IntrospectionEnabled,
+			DatadogAgentProfileEnabled: options.DatadogAgentProfileEnabled,
 		},
 	}).SetupWithManager(mgr)
 }
@@ -191,6 +193,11 @@ func startDatadogSLO(logger logr.Logger, mgr manager.Manager, info *version.Info
 }
 
 func startDatadogAgentProfiles(logger logr.Logger, mgr manager.Manager, vInfo *version.Info, pInfo kubernetes.PlatformInfo, options SetupOptions) error {
+	if !options.DatadogAgentProfileEnabled {
+		logger.Info("Feature disabled, not starting the controller", "controller", profileControllerName)
+		return nil
+	}
+
 	return (&DatadogAgentProfileReconciler{
 		Client:   mgr.GetClient(),
 		Log:      ctrl.Log.WithName("controllers").WithName(profileControllerName),

--- a/controllers/suite_v2_test.go
+++ b/controllers/suite_v2_test.go
@@ -103,10 +103,11 @@ var _ = BeforeSuite(func() {
 		SupportExtendedDaemonset: ExtendedDaemonsetOptions{
 			Enabled: false,
 		},
-		Creds:                 config.Creds{APIKey: "dummy_api_key", AppKey: "dummy_app_key"},
-		DatadogAgentEnabled:   true,
-		DatadogMonitorEnabled: true,
-		V2APIEnabled:          true,
+		Creds:                      config.Creds{APIKey: "dummy_api_key", AppKey: "dummy_app_key"},
+		DatadogAgentEnabled:        true,
+		DatadogMonitorEnabled:      true,
+		DatadogAgentProfileEnabled: true,
+		V2APIEnabled:               true,
 	}
 
 	err = SetupControllers(logger, mgr, options)

--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ type options struct {
 	v2APIEnabled                           bool
 	maximumGoroutines                      int
 	introspectionEnabled                   bool
+	datadogAgentProfileEnabled             bool
 
 	// Secret Backend options
 	secretBackendCommand string
@@ -161,6 +162,7 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.webhookEnabled, "webhookEnabled", false, "Enable CRD conversion webhook.")
 	flag.IntVar(&opts.maximumGoroutines, "maximumGoroutines", defaultMaximumGoroutines, "Override health check threshold for maximum number of goroutines.")
 	flag.BoolVar(&opts.introspectionEnabled, "introspectionEnabled", false, "Enable introspection (beta)")
+	flag.BoolVar(&opts.datadogAgentProfileEnabled, "datadogAgentProfileEnabled", false, "Enable DatadogAgentProfile controller (beta)")
 
 	// ExtendedDaemonset configuration
 	flag.BoolVar(&opts.supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
@@ -271,14 +273,15 @@ func run(opts *options) error {
 			CanaryAutoPauseMaxSlowStartDuration: opts.edsCanaryAutoPauseMaxSlowStartDuration,
 			MaxPodSchedulerFailure:              opts.edsMaxPodSchedulerFailure,
 		},
-		SupportCilium:          opts.supportCilium,
-		Creds:                  creds,
-		DatadogAgentEnabled:    opts.datadogAgentEnabled,
-		DatadogMonitorEnabled:  opts.datadogMonitorEnabled,
-		DatadogSLOEnabled:      opts.datadogSLOEnabled,
-		OperatorMetricsEnabled: opts.operatorMetricsEnabled,
-		V2APIEnabled:           opts.v2APIEnabled,
-		IntrospectionEnabled:   opts.introspectionEnabled,
+		SupportCilium:              opts.supportCilium,
+		Creds:                      creds,
+		DatadogAgentEnabled:        opts.datadogAgentEnabled,
+		DatadogMonitorEnabled:      opts.datadogMonitorEnabled,
+		DatadogSLOEnabled:          opts.datadogSLOEnabled,
+		OperatorMetricsEnabled:     opts.operatorMetricsEnabled,
+		V2APIEnabled:               opts.v2APIEnabled,
+		IntrospectionEnabled:       opts.introspectionEnabled,
+		DatadogAgentProfileEnabled: opts.datadogAgentProfileEnabled,
 	}
 
 	if err = controllers.SetupControllers(setupLog, mgr, options); err != nil {

--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -103,6 +103,9 @@ func ProfilesToApply(profiles []datadoghqv1alpha1.DatadogAgentProfile, nodes []v
 // ComponentOverrideFromProfile returns the component override that should be
 // applied according to the given profile.
 func ComponentOverrideFromProfile(profile *datadoghqv1alpha1.DatadogAgentProfile) v2alpha1.DatadogAgentComponentOverride {
+	if profile.Name == "" && profile.Namespace == "" {
+		return v2alpha1.DatadogAgentComponentOverride{}
+	}
 	overrideDSName := DaemonSetName(types.NamespacedName{
 		Namespace: profile.Namespace,
 		Name:      profile.Name,

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -471,6 +471,11 @@ func TestComponentOverrideFromProfile(t *testing.T) {
 		expectedOverride v2alpha1.DatadogAgentComponentOverride
 	}{
 		{
+			name:             "empty profile",
+			profile:          v1alpha1.DatadogAgentProfile{},
+			expectedOverride: v2alpha1.DatadogAgentComponentOverride{},
+		},
+		{
 			name: "profile without affinity or config",
 			profile: v1alpha1.DatadogAgentProfile{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### What does this PR do?

Adds a flag `datadogAgentProfileEnabled` to enable DAP. It is disabled by default

With no DAP CRD, introspection disabled, and DAP disabled
```shell
$ kubectl get pod
NAME                                       READY   STATUS    RESTARTS   AGE
datadog-agent-n5wrx                        3/3     Running   0          31s
datadog-agent-ztrwf                        3/3     Running   0          31s
datadog-cluster-agent-77654c4599-z7bz9     1/1     Running   0          31s
operator-datadog-operator-9f9986b9-zr6gg   1/1     Running   0          4m52s

$ kubectl get ds
NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent   2         2         2       2            2           <none>          46s
```

Enable introspection
```shell
$ kubectl get pod
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-default-6qc4n                  2/3     Running   0          4s
datadog-agent-gke-cos-tgpjg                  2/3     Running   0          4s
datadog-cluster-agent-68d7b6775c-qwgq8       1/1     Running   0          4s
operator-datadog-operator-5c6bf47c44-fxd8m   1/1     Running   0          76s

$ kubectl get ds
NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   1         1         0       1            0           <none>          6s
datadog-agent-gke-cos   1         1         0       1            0           <none>          6s
```

Install DAP CRD and enable DAP
```shell
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-default-9d556                  3/3     Running   0          10m
datadog-agent-gke-cos-m578v                  3/3     Running   0          10m
datadog-cluster-agent-7488cfd586-m2f29       1/1     Running   0          10m
operator-datadog-operator-58b4749bff-gj7wn   1/1     Running   0          11m

NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   1         1         1       1            1           <none>          12m
datadog-agent-gke-cos   1         1         1       1            1           <none>          12m
```

Add a profile
```shell
NAME                                                        READY   STATUS    RESTARTS   AGE
datadog-agent-default-9d556                                 3/3     Running   0          15m
datadog-agent-with-profile-default-dap-test-gke-cos-2wkhk   2/3     Running   0          8s
datadog-cluster-agent-7488cfd586-m2f29                      1/1     Running   0          15m
operator-datadog-operator-58b4749bff-gj7wn                  1/1     Running   0          17m

NAME                                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default                                 1         1         1       1            1           <none>          18m
datadog-agent-gke-cos                                 0         0         0       0            0           <none>          18m
datadog-agent-with-profile-default-dap-test-default   0         0         0       0            0           <none>          19s
datadog-agent-with-profile-default-dap-test-gke-cos   1         1         0       1            0           <none>          19s
```

Disabling introspection doesn't remove introspection-created DAPs and those DSs must be manually removed. This will be handled in a future PR.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

* Test with DDA only (no introspection, no DAP, no DAP CRD)
* Test with introspection enabled
* Test with DAP enabled
* Test with both introspection and DAP enabled

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
