### PR TITLE
Fix dead links for DDA v2alpha1 examples

### DIFF
--- a/docs/configuration.v1alpha1.md
+++ b/docs/configuration.v1alpha1.md
@@ -4,10 +4,9 @@
 
 * [Manifest with Logs, APM, process, and metrics collection enabled.][1]
 * [Manifest with Logs, APM, and metrics collection enabled.][2]
-* [Manifest with Logs and metrics collection enabled.][3]
-* [Manifest with APM and metrics collection enabled.][4]
-* [Manifest with Cluster Agent.][5]
-* [Manifest with tolerations.][6]
+* [Manifest with APM and metrics collection enabled.][3]
+* [Manifest with Cluster Agent.][4]
+* [Manifest with tolerations.][5]
 
 ## All configuration options
 
@@ -485,8 +484,7 @@ spec:
 | site | The site of the Datadog intake to send Agent data to. Set to 'datadoghq.eu' to send data to the EU site. |
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs-apm.yaml
-[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs.yaml
-[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-apm.yaml
-[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-clusteragent.yaml
-[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-tolerations.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs.yaml
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-apm.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-clusteragent.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-tolerations.yaml

--- a/docs/configuration.v1alpha1.md
+++ b/docs/configuration.v1alpha1.md
@@ -484,7 +484,7 @@ spec:
 | site | The site of the Datadog intake to send Agent data to. Set to 'datadoghq.eu' to send data to the EU site. |
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs-apm.yaml
 [3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-apm.yaml
 [4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-clusteragent.yaml
 [5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-tolerations.yaml

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -4,10 +4,9 @@
 
 * [Manifest with Logs, APM, process, and metrics collection enabled.][1]
 * [Manifest with Logs, APM, and metrics collection enabled.][2]
-* [Manifest with Logs and metrics collection enabled.][3]
-* [Manifest with APM and metrics collection enabled.][4]
-* [Manifest with Cluster Agent.][5]
-* [Manifest with tolerations.][6]
+* [Manifest with APM and metrics collection enabled.][3]
+* [Manifest with Cluster Agent.][4]
+* [Manifest with tolerations.][5]
 
 ## All configuration options
 
@@ -355,8 +354,7 @@ In the table, `spec.override.nodeAgent.image.name` and `spec.override.nodeAgent.
 | [key].volumes `[]object` | Specify additional volumes in the different components (Datadog Agent, Cluster Agent, Cluster Check Runner). |
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-logs-apm.yaml
-[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-logs.yaml
-[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-apm.yaml
-[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-clusteragent.yaml
-[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-tolerations.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-logs-apm.yaml
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-apm-hostport.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-clusteragent.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-tolerations.yaml

--- a/hack/generate-docs/header.markdown
+++ b/hack/generate-docs/header.markdown
@@ -4,10 +4,9 @@
 
 * [Manifest with Logs, APM, process, and metrics collection enabled.][1]
 * [Manifest with Logs, APM, and metrics collection enabled.][2]
-* [Manifest with Logs and metrics collection enabled.][3]
-* [Manifest with APM and metrics collection enabled.][4]
-* [Manifest with Cluster Agent.][5]
-* [Manifest with tolerations.][6]
+* [Manifest with APM and metrics collection enabled.][3]
+* [Manifest with Cluster Agent.][4]
+* [Manifest with tolerations.][5]
 
 ## All configuration options
 

--- a/hack/generate-docs/v1alpha1_footer.markdown
+++ b/hack/generate-docs/v1alpha1_footer.markdown
@@ -1,6 +1,6 @@
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs-apm.yaml
 [3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-apm.yaml
 [4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-clusteragent.yaml
 [5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-tolerations.yaml

--- a/hack/generate-docs/v1alpha1_footer.markdown
+++ b/hack/generate-docs/v1alpha1_footer.markdown
@@ -1,7 +1,6 @@
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs-apm.yaml
-[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs.yaml
-[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-apm.yaml
-[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-clusteragent.yaml
-[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-tolerations.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-logs.yaml
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-apm.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-clusteragent.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v1alpha1/datadog-agent-with-tolerations.yaml

--- a/hack/generate-docs/v2alpha1_footer.markdown
+++ b/hack/generate-docs/v2alpha1_footer.markdown
@@ -1,7 +1,6 @@
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-all.yaml
-[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-logs-apm.yaml
-[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-logs.yaml
-[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-apm.yaml
-[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-clusteragent.yaml
-[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-tolerations.yaml
+[2]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-logs-apm.yaml
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-apm-hostport.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-clusteragent.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-with-tolerations.yaml


### PR DESCRIPTION
### What does this PR do?

Fix dead links for example DDAs on https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md. The `Manifest with Logs and metrics collection enabled` example file was removed entirely so I removed that link.

### Motivation

https://github.com/DataDog/datadog-operator/issues/1176

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
