### PR TITLE
[CECO-1015] Propagate edsMaxPodUnavailable value to DS

### DIFF
--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -26,8 +26,8 @@ import (
 )
 
 // NewDefaultAgentDaemonset return a new default agent DaemonSet
-func NewDefaultAgentDaemonset(dda metav1.Object, agentComponent feature.RequiredComponent) *appsv1.DaemonSet {
-	daemonset := NewDaemonset(dda, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
+func NewDefaultAgentDaemonset(dda metav1.Object, edsOptions *ExtendedDaemonsetOptions, agentComponent feature.RequiredComponent) *appsv1.DaemonSet {
+	daemonset := NewDaemonset(dda, edsOptions, apicommon.DefaultAgentResourceSuffix, component.GetAgentName(dda), component.GetAgentVersion(dda), nil)
 	podTemplate := NewDefaultAgentPodTemplateSpec(dda, agentComponent, daemonset.GetLabels())
 	daemonset.Spec.Template = *podTemplate
 	return daemonset

--- a/controllers/datadogagent/component/agent/new.go
+++ b/controllers/datadogagent/component/agent/new.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewDaemonset use to generate the skeleton of a new daemonset based on few information
-func NewDaemonset(owner metav1.Object, componentKind, componentName, version string, selector *metav1.LabelSelector) *appsv1.DaemonSet {
+func NewDaemonset(owner metav1.Object, edsOptions *ExtendedDaemonsetOptions, componentKind, componentName, version string, selector *metav1.LabelSelector) *appsv1.DaemonSet {
 	labels, annotations, selector := component.GetDefaultMetadata(owner, componentKind, componentName, version, selector)
 
 	daemonset := &appsv1.DaemonSet{
@@ -30,6 +30,13 @@ func NewDaemonset(owner metav1.Object, componentKind, componentName, version str
 		Spec: appsv1.DaemonSetSpec{
 			Selector: selector,
 		},
+	}
+	if edsOptions != nil && edsOptions.MaxPodUnavailable != "" {
+		daemonset.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+			RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+				MaxUnavailable: newIntOrStringPointer(edsOptions.MaxPodUnavailable),
+			},
+		}
 	}
 	return daemonset
 }

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -124,7 +124,7 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 	}
 
 	// Start by creating the Default Agent daemonset
-	daemonset = componentagent.NewDefaultAgentDaemonset(dda, requiredComponents.Agent)
+	daemonset = componentagent.NewDefaultAgentDaemonset(dda, &r.options.ExtendedDaemonsetOptions, requiredComponents.Agent)
 	podManagers = feature.NewPodTemplateManagers(&daemonset.Spec.Template)
 	// Set Global setting on the default daemonset
 	daemonset.Spec.Template = *override.ApplyGlobalSettingsNodeAgent(logger, podManagers, dda, resourcesManager, singleContainerStrategyEnabled)


### PR DESCRIPTION
### What does this PR do?

Propagate the `edsMaxPodUnavailable` value to DSs if the arg is set in the operator. When using profiles, only the default profile uses an EDS; the others use DSs. Since we use default k8s DS values, the rollingUpdate strategy for maxUnavailable pods is `1`, which causes rollouts to be very slow

### Motivation

Internal request

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

When `edsMaxPodUnavailable` is not set, the default value for `maxUnavailable` should be used in a DS:
```
    updateStrategy:
      rollingUpdate:
        maxSurge: 0
        maxUnavailable: 1
      type: RollingUpdate
```

After enabling EDSs, profiles, and setting `edsMaxPodUnavailable=3%`, the EDS should have:
```
      rollingUpdate:
        maxParallelPodCreation: 250
        maxPodSchedulerFailure: 0
        maxUnavailable: 3%
        slowStartAdditiveIncrease: 1
        slowStartIntervalDuration: 1m0s
```

Create a profile, which should create a DS with `3%` instead of `1` for `maxUnavailable`:
```
    updateStrategy:
      rollingUpdate:
        maxSurge: 0
        maxUnavailable: 3%
      type: RollingUpdate
```

Even if we disable EDS, keeping the `edsMaxPodUnavailable=3%` arg, the DS should show:
```
    updateStrategy:
      rollingUpdate:
        maxSurge: 0
        maxUnavailable: 3%
      type: RollingUpdate
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
