### PR TITLE
Add details regarding watched namespaces for the DatadogMonitor objects

### DIFF
--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -41,7 +41,6 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
     kind: DatadogMonitor
     metadata:
       name: datadog-monitor-test
-      namespace: datadog
     spec:
       query: "avg(last_10m):avg:system.disk.in_use{*} by {host} > 0.5"
       type: "metric alert"
@@ -55,15 +54,14 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
    - Note: By default, the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. Therefore, you should deploy your Datadog objects in the same `namespace` as the Operator.
    - If you'd like to deploy your DatadogMonitors in a different `namespace`, then you will need to configure the Operator [`watchNamespaces`][8] section with these additional `namespaces`:
 
-   ```
-   (...)
+```yaml
+   #(...)
    watchNamespaces:
      - datadog
      - <NAMESPACE_1>
      - <NAMESPACE_2>
      - <NAMESPACE_3>
-   (...)
-   ```
+```
 
 1. Deploy the `DatadogMonitor` with the above configuration file:
 

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -53,7 +53,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
    - Note: By default the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. So you should deploy your Datadog objects in the same `namespace` as the Operator.
-   - If you'd like to deploy your DatadogMonitors in a different `namespace`, than you will need to configure the Operator [`watchNamespaces`][8] section with these additional `namespaces`:
+   - If you'd like to deploy your DatadogMonitors in a different `namespace`, then you will need to configure the Operator [`watchNamespaces`][8] section with these additional `namespaces`:
 
    ```
    (...)

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -52,7 +52,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
    - Note: By default, the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. Therefore, you should deploy your Datadog objects in the same `namespace` as the Operator.
-   - If you'd like to deploy your DatadogMonitors in a different `namespace`, then you will need to configure the Operator [`watchNamespaces`][8] section with these additional `namespaces`:
+   - If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][8] section with those additional namespaces:
 
    ```yaml
       #(...)

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -62,6 +62,8 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
         - <NAMESPACE_2>
         - <NAMESPACE_3>
    ```
+   - *Note*: Adding namespaces increases number of resources the Operator watches. 
+      - You may need to adjust the memory limits for these addition of namespaces.
 
 1. Deploy the `DatadogMonitor` with the above configuration file:
 

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -52,7 +52,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
 
-   By default, the Operator only watches its own namespace, so it will manage any `DatadogMonitor` objects within its own namespace. Therefore, you should deploy your Datadog objects in the same namespace as the Operator. If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][8] section with those additional namespaces:
+   By default, the Operator only watches its own namespace, so it will manage any `DatadogMonitor` objects within its own namespace. Therefore, you should deploy your Datadog objects in the same namespace as the Operator. If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][6] section with those additional namespaces:
 
    ```yaml
       #(...)
@@ -142,4 +142,3 @@ kubectl logs <my-datadog-operator-pod-name>
 [5]: https://app.datadoghq.com/account/settings#api
 [6]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog-operator/values.yaml
 [7]: https://app.datadoghq.com/monitors/manage?q=tag%3A"generated%3Akubernetes"
-[8]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/values.yaml#L147-L156

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -51,8 +51,8 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
     ```
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
-   - Note: By default, the Operator only watches its own namespace, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own namespace. Therefore, you should deploy your Datadog objects in the same namespace as the Operator.
-   - If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][8] section with those additional namespaces:
+
+   By default, the Operator only watches its own namespace, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own namespace. Therefore, you should deploy your Datadog objects in the same namespace as the Operator. If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][8] section with those additional namespaces:
 
    ```yaml
       #(...)
