### PR TITLE
[CECO-1183] Override install info tool version

### DIFF
--- a/apis/datadoghq/common/envvar.go
+++ b/apis/datadoghq/common/envvar.go
@@ -155,4 +155,8 @@ const (
 
 	EnvVarTrueValue  = "true"
 	EnvVarFalseValue = "false"
+
+	// InstallInfoToolVersion is used by the Operator to override the tool
+	// version value in the Agent's install info
+	InstallInfoToolVersion = "DD_TOOL_VERSION"
 )

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -7,6 +7,7 @@ package enabledefault
 
 import (
 	"fmt"
+	"os"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
@@ -444,16 +445,25 @@ func buildInstallInfoConfigMap(dda metav1.Object) *corev1.ConfigMap {
 			Namespace: dda.GetNamespace(),
 		},
 		Data: map[string]string{
-			"install_info": fmt.Sprintf(installInfoDataTmpl, version.Version),
+			"install_info": getInstallInfoValue(),
 		},
 	}
 
 	return configMap
 }
 
+func getInstallInfoValue() string {
+	toolVersion := "datadog-operator"
+	if envVar := os.Getenv(apicommon.InstallInfoToolVersion); envVar != "" {
+		toolVersion = envVar
+	}
+
+	return fmt.Sprintf(installInfoDataTmpl, toolVersion, version.Version)
+}
+
 const installInfoDataTmpl = `---
 install_method:
   tool: datadog-operator
-  tool_version: datadog-operator
+  tool_version: %s
   installer_version: %s
 `

--- a/controllers/datadogagent/feature/enabledefault/feature_test.go
+++ b/controllers/datadogagent/feature/enabledefault/feature_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package enabledefault
+
+import (
+	"testing"
+
+	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+type InstallInfoData struct {
+	InstallMethod InstallMethod `yaml:"install_method"`
+}
+
+type InstallMethod struct {
+	Tool             string `yaml:"tool"`
+	ToolVersion      string `yaml:"tool_version"`
+	InstallerVersion string `yaml:"installer_version"`
+}
+
+func Test_getInstallInfoValue(t *testing.T) {
+	tests := []struct {
+		name                   string
+		toolVersionEnvVarValue string
+		expectedToolVersion    string
+	}{
+		{
+			name:                   "Env var empty/unset (os.Getenv returns unset env var as empty string)",
+			toolVersionEnvVarValue: "",
+			expectedToolVersion:    "datadog-operator",
+		},
+		{
+			name:                   "Env var set",
+			toolVersionEnvVarValue: "foo",
+			expectedToolVersion:    "foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(apicommon.InstallInfoToolVersion, tt.toolVersionEnvVarValue)
+			installInfo := InstallInfoData{}
+
+			test := getInstallInfoValue()
+
+			err := yaml.Unmarshal([]byte(test), &installInfo)
+			assert.NoError(t, err)
+
+			assert.Equal(t, "datadog-operator", installInfo.InstallMethod.Tool)
+			assert.Equal(t, tt.expectedToolVersion, installInfo.InstallMethod.ToolVersion)
+			assert.Equal(t, "0.0.0", installInfo.InstallMethod.InstallerVersion)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add an env var that can override the node agent's install info tool version

### Motivation

CECO-1183

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* In a cluster, check that the `tool_version` in the created install info configmap defaults to `datadog-operator`
* Set the env var `DD_TOOL_VERSION` with a non-empty string value in the operator pod
* After the new operator becomes leader, check that the install info config map `tool_version` value changed
* Restart the agent pod so it reads from the updated configmap
* Check that the tool version changed to whatever the value of `DD_TOOL_VERSION` is (`install_method_tool_version` when running `agent status`)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
