### PR TITLE
Fix log line formatting for conflicting profiles

### DIFF
--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -64,7 +64,7 @@ func ProfilesToApply(profiles []datadoghqv1alpha1.DatadogAgentProfile, nodes []v
 				if existingProfile, found := profileAppliedPerNode[node.Name]; found {
 					// Conflict. This profile should not be applied.
 					conflicts = true
-					logger.Info("profile %s conflicts with existing profile %s, skipping", profile.Namespace+"/"+profile.Name, existingProfile.String())
+					logger.Info("conflict with existing profile, skipping", "conflicting profile", profile.Namespace+"/"+profile.Name, "existing profile", existingProfile.String())
 					break
 				} else {
 					nodesThatMatchProfile[node.Name] = true


### PR DESCRIPTION
### What does this PR do?

Log line formatting was not correct.

Before: `{"level":"INFO","ts":"2024-03-07T19:44:50Z","logger":"controllers.DatadogAgent","msg":"profile %s conflicts with existing profile %s, skipping","datadogagent":"default/datadog","default/dap-conflict":"default/dap-test"}`

After: `{"level":"INFO","ts":"2024-03-07T19:55:56Z","logger":"controllers.DatadogAgent","msg":"conflict with existing profile, skipping","datadogagent":"default/datadog","conflicting profile":"default/dap-conflict","existing profile":"default/dap-test"}`


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Enable profiles, and add 2 profiles that target the same node. The operator logs should show that there is profile conflict without formatting errors

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
