### PR TITLE
SBOM: limit env injection for SBOM feature to core agent

### DIFF
--- a/controllers/datadogagent/feature/sbom/feature.go
+++ b/controllers/datadogagent/feature/sbom/feature.go
@@ -137,7 +137,7 @@ func (f *sbomFeature) ManageNodeAgent(managers feature.PodTemplateManagers, prov
 	}
 
 	if f.hostEnabled {
-		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, &corev1.EnvVar{
 			Name:  apicommon.DDHostRootEnvVar,
 			Value: "/host",
 		})

--- a/controllers/datadogagent/feature/sbom/feature_test.go
+++ b/controllers/datadogagent/feature/sbom/feature_test.go
@@ -93,7 +93,7 @@ func Test_sbomFeature_Configure(t *testing.T) {
 	sbomWithHostWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
 
-		wantEnvVars := []*corev1.EnvVar{
+		wantAllAgentsEnvVars := []*corev1.EnvVar{
 			{
 				Name:  apicommon.DDSBOMEnabled,
 				Value: "true",
@@ -106,14 +106,19 @@ func Test_sbomFeature_Configure(t *testing.T) {
 				Name:  apicommon.DDSBOMHostEnabled,
 				Value: "true",
 			},
+		}
+
+		wantCoreAgentHostEnvVars := []*corev1.EnvVar{
 			{
 				Name:  apicommon.DDHostRootEnvVar,
 				Value: "/host",
 			},
 		}
 
-		nodeAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
-		assert.True(t, apiutils.IsEqualStruct(nodeAgentEnvVars, wantEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeAgentEnvVars, wantEnvVars))
+		nodeAllAgentsEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.AllContainers]
+		nodeCoreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommonv1.CoreAgentContainerName]
+		assert.True(t, apiutils.IsEqualStruct(nodeCoreAgentEnvVars, wantCoreAgentHostEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeCoreAgentEnvVars, wantCoreAgentHostEnvVars))
+		assert.True(t, apiutils.IsEqualStruct(nodeAllAgentsEnvVars, wantAllAgentsEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeAllAgentsEnvVars, wantAllAgentsEnvVars))
 
 		wantVolumeMounts := []corev1.VolumeMount{
 			{


### PR DESCRIPTION
### What does this PR do?

This change make sure that we inject SBOM related env vars only to core agent container.

### Motivation

Since https://github.com/DataDog/datadog-operator/pull/1044 the `HOST_ROOT` injected for `security-agent` was wrongly set to `/host` instead of `/host/root`. By limiting the env vars to the core agent container, we should avoid such regressions.

See incident-26035.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
