### PR TITLE
Update SLO reconcialition loop to avoid creating duplicate SLOs

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogslo_types.go
+++ b/apis/datadoghq/v1alpha1/datadogslo_types.go
@@ -128,6 +128,8 @@ type DatadogSLOSyncStatus string
 const (
 	// DatadogSLOSyncStatusOK means syncing is OK.
 	DatadogSLOSyncStatusOK DatadogSLOSyncStatus = "OK"
+	// DatadogSLOSyncCreating means we started a reconcialiation loop to create the SLO.
+	DatadogSLOSyncCreating DatadogSLOSyncStatus = "creating SLO"
 	// DatadogSLOSyncStatusValidateError means there is a SLO validation error.
 	DatadogSLOSyncStatusValidateError DatadogSLOSyncStatus = "error validating SLO"
 	// DatadogSLOSyncStatusUpdateError means there is a SLO update error.

--- a/controllers/datadogslo/controller.go
+++ b/controllers/datadogslo/controller.go
@@ -147,8 +147,8 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 	if shouldCreate {
 		// Set status to creating, ensure that only one SLO is created
 		status.SyncStatus = v1alpha1.DatadogSLOSyncCreating
-		if ctrlResult, err := r.updateStatusIfNeeded(logger, instance, status, result); err != nil {
-			return ctrlResult, err
+		if result, err = r.updateStatusIfNeeded(logger, instance, status, result); err != nil {
+			return result, err
 		}
 		// Check that required tags are present
 		if result, err = r.checkRequiredTags(logger, instance); err != nil || result.Requeue {

--- a/controllers/datadogslo/controller_test.go
+++ b/controllers/datadogslo/controller_test.go
@@ -119,6 +119,25 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}),
 			expectedResult: ctrl.Result{RequeueAfter: defaultRequeuePeriod},
 		},
+		{
+			name: "Creating SLO when StatusSync is in status creating should requeue",
+			request: ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: resourceNamespace,
+					Name:      resourceName,
+				},
+			},
+			mockOn: func(t *testing.T, m *mockedFields) {
+				slo := defaultSLO()
+				slo.Status.SyncStatus = v1alpha1.DatadogSLOSyncCreating
+				_ = m.k8sClient.Create(context.TODO(), slo)
+			},
+			datadogClientHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(defaultDatadogSLOResponse())
+			}),
+			expectedResult: ctrl.Result{RequeueAfter: defaultRequeuePeriod},
+		},
 	}
 
 	// Iterate through test cases


### PR DESCRIPTION
### What does this PR do?
We observed that the SLO controller creates duplicate SLO when running with more than 1 replica. ([issue 1062](https://github.com/DataDog/datadog-operator/issues/1062))  

The PR fixes the issue by adding a new `SyncStatus` state. The "creating SLO" `syncStatus` is used to ensure that only one reconcile loop can be creating an SLO at the time.

### Motivation

([issue 1062](https://github.com/DataDog/datadog-operator/issues/1062))  

### Additional Notes

N/A

### Minimum Agent Versions

N/A

### Describe your test plan

When running the latest version of the operator with more than 1 replica, we observed that a `DatadogSLO` would create 2 SLOs in Datadog. When building the PR, you will observe that only one SLO is created when applying a `DatadogSLO`.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
