### PR TITLE
remove webhook conversion and certmanager references from bundle

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -9,10 +9,10 @@ resources:
 - bases/v1/datadoghq.com_datadogagentprofiles.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+# patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_datadogagents.yaml
+# - patches/webhook_in_datadogagents.yaml
 #- patches/webhook_in_datadogmetrics.yaml
 #- patches/webhook_in_datadogmonitors.yaml
 #- patches/webhook_in_datadogagentprofiles.yaml
@@ -20,7 +20,7 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_datadogagents.yaml
+# - patches/cainjection_in_datadogagents.yaml
 #- patches/cainjection_in_datadogmetrics.yaml
 #- patches/cainjection_in_datadogmonitors.yaml
 #- patches/cainjection_in_datadogagentprofiles.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,13 +18,13 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- ../webhook
+# - ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-- ../certmanager
+# - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+# patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
@@ -32,7 +32,7 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+# - manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
@@ -40,22 +40,22 @@ patchesStrategicMerge:
 # - webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
+# vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
+# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#   objref:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # this name should match the one in certificate.yaml
+#   fieldref:
+#     fieldpath: metadata.namespace
+# - name: CERTIFICATE_NAME
+#   objref:
+#     kind: Certificate
+#     group: cert-manager.io
+#     version: v1
+#     name: serving-cert # this name should match the one in certificate.yaml
 # - name: SERVICE_NAMESPACE # namespace of the service
 #   objref:
 #     kind: Service

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,6 @@ spec:
         args:
         - --enable-leader-election
         - --pprof
-        - --webhookEnabled
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -30,9 +30,9 @@ $YQ -i '.metadata.annotations."features.operators.openshift.io/token-auth-aws" =
 $YQ -i '.metadata.annotations."features.operators.openshift.io/token-auth-azure" = "false"' bundle/manifests/datadog-operator.clusterserviceversion.yaml
 $YQ -i '.metadata.annotations."features.operators.openshift.io/token-auth-gcp" = "false"' bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
-# Add skipRange annotation to allow direct upgrades
+# Add skipRange annotation to allow direct upgrades. '>=1.7.0' is hard-coded because this is the version where the webhook conversion was removed from the bundle
 VERSION=$($YQ '.spec.version' bundle/manifests/datadog-operator.clusterserviceversion.yaml )
-$YQ -i ".metadata.annotations.\"olm.skipRange\" = \"<$VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
+$YQ -i ".metadata.annotations.\"olm.skipRange\" = \">=1.7.0 <$VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Set spec.replaces to latest released version
 $YQ -i ".spec.\"replaces\" = \"datadog-operator.v$LATEST_VERSION\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml


### PR DESCRIPTION
### What does this PR do?

Comment out lines pertaining to webhook conversion that are no longer needed 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

See team doc about testing in Openshift

Test that upgrades from bundle 1.6.0 -> 1.7.0 succeed with a DatadogAgent deployed

Test that upgrades from bundle 1.6.0 -> 1.8.0 (a dummy bundle) have an intermediary upgrade to 1.7.0 first

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
