### PR TITLE
Clarify dogstatsd.mapperProfiles configuration descriptions

### DIFF
--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -67,9 +67,9 @@ spec:
 | features.cws.syscallMonitorEnabled | SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only). Default: false |
 | features.dogstatsd.hostPortConfig.enabled | Enabled enables host port configuration Default: false |
 | features.dogstatsd.hostPortConfig.hostPort | Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.) If HostNetwork is enabled, this value must match the ContainerPort. |
-| features.dogstatsd.mapperProfiles.configData | ConfigData corresponds to the configuration file content. |
+| features.dogstatsd.mapperProfiles.configData | ConfigData corresponds to a multiline string of the YAML formatted configuration for the mapper profiles. |
 | features.dogstatsd.mapperProfiles.configMap.items | Items maps a ConfigMap data `key` to a file `path` mount. |
-| features.dogstatsd.mapperProfiles.configMap.name | Name is the name of the ConfigMap. |
+| features.dogstatsd.mapperProfiles.configMap.name | Name is the name of the ConfigMap storing the JSON formatted configuration for the mapper profiles. |
 | features.dogstatsd.originDetectionEnabled | OriginDetectionEnabled enables origin detection for container tagging. See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging |
 | features.dogstatsd.tagCardinality | TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low |
 | features.dogstatsd.unixDomainSocketConfig.enabled | Enabled enables Unix Domain Socket. Default: true |


### PR DESCRIPTION
### What does this PR do?

CONS-6330

Small change to the description of the two configuration options. As the

- `configData` is expecting the string formatted blob of YAML, that the Operator converts into a JSON formatted env var 
- `configMap.*` when referencing an existing ConfigMap this map, this loads this directly into the env var, which means it needs to be pre-formatted as JSON

### Motivation

Clear up the expected patterns for these two

### Additional Notes

Ex: configData

```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    #(...)
  features:
    dogstatsd:
      hostPortConfig:
        enabled: true
      mapperProfiles:
        configData: |-
          - name: airflow
            prefix: airflow.
            mappings:
            - match: airflow.*_start
              match_type: ""
              name: airflow.job.start
              tags:
                job_name: $1
            - match: airflow.*_end
              match_type: ""
              name: airflow.job.end
              tags:
                job_name: $1
```

Ex: ConfigMap loaded

```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    #(...)
  features:
    dogstatsd:
      hostPortConfig:
        enabled: true
      mapperProfiles:
        configMap:
          items:
          - key: dogstatsd_mapper_profiles.json
            path: dogstatsd_mapper_profiles.json
          name: datadog-mapper-profiles
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: datadog-mapper-profiles
data:
  dogstatsd_mapper_profiles.json: |-
    [
      {
        "prefix": "airflow.", 
        "name": "airflow", 
        "mappings": [
          {
            "name": "airflow.job.start", 
            "match": "airflow.*_start", 
            "tags": {
              "job_name": "$1"
            }
          }, 
          {
            "name": "airflow.job.end", 
            "match": "airflow.*_end", 
            "tags": {
              "job_name": "$1"
            }
          }
        ]
      }
    ]

```

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
