### PR TITLE
Make admission controller to have right registry name

### DIFF
--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -17,6 +17,7 @@ const (
 	DDAdmissionControllerServiceName                  = "DD_ADMISSION_CONTROLLER_SERVICE_NAME"
 	DDAdmissionControllerFailurePolicy                = "DD_ADMISSION_CONTROLLER_FAILURE_POLICY"
 	DDAdmissionControllerWebhookName                  = "DD_ADMISSION_CONTROLLER_WEBHOOK_NAME"
+	DDAdmissionControllerContainerRegistry            = "DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY"
 	DDAPIKey                                          = "DD_API_KEY"
 	DDAPMEnabled                                      = "DD_APM_ENABLED"
 	DDAPMInstrumentationInstallTime                   = "DD_INSTRUMENTATION_INSTALL_TIME"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
 - manager.yaml
 images:
 - name: controller
-  newName: gcr.io/datadoghq/operator
-  newTag: 1.4.0
+  newName: test/operator
+  newTag: test
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/controllers/datadogagent/override/global.go
+++ b/controllers/datadogagent/override/global.go
@@ -83,6 +83,10 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 		for idx := range manager.PodTemplateSpec().Spec.Containers {
 			manager.PodTemplateSpec().Spec.Containers[idx].Image = fullImage
 		}
+		manager.EnvVar().AddEnvVar(&corev1.EnvVar{
+			Name:  apicommon.DDAdmissionControllerContainerRegistry,
+			Value: *config.Registry,
+		})
 	}
 
 	// LogLevel sets logging verbosity. This can be overridden by container.


### PR DESCRIPTION
### What does this PR do?
This PR is for adding "DD_ADMISSION_CONTROLLER_CONTAINER_REGISTRY" in cluster agent when there is a change in registry config.

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?
: It was motivated by : https://github.com/DataDog/datadog-operator/issues/924
### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.51.0
* Cluster Agent: v7.51.0

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
