### PR TITLE
[remote-config] add envvars missing from core agent for system probe features

### DIFF
--- a/controllers/datadogagent/feature/cspm/feature.go
+++ b/controllers/datadogagent/feature/cspm/feature.go
@@ -344,8 +344,7 @@ func (f *cspmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, prov
 		Name:  apicommon.DDComplianceConfigEnabled,
 		Value: "true",
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enabledEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SecurityAgentContainerName, enabledEnvVar)
+	managers.EnvVar().AddEnvVarToContainers([]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SecurityAgentContainerName}, enabledEnvVar)
 
 	hostRootEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDHostRootEnvVar,

--- a/controllers/datadogagent/feature/cws/feature.go
+++ b/controllers/datadogagent/feature/cws/feature.go
@@ -190,28 +190,32 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommonv1.SystemProbeContainerName)
 
 	// envvars
+
+	// env vars for Core Agent, Security Agent and System Probe
+	containersForEnvVars := []apicommonv1.AgentContainerName{
+		apicommonv1.CoreAgentContainerName,
+		apicommonv1.SecurityAgentContainerName,
+		apicommonv1.SystemProbeContainerName,
+	}
+
 	enabledEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDRuntimeSecurityConfigEnabled,
 		Value: "true",
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enabledEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SecurityAgentContainerName, enabledEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enabledEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, enabledEnvVar)
 
 	runtimeSocketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDRuntimeSecurityConfigSocket,
 		Value: filepath.Join(apicommon.SystemProbeSocketVolumePath, "runtime-security.sock"),
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SecurityAgentContainerName, runtimeSocketEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, runtimeSocketEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, runtimeSocketEnvVar)
 
 	if f.syscallMonitorEnabled {
 		monitorEnvVar := &corev1.EnvVar{
 			Name:  apicommon.DDRuntimeSecurityConfigSyscallMonitorEnabled,
 			Value: "true",
 		}
-		managers.EnvVar().AddEnvVarToContainer(apicommonv1.SecurityAgentContainerName, monitorEnvVar)
-		managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, monitorEnvVar)
+		managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, monitorEnvVar)
 	}
 
 	if f.networkEnabled {

--- a/controllers/datadogagent/feature/cws/feature.go
+++ b/controllers/datadogagent/feature/cws/feature.go
@@ -273,7 +273,13 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	volMountMgr.AddVolumeMountToContainer(&socketVolMount, apicommonv1.SystemProbeContainerName)
 
 	_, socketVolMountReadOnly := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, true)
-	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMountReadOnly, apicommonv1.SecurityAgentContainerName)
+	managers.VolumeMount().AddVolumeMountToContainers(
+		&socketVolMountReadOnly,
+		[]apicommonv1.AgentContainerName{
+			apicommonv1.CoreAgentContainerName,
+			apicommonv1.SecurityAgentContainerName,
+		},
+	)
 	volMgr.AddVolume(&socketVol)
 
 	// procdir volume mount

--- a/controllers/datadogagent/feature/ebpfcheck/feature.go
+++ b/controllers/datadogagent/feature/ebpfcheck/feature.go
@@ -81,13 +81,13 @@ func (f *ebpfCheckFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 	_, socketVolMountReadOnly := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMountReadOnly, apicommonv1.CoreAgentContainerName)
 
+	// env vars
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDEnableEBPFCheckEnvVar,
 		Value: "true",
 	}
 
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enableEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
+	managers.EnvVar().AddEnvVarToContainers([]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName}, enableEnvVar)
 	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
 
 	socketEnvVar := &corev1.EnvVar{

--- a/controllers/datadogagent/feature/npm/feature.go
+++ b/controllers/datadogagent/feature/npm/feature.go
@@ -131,12 +131,7 @@ func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	// socket volume mount (needs write perms for the system probe container but not the others)
 	socketVol, socketVolMount := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, false)
 	managers.Volume().AddVolume(&socketVol)
-	managers.VolumeMount().AddVolumeMountToContainers(
-		&socketVolMount,
-		[]apicommonv1.AgentContainerName{
-			apicommonv1.SystemProbeContainerName,
-		},
-	)
+	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommonv1.SystemProbeContainerName)
 
 	_, socketVolMountReadOnly := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainers(

--- a/controllers/datadogagent/feature/npm/feature.go
+++ b/controllers/datadogagent/feature/npm/feature.go
@@ -143,35 +143,43 @@ func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	)
 
 	// env vars
