### PR TITLE
[CECO-848] Combine DS cleanup methods

### DIFF
--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	componentagent "github.com/DataDog/datadog-operator/controllers/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/override"
@@ -22,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -117,7 +119,10 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 					true,
 				)
 			}
-			return r.cleanupV2ExtendedDaemonSet(daemonsetLogger, dda, eds, newStatus)
+			if err := r.deleteV2ExtendedDaemonSet(daemonsetLogger, dda, eds, newStatus); err != nil {
+				return reconcile.Result{}, err
+			}
+			return reconcile.Result{}, nil
 		}
 		return r.createOrUpdateExtendedDaemonset(daemonsetLogger, dda, eds, newStatus, updateEDSStatusV2WithAgent)
 	}
@@ -188,8 +193,12 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 				true,
 			)
 		}
-		return r.cleanupV2DaemonSet(daemonsetLogger, dda, daemonset, newStatus)
+		if err := r.deleteV2DaemonSet(daemonsetLogger, dda, daemonset, newStatus); err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, nil
 	}
+
 	return r.createOrUpdateDaemonset(daemonsetLogger, dda, daemonset, newStatus, updateDSStatusV2WithAgent)
 }
 
@@ -205,117 +214,28 @@ func updateEDSStatusV2WithAgent(eds *edsv1alpha1.ExtendedDaemonSet, newStatus *d
 	newStatus.Agent = datadoghqv2alpha1.UpdateCombinedDaemonSetStatus(newStatus.AgentList)
 }
 
