### PR TITLE
[APM Onboarding] Use creation timestamp and UID of DatadogAgent as env vars for APM Telemetry KPIs

### DIFF
--- a/apis/datadoghq/v1alpha1/test/new.go
+++ b/apis/datadoghq/v1alpha1/test/new.go
@@ -7,6 +7,7 @@ package test
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -310,11 +311,11 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			ad.Spec.Agent.Apm.Env = []corev1.EnvVar{
 				{
 					Name:  apicommon.DDAPMInstrumentationInstallId,
-					Value: component.AgentInstallId,
+					Value: string(ad.GetUID()),
 				},
 				{
 					Name:  apicommon.DDAPMInstrumentationInstallTime,
-					Value: component.AgentInstallTime,
+					Value: strconv.FormatInt(ad.GetCreationTimestamp().Unix(), 10),
 				},
 				{
 					Name:  apicommon.DDAPMInstrumentationInstallType,

--- a/apis/datadoghq/v1alpha1/test/new.go
+++ b/apis/datadoghq/v1alpha1/test/new.go
@@ -13,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -21,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
+	"github.com/google/uuid"
 
 	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -31,6 +33,9 @@ var (
 	apiVersion   = fmt.Sprintf("%s/%s", datadoghqv1alpha1.GroupVersion.Group, datadoghqv1alpha1.GroupVersion.Version)
 	pullPolicy   = corev1.PullIfNotPresent
 	defaultImage = defaulting.GetLatestAgentImage()
+	// AgentInstallTime records the Agent install time
+	AgentInstallTime = metav1.NewTime(time.Now())
+	AgentInstallId   = types.UID(uuid.New().String())
 )
 
 // NewDatadogAgentOptions set of option for the DatadogAgent creation
@@ -109,10 +114,12 @@ func NewDefaultedDatadogAgent(ns, name string, options *NewDatadogAgentOptions) 
 			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  ns,
-			Name:       name,
-			Labels:     map[string]string{},
-			Finalizers: []string{"finalizer.agent.datadoghq.com"},
+			Namespace:         ns,
+			Name:              name,
+			Labels:            map[string]string{},
+			Finalizers:        []string{"finalizer.agent.datadoghq.com"},
+			CreationTimestamp: AgentInstallTime,
+			UID:               AgentInstallId,
 		},
 	}
 	ad.Spec = datadoghqv1alpha1.DatadogAgentSpec{

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -948,7 +948,7 @@ func defaultAPMContainerEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
-			Value: component.AgentInstallTime,
+			Value: strconv.FormatInt(test.AgentInstallTime.Unix(), 10),
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
@@ -956,7 +956,7 @@ func defaultAPMContainerEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_ID",
-			Value: component.AgentInstallId,
+			Value: string(test.AgentInstallId),
 		},
 	}
 }

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -208,7 +208,7 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
-			Value: component.AgentInstallTime,
+			Value: strconv.FormatInt(test.AgentInstallTime.Time.Unix(), 10),
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
@@ -216,7 +216,7 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_ID",
-			Value: component.AgentInstallId,
+			Value: string(test.AgentInstallId),
 		},
 	}
 }

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -311,11 +311,11 @@ func envVarsForTraceAgent(dda metav1.Object) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallId,
-			Value: component.AgentInstallId,
+			Value: string(dda.GetUID()),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallTime,
-			Value: component.AgentInstallTime,
+			Value: strconv.FormatInt(dda.GetCreationTimestamp().Unix(), 10),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallType,

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -311,11 +312,11 @@ func envVarsForTraceAgent(dda metav1.Object) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallId,
-			Value: string(dda.GetUID()),
+			Value: utils.GetDatadogAgentResourceUID(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallTime,
-			Value: strconv.FormatInt(dda.GetCreationTimestamp().Unix(), 10),
+			Value: utils.GetDatadogAgentResourceCreationTime(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallType,

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -147,11 +147,11 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallId,
-			Value: component.AgentInstallId,
+			Value: string(dda.GetUID()),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallTime,
-			Value: component.AgentInstallTime,
+			Value: strconv.FormatInt(dda.GetCreationTimestamp().Unix(), 10),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallType,

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -28,7 +28,6 @@ import (
 // NewDefaultClusterAgentDeployment return a new default cluster-agent deployment
 func NewDefaultClusterAgentDeployment(dda metav1.Object) *appsv1.Deployment {
 	deployment := component.NewDeployment(dda, apicommon.DefaultClusterAgentResourceSuffix, GetClusterAgentName(dda), GetClusterAgentVersion(dda), nil)
-
 	podTemplate := NewDefaultClusterAgentPodTemplateSpec(dda)
 	for key, val := range deployment.GetLabels() {
 		podTemplate.Labels[key] = val
@@ -147,11 +146,11 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallId,
-			Value: string(dda.GetUID()),
+			Value: utils.GetDatadogAgentResourceUID(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallTime,
-			Value: strconv.FormatInt(dda.GetCreationTimestamp().Unix(), 10),
+			Value: utils.GetDatadogAgentResourceCreationTime(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallType,

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -31,13 +31,6 @@ const (
 	DefaultAgentInstallType = "k8s_manual"
 )
 
-var (
-// AgentInstallTime records the Agent install time
-//AgentInstallTime = strconv.FormatInt(time.Now().Unix(), 10)
-
-// AgentInstallId = uuid.NewString()
-)
-
 // GetVolumeForConfig return the volume that contains the agent config
 func GetVolumeForConfig() corev1.Volume {
 	return corev1.Volume{

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -9,15 +9,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/version"
-
-	"github.com/google/uuid"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -35,10 +32,10 @@ const (
 )
 
 var (
-	// AgentInstallTime records the Agent install time
-	AgentInstallTime = strconv.FormatInt(time.Now().Unix(), 10)
+// AgentInstallTime records the Agent install time
+//AgentInstallTime = strconv.FormatInt(time.Now().Unix(), 10)
 
-	AgentInstallId = uuid.NewString()
+// AgentInstallId = uuid.NewString()
 )
 
 // GetVolumeForConfig return the volume that contains the agent config

--- a/pkg/controller/utils/shared_utils.go
+++ b/pkg/controller/utils/shared_utils.go
@@ -7,6 +7,7 @@ package utils
 
 import (
 	"fmt"
+	"strconv"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -31,4 +32,14 @@ func GetDatadogAgentResourceNamespace(dda metav1.Object) string {
 // GetDatadogTokenResourceName returns the name of the ConfigMap used by the cluster agent to store token
 func GetDatadogTokenResourceName(dda metav1.Object) string {
 	return fmt.Sprintf("%stoken", dda.GetName())
+}
+
+// GetDatadogAgentResourceNamespace returns the UID of the Datadog Agent Resource
+func GetDatadogAgentResourceUID(dda metav1.Object) string {
+	return string(dda.GetUID())
+}
+
+// GetDatadogAgentResourceCreationTime returns the creation timestamp of the Datadog Agent Resource
+func GetDatadogAgentResourceCreationTime(dda metav1.Object) string {
+	return strconv.FormatInt(dda.GetCreationTimestamp().Unix(), 10)
 }


### PR DESCRIPTION
### What does this PR do?

Move generation of DD_INSTALLATION_ID and DD_INSTALLATION_TIME from Datadog Operator to using values generated during DatadogAgent creation.

### Motivation

https://datadoghq.atlassian.net/browse/CECO-1087

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Created Datadog Operator image with the PR change. Deployed it to the test cluster together with DatadogAgent CRD.
2. Ran kubectl apply -f datadog-agent.yaml to. create CR, DA and DCA.
On CR:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"datadoghq.com/v2alpha1","kind":"DatadogAgent","metadata":{"annotations":{},"name":"datadog","namespace":"default"},"spec":{"global":{"clusterName":"apm-onboarding-injection","credentials":{"apiSecret":{"keyName":"api-key","secretName":"datadog-secret2"}},"site":"datad0g.com"}}}
  creationTimestamp: "2024-04-29T22:20:07Z"
  finalizers:
  - finalizer.agent.datadoghq.com
  generation: 1
  name: datadog
  namespace: default
  resourceVersion: "302000248"
  uid: b50e91aa-2744-4ee4-b89f-64c8bf8cf355

    - name: DD_INSTRUMENTATION_INSTALL_ID
      value: b50e91aa-2744-4ee4-b89f-64c8bf8cf355
    - name: DD_INSTRUMENTATION_INSTALL_TIME
      value: "1714429207"
```
4. DA and DCA are created with the following env vars:
    - name: DD_INSTRUMENTATION_INSTALL_ID
      value: b50e91aa-2744-4ee4-b89f-64c8bf8cf355
    - name: DD_INSTRUMENTATION_INSTALL_TIME
      value: "1714429207"

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
