### PR TITLE
Add v1beta1 CRD deprection warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > [!WARNING]
 > Operator release v1.7.0 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v1.8.0 will remove the conversion webhook as well, and users will not be able to apply the DatadogAgent `v1alpha1` manifest.
 > 
-> Operator release v1.8.0 will deprecate CRDs of `apiextensions.k8s.io/v1beta1` version. They will be kept in the repo but will not be updated. They will be removed in release v1.10.0.  
+> Operator v1.8.0 will deprecate custom resource definitions using `apiextensions.k8s.io/v1beta1`. They will be kept in the repository but will not be updated. They will be removed in v1.10.0.  
 
 The **Datadog Operator** aims to provide a new way of deploying the [Datadog Agent][1] on Kubernetes. Once deployed, the Datadog Operator provides:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Overview
 
 > [!WARNING]
-> Operator release v1.7.0 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v1.8.0 will remove conversion webhook as well and users will not be able to apply DadadogAgent `v1alpha1` manifest.
+> Operator release v1.7.0 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v1.8.0 will remove the conversion webhook as well, and users will not be able to apply the DatadogAgent `v1alpha1` manifest.
 > 
 > Operator release v1.8.0 will deprecate CRDs of `apiextensions.k8s.io/v1beta1` version. They will be kept in the repo but will not be updated. They will be removed in release v1.10.0.  
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Overview
 
 > [!WARNING]
-> Operator release v1.7.0 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v1.8.0 will remove the conversion webhook as well, and users will not be able to apply the DatadogAgent `v1alpha1` manifest.
+> Operator v1.7.0 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v1.8.0 will remove the conversion webhook as well, and users will not be able to apply the DatadogAgent `v1alpha1` manifest.
 > 
 > Operator v1.8.0 will deprecate custom resource definitions using `apiextensions.k8s.io/v1beta1`. They will be kept in the repository but will not be updated. They will be removed in v1.10.0.  
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 ## Overview
 
+> [!WARNING]
+> Operator release v0.1.7 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v0.1.8 will remove conversion webhook as well and users will not be able to apply DadadogAgent `v1alpha1` manifest.
+> 
+> Operator release v1.8.0 will deprecate CRDs of `apiextensions.k8s.io/v1beta1` version. They will be kept in the repo but will not be updated. They will be removed in release v1.10.0.  
+
 The **Datadog Operator** aims to provide a new way of deploying the [Datadog Agent][1] on Kubernetes. Once deployed, the Datadog Operator provides:
 
 - Agent configuration validation that limits configuration mistakes.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Overview
 
 > [!WARNING]
-> Operator release v0.1.7 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v0.1.8 will remove conversion webhook as well and users will not be able to apply DadadogAgent `v1alpha1` manifest.
+> Operator release v1.7.0 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v1.8.0 will remove conversion webhook as well and users will not be able to apply DadadogAgent `v1alpha1` manifest.
 > 
 > Operator release v1.8.0 will deprecate CRDs of `apiextensions.k8s.io/v1beta1` version. They will be kept in the repo but will not be updated. They will be removed in release v1.10.0.  
 

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/datadogclient"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/DataDog/datadog-operator/pkg/utils"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/version"
@@ -84,6 +85,14 @@ func SetupControllers(logger logr.Logger, mgr manager.Manager, options SetupOpti
 	versionInfo, err := discoveryClient.ServerVersion()
 	if err != nil {
 		return fmt.Errorf("unable to get APIServer version: %w", err)
+	}
+
+	if versionInfo != nil {
+		gitVersion := versionInfo.GitVersion
+		if !utils.IsAboveMinVersion(gitVersion, "1.16-0") {
+			logger.Error(nil, "Detected Kubernetes version <1.16 which requires CRD version apiextensions.k8s.io/v1beta1. "+
+				"CRDs of this version will be deprecated and will not be updated starting with Operator v1.8.0 and will be removed in v1.10.0.")
+		}
 	}
 
 	groups, resources, err := getServerGroupsAndResources(logger, discoveryClient)


### PR DESCRIPTION
### What does this PR do?

Adds log line about upcoming `v1beta1` CRD deprecation and warning in the readme.

Readme warning preview:

> [!WARNING]
> Operator release v0.1.7 removes support for DatadogAgent `v1alpha1` reconciliation (`v2APIEnabled` flag). v0.1.8 will remove conversion webhook as well and users will not be able to apply DadadogAgent `v1alpha1` manifest.
> 
> Operator release v1.8.0 will deprecate CRDs of `apiextensions.k8s.io/v1beta1` version. They will be kept in the repo but will not be updated. They will be removed in release v1.10.0.  

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
