### PR TITLE
[CECO-1109] Allow label overrides for ds for DDA updates

### DIFF
--- a/controllers/datadogagent/controller_reconcile_v2_common.go
+++ b/controllers/datadogagent/controller_reconcile_v2_common.go
@@ -133,13 +133,6 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 		return reconcile.Result{}, err
 	}
 
-	// From here the PodTemplateSpec should be ready, we can generate the hash that will be used to compare this daemonset with the current one (if it exists).
-	var hash string
-	hash, err = comparison.SetMD5DatadogAgentGenerationAnnotation(&daemonset.ObjectMeta, daemonset.Spec)
-	if err != nil {
-		return result, err
-	}
-
 	// Get the current daemonset and compare
 	nsName := types.NamespacedName{
 		Name:      daemonset.GetName(),
@@ -160,8 +153,38 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 	}
 
 	if alreadyExists {
+		// We need to recalculate the agentspechash because when overriding
+		// node labels, the hash could be updated without updating the pod
+		// template spec in <1.7.0. Pod template labels were copied over
+		// directly from the existing daemonset.
+		// With operator <1.7.0, it would look like:
+		// 1. Set override node label `abc: def`
+		//    a. Daemonset annotation: `agentspechash: 12345`
+		// 2. Change label to `abc: xyz`
+		//    a. Daemonset annotation: `agentspechash: 67890`
+		//    b. Pod template spec still has `abc: def` (set in step 1)
+		var recalculatedDSHash string
+		recalculatedDSHash, err = comparison.GenerateMD5ForSpec(currentDaemonset.Spec)
+		if err != nil {
+			return result, err
+		}
+
+		// TODO: remove in 1.8.0 when v1alpha1 is removed
+		// Spec.Selector is an immutable field and changing it leads to an error.
+		// Template.Labels must include Spec.Selector.
+		// See https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector
+		daemonset.Spec.Selector = currentDaemonset.Spec.Selector
+		daemonset.Spec.Template.Labels = ensureSelectorInPodTemplateLabels(logger, daemonset.Spec.Selector, daemonset.Spec.Template.Labels)
+
+		// From here the PodTemplateSpec should be ready, we can generate the hash that will be used to compare this daemonset with the current one (if it exists).
+		var hash string
+		hash, err = comparison.SetMD5DatadogAgentGenerationAnnotation(&daemonset.ObjectMeta, daemonset.Spec)
+		if err != nil {
+			return result, err
+		}
+
 		// check if same hash
-		needUpdate := !comparison.IsSameSpecMD5Hash(hash, currentDaemonset.GetAnnotations())
+		needUpdate := recalculatedDSHash != hash
 		if !needUpdate {
 			// Even if the DaemonSet is still the same, its status might have
 			// changed (for example, the number of pods ready). This call is
@@ -186,12 +209,6 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 		updateDaemonset.Annotations = mergeAnnotationsLabels(logger, currentDaemonset.GetAnnotations(), daemonset.GetAnnotations(), keepAnnotationsFilter)
 		updateDaemonset.Labels = mergeAnnotationsLabels(logger, currentDaemonset.GetLabels(), daemonset.GetLabels(), keepLabelsFilter)
 
-		// Spec.Selector is an immutable field and changing it leads to an error.
-		// Template.Labels must include Spec.Selector.
-		// See https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector
-		updateDaemonset.Spec.Selector = currentDaemonset.Spec.Selector
-		updateDaemonset.Spec.Template.Labels = ensureSelectorInPodTemplateLabels(logger, updateDaemonset.Spec.Selector, updateDaemonset.Spec.Template.Labels)
-
 		now := metav1.NewTime(time.Now())
 		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateDaemonset, currentDaemonset.ObjectMeta)
 		if err != nil {
@@ -202,6 +219,12 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 		r.recordEvent(dda, event)
 		updateStatusFunc(updateDaemonset, newStatus, now, metav1.ConditionTrue, updateSucceeded, "Daemonset updated")
 	} else {
+		// From here the PodTemplateSpec should be ready, we can generate the hash that will be added to this daemonset.
+		_, err = comparison.SetMD5DatadogAgentGenerationAnnotation(&daemonset.ObjectMeta, daemonset.Spec)
+		if err != nil {
+			return result, err
+		}
+
 		now := metav1.NewTime(time.Now())
 
 		err = r.client.Create(context.TODO(), daemonset)
@@ -283,12 +306,6 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(parentLogger logr.Logger, d
 		updateEDS.Annotations = mergeAnnotationsLabels(logger, currentEDS.GetAnnotations(), eds.GetAnnotations(), keepAnnotationsFilter)
 		updateEDS.Labels = mergeAnnotationsLabels(logger, currentEDS.GetLabels(), eds.GetLabels(), keepLabelsFilter)
 
-		// Spec.Selector is an immutable field and changing it leads to an error.
-		// Template.Labels must include Spec.Selector.
-		// See https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector
-		updateEDS.Spec.Selector = currentEDS.Spec.Selector
-		updateEDS.Spec.Template.Labels = ensureSelectorInPodTemplateLabels(logger, updateEDS.Spec.Selector, updateEDS.Spec.Template.Labels)
-
 		now := metav1.NewTime(time.Now())
 		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateEDS, currentEDS.ObjectMeta)
 		if err != nil {
@@ -316,6 +333,7 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(parentLogger logr.Logger, d
 	return result, err
 }
 
+// TODO: remove in 1.8.0 when v1alpha1 is removed
 // ensureSelectorInPodTemplateLabels checks that a label selector's MatchLabels
 // are present in the pod template labels. If the label is missing, it adds it
 // to the pod template labels. If the value doesn't match, it changes the label

--- a/controllers/datadogagent/controller_reconcile_v2_common_test.go
+++ b/controllers/datadogagent/controller_reconcile_v2_common_test.go
@@ -1,0 +1,103 @@
+package datadogagent
+
+import (
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func Test_ensureSelectorInPodTemplateLabels(t *testing.T) {
+	logger := logf.Log.WithName("Test_ensureSelectorInPodTemplateLabels")
+
+	tests := []struct {
+		name              string
+		selector          *metav1.LabelSelector
+		podTemplateLabels map[string]string
+		expectedLabels    map[string]string
+	}{
+		{
+			name:     "Nil selector",
+			selector: nil,
+			podTemplateLabels: map[string]string{
+				"foo": "bar",
+			},
+			expectedLabels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name:     "Empty selector",
+			selector: &metav1.LabelSelector{},
+			podTemplateLabels: map[string]string{
+				"foo": "bar",
+			},
+			expectedLabels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "Selector in template labels",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			podTemplateLabels: map[string]string{
+				"foo": "bar",
+			},
+			expectedLabels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "Selector not in template labels",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"bar": "foo",
+				},
+			},
+			podTemplateLabels: map[string]string{
+				"foo": "bar",
+			},
+			expectedLabels: map[string]string{
+				"foo": "bar",
+				"bar": "foo",
+			},
+		},
+		{
+			name: "Selector label value does not match template labels",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "foo",
+				},
+			},
+			podTemplateLabels: map[string]string{
+				"foo": "bar",
+			},
+			expectedLabels: map[string]string{
+				"foo": "foo",
+			},
+		},
+		{
+			name: "Nil pod template labels",
+			selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "foo",
+				},
+			},
+			podTemplateLabels: nil,
+			expectedLabels: map[string]string{
+				"foo": "foo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := ensureSelectorInPodTemplateLabels(logger, tt.selector, tt.podTemplateLabels)
+			assert.Equal(t, tt.expectedLabels, labels)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Allows node label overrides for daemonsets when updating DDAs. After creating a DDA, subsequent changes to the node agent label overrides weren't being propagated to the agent pods.

### Motivation

CECO-1109

### Additional Notes

Fixes https://github.com/DataDog/datadog-operator/issues/1156

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

1. Testing label overrides with 1.7.0+:
* Create a DDA with or without node agent label overrides
* Add a label to modify the value of one of the label selectors on the daemonset
```yaml
  override:
    nodeAgent:
      labels:
        "agent.datadoghq.com/name": "bar"
```
* Check that the label on the agent pod remains the same as the label selector (`agent.datadoghq.com/name=datadog` instead of `agent.datadoghq.com/name=bar`) and that this log is in the operator logs: 
```
{"level":"INFO","ts":"2024-05-08T18:00:52Z","logger":"controllers.DatadogAgent","msg":"Selector value does not match template labels, modifying template labels","datadogagent":"default/datadog","component":"nodeAgent","daemonset.Namespace":"default","daemonset.Name":"datadog-agent","selector label":"agent.datadoghq.com/name: datadog","template label":"agent.datadoghq.com/name: bar"}
```
* Add (or change) the node agent label override
```yaml
  override:
    nodeAgent:
      labels:
        "foo": "bar"
```
* Check that the new label was added to the agent pod
* Remove the override. The label should not be present in the new agent pod

2. Testing daemonset restarts from previous operator version:
* Create a DDA with operator <1.7.0 with a node label override
```yaml
  override:
    nodeAgent:
      labels:
        "foo": "bar"
```
* The daemonset label should be the same as the pod template label. Also note the `agent.datadoghq.com/agentspechash` annotation on the daemonset to use for comparison in later steps
* Change the label override
```yaml
  override:
    nodeAgent:
      labels:
        "foo": "bar123"
```
* The `agent.datadoghq.com/agentspechash` annotation value should change, the daemonset label should change to `foo:bar123`, but the pod template spec should still have the old `foo:bar` label and the node agent pod shouldn't have restarted
* Update the operator to 1.7.0+
* The node agent pod should have restarted. The `agent.datadoghq.com/agentspechash` annotation value should be the same and both the daemonset label and pod template spec label should say `foo:bar123`

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