+
+	// env vars for Core Agent, Process Agent and System Probe
+	containersForEnvVars := []apicommonv1.AgentContainerName{
+		apicommonv1.CoreAgentContainerName,
+		apicommonv1.ProcessAgentContainerName,
+		apicommonv1.SystemProbeContainerName,
+	}
+
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeNPMEnabled,
 		Value: "true",
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.ProcessAgentContainerName, enableEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, enableEnvVar)
 
 	sysProbeEnableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeEnabled,
 		Value: "true",
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.ProcessAgentContainerName, sysProbeEnableEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, sysProbeEnableEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, sysProbeEnableEnvVar)
 
 	socketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeSocket,
 		Value: apicommon.DefaultSystemProbeSocketPath,
 	}
+	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, socketEnvVar)
 
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, &corev1.EnvVar{
+	collectDNSStatsEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeCollectDNSStatsEnabled,
 		Value: apiutils.BoolToString(&f.collectDNSStats),
-	})
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, &corev1.EnvVar{
+	}
+	managers.EnvVar().AddEnvVarToContainers([]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName}, collectDNSStatsEnvVar)
+
+	connTrackEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeConntrackEnabled,
 		Value: apiutils.BoolToString(&f.enableConntrack),
-	})
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.ProcessAgentContainerName, socketEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, socketEnvVar)
+	}
+	managers.EnvVar().AddEnvVarToContainers([]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName}, connTrackEnvVar)
 
 	// env vars for Process Agent only
 	sysProbeExternalEnvVar := &corev1.EnvVar{

--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -115,22 +115,19 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers, p
 	_, socketVolMountReadOnly := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMountReadOnly, apicommonv1.CoreAgentContainerName)
 
+	// env vars
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDEnableOOMKillEnvVar,
 		Value: "true",
 	}
-
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enableEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
+	managers.EnvVar().AddEnvVarToContainers([]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName}, enableEnvVar)
 	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
 
 	socketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeSocket,
 		Value: apicommon.DefaultSystemProbeSocketPath,
 	}
-
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, socketEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, socketEnvVar)
+	managers.EnvVar().AddEnvVarToContainers([]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName}, socketEnvVar)
 
 	return nil
 }

--- a/controllers/datadogagent/feature/oomkill/feature.go
+++ b/controllers/datadogagent/feature/oomkill/feature.go
@@ -123,6 +123,15 @@ func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers, p
 	managers.EnvVar().AddEnvVarToContainers([]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName}, enableEnvVar)
 	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
 
+	sysProbeEnableEnvVar := &corev1.EnvVar{
+		Name:  apicommon.DDSystemProbeEnabled,
+		Value: "true",
+	}
+	managers.EnvVar().AddEnvVarToContainers(
+		[]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName},
+		sysProbeEnableEnvVar,
+	)
+
 	socketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeSocket,
 		Value: apicommon.DefaultSystemProbeSocketPath,

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -119,22 +119,25 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 	_, socketVolMountReadOnly := volume.GetVolumesEmptyDir(apicommon.SystemProbeSocketVolumeName, apicommon.SystemProbeSocketVolumePath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMountReadOnly, apicommonv1.CoreAgentContainerName)
 
+	// env vars
 	enableEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDEnableTCPQueueLengthEnvVar,
 		Value: "true",
 	}
-
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enableEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enableEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(
+		[]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName},
+		enableEnvVar,
+	)
 	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
 
 	socketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeSocket,
 		Value: apicommon.DefaultSystemProbeSocketPath,
 	}
-
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, socketEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, socketEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(
+		[]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName},
+		socketEnvVar,
+	)
 
 	return nil
 }

--- a/controllers/datadogagent/feature/tcpqueuelength/feature.go
+++ b/controllers/datadogagent/feature/tcpqueuelength/feature.go
@@ -130,6 +130,15 @@ func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateMana
 	)
 	managers.EnvVar().AddEnvVarToInitContainer(apicommonv1.InitConfigContainerName, enableEnvVar)
 
+	sysProbeEnableEnvVar := &corev1.EnvVar{
+		Name:  apicommon.DDSystemProbeEnabled,
+		Value: "true",
+	}
+	managers.EnvVar().AddEnvVarToContainers(
+		[]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName},
+		sysProbeEnableEnvVar,
+	)
+
 	socketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeSocket,
 		Value: apicommon.DefaultSystemProbeSocketPath,

--- a/controllers/datadogagent/feature/usm/feature.go
+++ b/controllers/datadogagent/feature/usm/feature.go
@@ -146,21 +146,24 @@ func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 		},
 	)
 
