### PR TITLE
Add notify_by, groupby_simple_monitor, & renotify_occurrences config options to monitors crd

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -110,7 +110,7 @@ type DatadogMonitorOptions struct {
 	// For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
 	// cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
 	// be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
-	// notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.
+	// notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
 	NotifyBy []string `json:"notifyBy,omitempty"`
 	// A Boolean indicating whether this monitor notifies when data stops reporting.
 	NotifyNoData *bool `json:"notifyNoData,omitempty"`

--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -91,7 +91,7 @@ type DatadogMonitorOptions struct {
 	EvaluationDelay *int64 `json:"evaluationDelay,omitempty"`
 	// A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
 	IncludeTags *bool `json:"includeTags,omitempty"`
-	// Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+	// A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
 	GroupbySimpleMonitor *bool `json:"groupbySimpleMonitor,omitempty"`
 	// Whether or not the monitor is locked (only editable by creator and admins).
 	Locked *bool `json:"locked,omitempty"`

--- a/apis/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/apis/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -91,6 +91,8 @@ type DatadogMonitorOptions struct {
 	EvaluationDelay *int64 `json:"evaluationDelay,omitempty"`
 	// A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
 	IncludeTags *bool `json:"includeTags,omitempty"`
+	// Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+	GroupbySimpleMonitor *bool `json:"groupbySimpleMonitor,omitempty"`
 	// Whether or not the monitor is locked (only editable by creator and admins).
 	Locked *bool `json:"locked,omitempty"`
 	// Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
@@ -104,6 +106,12 @@ type DatadogMonitorOptions struct {
 	NotificationPresetName DatadogMonitorOptionsNotificationPreset `json:"notificationPresetName,omitempty"`
 	// A Boolean indicating whether tagged users are notified on changes to this monitor.
 	NotifyAudit *bool `json:"notifyAudit,omitempty"`
+	// A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+	// For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+	// cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+	// be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+	// notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.
+	NotifyBy []string `json:"notifyBy,omitempty"`
 	// A Boolean indicating whether this monitor notifies when data stops reporting.
 	NotifyNoData *bool `json:"notifyNoData,omitempty"`
 	// An enum that controls how groups or monitors are treated if an evaluation does not return data points.
@@ -115,6 +123,8 @@ type DatadogMonitorOptions struct {
 	// The number of minutes after the last notification before a monitor re-notifies on the current status.
 	// It only re-notifies if it’s not resolved.
 	RenotifyInterval *int64 `json:"renotifyInterval,omitempty"`
+	// The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
+	RenotifyOccurrences *int64 `json:"renotifyOccurrences,omitempty"`
 	// A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
 	// recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
 	RequireFullWindow *bool `json:"requireFullWindow,omitempty"`

--- a/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -1442,6 +1442,11 @@ func (in *DatadogMonitorOptions) DeepCopyInto(out *DatadogMonitorOptions) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.GroupbySimpleMonitor != nil {
+		in, out := &in.GroupbySimpleMonitor, &out.GroupbySimpleMonitor
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Locked != nil {
 		in, out := &in.Locked, &out.Locked
 		*out = new(bool)
@@ -1462,6 +1467,11 @@ func (in *DatadogMonitorOptions) DeepCopyInto(out *DatadogMonitorOptions) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NotifyBy != nil {
+		in, out := &in.NotifyBy, &out.NotifyBy
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.NotifyNoData != nil {
 		in, out := &in.NotifyNoData, &out.NotifyNoData
 		*out = new(bool)
@@ -1469,6 +1479,11 @@ func (in *DatadogMonitorOptions) DeepCopyInto(out *DatadogMonitorOptions) {
 	}
 	if in.RenotifyInterval != nil {
 		in, out := &in.RenotifyInterval, &out.RenotifyInterval
+		*out = new(int64)
+		**out = **in
+	}
+	if in.RenotifyOccurrences != nil {
+		in, out := &in.RenotifyOccurrences, &out.RenotifyOccurrences
 		*out = new(int64)
 		**out = **in
 	}

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -2124,6 +2124,13 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorOptions(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"groupbySimpleMonitor": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"locked": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether or not the monitor is locked (only editable by creator and admins).",
@@ -2159,6 +2166,21 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorOptions(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"notifyBy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to [\"cluster\"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"notifyNoData": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A Boolean indicating whether this monitor notifies when data stops reporting.",
@@ -2176,6 +2198,13 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorOptions(ref common.ReferenceC
 					"renotifyInterval": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it’s not resolved.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"renotifyOccurrences": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The number of times re-notification messages should be sent on the current status at the provided re-notification interval.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -2126,7 +2126,7 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorOptions(ref common.ReferenceC
 					},
 					"groupbySimpleMonitor": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.",
+							Description: "A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -2168,7 +2168,7 @@ func schema__apis_datadoghq_v1alpha1_DatadogMonitorOptions(ref common.ReferenceC
 					},
 					"notifyBy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to [\"cluster\"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.",
+							Description: "A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to [\"cluster\"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -102,7 +102,7 @@ spec:
                       description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                       type: boolean
                     notifyBy:
-                      description: A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.
+                      description: A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
                       items:
                         type: string
                       type: array

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -78,6 +78,9 @@ spec:
                       description: Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
                       format: int64
                       type: integer
+                    groupbySimpleMonitor:
+                      description: Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      type: boolean
                     includeTags:
                       description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
                       type: boolean
@@ -98,6 +101,11 @@ spec:
                     notifyAudit:
                       description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                       type: boolean
+                    notifyBy:
+                      description: A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.
+                      items:
+                        type: string
+                      type: array
                     notifyNoData:
                       description: A Boolean indicating whether this monitor notifies when data stops reporting.
                       type: boolean
@@ -106,6 +114,10 @@ spec:
                       type: string
                     renotifyInterval:
                       description: The number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it’s not resolved.
+                      format: int64
+                      type: integer
+                    renotifyOccurrences:
+                      description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
                       format: int64
                       type: integer
                     requireFullWindow:

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -79,7 +79,7 @@ spec:
                       format: int64
                       type: integer
                     groupbySimpleMonitor:
-                      description: Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                      description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
                       type: boolean
                     includeTags:
                       description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -80,7 +80,7 @@ spec:
                   format: int64
                   type: integer
                 groupbySimpleMonitor:
-                  description: Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                  description: A Boolean indicating whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
                   type: boolean
                 includeTags:
                   description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -79,6 +79,9 @@ spec:
                   description: Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min), the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55. This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
                   format: int64
                   type: integer
+                groupbySimpleMonitor:
+                  description: Whether the log alert monitor triggers a single alert or multiple alerts when any group breaches a threshold.
+                  type: boolean
                 includeTags:
                   description: A Boolean indicating whether notifications from this monitor automatically inserts its triggering tags into the title.
                   type: boolean
@@ -99,6 +102,11 @@ spec:
                 notifyAudit:
                   description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                   type: boolean
+                notifyBy:
+                  description: A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.
+                  items:
+                    type: string
+                  type: array
                 notifyNoData:
                   description: A Boolean indicating whether this monitor notifies when data stops reporting.
                   type: boolean
@@ -107,6 +115,10 @@ spec:
                   type: string
                 renotifyInterval:
                   description: The number of minutes after the last notification before a monitor re-notifies on the current status. It only re-notifies if it’s not resolved.
+                  format: int64
+                  type: integer
+                renotifyOccurrences:
+                  description: The number of times re-notification messages should be sent on the current status at the provided re-notification interval.
                   format: int64
                   type: integer
                 requireFullWindow:

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogmonitors.yaml
@@ -103,7 +103,7 @@ spec:
                   description: A Boolean indicating whether tagged users are notified on changes to this monitor.
                   type: boolean
                 notifyBy:
-                  description: A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor  to notify as a simple-alert.
+                  description: A string indicating the granularity a monitor alerts on. Only available for monitors with groupings. For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
                   items:
                     type: string
                   type: array

--- a/controllers/datadogmonitor/monitor.go
+++ b/controllers/datadogmonitor/monitor.go
@@ -105,6 +105,10 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 		o.SetEvaluationDelay(*options.EvaluationDelay)
 	}
 
+	if options.GroupbySimpleMonitor != nil {
+		o.SetGroupbySimpleMonitor(*options.GroupbySimpleMonitor)
+	}
+
 	if options.IncludeTags != nil {
 		o.SetIncludeTags(*options.IncludeTags)
 	}
@@ -129,6 +133,10 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 		o.SetNotifyAudit(*options.NotifyAudit)
 	}
 
+	if options.NotifyBy != nil {
+		o.SetNotifyBy(options.NotifyBy)
+	}
+
 	if options.NotifyNoData != nil {
 		o.SetNotifyNoData(*options.NotifyNoData)
 	}
@@ -139,6 +147,10 @@ func buildMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (*da
 
 	if options.RenotifyInterval != nil {
 		o.SetRenotifyInterval(*options.RenotifyInterval)
+	}
+
+	if options.RenotifyOccurrences != nil {
+		o.SetRenotifyOccurrences(*options.RenotifyOccurrences)
 	}
 
 	if options.TimeoutH != nil {

--- a/controllers/datadogmonitor/monitor_test.go
+++ b/controllers/datadogmonitor/monitor_test.go
@@ -33,6 +33,7 @@ func Test_buildMonitor(t *testing.T) {
 	newGroupDelay := int64(400)
 	noDataTimeframe := int64(15)
 	renotifyInterval := int64(1440)
+	renotifyOccurrences := int64(1)
 	timeoutH := int64(2)
 	critThreshold := "0.05"
 	warnThreshold := "0.02"
@@ -56,14 +57,21 @@ func Test_buildMonitor(t *testing.T) {
 				EvaluationDelay:        &evalDelay,
 				EscalationMessage:      &escalationMsg,
 				IncludeTags:            &valTrue,
+				GroupbySimpleMonitor:   &valTrue,
 				Locked:                 &valTrue,
 				NewGroupDelay:          &newGroupDelay,
 				NoDataTimeframe:        &noDataTimeframe,
 				NotificationPresetName: "show_all",
-				NotifyNoData:           &valTrue,
-				OnMissingData:          "default",
-				RenotifyInterval:       &renotifyInterval,
-				TimeoutH:               &timeoutH,
+				NotifyBy: []string{
+					"env",
+					"kube_namespace",
+					"kube_cluster",
+				},
+				NotifyNoData:        &valTrue,
+				OnMissingData:       "default",
+				RenotifyOccurrences: &renotifyOccurrences,
+				RenotifyInterval:    &renotifyInterval,
+				TimeoutH:            &timeoutH,
 				Thresholds: &datadoghqv1alpha1.DatadogMonitorOptionsThresholds{
 					Critical: &critThreshold,
 					Warning:  &warnThreshold,
@@ -101,6 +109,9 @@ func Test_buildMonitor(t *testing.T) {
 	assert.Equal(t, *dm.Spec.Options.EscalationMessage, monitor.Options.GetEscalationMessage(), "discrepancy found in parameter: EscalationMessage")
 	assert.Equal(t, *dm.Spec.Options.EscalationMessage, monitorUR.Options.GetEscalationMessage(), "discrepancy found in parameter: EscalationMessage")
 
+	assert.Equal(t, *dm.Spec.Options.GroupbySimpleMonitor, monitor.Options.GetGroupbySimpleMonitor(), "discrepancy found in parameter: GroupbySimpleMonitor")
+	assert.Equal(t, *dm.Spec.Options.GroupbySimpleMonitor, monitorUR.Options.GetGroupbySimpleMonitor(), "discrepancy found in parameter: GroupbySimpleMonitor")
+
 	assert.Equal(t, *dm.Spec.Options.IncludeTags, monitor.Options.GetIncludeTags(), "discrepancy found in parameter: IncludeTags")
 	assert.Equal(t, *dm.Spec.Options.IncludeTags, monitorUR.Options.GetIncludeTags(), "discrepancy found in parameter: IncludeTags")
 
@@ -116,6 +127,9 @@ func Test_buildMonitor(t *testing.T) {
 	assert.Equal(t, string(dm.Spec.Options.NotificationPresetName), string(monitor.Options.GetNotificationPresetName()), "discrepancy found in parameter: NotificationPresetName")
 	assert.Equal(t, string(dm.Spec.Options.NotificationPresetName), string(monitorUR.Options.GetNotificationPresetName()), "discrepancy found in parameter: NotificationPresetName")
 
+	assert.Equal(t, dm.Spec.Options.NotifyBy, monitor.Options.GetNotifyBy(), "discrepancy found in parameter: NotifyBy")
+	assert.Equal(t, dm.Spec.Options.NotifyBy, monitorUR.Options.GetNotifyBy(), "discrepancy found in parameter: NotifyBy")
+
 	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitor.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
 	assert.Equal(t, *dm.Spec.Options.NotifyNoData, monitorUR.Options.GetNotifyNoData(), "discrepancy found in parameter: NotifyNoData")
 
@@ -124,6 +138,9 @@ func Test_buildMonitor(t *testing.T) {
 
 	assert.Equal(t, *dm.Spec.Options.RenotifyInterval, monitor.Options.GetRenotifyInterval(), "discrepancy found in parameter: RenotifyInterval")
 	assert.Equal(t, *dm.Spec.Options.RenotifyInterval, monitorUR.Options.GetRenotifyInterval(), "discrepancy found in parameter: RenotifyInterval")
+
+	assert.Equal(t, *dm.Spec.Options.RenotifyOccurrences, monitor.Options.GetRenotifyOccurrences(), "discrepancy found in parameter: RenotifyOccurrences")
+	assert.Equal(t, *dm.Spec.Options.RenotifyOccurrences, monitorUR.Options.GetRenotifyOccurrences(), "discrepancy found in parameter: RenotifyOccurrences")
 
 	assert.Equal(t, *dm.Spec.Options.TimeoutH, monitor.Options.GetTimeoutH(), "discrepancy found in parameter: TimeoutH")
 	assert.Equal(t, *dm.Spec.Options.TimeoutH, monitorUR.Options.GetTimeoutH(), "discrepancy found in parameter: TimeoutH")


### PR DESCRIPTION
### What does this PR do?

Provides the [notify_by](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#notify_by), [groupby_simple_monitor](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#groupby_simple_monitor) & [renotify_occurrences](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/monitor#renotify_occurrences) monitor options

### Motivation

**Closes:**
https://github.com/DataDog/datadog-operator/issues/833
https://github.com/DataDog/datadog-operator/issues/814

### Additional Notes

`groupby_simple_monitor` only updates Log Monitors. `renotifyOccurrences` requires `renotifyInterval` to be configured. The unit test in monitor_test.go only tests the monitor can be built and passed to the API go client, ultimately the validation is handled by the API go client, returning a 4xx if invalid.

### Minimum Agent Versions

N/A

### Describe your test plan

- Checkout branch levipe01/monitors_crd_additional_options
- Update `config/manager/manager.yaml` to disable the webhook, enable Datadog monitors and apply Datadog API/App keys:

```
    spec:
      containers:
      - command:
        - /manager
        args:
        - --enable-leader-election
        - --pprof
        - --webhookEnabled=false
        - --datadogMonitorEnabled=true
...
        env:
        - name: DD_API_KEY
          valueFrom:
            secretKeyRef:
              name: "datadog-secret"
              key: api-key
        - name: DD_APP_KEY
          valueFrom:
            secretKeyRef:
              name: "datadog-secret"
              key: app-key
```

- Following steps from [how-to-contribute.md](https://github.com/DataDog/datadog-operator/blob/main/docs/how-to-contribute.md) and using a kind cluster run:
  - make build
  - make IMG=test/operator:test IMG_CHECK=test/operator-check:test docker-build
  - kind load docker-image test/operator:test
  - kind load docker-image test/operator-check:test
  - make IMG=test/operator:test IMG_CHECK=test/operator-check:test deploy

- Apply a DatadogAgent with the below config to generate logs:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
 name: datadog
spec:
 global:
  kubelet:
    tlsVerify: false
  clusterName: kind
  credentials:
   apiSecret:
    keyName: api-key
    secretName: datadog-secret
 features:
  logCollection:
    enabled: true
    containerCollectAll: true
```

- For each config option:
  - Apply a new log monitor using the below config (subbing in each new config option separately):
```
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMonitor
metadata:
  name: datadog-log-alert-test
  namespace: system
spec:
  query: "logs(\"source:agent\").index(\"main\").rollup(\"count\").by(\"status,host\").last(\"1h\") > 5"
  type: "log alert"
  name: "Test log alert made from DatadogMonitor"
  message: "1-2-3 testing"
  tags:
    - "test:datadog"
  priority: 5
  options:
    renotifyInterval: 1
    renotifyOccurrences: 3
    groupbySimpleMonitor: false
    notifyBy: ["abc"]
```

- For each config option, passing in an invalid setting should result in a 4xx error visible in the logs of the operator. For example the above `notifyBy` config should yield the below log:
```
{"level":"ERROR","ts":"2024-03-15T17:00:01Z","logger":"controllers.DatadogMonitor","msg":"error updating monitor","datadogmonitor":"system/datadog-log-alert-test","Monitor ID":141258523,"error":"error validating monitor: 400 Bad Request: {\"errors\":[\"Invalid notify_by value found: 'abc'; values must match the query's group keys: 'host,status'\"]}"}
```

- Adding a valid config should update the below fields in the UI (visible when editing the generated monitor):
![2024-03-15_13-05-40](https://github.com/DataDog/datadog-operator/assets/7349920/2eb7371a-3baa-4c4a-918c-05c3e9432682)

- Changing the configuration with another valid setting should update the monitor successfully.
- Deleting the corresponding DatadogMonitor object should delete the monitor from the UI.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
