### PR TITLE
[SLO] fix reconcile bugs, add predicate to builder

### DIFF
--- a/controllers/datadogslo/controller_test.go
+++ b/controllers/datadogslo/controller_test.go
@@ -29,6 +29,7 @@ import (
 
 	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/DataDog/datadog-operator/controllers/utils"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 )
@@ -174,6 +175,7 @@ func defaultSLO() *v1alpha1.DatadogSLO {
 			Type:            v1alpha1.DatadogSLOTypeMetric,
 			TargetThreshold: resource.MustParse("99.0"),
 			Timeframe:       v1alpha1.DatadogSLOTimeFrame30d,
+			Tags:            utils.GetRequiredTags(),
 		},
 	}
 }

--- a/controllers/datadogslo_controller.go
+++ b/controllers/datadogslo_controller.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -44,7 +45,8 @@ func (r *DatadogSLOReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.internal = datadogslo.NewReconciler(r.Client, r.DDClient, r.VersionInfo, r.Log, r.Recorder)
 
 	builder := ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.DatadogSLO{})
+		For(&v1alpha1.DatadogSLO{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{})
 
 	err := builder.Complete(r)
 	if err != nil {

--- a/controllers/utils/tag.go
+++ b/controllers/utils/tag.go
@@ -7,14 +7,14 @@ package utils
 
 const requiredTag = "generated:kubernetes"
 
-func getRequiredTags() []string {
+func GetRequiredTags() []string {
 	return []string{requiredTag}
 }
 
 func GetTagsToAdd(tags []string) []string {
 	tagsToAdd := []string{}
 	var found bool
-	for _, rT := range getRequiredTags() {
+	for _, rT := range GetRequiredTags() {
 		found = false
 		for _, t := range tags {
 			if t == rT {


### PR DESCRIPTION
### What does this PR do?

Update reconcile code to 1) not continue reconciling if tags have been updated; 2) set `LastForceSyncTime` on create and update, so that the status update does not trigger a reconcile; and 3) for good measure, add the GenerationChanged predicate filter so that any status-only updates do not trigger a reconcile.

### Motivation

Address #1062 .

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
