### PR TITLE
[tooling] update goreleaser skip flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: build --skip-validate --config .goreleaser-for-linux.yaml
+          args: build --skip=validate --config .goreleaser-for-linux.yaml
   build-darwin-binary:
     runs-on: macos-latest
     steps:
@@ -41,7 +41,7 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: build --skip-validate --config .goreleaser-for-darwin.yaml
+          args: build --skip=validate --config .goreleaser-for-darwin.yaml
   build-windows-binary:
     runs-on: ubuntu-latest
     steps:
@@ -58,4 +58,4 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: build --skip-validate --config .goreleaser-for-windows.yaml
+          args: build --skip=validate --config .goreleaser-for-windows.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --skip-publish --config .goreleaser-for-linux.yaml
+          args: release --skip=publish --config .goreleaser-for-linux.yaml
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: release --skip-publish --config .goreleaser-for-darwin.yaml
+          args: release --skip=publish --config .goreleaser-for-darwin.yaml
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload
@@ -106,7 +106,7 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: release --skip-publish --config .goreleaser-for-windows.yaml
+          args: release --skip=publish --config .goreleaser-for-windows.yaml
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload


### PR DESCRIPTION
### What does this PR do?

Update goreleaser args following v2 release according to https://goreleaser.com/deprecations/#-skip

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
