### PR TITLE
Adding KubeValidation Markers to align Datadog Operator behaviour with Helm for invalid clusterName

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -56,6 +56,8 @@ type DatadogAgentSpec struct {
 
 	// Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily.
 	// +optional
+	// +kubebuilder:validation:Pattern=^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
+	// +kubebuilder:validation:MaxLength=80	
 	ClusterName string `json:"clusterName,omitempty"`
 
 	// The site of the Datadog intake to send Agent data to.

--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -758,6 +758,8 @@ type GlobalConfig struct {
 
 	// ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app.
 	// +optional
+	// +kubebuilder:validation:Pattern=^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
+	// +kubebuilder:validation:MaxLength=80
 	ClusterName *string `json:"clusterName,omitempty"`
 
 	// Site is the Datadog intake site Agent data are sent to.


### PR DESCRIPTION
### What does this PR do?
Adding KubeValidation Markers to align Datadog Operator behaviour with Helm for invalid clusterName.
Helm handles this currently at the _helpers.tpl file - https://github.com/DataDog/helm-charts/pull/1324/files

### Motivation

I realized that when using helm to install Datadog, if i were to define a clusterName that does not conform to our requirements, we are able to throw an error. 
```
  ## * Lowercase letters, numbers, and hyphens only.
  ## * Must start with a letter.
  ## * Must end with a number or a letter.
  ## * Overall length should not be higher than 80 characters.
```
when doing the same for operator, the error can only be seen in the Datadog Cluster Agent logs
```
2024-04-16 01:17:12 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/clustername/clustername.go:82 in getClusterName) | "Jon-test" isn't a valid cluster name. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, and cannot end with a hyphen nor have a dot adjacent to a hyphen.
```
Proposal for Improvement
Enforce this validation at the DatadogAgent Custom Resource Definition object.
Using markers from [kubebuilder](https://book.kubebuilder.io/reference/markers/crd-validation)?
This allows us to call out clusterName that does not conform to our requirements early and made it known to the user when the user is creating the CR.

### Additional Notes

Anything else we should know when reviewing?
- Refer to slack thread here: https://dd.slack.com/archives/C037CDX0WJV/p1713362418971749

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?
No

### Describe your test plan

`make manifest` > generated CustomResourceDefinition object with the markers.
- This will add the following into the CRD:
```
                  clusterName:
                    description: ClusterName sets a unique cluster name for the deployment
                      to easily scope monitoring data in the Datadog app.
                    maxLength: 80
                    pattern: ^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
                    type: string
```

1. Apply the CRD into a kubernetes cluster
2. Try creating DatadogAgent CR with `spec.global.clusterName` ranging from test cases defined in positive and negative scenarios.

Refer to https://docs.google.com/document/d/1Ht5rtSWUULkyFo6RC-mECzjVx2AUbhSAc0cJPXx27uU/edit for screenshots of test cases.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