-func (r *Reconciler) cleanupV2DaemonSet(logger logr.Logger, dda *datadoghqv2alpha1.DatadogAgent, ds *appsv1.DaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	nsName := types.NamespacedName{
-		Name:      ds.GetName(),
-		Namespace: ds.GetNamespace(),
+func (r *Reconciler) deleteV2DaemonSet(logger logr.Logger, dda *datadoghqv2alpha1.DatadogAgent, ds *appsv1.DaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus) error {
+	err := r.client.Delete(context.TODO(), ds)
+	if err != nil {
+		return err
 	}
+	logger.Info("Delete DaemonSet", "daemonSet.Namespace", ds.Namespace, "daemonSet.Name", ds.Name)
+	event := buildEventInfo(ds.Name, ds.Namespace, daemonSetKind, datadog.DeletionEvent)
+	r.recordEvent(dda, event)
+	removeStaleStatus(newStatus, ds.Name)
 
-	// DS attached to this instance
-	instance := &appsv1.DaemonSet{}
-	if err := r.client.Get(context.TODO(), nsName, instance); err != nil {
-		if !errors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-	} else {
-		err := r.client.Delete(context.TODO(), ds)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		logger.Info("Delete DaemonSet", "daemonSet.Namespace", ds.Namespace, "daemonSet.Name", ds.Name)
-		event := buildEventInfo(ds.Name, ds.Namespace, daemonSetKind, datadog.DeletionEvent)
-		r.recordEvent(dda, event)
-	}
-	newStatus.Agent = nil
-
-	return reconcile.Result{}, nil
+	return nil
 }
 
-func (r *Reconciler) cleanupV2ExtendedDaemonSet(logger logr.Logger, dda *datadoghqv2alpha1.DatadogAgent, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus) (reconcile.Result, error) {
-	nsName := types.NamespacedName{
-		Name:      eds.GetName(),
-		Namespace: eds.GetNamespace(),
+func (r *Reconciler) deleteV2ExtendedDaemonSet(logger logr.Logger, dda *datadoghqv2alpha1.DatadogAgent, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus) error {
+	err := r.client.Delete(context.TODO(), eds)
+	if err != nil {
+		return err
 	}
-
-	// EDS attached to this instance
-	instance := &edsv1alpha1.ExtendedDaemonSet{}
-	if err := r.client.Get(context.TODO(), nsName, instance); err != nil {
-		if !errors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-	} else {
-		err := r.client.Delete(context.TODO(), eds)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		logger.Info("Delete DaemonSet", "extendedDaemonSet.Namespace", eds.Namespace, "extendedDaemonSet.Name", eds.Name)
-		event := buildEventInfo(eds.Name, eds.Namespace, extendedDaemonSetKind, datadog.DeletionEvent)
-		r.recordEvent(dda, event)
-	}
-	newStatus.Agent = nil
-
-	return reconcile.Result{}, nil
-}
-
-func (r *Reconciler) handleProviders(ctx context.Context, dda *datadoghqv2alpha1.DatadogAgent, ddaStatus *datadoghqv2alpha1.DatadogAgentStatus,
-	nodeList []corev1.Node, logger logr.Logger) (map[string]struct{}, error) {
-	providerList := kubernetes.GetProviderListFromNodeList(nodeList, logger)
-
-	if err := r.cleanupDaemonSetsForProvidersThatNoLongerApply(ctx, dda, ddaStatus, providerList); err != nil {
-		return nil, err
-	}
-
-	return providerList, nil
-}
-
-// cleanupDaemonSetsForProvidersThatNoLongerApply deletes ds/eds from providers
-// that are not present in the provider store. If there are no providers in the
-// provider store, do not delete any ds/eds since that would delete all node
-// agents.
-func (r *Reconciler) cleanupDaemonSetsForProvidersThatNoLongerApply(ctx context.Context, dda *datadoghqv2alpha1.DatadogAgent,
-	ddaStatus *datadoghqv2alpha1.DatadogAgentStatus, providerList map[string]struct{}) error {
-	if len(providerList) > 0 {
-		if r.options.ExtendedDaemonsetOptions.Enabled {
-			edsList := edsv1alpha1.ExtendedDaemonSetList{}
-			if err := r.client.List(ctx, &edsList, client.HasLabels{apicommon.MD5AgentDeploymentProviderLabelKey}); err != nil {
-				return err
-			}
-
-			for _, eds := range edsList.Items {
-				provider := eds.Labels[apicommon.MD5AgentDeploymentProviderLabelKey]
-				if _, ok := providerList[provider]; !ok {
-					if err := r.client.Delete(ctx, &eds); err != nil {
-						return err
-					}
-					r.log.Info("Deleted ExtendedDaemonSet", "extendedDaemonSet.Namespace", eds.Namespace, "extendedDaemonSet.Name", eds.Name)
-					event := buildEventInfo(eds.Name, eds.Namespace, extendedDaemonSetKind, datadog.DeletionEvent)
-					r.recordEvent(dda, event)
-
-					removeStaleStatus(ddaStatus, eds.Name)
-				}
-			}
-
-			return nil
-		}
-
-		daemonSetList := appsv1.DaemonSetList{}
-		if err := r.client.List(ctx, &daemonSetList, client.HasLabels{apicommon.MD5AgentDeploymentProviderLabelKey}); err != nil {
-			return err
-		}
-		for _, ds := range daemonSetList.Items {
-			provider := ds.Labels[apicommon.MD5AgentDeploymentProviderLabelKey]
-			if _, ok := providerList[provider]; !ok {
-				if err := r.client.Delete(ctx, &ds); err != nil {
-					return err
-				}
-				r.log.Info("Deleted DaemonSet", "daemonSet.Namespace", ds.Namespace, "daemonSet.Name", ds.Name)
-				event := buildEventInfo(ds.Name, ds.Namespace, daemonSetKind, datadog.DeletionEvent)
-				r.recordEvent(dda, event)
-
-				removeStaleStatus(ddaStatus, ds.Name)
-			}
-		}
-	}
+	logger.Info("Delete DaemonSet", "extendedDaemonSet.Namespace", eds.Namespace, "extendedDaemonSet.Name", eds.Name)
+	event := buildEventInfo(eds.Name, eds.Namespace, extendedDaemonSetKind, datadog.DeletionEvent)
+	r.recordEvent(dda, event)
+	removeStaleStatus(newStatus, eds.Name)
 
 	return nil
 }
@@ -334,54 +254,13 @@ func removeStaleStatus(ddaStatus *datadoghqv2alpha1.DatadogAgentStatus, name str
 	}
 }
 
-func (r *Reconciler) handleProfiles(ctx context.Context, profiles []v1alpha1.DatadogAgentProfile, profilesByNode map[string]types.NamespacedName,
-	ddaNamespace string, providerList map[string]struct{}) error {
-	if err := r.cleanupDaemonSetsForProfilesThatNoLongerApply(ctx, profiles, providerList); err != nil {
-		return err
-	}
-
+func (r *Reconciler) handleProfiles(ctx context.Context, profilesByNode map[string]types.NamespacedName, ddaNamespace string) error {
 	if err := r.labelNodesWithProfiles(ctx, profilesByNode); err != nil {
 		return err
 	}
 
 	if err := r.cleanupPodsForProfilesThatNoLongerApply(ctx, profilesByNode, ddaNamespace); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (r *Reconciler) cleanupDaemonSetsForProfilesThatNoLongerApply(ctx context.Context, profiles []v1alpha1.DatadogAgentProfile, providerList map[string]struct{}) error {
-	daemonSets, err := r.agentProfileDaemonSetsCreatedByOperator(ctx)
-	if err != nil {
-		return err
-	}
-
-	daemonSetNamesBelongingToProfiles := map[string]struct{}{}
-	for _, profile := range profiles {
-		name := types.NamespacedName{
-			Namespace: profile.Namespace,
-			Name:      profile.Name,
-		}
-		dsProfileName := agentprofile.DaemonSetName(name)
-
-		if r.options.IntrospectionEnabled {
-			for provider := range providerList {
-				daemonSetNamesBelongingToProfiles[kubernetes.GetAgentNameWithProvider(dsProfileName, provider)] = struct{}{}
-			}
-		} else {
-			daemonSetNamesBelongingToProfiles[dsProfileName] = struct{}{}
-		}
-	}
-
-	for _, daemonSet := range daemonSets {
-		if _, belongsToProfile := daemonSetNamesBelongingToProfiles[daemonSet.Name]; belongsToProfile {
-			continue
-		}
-
-		if err = r.client.Delete(ctx, &daemonSet); err != nil {
-			return err
-		}
 	}
 
 	return nil
@@ -493,12 +372,131 @@ func (r *Reconciler) cleanupPodsForProfilesThatNoLongerApply(ctx context.Context
 	return nil
 }
 
-func (r *Reconciler) agentProfileDaemonSetsCreatedByOperator(ctx context.Context) ([]appsv1.DaemonSet, error) {
-	daemonSetList := appsv1.DaemonSetList{}
-
-	if err := r.client.List(ctx, &daemonSetList, client.HasLabels{agentprofile.ProfileLabelKey}); err != nil {
-		return nil, err
+// cleanupExtraneousDaemonSets deletes DSs/EDSs that no longer apply.
+// Use cases include deleting old DSs/EDSs when:
+// - a DaemonSet's name is changed using node overrides
+// - introspection is disabled or enabled
+// - a profile is deleted
+func (r *Reconciler) cleanupExtraneousDaemonSets(ctx context.Context, logger logr.Logger, dda *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus,
+	providerList map[string]struct{}, profiles []v1alpha1.DatadogAgentProfile) error {
+	matchLabels := client.MatchingLabels{
+		apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultAgentResourceSuffix,
+		kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
 	}
 
-	return daemonSetList.Items, nil
+	dsName := getDaemonSetNameFromDatadogAgent(dda)
+	validDaemonSetNames, validExtendedDaemonSetNames := r.getValidDaemonSetNames(dsName, providerList, profiles)
+
+	// Only the default profile uses an EDS when profiles are enabled
+	// Multiple EDSs can be created with introspection
+	if r.options.ExtendedDaemonsetOptions.Enabled {
+		edsList := edsv1alpha1.ExtendedDaemonSetList{}
+		if err := r.client.List(ctx, &edsList, matchLabels); err != nil {
+			return err
+		}
+
+		for _, eds := range edsList.Items {
+			if _, ok := validExtendedDaemonSetNames[eds.Name]; !ok {
+				if err := r.deleteV2ExtendedDaemonSet(logger, dda, &eds, newStatus); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	daemonSetList := appsv1.DaemonSetList{}
+	if err := r.client.List(ctx, &daemonSetList, matchLabels); err != nil {
+		return err
+	}
+
+	for _, daemonSet := range daemonSetList.Items {
+		if _, ok := validDaemonSetNames[daemonSet.Name]; !ok {
+			if err := r.deleteV2DaemonSet(logger, dda, &daemonSet, newStatus); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// getValidDaemonSetNames generates a list of valid DS and EDS names
+func (r *Reconciler) getValidDaemonSetNames(dsName string, providerList map[string]struct{}, profiles []v1alpha1.DatadogAgentProfile) (map[string]struct{}, map[string]struct{}) {
+	validDaemonSetNames := map[string]struct{}{}
+	validExtendedDaemonSetNames := map[string]struct{}{}
+
+	// Introspection includes names with a provider suffix
+	if r.options.IntrospectionEnabled {
+		for provider := range providerList {
+			if r.options.ExtendedDaemonsetOptions.Enabled {
+				validExtendedDaemonSetNames[kubernetes.GetAgentNameWithProvider(dsName, provider)] = struct{}{}
+			} else {
+				validDaemonSetNames[kubernetes.GetAgentNameWithProvider(dsName, provider)] = struct{}{}
+			}
+		}
+	}
+	// Profiles include names with the profile prefix and the DS/EDS name for the default profile
+	if r.options.DatadogAgentProfileEnabled {
+		for _, profile := range profiles {
+			name := types.NamespacedName{
+				Namespace: profile.Namespace,
+				Name:      profile.Name,
+			}
+			dsProfileName := agentprofile.DaemonSetName(name)
+
+			// The default profile can be a DS or an EDS and uses the DS/EDS name
+			if agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
+				if r.options.IntrospectionEnabled {
+					for provider := range providerList {
+						if r.options.ExtendedDaemonsetOptions.Enabled {
+							validExtendedDaemonSetNames[kubernetes.GetAgentNameWithProvider(dsName, provider)] = struct{}{}
+						} else {
+							validDaemonSetNames[kubernetes.GetAgentNameWithProvider(dsName, provider)] = struct{}{}
+						}
+					}
+				} else {
+					if r.options.ExtendedDaemonsetOptions.Enabled {
+						validExtendedDaemonSetNames[dsName] = struct{}{}
+					} else {
+						validDaemonSetNames[dsName] = struct{}{}
+					}
+				}
+			}
+			// Non-default profiles can only be DaemonSets
+			if r.options.IntrospectionEnabled {
+				for provider := range providerList {
+					validDaemonSetNames[kubernetes.GetAgentNameWithProvider(dsProfileName, provider)] = struct{}{}
+				}
+			} else {
+				validDaemonSetNames[dsProfileName] = struct{}{}
+			}
+		}
+	}
+
+	// If neither introspection nor profiles are enabled, only the current DS/EDS name is valid
+	if !r.options.IntrospectionEnabled && !r.options.DatadogAgentProfileEnabled {
+		if r.options.ExtendedDaemonsetOptions.Enabled {
+			validExtendedDaemonSetNames = map[string]struct{}{
+				dsName: {},
+			}
+		} else {
+			validDaemonSetNames = map[string]struct{}{
+				dsName: {},
+			}
+		}
+	}
+
+	return validDaemonSetNames, validExtendedDaemonSetNames
+}
+
+// getDaemonSetNameFromDatadogAgent returns the expected DS/EDS name based on
+// the DDA name and nodeAgent name override
+func getDaemonSetNameFromDatadogAgent(dda *datadoghqv2alpha1.DatadogAgent) string {
+	dsName := component.GetAgentName(dda)
+	if componentOverride, ok := dda.Spec.Override[datadoghqv2alpha1.NodeAgentComponentName]; ok {
+		if componentOverride.Name != nil && *componentOverride.Name != "" {
+			dsName = *componentOverride.Name
+		}
+	}
+	return dsName
 }


### PR DESCRIPTION
### What does this PR do?

Combines DS/EDS cleanup methods for profiles, introspection, and the `cleanupV2DaemonSet/ExtendedDaemonSet` methods

### Motivation

* https://datadoghq.atlassian.net/browse/CECO-848
* Fix bug where old DS/EDSs aren't deleted automatically

### Additional Notes

This is what was tested locally on a kind cluster. Each shows the output of `kubectl get pods` and then `kubectl get ds`:

No introspection, no profiles
```
NAME                                       READY   STATUS    RESTARTS   AGE
datadog-agent-9fq4t                        3/3     Running   0          77s
datadog-agent-vk8vm                        3/3     Running   0          77s
datadog-cluster-agent-5684d697-mj7d2       1/1     Running   0          77s
operator-datadog-operator-9f9986b9-4k78b   1/1     Running   0          2m51s

NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent   2         2         2       2            2           <none>          80s
```
Add a name override `foo` to the `nodeAgent`
```
NAME                                       READY   STATUS    RESTARTS   AGE
datadog-cluster-agent-5684d697-mj7d2       1/1     Running   0          105s
foo-287qp                                  2/3     Running   0          16s
foo-8dm9l                                  2/3     Running   0          16s
operator-datadog-operator-9f9986b9-4k78b   1/1     Running   0          3m19s

NAME   DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
foo    2         2         2       2            2           <none>          44s
```
Remove name override
```
NAME                                       READY   STATUS     RESTARTS   AGE
datadog-agent-fpq95                        0/3     Init:1/2   0          2s
datadog-agent-v5ncp                        0/3     Init:1/2   0          2s
datadog-cluster-agent-5684d697-mj7d2       1/1     Running    0          2m32s
operator-datadog-operator-9f9986b9-4k78b   1/1     Running    0          4m6s

NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent   2         2         0       2            0           <none>          4s
```


Enable introspection (using all default provider nodes)
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-default-7cx2d                  3/3     Running   0          39s
datadog-agent-default-f9v8q                  3/3     Running   0          39s
datadog-cluster-agent-6d465ff787-8npr9       1/1     Running   0          39s
operator-datadog-operator-5c6bf47c44-6mtwv   1/1     Running   0          119s

NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   2         2         2       2            2           <none>          41s
```
Add `foo` name override
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-cluster-agent-6d465ff787-8npr9       1/1     Running   0          72s
foo-default-jfrpv                            2/3     Running   0          6s
foo-default-ztjz5                            2/3     Running   0          6s
operator-datadog-operator-5c6bf47c44-6mtwv   1/1     Running   0          2m32s

NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
foo-default   2         2         0       2            0           <none>          21s
```
Add a node label to one nodes to mimic a `gke-cos` node
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-cluster-agent-6d465ff787-8npr9       1/1     Running   0          117s
foo-default-mzzhc                            2/3     Running   0          5s
foo-gke-cos-5tvjj                            2/3     Running   0          7s
operator-datadog-operator-5c6bf47c44-6mtwv   1/1     Running   0          3m17s

NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
foo-default   1         1         0       1            0           <none>          61s
foo-gke-cos   1         1         0       1            0           <none>          17s

```
Remove name override
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-default-k2xkw                  2/3     Running   0          7s
datadog-agent-gke-cos-6n7r2                  2/3     Running   0          7s
datadog-cluster-agent-6d465ff787-8npr9       1/1     Running   0          2m33s
operator-datadog-operator-5c6bf47c44-6mtwv   1/1     Running   0          3m53s

NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   1         1         0       1            0           <none>          16s
datadog-agent-gke-cos   1         1         0       1            0           <none>          16s
```
Disable introspection
```
NAME                                       READY   STATUS    RESTARTS   AGE
datadog-agent-lng6p                        2/3     Running   0          19s
datadog-agent-zs9v6                        2/3     Running   0          19s
datadog-cluster-agent-5d9fbd6876-6ckkd     1/1     Running   0          19s
operator-datadog-operator-9f9986b9-wj7cs   1/1     Running   0          102s

NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent   2         2         0       2            0           <none>          30s
```


Enable profiles
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-7xq4q                          2/3     Running   0          17s
datadog-agent-99r8r                          3/3     Running   0          49s
datadog-cluster-agent-86c6c8f65c-bnqrf       1/1     Running   0          50s
operator-datadog-operator-76ccc45f9b-b6bqb   1/1     Running   0          2m1s

NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent   2         2         1       2            1           <none>          3m11s
```
Add a profile `default/dap-test`
```
NAME                                                READY   STATUS    RESTARTS   AGE
datadog-agent-7xq4q                                 3/3     Running   0          45s
datadog-agent-with-profile-default-dap-test-mkvrd   2/3     Running   0          5s
datadog-cluster-agent-86c6c8f65c-bnqrf              1/1     Running   0          78s
operator-datadog-operator-76ccc45f9b-b6bqb          1/1     Running   0          2m29s

NAME                                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent                                 1         1         1       1            1           <none>          3m39s
datadog-agent-with-profile-default-dap-test   1         1         0       1            0           <none>          14s
```
Delete profile
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-7xq4q                          3/3     Running   0          104s
datadog-agent-dgm9g                          2/3     Running   0          8s
datadog-cluster-agent-86c6c8f65c-bnqrf       1/1     Running   0          2m17s
operator-datadog-operator-76ccc45f9b-b6bqb   1/1     Running   0          3m28s

NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent   2         2         1       2            1           <none>          4m36s
```
Add back profile
```
NAME                                                READY   STATUS    RESTARTS   AGE
datadog-agent-7xq4q                                 3/3     Running   0          2m13s
datadog-agent-with-profile-default-dap-test-2sn5f   2/3     Running   0          9s
datadog-cluster-agent-86c6c8f65c-bnqrf              1/1     Running   0          2m46s
operator-datadog-operator-76ccc45f9b-b6bqb          1/1     Running   0          3m57s

NAME                                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent                                 1         1         1       1            1           <none>          5m3s
datadog-agent-with-profile-default-dap-test   1         1         0       1            0           <none>          14s

```
Disable profiles in the operator, keeping the `dap-test` profile present
```
NAME                                       READY   STATUS    RESTARTS   AGE
datadog-agent-2gsj5                        3/3     Running   0          34s
datadog-agent-pjvpv                        3/3     Running   0          67s
datadog-cluster-agent-6b5c65ff59-zg7wr     1/1     Running   0          67s
operator-datadog-operator-9f9986b9-q54kl   1/1     Running   0          2m10s

NAME            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent   2         2         2       2            2           <none>          7m37s
```
Delete profile (does nothing)

Enable introspection and profiles
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-default-4ht7z                  3/3     Running   0          79s
datadog-agent-gke-cos-4sql4                  3/3     Running   0          77s
datadog-cluster-agent-8549bcc655-rx5dq       1/1     Running   0          79s
operator-datadog-operator-58b4749bff-rjmmw   1/1     Running   0          2m23s

NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   1         1         1       1            1           <none>          92s
datadog-agent-gke-cos   1         1         1       1            1           <none>          92s
```
Add profile
```
NAME                                                        READY   STATUS    RESTARTS   AGE
datadog-agent-default-4ht7z                                 3/3     Running   0          107s
datadog-agent-with-profile-default-dap-test-gke-cos-5f4qt   2/3     Running   0          5s
datadog-cluster-agent-8549bcc655-rx5dq                      1/1     Running   0          107s
operator-datadog-operator-58b4749bff-rjmmw                  1/1     Running   0          2m51s

NAME                                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default                                 1         1         1       1            1           <none>          115s
datadog-agent-gke-cos                                 0         0         0       0            0           <none>          115s
datadog-agent-with-profile-default-dap-test-default   0         0         0       0            0           <none>          13s
datadog-agent-with-profile-default-dap-test-gke-cos   1         1         0       1            0           <none>          13s
```
Remove gke cos label on node so all nodes use default provider
```
NAME                                                        READY   STATUS    RESTARTS   AGE
datadog-agent-default-qh8vl                                 2/3     Running   0          3s
datadog-agent-with-profile-default-dap-test-default-57cqt   2/3     Running   0          5s
datadog-cluster-agent-8549bcc655-rx5dq                      1/1     Running   0          2m28s
operator-datadog-operator-58b4749bff-rjmmw                  1/1     Running   0          3m32s

NAME                                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default                                 1         1         0       1            0           <none>          2m37s
datadog-agent-with-profile-default-dap-test-default   1         1         0       1            0           <none>          55s
```
Delete profile
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-default-4tnmj                  2/3     Running   0          23s
datadog-agent-default-qh8vl                  3/3     Running   0          98s
datadog-cluster-agent-8549bcc655-rx5dq       1/1     Running   0          4m3s
operator-datadog-operator-58b4749bff-rjmmw   1/1     Running   0          5m7s

NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   2         2         2       2            2           <none>          4m11s
```
Add profile
```
NAME                                                        READY   STATUS    RESTARTS   AGE
datadog-agent-default-qh8vl                                 3/3     Running   0          2m5s
datadog-agent-with-profile-default-dap-test-default-q2r7f   2/3     Running   0          8s
datadog-cluster-agent-8549bcc655-rx5dq                      1/1     Running   0          4m30s
operator-datadog-operator-58b4749bff-rjmmw                  1/1     Running   0          5m34s

NAME                                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default                                 1         1         1       1            1           <none>          4m37s
datadog-agent-with-profile-default-dap-test-default   1         1         0       1            0           <none>          16s
```
Add gke cos labels to all nodes so all nodes use the `gke-cos` provider
```
NAME                                                        READY   STATUS    RESTARTS   AGE
datadog-agent-gke-cos-66qcs                                 2/3     Running   0          36s
datadog-agent-with-profile-default-dap-test-gke-cos-gwnpj   3/3     Running   0          39s
datadog-cluster-agent-8549bcc655-rx5dq                      1/1     Running   0          5m34s
operator-datadog-operator-58b4749bff-rjmmw                  1/1     Running   0          6m38s

NAME                                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default                                 0         0         0       0            0           <none>          5m43s
datadog-agent-gke-cos                                 1         1         0       1            0           <none>          48s
datadog-agent-with-profile-default-dap-test-default   0         0         0       0            0           <none>          82s
datadog-agent-with-profile-default-dap-test-gke-cos   1         1         1       1            1           <none>          48s
```
Delete profile
```
NAME                                         READY   STATUS    RESTARTS   AGE
datadog-agent-gke-cos-66qcs                  3/3     Running   0          67s
datadog-agent-gke-cos-m8pr6                  2/3     Running   0          4s
datadog-cluster-agent-8549bcc655-rx5dq       1/1     Running   0          6m5s
operator-datadog-operator-58b4749bff-rjmmw   1/1     Running   0          7m9s

NAME                    DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
datadog-agent-default   0         0         0       0            0           <none>          6m11s
datadog-agent-gke-cos   2         2         1       2            1           <none>          76s
```

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

* Test that changing the nodeAgent name via overrides deletes the old DS/EDS
* Test that enabling and disabling introspection (`introspectionEnabled`) deletes the old DS/EDS
* Test that enabling and disabling profiles (`datadogAgentProfileEnabled`) still works as expected, and that adding and removing profile still deletes the unused DS/EDSs

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
