### PR TITLE
Add Datadog SLO to PROJECT

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -46,6 +46,14 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+  domain: com
+  group: datadoghq
+  kind: DatadogSLO
+  path: github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1
+  version: v1alpha1
+- api:
+    crdVersion: v1
+    namespaced: true
   controller: true
   domain: com
   group: datadoghq


### PR DESCRIPTION
### What does this PR do?

Add Datadog SLO api to PROJECT file

### Motivation

The Datadog SLO crd tile is not displaying the expected metadata in operatorhub: https://operatorhub.io/operator/datadog-operator/stable/datadog-operator.v1.5.0

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Pre 1.7.0 RC (skip this if testing with the 1.7.0 RC and proceed to checking the CSV files):

* Cherry-pick commit onto the v1.6 branch
* Run `make VERSION=1.6.0-rc.1 LATEST_VERSION=1.6.0 bundle`

Check that Datadog SLO is present in `config/manifests/bases/datadog-operator.clusterserviceversion.yaml` and in `bundle` and `bundle-community-operators` CSV files

```
+    - description: DatadogSLO allows a user to define and manage datadog SLOs from
+        Kubernetes cluster.
+      displayName: Datadog SLO
+      kind: DatadogSLO
+      name: datadogslos.datadoghq.com
+      version: v1alpha1
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
