### PR TITLE
[APM Onboarding] Use creation timestamp and UID of DatadogAgent as env vars for APM Telemetry KPIs (#1157)

### DIFF
--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -948,7 +948,7 @@ func defaultAPMContainerEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
-			Value: component.AgentInstallTime,
+			Value: strconv.FormatInt(test.AgentInstallTime.Unix(), 10),
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
@@ -956,7 +956,7 @@ func defaultAPMContainerEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_ID",
-			Value: component.AgentInstallId,
+			Value: string(test.AgentInstallId),
 		},
 	}
 }

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -208,7 +208,7 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
-			Value: component.AgentInstallTime,
+			Value: strconv.FormatInt(test.AgentInstallTime.Time.Unix(), 10),
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
@@ -216,7 +216,7 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_ID",
-			Value: component.AgentInstallId,
+			Value: string(test.AgentInstallId),
 		},
 	}
 }

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	componentdca "github.com/DataDog/datadog-operator/controllers/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -311,11 +312,11 @@ func envVarsForTraceAgent(dda metav1.Object) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallId,
-			Value: component.AgentInstallId,
+			Value: utils.GetDatadogAgentResourceUID(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallTime,
-			Value: component.AgentInstallTime,
+			Value: utils.GetDatadogAgentResourceCreationTime(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallType,

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -28,7 +28,6 @@ import (
 // NewDefaultClusterAgentDeployment return a new default cluster-agent deployment
 func NewDefaultClusterAgentDeployment(dda metav1.Object) *appsv1.Deployment {
 	deployment := component.NewDeployment(dda, apicommon.DefaultClusterAgentResourceSuffix, GetClusterAgentName(dda), GetClusterAgentVersion(dda), nil)
-
 	podTemplate := NewDefaultClusterAgentPodTemplateSpec(dda)
 	for key, val := range deployment.GetLabels() {
 		podTemplate.Labels[key] = val
@@ -147,11 +146,11 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallId,
-			Value: component.AgentInstallId,
+			Value: utils.GetDatadogAgentResourceUID(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallTime,
-			Value: component.AgentInstallTime,
+			Value: utils.GetDatadogAgentResourceCreationTime(dda),
 		},
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallType,

--- a/controllers/datadogagent/component/utils.go
+++ b/controllers/datadogagent/component/utils.go
@@ -9,15 +9,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/version"
-
-	"github.com/google/uuid"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -32,13 +29,6 @@ const (
 	localServiceDefaultMinimumVersion = "1.22-0"
 
 	DefaultAgentInstallType = "k8s_manual"
-)
-
-var (
-	// AgentInstallTime records the Agent install time
-	AgentInstallTime = strconv.FormatInt(time.Now().Unix(), 10)
-
-	AgentInstallId = uuid.NewString()
 )
 
 // GetVolumeForConfig return the volume that contains the agent config

--- a/pkg/controller/utils/shared_utils.go
+++ b/pkg/controller/utils/shared_utils.go
@@ -7,6 +7,7 @@ package utils
 
 import (
 	"fmt"
+	"strconv"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -31,4 +32,14 @@ func GetDatadogAgentResourceNamespace(dda metav1.Object) string {
 // GetDatadogTokenResourceName returns the name of the ConfigMap used by the cluster agent to store token
 func GetDatadogTokenResourceName(dda metav1.Object) string {
 	return fmt.Sprintf("%stoken", dda.GetName())
+}
+
+// GetDatadogAgentResourceNamespace returns the UID of the Datadog Agent Resource
+func GetDatadogAgentResourceUID(dda metav1.Object) string {
+	return string(dda.GetUID())
+}
+
+// GetDatadogAgentResourceCreationTime returns the creation timestamp of the Datadog Agent Resource
+func GetDatadogAgentResourceCreationTime(dda metav1.Object) string {
+	return strconv.FormatInt(dda.GetCreationTimestamp().Unix(), 10)
 }


### PR DESCRIPTION
### What does this PR do?

Cherry-pick #1157 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
