### PR TITLE
Fix readinessprobe and livenessprobe for non-nil probehandler overrides

### DIFF
--- a/controllers/datadogagent/override/container.go
+++ b/controllers/datadogagent/override/container.go
@@ -222,7 +222,7 @@ func overrideAppArmorProfile(containerName commonv1.AgentContainerName, manager 
 
 func overrideReadinessProbe(readinessProbeOverride *corev1.Probe) *corev1.Probe {
 	// Add default httpGet.path and httpGet.port if not present in readinessProbe override
-	if readinessProbeOverride.HTTPGet == nil {
+	if readinessProbeOverride == nil && readinessProbeOverride.HTTPGet == nil {
 		readinessProbeOverride.HTTPGet = &corev1.HTTPGetAction{
 			Path: common.DefaultReadinessProbeHTTPPath,
 			Port: intstr.IntOrString{IntVal: common.DefaultAgentHealthPort}}
@@ -232,7 +232,7 @@ func overrideReadinessProbe(readinessProbeOverride *corev1.Probe) *corev1.Probe 
 
 func overrideLivenessProbe(livenessProbeOverride *corev1.Probe) *corev1.Probe {
 	// Add default httpGet.path and httpGet.port if not present in livenessProbe override
-	if livenessProbeOverride.HTTPGet == nil {
+	if livenessProbeOverride == nil && livenessProbeOverride.HTTPGet == nil {
 		livenessProbeOverride.HTTPGet = &corev1.HTTPGetAction{
 			Path: common.DefaultLivenessProbeHTTPPath,
 			Port: intstr.IntOrString{IntVal: common.DefaultAgentHealthPort}}

--- a/controllers/datadogagent/override/container.go
+++ b/controllers/datadogagent/override/container.go
@@ -221,8 +221,8 @@ func overrideAppArmorProfile(containerName commonv1.AgentContainerName, manager 
 }
 
 func overrideReadinessProbe(readinessProbeOverride *corev1.Probe) *corev1.Probe {
-	// Add default httpGet.path and httpGet.port if not present in readinessProbe override
-	if readinessProbeOverride == nil && readinessProbeOverride.HTTPGet == nil {
+	// Add default httpGet probeHandler if probeHandler is not configured in readinessProbe override
+	if !hasProbeHandler(readinessProbeOverride) {
 		readinessProbeOverride.HTTPGet = &corev1.HTTPGetAction{
 			Path: common.DefaultReadinessProbeHTTPPath,
 			Port: intstr.IntOrString{IntVal: common.DefaultAgentHealthPort}}
@@ -231,8 +231,8 @@ func overrideReadinessProbe(readinessProbeOverride *corev1.Probe) *corev1.Probe 
 }
 
 func overrideLivenessProbe(livenessProbeOverride *corev1.Probe) *corev1.Probe {
-	// Add default httpGet.path and httpGet.port if not present in livenessProbe override
-	if livenessProbeOverride == nil && livenessProbeOverride.HTTPGet == nil {
+	// Add default httpGet probeHandler if probeHandler is not configured in livenessProbe override
+	if !hasProbeHandler(livenessProbeOverride) {
 		livenessProbeOverride.HTTPGet = &corev1.HTTPGetAction{
 			Path: common.DefaultLivenessProbeHTTPPath,
 			Port: intstr.IntOrString{IntVal: common.DefaultAgentHealthPort}}

--- a/controllers/datadogagent/override/container_test.go
+++ b/controllers/datadogagent/override/container_test.go
@@ -394,22 +394,23 @@ func TestContainer(t *testing.T) {
 			},
 			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers, containerName string) {
 				assertContainerMatch(t, manager.PodTemplateSpec().Spec.Containers, containerName, func(container corev1.Container) bool {
-					return reflect.DeepEqual(
-						&corev1.Probe{
-							InitialDelaySeconds: 10,
-							TimeoutSeconds:      5,
-							PeriodSeconds:       30,
-							SuccessThreshold:    1,
-							FailureThreshold:    5,
-							ProbeHandler: corev1.ProbeHandler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/ready",
-									Port: intstr.IntOrString{
-										IntVal: 5555,
-									},
+					want := &corev1.Probe{
+						InitialDelaySeconds: 10,
+						TimeoutSeconds:      5,
+						PeriodSeconds:       30,
+						SuccessThreshold:    1,
+						FailureThreshold:    5,
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/ready",
+								Port: intstr.IntOrString{
+									IntVal: 5555,
 								},
 							},
 						},
+					}
+					return reflect.DeepEqual(
+						want,
 						container.ReadinessProbe)
 				})
 			},

--- a/controllers/datadogagent/override/container_test.go
+++ b/controllers/datadogagent/override/container_test.go
@@ -415,6 +415,49 @@ func TestContainer(t *testing.T) {
 			},
 		},
 		{
+			name:          "override readiness probe with non-HTTPGet handler",
+			containerName: commonv1.CoreAgentContainerName,
+			existingManager: func() *fake.PodTemplateManagers {
+				return fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{*agentContainer},
+					},
+				})
+			},
+			override: v2alpha1.DatadogAgentGenericContainer{
+				ReadinessProbe: &corev1.Probe{
+					InitialDelaySeconds: 10,
+					TimeoutSeconds:      5,
+					PeriodSeconds:       30,
+					SuccessThreshold:    1,
+					FailureThreshold:    5,
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"echo", "foo", "bar"},
+						},
+					},
+				},
+			},
+			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers, containerName string) {
+				assertContainerMatch(t, manager.PodTemplateSpec().Spec.Containers, containerName, func(container corev1.Container) bool {
+					return reflect.DeepEqual(
+						&corev1.Probe{
+							InitialDelaySeconds: 10,
+							TimeoutSeconds:      5,
+							PeriodSeconds:       30,
+							SuccessThreshold:    1,
+							FailureThreshold:    5,
+							ProbeHandler: corev1.ProbeHandler{
+								Exec: &corev1.ExecAction{
+									Command: []string{"echo", "foo", "bar"},
+								},
+							},
+						},
+						container.ReadinessProbe)
+				})
+			},
+		},
+		{
 			name:          "override readiness probe",
 			containerName: commonv1.CoreAgentContainerName,
 			existingManager: func() *fake.PodTemplateManagers {
@@ -497,6 +540,49 @@ func TestContainer(t *testing.T) {
 									Port: intstr.IntOrString{
 										IntVal: 5555,
 									},
+								},
+							},
+						},
+						container.LivenessProbe)
+				})
+			},
+		},
+		{
+			name:          "override liveness probe with non-HTTPGet handler",
+			containerName: commonv1.CoreAgentContainerName,
+			existingManager: func() *fake.PodTemplateManagers {
+				return fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{*agentContainer},
+					},
+				})
+			},
+			override: v2alpha1.DatadogAgentGenericContainer{
+				LivenessProbe: &corev1.Probe{
+					InitialDelaySeconds: 10,
+					TimeoutSeconds:      5,
+					PeriodSeconds:       30,
+					SuccessThreshold:    1,
+					FailureThreshold:    5,
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"echo", "foo", "bar"},
+						},
+					},
+				},
+			},
+			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers, containerName string) {
+				assertContainerMatch(t, manager.PodTemplateSpec().Spec.Containers, containerName, func(container corev1.Container) bool {
+					return reflect.DeepEqual(
+						&corev1.Probe{
+							InitialDelaySeconds: 10,
+							TimeoutSeconds:      5,
+							PeriodSeconds:       30,
+							SuccessThreshold:    1,
+							FailureThreshold:    5,
+							ProbeHandler: corev1.ProbeHandler{
+								Exec: &corev1.ExecAction{
+									Command: []string{"echo", "foo", "bar"},
 								},
 							},
 						},

--- a/controllers/datadogagent/override/container_test.go
+++ b/controllers/datadogagent/override/container_test.go
@@ -394,23 +394,22 @@ func TestContainer(t *testing.T) {
 			},
 			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers, containerName string) {
 				assertContainerMatch(t, manager.PodTemplateSpec().Spec.Containers, containerName, func(container corev1.Container) bool {
-					want := &corev1.Probe{
-						InitialDelaySeconds: 10,
-						TimeoutSeconds:      5,
-						PeriodSeconds:       30,
-						SuccessThreshold:    1,
-						FailureThreshold:    5,
-						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path: "/ready",
-								Port: intstr.IntOrString{
-									IntVal: 5555,
+					return reflect.DeepEqual(
+						&corev1.Probe{
+							InitialDelaySeconds: 10,
+							TimeoutSeconds:      5,
+							PeriodSeconds:       30,
+							SuccessThreshold:    1,
+							FailureThreshold:    5,
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/ready",
+									Port: intstr.IntOrString{
+										IntVal: 5555,
+									},
 								},
 							},
 						},
-					}
-					return reflect.DeepEqual(
-						want,
 						container.ReadinessProbe)
 				})
 			},

--- a/controllers/datadogagent/override/utils.go
+++ b/controllers/datadogagent/override/utils.go
@@ -8,8 +8,18 @@ package override
 import (
 	"fmt"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func getDefaultConfigMapName(ddaName, fileName string) string {
 	return fmt.Sprintf("%s-%s-yaml", ddaName, strings.Split(fileName, ".")[0])
+}
+
+func hasProbeHandler(probe *corev1.Probe) bool {
+	handler := &probe.ProbeHandler
+	if handler.Exec != nil || handler.HTTPGet != nil || handler.TCPSocket != nil || handler.GRPC != nil {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
### What does this PR do?

Fix readinessprobe and livenessprobe for non-nil probehandler overrides. 

### Motivation

Customer case
Fix for bug introduced in #998 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Configure a DDA `readinessProbe` and/or `livenessProbe` container overrides with non-httpGet probeHandlers:
```
  override:
    nodeAgent:
      containers:
        agent:  # should have expected probes
          readinessProbe:
            exec:
              command: ["echo", "ok"]
          livenessProbe:
            httpGet:
              path: /ready
              port: 5555
        process-agent: # should have expected probes
          readinessProbe:
            exec:
              command: ["echo", "ok"]
          livenessProbe:  # should have a default httpGet probeHandler
            timeoutSeconds: 30
            periodSeconds: 40
```

* Agent pods should not error
* Check the daemonset yaml `kubectl get <agent_pod> -oyaml`. 
* Container template specs should have the expected override-specified probes and probeHandlers. 
* If probe is configured and a probeHandler is not specified explicitly, it should have the default httpGet probeHandler

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
