### PR TITLE
Include milliseconds in log timestamps

### DIFF
--- a/main.go
+++ b/main.go
@@ -364,7 +364,7 @@ func cacheOptions() cache.Options {
 func customSetupLogging(logLevel zapcore.Level, logEncoder string) error {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
-	encoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	var encoder zapcore.Encoder
 	switch logEncoder {


### PR DESCRIPTION
### What does this PR do?

Adds milliseconds to log timestamps
before
```
{"level":"INFO","ts":"2024-05-24T19:05:12Z","logger":"setup","msg":"Version: v1.5.0"}
{"level":"INFO","ts":"2024-05-24T19:05:12Z","logger":"setup","msg":"Build time: 2024-03-25/17:45:26"}
{"level":"INFO","ts":"2024-05-24T19:05:12Z","logger":"setup","msg":"Git Commit: 3ce57899c62d71c1443df824a64dc9424645eda6"}
{"level":"INFO","ts":"2024-05-24T19:05:12Z","logger":"setup","msg":"Go Version: go1.19.13"}
```

after
```
{"level":"INFO","ts":"2024-05-24T19:01:08.444Z","logger":"setup","msg":"Version: v1.6.0-rc.4_89818557"}
{"level":"INFO","ts":"2024-05-24T19:01:08.444Z","logger":"setup","msg":"Build time: 2024-05-24/14:51:48"}
{"level":"INFO","ts":"2024-05-24T19:01:08.444Z","logger":"setup","msg":"Git Commit: 89818557d2e58ec91a4544702808abe2c8224550"}
{"level":"INFO","ts":"2024-05-24T19:01:08.444Z","logger":"setup","msg":"Go Version: go1.19.13"}
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
