### PR TITLE
[CECO-1184] Add tool version for community operators

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: DD_TOOL_VERSION
+          value: "datadog-operator"
         resources:
           limits:
             cpu: 100m

--- a/hack/patch-bundle.sh
+++ b/hack/patch-bundle.sh
@@ -40,9 +40,11 @@ $YQ -i ".spec.\"replaces\" = \"datadog-operator.v$LATEST_VERSION\"" bundle/manif
 # Add OpenShift version annotation (adding in main bundle as it's used for OpenShift Community)
 $YQ -i ".annotations.\"com.redhat.openshift.versions\" = \"v4.6\"" bundle/metadata/annotations.yaml
 
+# set `DD_TOOL_VERSION` to `redhat`
+$YQ -i "(.spec.install.spec.deployments[] | select(.name == \"datadog-operator-manager\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .env[] | select(.name == \"DD_TOOL_VERSION\") | .value) = \"redhat\"" bundle/manifests/datadog-operator.clusterserviceversion.yaml
+
 # Patch deploymentName, as `operator-sdk generate bundle` sets it to something that doesn't exist
 eval $SED 's/datadog-operator-webhook/datadog-operator-manager/g' bundle/manifests/datadog-operator.clusterserviceversion.yaml
-
 
 # The Operators in k8s-operatorhub/community-operators have slightly different requirements
 COMM_OPS_PATH="bundle-community-operators/"
@@ -51,3 +53,6 @@ cp -R "bundle/" "$COMM_OPS_PATH"
 
 # Delete spec.replaces
 $YQ -i "del(.spec.\"replaces\")" "$COMM_OPS_PATH/manifests/datadog-operator.clusterserviceversion.yaml"
+
+# set `DD_TOOL_VERSION` to `operatorhub`
+$YQ -i "(.spec.install.spec.deployments[] | select(.name == \"datadog-operator-manager\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .env[] | select(.name == \"DD_TOOL_VERSION\") | .value) = \"operatorhub\"" $COMM_OPS_PATH/manifests/datadog-operator.clusterserviceversion.yaml

--- a/hack/redhat-bundle.sh
+++ b/hack/redhat-bundle.sh
@@ -22,6 +22,9 @@ eval $SED -e \'s/operators.operatorframework.io.bundle.package.v1: datadog-opera
 eval $SED \'s#image: gcr.io/datadoghq/operator:#image: registry.connect.redhat.com/datadog/operator:#g\' "$RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml"
 eval $SED \'s#containerImage: gcr.io/datadoghq/operator:#containerImage: registry.connect.redhat.com/datadog/operator:#g\' "$RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml"
 
+# set `DD_TOOL_VERSION` to `redhat`
+$YQ -i "(.spec.install.spec.deployments[] | select(.name == \"datadog-operator-manager\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .env[] | select(.name == \"DD_TOOL_VERSION\") | .value) = \"redhat\"" $RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml
+
 # Pin images
 $ROOT/bin/$PLATFORM/operator-manifest-tools pinning pin "$RH_BUNDLE_PATH/manifests" -a ~/.redhat/auths.json
 
@@ -39,3 +42,6 @@ eval $SED \'s/datadog-operator-certified/datadog-operator-certified-rhmp/g\' "$R
 # Add marketplace annotations in CSV
 $YQ -i '.metadata.annotations."marketplace.openshift.io/remote-workflow" = "https://marketplace.redhat.com/en-us/operators/datadog-operator-certified-rhmp/pricing?utm_source=openshift_console"' $RHMP_BUNDLE_PATH/manifests/datadog-operator-certified-rhmp.clusterserviceversion.yaml
 $YQ -i '.metadata.annotations."marketplace.openshift.io/support-workflow" = "https://marketplace.redhat.com/en-us/operators/datadog-operator-certified-rhmp/support?utm_source=openshift_console"' $RHMP_BUNDLE_PATH/manifests/datadog-operator-certified-rhmp.clusterserviceversion.yaml
+
+# set `DD_TOOL_VERSION` to `redhat`
+$YQ -i "(.spec.install.spec.deployments[] | select(.name == \"datadog-operator-manager\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .env[] | select(.name == \"DD_TOOL_VERSION\") | .value) = \"redhat\"" $RHMP_BUNDLE_PATH/manifests/datadog-operator-certified-rhmp.clusterserviceversion.yaml


### PR DESCRIPTION
### What does this PR do?

Add custom tool version for community operators. Key is `DD_TOOL_VERSION`, value changes based on the bundle:
1. k8s-operatorhub/community-operators: `operatorhub`
2. community-operators-prod: `redhat`
3. redhat-marketplace-operators: `redhat`
4. certified-operators: `redhat`

### Motivation

CECO-1184

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Run the bundle command `make VERSION=X.Y.Z LATEST_VERSION=X.Y.Z bundle` and check that the `DD_TOOL_VERSION` env var is in the `bundle` and `bundle-community-operators` clusterserviceversion files. The `bundle`'s value should be `redhat`. The `bundle-community-operators`'s value should be `operatorhub`
* Run `make bundle-redhat` (X.Y.Z must be an existing image tag in the redhat registry) and check that the `DD_TOOL_VERSION` env var is present in the `bundle-redhat` and `bundle-redhat-marketplace` csv files with value `redhat`

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
