### PR TITLE
Revert "Adding KubeValidation Markers to align Datadog Operator behav…

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v1alpha1/datadogagent_types.go
@@ -54,10 +54,8 @@ type DatadogAgentSpec struct {
 	// +optional
 	ClusterChecksRunner DatadogAgentSpecClusterChecksRunnerSpec `json:"clusterChecksRunner,omitempty"`
 
-	// Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.
+	// Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily.
 	// +optional
-	// +kubebuilder:validation:Pattern=^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
-	// +kubebuilder:validation:MaxLength=80
 	ClusterName string `json:"clusterName,omitempty"`
 
 	// The site of the Datadog intake to send Agent data to.

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -1227,7 +1227,7 @@ func schema__apis_datadoghq_v1alpha1_DatadogAgentSpec(ref common.ReferenceCallba
 					},
 					"clusterName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.",
+							Description: "Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/apis/datadoghq/v2alpha1/datadogagent_types.go
+++ b/apis/datadoghq/v2alpha1/datadogagent_types.go
@@ -828,10 +828,8 @@ type GlobalConfig struct {
 	// ClusterAgentTokenSecret is the secret containing the Cluster Agent token.
 	ClusterAgentTokenSecret *commonv1.SecretConfig `json:"clusterAgentTokenSecret,omitempty"`
 
-	// ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.
+	// ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app.
 	// +optional
-	// +kubebuilder:validation:Pattern=^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
-	// +kubebuilder:validation:MaxLength=80
 	ClusterName *string `json:"clusterName,omitempty"`
 
 	// Site is the Datadog intake site Agent data are sent to.

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -7414,9 +7414,7 @@ spec:
                       x-kubernetes-list-type: atomic
                   type: object
                 clusterName:
-                  description: Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.
-                  maxLength: 80
-                  pattern: ^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
+                  description: Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily.
                   type: string
                 credentials:
                   description: Configure the credentials needed to run Agents. If not set, then the credentials set in the DatadogOperator will be used.
@@ -8547,9 +8545,7 @@ spec:
                         - secretName
                       type: object
                     clusterName:
-                      description: ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.
-                      maxLength: 80
-                      pattern: ^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
+                      description: ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app.
                       type: string
                     containerStrategy:
                       description: 'ContainerStrategy determines whether agents run in a single or multiple containers. Default: ''optimized'''

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogagents.yaml
@@ -7418,9 +7418,7 @@ spec:
                       x-kubernetes-list-type: atomic
                   type: object
                 clusterName:
-                  description: Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.
-                  maxLength: 80
-                  pattern: ^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
+                  description: Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily.
                   type: string
                 credentials:
                   description: Configure the credentials needed to run Agents. If not set, then the credentials set in the DatadogOperator will be used.
@@ -15135,9 +15133,7 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     clusterName:
-                      description: Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.
-                      maxLength: 80
-                      pattern: ^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
+                      description: Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily.
                       type: string
                     credentials:
                       description: Configure the credentials needed to run Agents. If not set, then the credentials set in the DatadogOperator will be used.
@@ -16099,9 +16095,7 @@ spec:
                         - secretName
                       type: object
                     clusterName:
-                      description: ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars.
-                      maxLength: 80
-                      pattern: ^([a-z]([a-z0-9\\-]*[a-z0-9])?\\.)*([a-z]([a-z0-9\\-]*[a-z0-9])?)$
+                      description: ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app.
                       type: string
                     containerStrategy:
                       description: 'ContainerStrategy determines whether agents run in a single or multiple containers. Default: ''optimized'''

--- a/docs/configuration.v1alpha1.md
+++ b/docs/configuration.v1alpha1.md
@@ -443,7 +443,7 @@ spec:
 | clusterChecksRunner.rbac.serviceAccountName | Used to set up the service account name to use. Ignored if the field Create is true. |
 | clusterChecksRunner.replicas | Number of the Cluster Checks Runner replicas. |
 | clusterChecksRunner.tolerations | If specified, the Cluster-Checks pod's tolerations. |
-| clusterName | Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars. |
+| clusterName | Set a unique cluster name to allow scoping hosts and Cluster Checks Runner easily. |
 | credentials.apiKey | APIKey Set this to your Datadog API key before the Agent runs. See also: https://app.datadoghq.com/account/settings#agent/kubernetes |
 | credentials.apiKeyExistingSecret | APIKeyExistingSecret is DEPRECATED. In order to pass the API key through an existing secret, please consider "apiSecret" instead. If set, this parameter takes precedence over "apiKey". |
 | credentials.apiSecret.keyName | KeyName is the key of the secret to use. |

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -153,7 +153,7 @@ spec:
 | global.clusterAgentToken | ClusterAgentToken is the token for communication between the NodeAgent and ClusterAgent. |
 | global.clusterAgentTokenSecret.keyName | KeyName is the key of the secret to use. |
 | global.clusterAgentTokenSecret.secretName | SecretName is the name of the secret. |
-| global.clusterName | ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app. It must be dot-separated tokens where tokens start with a lowercase letter followed by lowercase letters, numbers, or hyphens, cannot end with a hyphen nor have a dot adjacent to a hyphen, and be below 80 chars. |
+| global.clusterName | ClusterName sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app. |
 | global.containerStrategy | ContainerStrategy determines whether agents run in a single or multiple containers. Default: 'optimized' |
 | global.credentials.apiKey | APIKey configures your Datadog API key. See also: https://app.datadoghq.com/account/settings#agent/kubernetes |
 | global.credentials.apiSecret.keyName | KeyName is the key of the secret to use. |


### PR DESCRIPTION
…iour with Helm for invalid clusterName (#1145)"

This reverts commit faef9165915a848a68a6c8f06b6d49451152356d.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

Failing kubevalidation for `clusterName` breaks agent deployments. 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Deploy a DDA with a clusterName that doesn't adhere to convention, i.e. `MY-CLUSTER`, and verify that the agent pod gets created. 

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