-	// env vars for System Probe and Process Agent
+	// env vars for Core Agent, Process Agent and System Probe
+	containersForEnvVars := []apicommonv1.AgentContainerName{
+		apicommonv1.CoreAgentContainerName,
+		apicommonv1.ProcessAgentContainerName,
+		apicommonv1.SystemProbeContainerName,
+	}
+
 	enabledEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeServiceMonitoringEnabled,
 		Value: "true",
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, enabledEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.ProcessAgentContainerName, enabledEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.CoreAgentContainerName, enabledEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, enabledEnvVar)
 
 	sysProbeSocketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeSocket,
 		Value: apicommon.DefaultSystemProbeSocketPath,
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.ProcessAgentContainerName, sysProbeSocketEnvVar)
-	managers.EnvVar().AddEnvVarToContainer(apicommonv1.SystemProbeContainerName, sysProbeSocketEnvVar)
+	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, sysProbeSocketEnvVar)
 
 	// env vars for Process Agent only
 	sysProbeExternalEnvVar := &corev1.EnvVar{

--- a/controllers/datadogagent/feature/usm/feature.go
+++ b/controllers/datadogagent/feature/usm/feature.go
@@ -159,6 +159,15 @@ func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	}
 	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, enabledEnvVar)
 
+	sysProbeEnableEnvVar := &corev1.EnvVar{
+		Name:  apicommon.DDSystemProbeEnabled,
+		Value: "true",
+	}
+	managers.EnvVar().AddEnvVarToContainers(
+		[]apicommonv1.AgentContainerName{apicommonv1.CoreAgentContainerName, apicommonv1.SystemProbeContainerName},
+		sysProbeEnableEnvVar,
+	)
+
 	sysProbeSocketEnvVar := &corev1.EnvVar{
 		Name:  apicommon.DDSystemProbeSocket,
 		Value: apicommon.DefaultSystemProbeSocketPath,

--- a/controllers/datadogagent/merger/envvars.go
+++ b/controllers/datadogagent/merger/envvars.go
@@ -21,6 +21,8 @@ type EnvVarManager interface {
 	AddEnvVarWithMergeFunc(newEnvVar *corev1.EnvVar, mergeFunc EnvVarMergeFunction) error
 	// AddEnvVarToContainer use to add an environment variable to a specific container present in the Pod.
 	AddEnvVarToContainer(containerName commonv1.AgentContainerName, newEnvVar *corev1.EnvVar)
+	// AddEnvVarToContainers use to add an environment variable to specified containers present in the Pod.
+	AddEnvVarToContainers(containerNames []commonv1.AgentContainerName, newEnvVar *corev1.EnvVar)
 	// AddEnvVarToInitContainer use to add an environment variable to a specific init container present in the Pod.
 	AddEnvVarToInitContainer(containerName commonv1.AgentContainerName, newEnvVar *corev1.EnvVar)
 	// AddEnvVarWithMergeFunc use to add an environment variable to a specific container present in the Pod.
@@ -57,6 +59,12 @@ func (impl *envVarManagerImpl) AddEnvVarWithMergeFunc(newEnvVar *corev1.EnvVar, 
 
 func (impl *envVarManagerImpl) AddEnvVarToContainer(containerName commonv1.AgentContainerName, newEnvVar *corev1.EnvVar) {
 	_ = impl.AddEnvVarToContainerWithMergeFunc(containerName, newEnvVar, DefaultEnvVarMergeFunction)
+}
+
+func (impl *envVarManagerImpl) AddEnvVarToContainers(containerNames []commonv1.AgentContainerName, newEnvVar *corev1.EnvVar) {
+	for _, containerName := range containerNames {
+		_ = impl.AddEnvVarToContainerWithMergeFunc(containerName, newEnvVar, DefaultEnvVarMergeFunction)
+	}
 }
 
 func (impl *envVarManagerImpl) AddEnvVarToInitContainer(initContainerName commonv1.AgentContainerName, newEnvVar *corev1.EnvVar) {

--- a/controllers/datadogagent/merger/fake/envvar_manager.go
+++ b/controllers/datadogagent/merger/fake/envvar_manager.go
@@ -37,6 +37,13 @@ func (_m *EnvVarManager) AddEnvVarToContainer(containerName commonv1.AgentContai
 	}
 }
 
+// AddEnvVarToContainers provides a mock function with given fields: containerNames, newEnvVar
+func (_m *EnvVarManager) AddEnvVarToContainers(containerNames []commonv1.AgentContainerName, newEnvVar *v1.EnvVar) {
+	for _, containerName := range containerNames {
+		_m.AddEnvVarToContainer(containerName, newEnvVar)
+	}
+}
+
 // AddEnvVarToInitContainer provides a mock function with given fields: containerName, newEnvVar
 func (_m *EnvVarManager) AddEnvVarToInitContainer(containerName commonv1.AgentContainerName, newEnvVar *v1.EnvVar) {
 	for _, initContainerName := range initContainerNames {


### PR DESCRIPTION
### What does this PR do?

Add system probe envvars needed in core agent container, such as `DD_SYSPROBE_SOCKET` and `DD_SYSTEM_PROBE_ENABLED`

Add socket mount to core agent container where it is missing

Add new function to envvar manager `AddEnvVarToContainers` so that envvars can be added to multiple containers with a single function

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
