### PR TITLE
Update v1alpha1 deprecation log line

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func run(opts *options) error {
 		setupLog.Error(nil, "The 'v2APIEnabled' flag is deprecated since v1.2.0+ and will be removed in v1.7.0. "+
 			"Once removed, the Datadog Operator cannot be configured to reconcile the v1alpha1 DatadogAgent CRD. "+
 			"However, you will still be able to apply a v1alpha1 manifest with the conversion webhook enabled (using the flag 'webhookEnabled'). "+
-			"DatadogAgent v1alpha1 and conversion webhook hook will be removed in v1.8.0. "+
+			"DatadogAgent v1alpha1 and the conversion webhook will be removed in v1.8.0. "+
 			"See the migration page for instructions on migrating to v2alpha1: https://docs.datadoghq.com/containers/guide/datadogoperator_migration/")
 	}
 


### PR DESCRIPTION
### What does this PR do?

Switched to ERROR log and indicated versions of flag and CRD deprecation, first line of Operator log when `v2APIEnabled` is set to `false`.


> {"level":"INFO","ts":"2024-02-23T17:23:01Z","logger":"setup","msg":"Version: v1.4.0-rc.3_910ccf3f"}
{"level":"INFO","ts":"2024-02-23T17:23:01Z","logger":"setup","msg":"Build time: 2024-02-23/12:19:48"}
{"level":"INFO","ts":"2024-02-23T17:23:01Z","logger":"setup","msg":"Git Commit: 910ccf3f64a7f1fb2c7789ce2cd8aa3bfb689a8a"}
{"level":"INFO","ts":"2024-02-23T17:23:01Z","logger":"setup","msg":"Go Version: go1.19.13"}
{"level":"INFO","ts":"2024-02-23T17:23:01Z","logger":"setup","msg":"Go OS/Arch: linux/arm64"}
{"level":"ERROR","ts":"2024-02-23T17:23:01Z","logger":"setup","msg":"The 'v2APIEnabled' flag is deprecated since v1.2.0+ and will be removed in a v1.7.0. Once removed, the Datadog Operator cannot be configured to reconcile the v1alpha1 DatadogAgent CRD. However, you will still be able to apply a v1alpha1 manifest with the conversion webhook enabled (using the flag 'webhookEnabled'). DatadogAgent v1alpha1 and conversion webhook hook will be removed from v1.8.0. See migration page for more details https://docs.datadoghq.com/containers/guide/datadogoperator_migration/"}
{"level":"INFO","ts":"2024-02-23T17:23:01Z","logger":"setup","msg":"Manager will be watching namespace","namespace":"system"}


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
