### PR TITLE
chore(mergequeue): add configuration

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -12,6 +12,5 @@ github_teams_restrictions:
   - Documentation
   - Vector
 github_users_restrictions:
-  - cahillsf
   - clamoriniere
   - hkaj

--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -9,10 +9,7 @@ github_teams_restrictions:
   - container-helm-chart-maintainers
   - container-integrations
   - container-t2
-  - Synthetics
   - Documentation
-  - Observability Pipelines
-  - Telemetry and Analytics
   - Vector
 github_users_restrictions:
   - cahillsf

--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,20 @@
+---
+schema-version: v1
+kind: mergequeue
+gitlab_check_enable: false
+github_teams_restrictions:
+  - agent-all
+  - container-app
+  - container-ecosystems
+  - container-helm-chart-maintainers
+  - container-integrations
+  - container-t2
+  - Synthetics
+  - Documentation
+  - Observability Pipelines
+  - Telemetry and Analytics
+  - Vector
+github_users_restrictions:
+  - cahillsf
+  - clamoriniere
+  - hkaj


### PR DESCRIPTION
### What does this PR do?

This PR adds the same Merge Queue configuration as the [Helm Chart](https://github.com/DataDog/helm-charts) repository.

### Motivation

This is needed to be able to merge using Merge Queue.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
