### PR TITLE
Bump agent image versions to 7.54

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.53.0"
+	AgentLatestVersion = "7.54.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.53.0"
+	ClusterAgentLatestVersion = "7.54.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.0.1"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry


### PR DESCRIPTION
### What does this PR do?

This PR is for upgrading default agent image version to 7.54.0.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Testing label overrides with 1.7.0+:
- Create a DDA with basic configuration

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    clusterName: my-example-cluster
    credentials:
      apiKey: <DATADOG_API_KEY>
```

- Check If the agent and cluster agent image tag are set to 7.54.0
- kubectl describe pod <AGENT_POD> | grep -i Image:

```
k describe pod <AGENT_POD> | grep -i Image:
    Image:         gcr.io/datadoghq/agent:7.54.0
    Image:         gcr.io/datadoghq/agent:7.54.0
    Image:         gcr.io/datadoghq/agent:7.54.0
    Image:         gcr.io/datadoghq/agent:7.54.0
k describe pod <CLUSTER_AGENT_POD> | grep -i Image:
    Image:         gcr.io/datadoghq/cluster-agent:7.54.0
    Image:          gcr.io/datadoghq/cluster-agent:7.54.0
```

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
