### PR TITLE
[DatadogAgent] Aligns KSM Core default ConfigMap with Helm : adds pdbs, storageclasses, volumeattachments

### DIFF
--- a/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
@@ -74,6 +74,8 @@ instances:
     - persistentvolumeclaims
     - persistentvolumes
     - ingresses
+    - storageclasses
+    - volumeattachments
 `, stringVal, stringVal)
 
 	if collectorOpts.enableVPA {

--- a/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
+++ b/controllers/datadogagent/feature/kubernetesstatecore/configmap.go
@@ -66,6 +66,7 @@ instances:
     - endpoints
     - daemonsets
     - horizontalpodautoscalers
+    - poddisruptionbudgets
     - limitranges
     - resourcequotas
     - secrets


### PR DESCRIPTION
### What does this PR do?

* As with the Helm installation (https://github.com/DataDog/helm-charts/blob/bde0d7084967bc5e3b7177b642b168d7e09a97f0/charts/datadog/templates/_kubernetes_state_core_config.yaml#L41), aligns the default KSM Core ConfigMap : addition of pdbs, storageclasses & volumeattachments

### Motivation

* Customer request : https://datadog.zendesk.com/agent/tickets/1711557

### Additional Notes

* No additional RBACs are required as they were already present : 
    * PDB Operator RBAC : https://github.com/DataDog/datadog-operator/blob/a900de12525356d6f1fb6fdc7915dea8aee907b9/config/rbac/role.yaml#L521-L532
    * PDB KSM RBAC : https://github.com/DataDog/datadog-operator/blob/a900de12525356d6f1fb6fdc7915dea8aee907b9/controllers/datadogagent/feature/kubernetesstatecore/rbac.go#L67-L70
    * storageclasses and volumeattachments Operator RBAC : https://github.com/DataDog/datadog-operator/blob/a900de12525356d6f1fb6fdc7915dea8aee907b9/config/rbac/role.yaml#L652-L659
    * storageclasses and volumeattachments KSM RBAC : https://github.com/DataDog/datadog-operator/blob/a900de12525356d6f1fb6fdc7915dea8aee907b9/controllers/datadogagent/feature/kubernetesstatecore/rbac.go#L78-L83

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* With the KSM feature without override (enabled by default), ensures `poddisruptionbudgets`, `volumeattachments` and `storageclasses` are present in the `datadog-kube-state-metrics-core-config` ConfigMap (ConfigMap name depends on the `DatadogAgent` custom resource name)
* Apply pdb, e.g. with the manifest below : 
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: squid-config
data:
  squid.conf: |-
    http_port 0.0.0.0:3128
    acl local src 127.0.0.1/32
    acl Datadog dstdomain .datadoghq.com
    http_access allow Datadog
    http_access allow local manager
    debug_options ALL,6
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: squid-deploy
  labels:
    app: squid
spec:
  replicas: 1
  selector:
    matchLabels:
      app: squid
  template:
    metadata:
      labels:
        app: squid
    spec:
      containers:
      - name: squid
        image: ubuntu/squid:5.2-22.04_beta
        ports:
        - containerPort: 3128
        volumeMounts:
        - name: conf
          mountPath: /etc/squid
      volumes:
      - name: conf
        configMap:
          name: squid-config
---
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: squid-pdb
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app: squid
```
* Ensures `kubernetes_state.pdb.*` metrics are collected from running the check manually or verify in your account the metrics are present : 
<img width="2070" alt="image" src="https://github.com/DataDog/datadog-operator/assets/97530782/f8de0841-4a49-442e-8de2-8c999bf346cf">



### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
