### PR TITLE
Add md5 hash config annotation to helm check

### DIFF
--- a/controllers/datadogagent/feature/helmcheck/feature.go
+++ b/controllers/datadogagent/feature/helmcheck/feature.go
@@ -102,7 +102,7 @@ func (f *helmCheckFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp featur
 		}
 
 		f.configAnnotationValue = hash
-		f.configAnnotationKey = fmt.Sprintf("checksum/%s-config", feature.HelmCheckIDType)
+		f.configAnnotationKey = object.GetChecksumAnnotationKey(feature.HelmCheckIDType)
 	}
 
 	return reqComp

--- a/controllers/datadogagent/feature/helmcheck/feature_test.go
+++ b/controllers/datadogagent/feature/helmcheck/feature_test.go
@@ -195,7 +195,7 @@ instances:
 			assert.NoError(t, err)
 
 			wantAnnotations := map[string]string{
-				fmt.Sprintf("checksum/%s-config", feature.HelmCheckIDType): hash,
+				fmt.Sprintf(apicommon.MD5ChecksumAnnotationKey, feature.HelmCheckIDType): hash,
 			}
 
 			annotations := mgr.AnnotationMgr.Annotations


### PR DESCRIPTION
### What does this PR do?

Add md5 hash annotation to helm check configMap and cluster agent pod template spec for helm check config changes.

### Motivation

QA https://github.com/datadog/datadog-operator/pull/1060

Helm check config changes were not being taken into account by the cluster agent/CCR and the cluster agent and CCR pods were not restarting after config changes. 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

QA steps for https://github.com/datadog/datadog-operator/pull/1060 + 

* `datadog-helm-check-config` configmap should have the annotation `checksum/helm_check-custom-config: <md5_hash>`
* Change any helmCheck config other than `helmCheck.enabled`: e.g 
  * `helmCheck.collectEvents: true` to `helmCheck.collectEvents: false` or 
  * `helmCheck.valuesAsTags: {"image.tag": "image_tag",  "image.repository": "image_repo"}`  to `helmCheck.valuesAsTags: {"image.tag": "image_tag"}`
* Uninstall and reinstall any helm chart
* CCR and/or DCA pods should restart
* Check for expected behavior in the Datadog app

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