@@ -62,8 +62,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
         - <NAMESPACE_2>
         - <NAMESPACE_3>
    ```
-   - *Note*: Adding namespaces increases number of resources the Operator watches. 
-      - You may need to adjust the memory limits for these addition of namespaces.
+   *Note:* Adding namespaces increases number of resources the Operator watches. You may need to adjust the memory limits for these addition of namespaces.
 
 1. Deploy the `DatadogMonitor` with the above configuration file:
 

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -54,14 +54,14 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
    - Note: By default, the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. Therefore, you should deploy your Datadog objects in the same `namespace` as the Operator.
    - If you'd like to deploy your DatadogMonitors in a different `namespace`, then you will need to configure the Operator [`watchNamespaces`][8] section with these additional `namespaces`:
 
-```yaml
-   #(...)
-   watchNamespaces:
-     - datadog
-     - <NAMESPACE_1>
-     - <NAMESPACE_2>
-     - <NAMESPACE_3>
-```
+   ```yaml
+      #(...)
+      watchNamespaces:
+        - datadog
+        - <NAMESPACE_1>
+        - <NAMESPACE_2>
+        - <NAMESPACE_3>
+   ```
 
 1. Deploy the `DatadogMonitor` with the above configuration file:
 

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -52,7 +52,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
     ```
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
-   - Note: By default the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. So you should deploy your Datadog objects in the same `namespace` as the Operator.
+   - Note: By default, the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. Therefore, you should deploy your Datadog objects in the same `namespace` as the Operator.
    - If you'd like to deploy your DatadogMonitors in a different `namespace`, then you will need to configure the Operator [`watchNamespaces`][8] section with these additional `namespaces`:
 
    ```

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -51,7 +51,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
     ```
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
-   - Note: By default, the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. Therefore, you should deploy your Datadog objects in the same `namespace` as the Operator.
+   - Note: By default, the Operator only watches its own namespace, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own namespace. Therefore, you should deploy your Datadog objects in the same namespace as the Operator.
    - If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][8] section with those additional namespaces:
 
    ```yaml

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -52,7 +52,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
 
-   By default, the Operator only watches its own namespace, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own namespace. Therefore, you should deploy your Datadog objects in the same namespace as the Operator. If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][8] section with those additional namespaces:
+   By default, the Operator only watches its own namespace, so it will manage any `DatadogMonitor` objects within its own namespace. Therefore, you should deploy your Datadog objects in the same namespace as the Operator. If you'd like to deploy your DatadogMonitors in different namespaces, then you will need to configure the Operator [`watchNamespaces`][8] section with those additional namespaces:
 
    ```yaml
       #(...)

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -41,6 +41,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
     kind: DatadogMonitor
     metadata:
       name: datadog-monitor-test
+      namespace: datadog
     spec:
       query: "avg(last_10m):avg:system.disk.in_use{*} by {host} > 0.5"
       type: "metric alert"
@@ -51,6 +52,18 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
     ```
 
     For additional examples, see [examples/datadog-monitor](../examples/datadogmonitor). Note that only metric alerts, query alerts, and service checks are supported.
+   - Note: By default the Operator only watches its own `namespace`, so it will manage any `DatadogAgent` and `DatadogMonitor` objects within its own `namespace`. So you should deploy your Datadog objects in the same `namespace` as the Operator.
+   - If you'd like to deploy your DatadogMonitors in a different `namespace`, than you will need to configure the Operator [`watchNamespaces`][8] section with these additional `namespaces`:
+
+   ```
+   (...)
+   watchNamespaces:
+     - datadog
+     - <NAMESPACE_1>
+     - <NAMESPACE_2>
+     - <NAMESPACE_3>
+   (...)
+   ```
 
 1. Deploy the `DatadogMonitor` with the above configuration file:
 
@@ -130,3 +143,4 @@ kubectl logs <my-datadog-operator-pod-name>
 [5]: https://app.datadoghq.com/account/settings#api
 [6]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog-operator/values.yaml
 [7]: https://app.datadoghq.com/monitors/manage?q=tag%3A"generated%3Akubernetes"
+[8]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/values.yaml#L147-L156


### PR DESCRIPTION
### What does this PR do?

- Adds additional context for use specifying the `namespaces`

### Motivation
- https://datadog.zendesk.com/agent/tickets/1666229
- Thought possibly a good note due to ticket

### Additional Notes

N/A

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent:  >= v1.20.X
* Datadog Operator v0.6+

### Describe your test plan

- Was validated in OH with TEE in `minikube` sandbox.
- `DatadogMonitor` not found when Operator was in different `namespace` or vice-a-versa.

### Checklist

- [X ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ X] PR has a milestone or the `qa/skip-qa` label
