### PR TITLE
Add cluster name to all v2alpha examples

### DIFF
--- a/examples/datadogagent/v2alpha1/datadog-agent-all.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-all.yaml
@@ -4,6 +4,7 @@ metadata:
   name: datadog
 spec:
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-minimum.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-minimum.yaml
@@ -4,5 +4,6 @@ metadata:
   name: datadog
 spec:
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-on-openshift.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-on-openshift.yaml
@@ -14,6 +14,7 @@ spec:
     apm:
       enabled: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_API_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-apm-hostport.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-apm-hostport.yaml
@@ -10,6 +10,7 @@ spec:
         enabled: true
         hostPort: 8126
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-clusteragent.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-clusteragent.yaml
@@ -8,6 +8,7 @@ spec:
       enabled: true
       useDatadogMetrics: false
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-dca-clusterchecksrunner.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-dca-clusterchecksrunner.yaml
@@ -11,6 +11,7 @@ spec:
       enabled: true
       useClusterChecksRunners: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-dca-with-orchestrator-explorer.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-dca-with-orchestrator-explorer.yaml
@@ -7,6 +7,7 @@ spec:
     orchestratorExplorer:
       enabled: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-extraconfd.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-extraconfd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: datadog
 spec:
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
   override:

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-logs-apm.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-logs-apm.yaml
@@ -9,6 +9,7 @@ spec:
     apm:
       enabled: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-otlp.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-otlp.yaml
@@ -14,6 +14,7 @@ spec:
           http:
             enabled: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-remote-configuration.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-remote-configuration.yaml
@@ -7,6 +7,7 @@ spec:
     remoteConfiguration:
       enabled: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-secret-backend.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-secret-backend.yaml
@@ -7,6 +7,7 @@ spec:
     apm:
       enabled: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: ENC[api_key]
       appKey: ENC[app_key]

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-secret-keys.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-secret-keys.yaml
@@ -4,6 +4,7 @@ metadata:
   name: datadog
 spec:
   global:
+    clusterName: my-example-cluster
     credentials:
       apiSecret:
         secretName: datadog-secret

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-tolerations.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-tolerations.yaml
@@ -4,6 +4,7 @@ metadata:
   name: datadog
 spec:
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
   override:

--- a/examples/datadogagent/v2alpha1/datadog-agent-with-unix-socket.yaml
+++ b/examples/datadogagent/v2alpha1/datadog-agent-with-unix-socket.yaml
@@ -13,6 +13,7 @@ spec:
       unixDomainSocketConfig:
         enabled: true
   global:
+    clusterName: my-example-cluster
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>


### PR DESCRIPTION
### What does this PR do?

Add clusterName to all v2alpha examples.
### Motivation

While implementing on Azure Redhat OpenShift, we used the example and had to add clusterName to properly view the data in our Kubernetes Overview page. 

It is a known issue that without the clusterName, the Kubernetes explorer will not be useful as nothing will show besides the container view.  

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
