### PR TITLE
Fix agentConfig struct

### DIFF
--- a/pkg/remoteconfig/updater.go
+++ b/pkg/remoteconfig/updater.go
@@ -57,7 +57,8 @@ type RcServiceConfiguration struct {
 
 // DatadogAgentRemoteConfig contains the struct used to update DatadogAgent object from RemoteConfig
 type DatadogAgentRemoteConfig struct {
-	ID            string                       `json:"name"`
+	ID            string                       `json:""`
+	Name          string                       `json:"name"`
 	CoreAgent     *CoreAgentFeaturesConfig     `json:"config"`
 	SystemProbe   *SystemProbeFeaturesConfig   `json:"system_probe"`
 	SecurityAgent *SecurityAgentFeaturesConfig `json:"security_agent"`
@@ -269,8 +270,8 @@ func (r *RemoteConfigUpdater) parseReceivedUpdates(updates map[string]state.RawC
 				applyStatus(configPath, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 				r.logger.Info("Error unmarshalling JSON:", "err", err)
 				return DatadogAgentRemoteConfig{}, fmt.Errorf("could not unmarshall configuration %s", c.Metadata.ID)
-
 			} else {
+				configData.ID = c.Metadata.ID
 				configs = append(configs, configData)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?
This PR adds the right `ID` field to the agentConfigData Struct
A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
