### PR TITLE
[CECO-1154][CECO-1155] Add introspection and dap enabled metrics

### DIFF
--- a/controllers/metrics/const.go
+++ b/controllers/metrics/const.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+const (
+	datadogAgentSubsystem        = "datadogagent"
+	datadogAgentProfileSubsystem = "datadogagentprofile"
+
+	EnabledValue  = 1.0
+	DisabledValue = 0.0
+)

--- a/controllers/metrics/datadogagent.go
+++ b/controllers/metrics/datadogagent.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// introspection enabled
+	IntrospectionEnabled = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: datadogAgentSubsystem,
+			Name:      "introspection_enabled",
+			Help:      "1 if introspection is enabled. 0 if introspection is disabled",
+		},
+	)
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(IntrospectionEnabled)
+}

--- a/controllers/metrics/datadogagentprofile.go
+++ b/controllers/metrics/datadogagentprofile.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// datadogagentprofile enabled
+	DAPEnabled = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: datadogAgentProfileSubsystem,
+			Name:      "enabled",
+			Help:      "1 if DatadogAgentProfiles are enabled. 0 if DatadogAgentProfiles are disabled",
+		},
+	)
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(DAPEnabled)
+}


### PR DESCRIPTION
### What does this PR do?

Adds metrics to indicate whether introspection and dap are enabled or not.

```
# HELP datadogagent_introspection_enabled 1 if introspection is enabled. 0 if introspection is disabled
# TYPE datadogagent_introspection_enabled gauge
datadogagent_introspection_enabled 0
# HELP datadogagentprofile_enabled 1 if DatadogAgentProfiles are enabled. 0 if DatadogAgentProfiles are disabled
# TYPE datadogagentprofile_enabled gauge
datadogagentprofile_enabled 1
```

In app metrics would be:
* `datadog.operator.datadogagent_introspection_enabled`
* `datadog.operator.datadogagentprofile_enabled`

### Motivation

CECO-1154
CECO-1155

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy operator without introspection or profiles enabled. Check that those metrics report `0`
* Enable introspection and/or profiles. Check that the enabled feature(s) now shows metric value `1`

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
