### PR TITLE
Refactoring cwsInstrumentation test in AC test

### DIFF
--- a/apis/datadoghq/v2alpha1/test/builder.go
+++ b/apis/datadoghq/v2alpha1/test/builder.go
@@ -599,6 +599,26 @@ func (builder *DatadogAgentBuilder) WithCWSEnabled(enabled bool) *DatadogAgentBu
 	return builder
 }
 
+// cwsInstrumentation
+
+func (builder *DatadogAgentBuilder) initCWSInstrumentation() {
+	if builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation == nil {
+		builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation = &v2alpha1.CWSInstrumentationConfig{}
+	}
+}
+
+func (builder *DatadogAgentBuilder) WithCWSInstrumentationEnabled(enabled bool) *DatadogAgentBuilder {
+	builder.initCWSInstrumentation()
+	builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation.Enabled = apiutils.NewBoolPointer(enabled)
+	return builder
+}
+
+func (builder *DatadogAgentBuilder) WithCWSInstrumentationMode(mode string) *DatadogAgentBuilder {
+	builder.initCWSInstrumentation()
+	builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation.Mode = apiutils.NewStringPointer(mode)
+	return builder
+}
+
 // OOMKill
 
 func (builder *DatadogAgentBuilder) initOOMKill() {

--- a/controllers/datadogagent/feature/admissioncontroller/feature_test.go
+++ b/controllers/datadogagent/feature/admissioncontroller/feature_test.go
@@ -212,42 +212,6 @@ func newV1Agent(enabled bool) *v1alpha1.DatadogAgent {
 	}
 }
 
-func newV2Agent(enabled bool, acm, registry string, cwsInstrumentationEnabled bool, apm *v2alpha1.APMFeatureConfig, dsd *v2alpha1.DogstatsdFeatureConfig, global *v2alpha1.GlobalConfig) *v2alpha1.DatadogAgent {
-	dda := &v2alpha1.DatadogAgent{
-		Spec: v2alpha1.DatadogAgentSpec{
-			Global: &v2alpha1.GlobalConfig{},
-			Features: &v2alpha1.DatadogFeatures{
-				AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{
-					Enabled:          apiutils.NewBoolPointer(enabled),
-					MutateUnlabelled: apiutils.NewBoolPointer(true),
-					ServiceName:      apiutils.NewStringPointer("testServiceName"),
-					CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
-						Enabled: apiutils.NewBoolPointer(cwsInstrumentationEnabled),
-						Mode:    apiutils.NewStringPointer("test-mode"),
-					},
-				},
-			},
-		},
-	}
-	if acm != "" {
-		dda.Spec.Features.AdmissionController.AgentCommunicationMode = apiutils.NewStringPointer(acm)
-	}
-	if apm != nil {
-		dda.Spec.Features.APM = apm
-	}
-	if dsd != nil {
-		dda.Spec.Features.Dogstatsd = dsd
-	}
-	if registry != "" {
-		dda.Spec.Features.AdmissionController.Registry = apiutils.NewStringPointer(registry)
-
-	}
-	if global != nil {
-		dda.Spec.Global = global
-	}
-	return dda
-}
-
 func testDCAResources(acm string, registry string, cwsInstrumentationEnabled bool) *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {


### PR DESCRIPTION
### What does this PR do?

This PR is for refactoring cwsInstrumentation test in admission controller test file.

### Motivation

What inspired you to submit this pull request? 

It's a follow-up PR for refactoring admission controller test code #1207 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

- tested with release v1.7.0
- Run the admissionController feature_test.go
- Check the result is OK.

```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^Test_admissionControllerFeature_Configure$ github.com/DataDog/datadog-operator/controllers/datadogagent/feature/admissioncontroller

ok  	github.com/DataDog/datadog-operator/controllers/datadogagent/feature/admissioncontroller	0.670s
```

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
