### PR TITLE
fix(controller): always try to update status

### DIFF
--- a/apis/datadoghq/v2alpha1/condition.go
+++ b/apis/datadoghq/v2alpha1/condition.go
@@ -71,6 +71,14 @@ func SetDatadogAgentStatusCondition(status *DatadogAgentStatus, condition *metav
 	}
 }
 
+// DeleteDatadogAgentStatusCondition use to delete a condition
+func DeleteDatadogAgentStatusCondition(status *DatadogAgentStatus, conditionType string) {
+	idConditionComplete := getIndexForConditionType(status, conditionType)
+	if idConditionComplete >= 0 {
+		status.Conditions = append(status.Conditions[:idConditionComplete], status.Conditions[idConditionComplete+1:]...)
+	}
+}
+
 // NewDatadogAgentStatusCondition returns new metav1.Condition instance
 func NewDatadogAgentStatusCondition(conditionType string, conditionStatus metav1.ConditionStatus, now metav1.Time, reason, message string) metav1.Condition {
 	return metav1.Condition{

--- a/apis/datadoghq/v2alpha1/condition.go
+++ b/apis/datadoghq/v2alpha1/condition.go
@@ -71,7 +71,7 @@ func SetDatadogAgentStatusCondition(status *DatadogAgentStatus, condition *metav
 	}
 }
 
-// DeleteDatadogAgentStatusCondition use to delete a condition
+// DeleteDatadogAgentStatusCondition is used to delete a condition
 func DeleteDatadogAgentStatusCondition(status *DatadogAgentStatus, conditionType string) {
 	idConditionComplete := getIndexForConditionType(status, conditionType)
 	if idConditionComplete >= 0 {

--- a/apis/datadoghq/v2alpha1/condition_test.go
+++ b/apis/datadoghq/v2alpha1/condition_test.go
@@ -1,0 +1,103 @@
+package v2alpha1
+
+import (
+	"testing"
+
+	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+	"github.com/google/go-cmp/cmp"
+	assert "github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeleteDatadogAgentStatusCondition(t *testing.T) {
+	type args struct {
+		status    *DatadogAgentStatus
+		condition string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		expectedStatus *DatadogAgentStatus
+	}{
+		{
+			name: "empty status",
+			args: args{
+				status:    &DatadogAgentStatus{},
+				condition: "fooType",
+			},
+			expectedStatus: &DatadogAgentStatus{},
+		},
+		{
+			name: "not present status",
+			args: args{
+				status: &DatadogAgentStatus{
+					Conditions: []v1.Condition{
+						{
+							Type: "barType",
+						},
+					},
+				},
+				condition: "fooType",
+			},
+			expectedStatus: &DatadogAgentStatus{
+				Conditions: []v1.Condition{
+					{
+						Type: "barType",
+					},
+				},
+			},
+		},
+		{
+			name: "status present at the end",
+			args: args{
+				status: &DatadogAgentStatus{
+					Conditions: []v1.Condition{
+						{
+							Type: "barType",
+						},
+						{
+							Type: "fooType",
+						},
+					},
+				},
+				condition: "fooType",
+			},
+			expectedStatus: &DatadogAgentStatus{
+				Conditions: []v1.Condition{
+					{
+						Type: "barType",
+					},
+				},
+			},
+		},
+		{
+			name: "status present at the begining",
+			args: args{
+				status: &DatadogAgentStatus{
+					Conditions: []v1.Condition{
+						{
+							Type: "fooType",
+						},
+						{
+							Type: "barType",
+						},
+					},
+				},
+				condition: "fooType",
+			},
+			expectedStatus: &DatadogAgentStatus{
+				Conditions: []v1.Condition{
+					{
+						Type: "barType",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DeleteDatadogAgentStatusCondition(tt.args.status, tt.args.condition)
+			assert.True(t, apiutils.IsEqualStruct(tt.args.status, tt.expectedStatus), "status \ndiff = %s", cmp.Diff(tt.args.status, tt.expectedStatus))
+		})
+	}
+}

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -158,23 +158,27 @@ func (o *Options) getV2Status() (common.StatusWrapper, error) {
 	return common.NewV2StatusWrapper(datadogAgent), nil
 }
 
-func isReconcileError(conditions []metav1.Condition) bool {
+func isReconcileError(conditions []metav1.Condition) error {
 	for _, condition := range conditions {
-		if (condition.Type == "DatadogAgentReconcileError" && condition.Status == metav1.ConditionTrue) ||
-			(condition.Type == "AgentReconcile" && condition.Status == metav1.ConditionFalse) ||
-			(condition.Type == "ClusterAgentReconcile" && condition.Status == metav1.ConditionFalse) ||
-			(condition.Type == "ClusterChecksRunnerReconcile" && condition.Status == metav1.ConditionFalse) {
-			return true
+		switch {
+		case condition.Type == "DatadogAgentReconcileError" && condition.Status == metav1.ConditionTrue:
+			return fmt.Errorf("datadogAgent reconciliation error message: %s", condition.Message)
+		case condition.Type == "AgentReconcile" && condition.Status == metav1.ConditionFalse:
+			return fmt.Errorf("agent reconciliation error message: %s", condition.Message)
+		case condition.Type == "ClusterAgentReconcile" && condition.Status == metav1.ConditionFalse:
+			return fmt.Errorf("cluster Agent reconciliation error message: %s", condition.Message)
+		case condition.Type == "ClusterChecksRunnerReconcile" && condition.Status == metav1.ConditionFalse:
+			return fmt.Errorf("cluster Check Runner reconciliation error message: %s", condition.Message)
 		}
 	}
-	return false
+	return nil
 }
 
 // Run use to run the command.
 func (o *Options) Run() error {
 	o.printOutf("Start checking rolling-update status")
-	agentDone, dcaDone, clcDone := false, false, false
 	checkFunc := func() (bool, error) {
+		var agentDone, dcaDone, clcDone, reconcileError bool
 		v2Available, err := common.IsV2Available(o.Clientset)
 		if err != nil {
 			return false, fmt.Errorf("unable to detect if CRD v2 is available, err:%w", err)
@@ -195,8 +199,9 @@ func (o *Options) Run() error {
 			return false, fmt.Errorf("unable to get the DatadogAgent.status, err:%w", err)
 		}
 
-		if isReconcileError(status.GetStatusCondition()) {
-			return false, fmt.Errorf("got reconcile error")
+		if err = isReconcileError(status.GetStatusCondition()); err != nil {
+			o.printOutf("received a reconcile error: %v", err)
+			reconcileError = true
 		}
 
 		if !agentDone {
@@ -211,7 +216,7 @@ func (o *Options) Run() error {
 			clcDone = o.isDeploymentDone(status.GetClusterChecksRunnerStatus(), o.clcMinUpToDate, "Cluster Check Runner")
 		}
 
-		if agentDone && dcaDone && clcDone {
+		if agentDone && dcaDone && clcDone && !reconcileError {
 			return true, nil
 		}
 

--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -178,7 +178,7 @@ func isReconcileError(conditions []metav1.Condition) error {
 func (o *Options) Run() error {
 	o.printOutf("Start checking rolling-update status")
 	checkFunc := func() (bool, error) {
-		var agentDone, dcaDone, clcDone, reconcileError bool
+		var agentDone, dcaDone, ccrDone, reconcileError bool
 		v2Available, err := common.IsV2Available(o.Clientset)
 		if err != nil {
 			return false, fmt.Errorf("unable to detect if CRD v2 is available, err:%w", err)
@@ -212,11 +212,11 @@ func (o *Options) Run() error {
 			dcaDone = o.isDeploymentDone(status.GetClusterAgentStatus(), o.dcaMinUpToDate, "Cluster Agent")
 		}
 
-		if !clcDone {
-			clcDone = o.isDeploymentDone(status.GetClusterChecksRunnerStatus(), o.clcMinUpToDate, "Cluster Check Runner")
+		if !ccrDone {
+			ccrDone = o.isDeploymentDone(status.GetClusterChecksRunnerStatus(), o.clcMinUpToDate, "Cluster Check Runner")
 		}
 
-		if agentDone && dcaDone && clcDone && !reconcileError {
+		if agentDone && dcaDone && ccrDone && !reconcileError {
 			return true, nil
 		}
 

--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -197,6 +197,7 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 		if err := r.deleteV2DaemonSet(daemonsetLogger, dda, daemonset, newStatus); err != nil {
 			return reconcile.Result{}, err
 		}
+		deleteStatusWithAgent(newStatus)
 		return reconcile.Result{}, nil
 	}
 
@@ -239,6 +240,11 @@ func (r *Reconciler) deleteV2ExtendedDaemonSet(logger logr.Logger, dda *datadogh
 	removeStaleStatus(newStatus, eds.Name)
 
 	return nil
+}
+
+func deleteStatusWithAgent(newStatus *datadoghqv2alpha1.DatadogAgentStatus) {
+	newStatus.Agent = nil
+	datadoghqv2alpha1.DeleteDatadogAgentStatusCondition(newStatus, datadoghqv2alpha1.AgentReconcileConditionType)
 }
 
 // removeStaleStatus removes a DaemonSet's status from a DatadogAgent's

--- a/controllers/datadogagent/controller_reconcile_ccr.go
+++ b/controllers/datadogagent/controller_reconcile_ccr.go
@@ -109,6 +109,12 @@ func (r *Reconciler) cleanupV2ClusterChecksRunner(logger logr.Logger, dda *datad
 		}
 	}
 
-	newStatus.ClusterChecksRunner = nil
+	deleteStatusWithClusterChecksRunner(newStatus)
+
 	return reconcile.Result{}, nil
+}
+
+func deleteStatusWithClusterChecksRunner(newStatus *datadoghqv2alpha1.DatadogAgentStatus) {
+	newStatus.ClusterChecksRunner = nil
+	datadoghqv2alpha1.DeleteDatadogAgentStatusCondition(newStatus, datadoghqv2alpha1.ClusterChecksRunnerReconcileConditionType)
 }

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -129,7 +129,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	}
 
 	// Examine user configuration to override any external dependencies (e.g. RBACs)
-	errs = append(errs, override.Dependencies(logger, resourceManagers, instance)...)
+	errs = override.Dependencies(logger, resourceManagers, instance)
 	if len(errs) > 0 {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, errors.NewAggregate(errs))
 	}

--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -200,7 +200,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	if utils.ShouldReturn(result, errors.NewAggregate(errs)) {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, errors.NewAggregate(errs))
 	} else {
-		// Update the status to make it the AgentReconcileConditionType successful
+		// Update the status to set AgentReconcileConditionType to successful
 		datadoghqv2alpha1.UpdateDatadogAgentStatusConditions(newStatus, now, datadoghqv2alpha1.AgentReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
 	}
 
@@ -208,7 +208,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	if utils.ShouldReturn(result, err) {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err)
 	} else {
-		// Update the status to make it the ClusterChecksRunnerReconcileConditionType successful
+		// Update the status to set ClusterChecksRunnerReconcileConditionType to successful
 		datadoghqv2alpha1.UpdateDatadogAgentStatusConditions(newStatus, now, datadoghqv2alpha1.ClusterChecksRunnerReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
 	}
 


### PR DESCRIPTION
### What does this PR do?

* Always update the `DatadogAgent` call the function that might update the status in the controller functions.
* Cleanup status when a component is disabled
* Make the logs more informative in the `check-operator` binary.

### Motivation

the `DatadogAgent.Status` was not always updated to reflect the fact an error was remove

### Additional Notes

During a deployment the `check-operator` process that is use to validate the agent deployment/upgrade was always failing with the following logs error

```
[2024-04-27T06:52:05.998Z] DatadogAgent 'datadog-agent/datadog-agent': Start checking rolling-update status
[2024-04-27T06:52:36.016Z] DatadogAgent 'datadog-agent/datadog-agent': v2alpha1 is available
Error: got reconcile error
```

Which means that a condition is in an error state in `DatadogAgent.status.conditions`. In the following example case it is the `AgentReconcile` condition that failed.

```yaml
# ➜ k get datadogagent datadog-agent -o yaml | yq .status.conditions
- lastTransitionTime: "2024-03-21T15:53:44Z"
  message: Deployment up-to-date
  reason: DeploymentUpToDate
  status: "True"
  type: ClusterAgentReconcile
- lastTransitionTime: "2024-04-27T01:40:11Z"
  message: Unable to update ExtendedDaemonSet
  reason: UpdateSucceeded
  status: "False"
  type: AgentReconcile
- lastTransitionTime: "2024-03-21T15:53:45Z"
  message: Deployment up-to-date
  reason: DeploymentUpToDate
  status: "True"
  type: ClusterChecksRunnerReconcile
- lastTransitionTime: "2024-03-21T15:53:45Z"
  message: Datadog metrics forwarding ok
  reason: MetricsForwardingSucceeded
  status: "True"
  type: ActiveDatadogMetrics
- lastTransitionTime: "2024-04-27T01:40:12Z"
  message: DatadogAgent reconcile ok
  reason: DatadogAgent_reconcile_ok
  status: "False"
  type: DatadogAgentReconcileError
```

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Deploy a DatadogAgent in a cluster. verify that all the reconcile conditions status are equal to "True". 

Try to edit manually a condition status to set it to `False` and check that the operator is updating properly the value again.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
