### PR TITLE
[profiles] Stop using pod indexer

### DIFF
--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -452,42 +452,43 @@ func (r *Reconciler) labelNodesWithProfiles(ctx context.Context, profilesByNode 
 // Notice that "RequiredDuringSchedulingRequiredDuringExecution" is not
 // available in Kubernetes yet.
 func (r *Reconciler) cleanupPodsForProfilesThatNoLongerApply(ctx context.Context, profilesByNode map[string]types.NamespacedName, ddaNamespace string) error {
-	for nodeName, profileNamespacedName := range profilesByNode {
-		// Get the agent pods running on the node
-		podList := &corev1.PodList{}
-		err := r.client.List(
-			ctx,
-			podList,
-			client.MatchingLabels(map[string]string{
-				apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultAgentResourceSuffix,
-			}),
-			client.InNamespace(ddaNamespace),
-			client.MatchingFields{"spec.nodeName": nodeName})
-		if err != nil {
-			return err
+	agentPods := &corev1.PodList{}
+	err := r.client.List(
+		ctx,
+		agentPods,
+		client.MatchingLabels(map[string]string{
+			apicommon.AgentDeploymentComponentLabelKey: apicommon.DefaultAgentResourceSuffix,
+		}),
+		client.InNamespace(ddaNamespace),
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, agentPod := range agentPods.Items {
+		profileNamespacedName, found := profilesByNode[agentPod.Spec.NodeName]
+		if !found {
+			continue
 		}
 
-		// Delete the agent pods that should be in the node according to the
-		// profiles that need to be applied
 		isDefaultProfile := agentprofile.IsDefaultProfile(profileNamespacedName.Namespace, profileNamespacedName.Name)
-		for _, pod := range podList.Items {
-			profileLabelValue, profileLabelExists := pod.Labels[agentprofile.ProfileLabelKey]
-			expectedProfileLabelValue := fmt.Sprintf("%s-%s", profileNamespacedName.Namespace, profileNamespacedName.Name)
+		expectedProfileLabelValue := fmt.Sprintf("%s-%s", profileNamespacedName.Namespace, profileNamespacedName.Name)
 
-			deletePod := (isDefaultProfile && profileLabelExists) ||
-				(!isDefaultProfile && !profileLabelExists) ||
-				(!isDefaultProfile && profileLabelValue != expectedProfileLabelValue)
+		profileLabelValue, profileLabelExists := agentPod.Labels[agentprofile.ProfileLabelKey]
 
-			if deletePod {
-				toDelete := corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: pod.Namespace,
-						Name:      pod.Name,
-					},
-				}
-				if err = r.client.Delete(ctx, &toDelete); err != nil {
-					return err
-				}
+		deletePod := (isDefaultProfile && profileLabelExists) ||
+			(!isDefaultProfile && !profileLabelExists) ||
+			(!isDefaultProfile && profileLabelValue != expectedProfileLabelValue)
+
+		if deletePod {
+			toDelete := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: agentPod.Namespace,
+					Name:      agentPod.Name,
+				},
+			}
+			if err = r.client.Delete(ctx, &toDelete); err != nil {
+				return err
 			}
 		}
 	}

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"reflect"
 
-	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -183,23 +182,6 @@ func (r *DatadogAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 // SetupWithManager creates a new DatadogAgent controller.
 func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// This is for the agent profiles feature. To delete the pods of profiles
-	// that no longer apply, we need to be able to get the agent pods of a
-	// specific node.
-	// Notice that only node agent pods are indexed.
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, "spec.nodeName", func(rawObj client.Object) []string {
-		pod := rawObj.(*corev1.Pod)
-
-		// Don't store the pod if it's not a node agent pod
-		if pod.Labels[apicommon.AgentDeploymentComponentLabelKey] != apicommon.DefaultAgentResourceSuffix {
-			return nil
-		}
-
-		return []string{pod.Spec.NodeName}
-	}); err != nil {
-		return err
-	}
-
 	builder := ctrl.NewControllerManagedBy(mgr).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).


### PR DESCRIPTION
### What does this PR do?

Deletes the pod index used for the profiles feature. It seems that it causes an initial memory spike and it's not really needed anymore. This PR rewrites the `cleanupPodsForProfilesThatNoLongerApply` so that it doesn't rely on the index and to my knowledge the behavior and performance should be roughly the same except for that initial memory spike that no longer happens.

### Describe your test plan

Try with profiles enabled. Check that the memory spike at startup that we observed no longer happens.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
