### PR TITLE
[kustomize] update operator manager rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -723,3 +723,9 @@ rules:
     - datadogagentprofiles/finalizers
   verbs:
     - update
+- apiGroups:
+    - ""
+  resources:
+    - pods/exec
+  verbs:
+    - create


### PR DESCRIPTION
### What does this PR do?

Update cluster role for https://github.com/DataDog/datadog-operator/pull/1146

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Deploy the operator with `make deploy`.

Enable `admissionController.cwsInstrumentation` and make sure there are no RBAC errors like the following:

```
{"level":"ERROR","ts":"2024-06-04T18:17:32Z","msg":"Reconciler error","controller":"datadogagent","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgent","datadogAgent":{"name":"datadog","namespace":"system"},"namespace":"system","name":"datadog","reconcileID":"acfb8cb6-e425-4e62-954b-4b2e3e051a63","error":"clusterroles.rbac.authorization.k8s.io \"datadog-cluster-agent\" is forbidden: user \"system:serviceaccount:system:datadog-operator-controller-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"pods/exec\"], Verbs:[\"create\"]}","errorCauses":[{"error":"clusterroles.rbac.authorization.k8s.io \"datadog-cluster-agent\" is forbidden: user \"system:serviceaccount:system:datadog-operator-controller-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"pods/exec\"], Verbs:[\"create\"]}"}]}
```

```
  features:
    admissionController:
      enabled: true
      cwsInstrumentation:
        enabled: true
        mode: "remote_copy"
```
### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
