### PR TITLE
feat(probe): add startup probes

### DIFF
--- a/apis/datadoghq/common/common.go
+++ b/apis/datadoghq/common/common.go
@@ -48,6 +48,24 @@ func GetDefaultReadinessProbe() *corev1.Probe {
 	return readinessProbe
 }
 
+// GetDefaultStartupProbe creates a defaulted StartupProbe
+func GetDefaultStartupProbe() *corev1.Probe {
+	startupProbe := &corev1.Probe{
+		InitialDelaySeconds: DefaultStartupProbeInitialDelaySeconds,
+		PeriodSeconds:       DefaultStartupProbePeriodSeconds,
+		TimeoutSeconds:      DefaultStartupProbeTimeoutSeconds,
+		SuccessThreshold:    DefaultStartupProbeSuccessThreshold,
+		FailureThreshold:    DefaultStartupProbeFailureThreshold,
+	}
+	startupProbe.HTTPGet = &corev1.HTTPGetAction{
+		Path: DefaultStartupProbeHTTPPath,
+		Port: intstr.IntOrString{
+			IntVal: DefaultAgentHealthPort,
+		},
+	}
+	return startupProbe
+}
+
 // GetDefaultTraceAgentProbe creates a defaulted liveness/readiness probe for the Trace Agent
 func GetDefaultTraceAgentProbe() *corev1.Probe {
 	probe := &corev1.Probe{

--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -81,13 +81,15 @@ const (
 	// DefaultHelmCheckConf default Helm Check ConfigMap name
 	DefaultHelmCheckConf string = "helm-check-config"
 
+	// DefaultAgentHealthPort default agent health port
+	DefaultAgentHealthPort int32 = 5555
+
 	// Liveness probe default config
 	DefaultLivenessProbeInitialDelaySeconds int32 = 15
 	DefaultLivenessProbePeriodSeconds       int32 = 15
 	DefaultLivenessProbeTimeoutSeconds      int32 = 5
 	DefaultLivenessProbeSuccessThreshold    int32 = 1
 	DefaultLivenessProbeFailureThreshold    int32 = 6
-	DefaultAgentHealthPort                  int32 = 5555
 	DefaultLivenessProbeHTTPPath                  = "/live"
 
 	// Readiness probe default config
@@ -97,6 +99,14 @@ const (
 	DefaultReadinessProbeSuccessThreshold    int32 = 1
 	DefaultReadinessProbeFailureThreshold    int32 = 6
 	DefaultReadinessProbeHTTPPath                  = "/ready"
+
+	// Startup probe default config
+	DefaultStartupProbeInitialDelaySeconds int32 = 15
+	DefaultStartupProbePeriodSeconds       int32 = 15
+	DefaultStartupProbeTimeoutSeconds      int32 = 5
+	DefaultStartupProbeSuccessThreshold    int32 = 1
+	DefaultStartupProbeFailureThreshold    int32 = 6
+	DefaultStartupProbeHTTPPath                  = "/startup"
 
 	// Default Image name
 	DefaultAgentImageName        string = "agent"

--- a/controllers/datadogagent/agent_test.go
+++ b/controllers/datadogagent/agent_test.go
@@ -126,6 +126,24 @@ func defaultReadinessProbe() *corev1.Probe {
 	}
 }
 
+func defaultStartupProbe() *corev1.Probe {
+	return &corev1.Probe{
+		InitialDelaySeconds: 15,
+		PeriodSeconds:       15,
+		TimeoutSeconds:      5,
+		SuccessThreshold:    1,
+		FailureThreshold:    6,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/startup",
+				Port: intstr.IntOrString{
+					IntVal: 5555,
+				},
+			},
+		},
+	}
+}
+
 func defaultVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{

--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -61,6 +61,7 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 				},
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
+				StartupProbe:   defaultStartupProbe(),
 				SecurityContext: &corev1.SecurityContext{
 					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(true),
 					AllowPrivilegeEscalation: apiutils.NewBoolPointer(false),

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -155,6 +155,7 @@ func coreAgentContainer(dda metav1.Object) corev1.Container {
 		VolumeMounts:   volumeMountsForCoreAgent(),
 		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
 		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+		StartupProbe:   apicommon.GetDefaultStartupProbe(),
 	}
 }
 

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -102,6 +102,7 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				VolumeMounts:   volumeMounts,
 				LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
 				ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+				StartupProbe:   apicommon.GetDefaultStartupProbe(),
 				Command:        nil,
 				Args:           nil,
 				SecurityContext: &corev1.SecurityContext{

--- a/controllers/datadogagent/component/clusteragent/default_test.go
+++ b/controllers/datadogagent/component/clusteragent/default_test.go
@@ -80,6 +80,7 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 				},
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
+				StartupProbe:   defaultStartupProbe(),
 				SecurityContext: &corev1.SecurityContext{
 					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(true),
 					AllowPrivilegeEscalation: apiutils.NewBoolPointer(false),
@@ -183,6 +184,24 @@ func defaultReadinessProbe() *corev1.Probe {
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/ready",
+				Port: intstr.IntOrString{
+					IntVal: 5555,
+				},
+			},
+		},
+	}
+}
+
+func defaultStartupProbe() *corev1.Probe {
+	return &corev1.Probe{
+		InitialDelaySeconds: 15,
+		PeriodSeconds:       15,
+		TimeoutSeconds:      5,
+		SuccessThreshold:    1,
+		FailureThreshold:    6,
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/startup",
 				Port: intstr.IntOrString{
 					IntVal: 5555,
 				},

--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -233,6 +233,7 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				},
 				LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
 				ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+				StartupProbe:   apicommon.GetDefaultStartupProbe(),
 				SecurityContext: &corev1.SecurityContext{
 					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(true),
 					AllowPrivilegeEscalation: apiutils.NewBoolPointer(false),


### PR DESCRIPTION
### What does this PR do?

Adds Kubernetes startup probe support for:
* Agent
* Cluster Agent
* Cluster Check Runner

### Motivation

This is needed to add support for the new Kubernetes Startup probe for the Agent components.

### Additional Notes

Note that currently the `/startup` endpoint is returning the default `/health` endpoint. Support for the dedicated `/startup` endpoint has been added in Agent `7.55`. No components currently register a startup health check.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy the Operator
```
➜  datadog-dev git:(main) ✗ k get pod
NAME                                             READY   STATUS    RESTARTS   AGE
datadog-agent-8mmmp                              5/5     Running   0          4m10s
datadog-cluster-agent-6f58f64977-pjvhs           1/1     Running   0          4m11s
datadog-cluster-checks-runner-7f6b8b574d-rhtdk   1/1     Running   0          4m11s
datadog-operator-manager-584b8d9498-sx8bd        1/1     Running   0          4m32s
```
* Check the startup probes.
* * For the Agent
```
➜  datadog-dev git:(main) ✗ k describe pod datadog-agent-8mmmp | grep Startup
    Startup:        http-get http://:5555/startup delay=15s timeout=5s period=15s #success=1 #failure=6
```
* * For the Cluster Agent
```
➜  datadog-dev git:(main) ✗ k describe pod datadog-cluster-agent-6f58f64977-pjvhs| grep Startup
    Startup:        http-get http://:5555/startup delay=15s timeout=5s period=15s #success=1 #failure=6
```
* * For the Cluster Check Runner
```
➜  datadog-dev git:(main) ✗ k describe pod datadog-cluster-checks-runner-7f6b8b574d-rhtdk| grep Startup
    Startup:        http-get http://:5555/startup delay=15s timeout=5s period=15s #success=1 #failure=6
```

We can also make sure that the endpoints are working as intended.
* * For the Agent
```
➜  datadog-dev git:(main) ✗ k exec -it daemonsets/datadog-agent -- curl http://localhost:5555/startup
Defaulted container "agent" out of: agent, trace-agent, security-agent, system-probe, process-agent, init-volume (init), init-config (init), seccomp-setup (init)
{"Healthy":["healthcheck","ad-config-provider-kubernetes-container-allinone","tagger-store","ad-kubeletlistener","collector-queue-15s","collector-queue-900s","ad-servicelistening","tagger-workloadmeta","workloadmeta-store","logs-agent","collector-queue-20s","ad-config-provider-endpoints-checks","aggregator","workloadmeta-puller","workloadmeta-docker","dogstatsd-main"],"Unhealthy":null}%
```
* * For the Cluster Agent
```
➜  datadog-dev git:(main) ✗ k exec -it deployments/datadog-cluster-agent -- curl http://localhost:5555/startup
{"Healthy":["healthcheck","ad-servicelistening","tagger-workloadmeta","clusterchecks-leadership","clusterchecks-dispatch","aggregator","workloadmeta-puller","tagger-store","collector-queue-15s","ad-config-provider-kubernetes-services","ad-config-provider-kubernetes-endpoints","workloadmeta-store"],"Unhealthy":null}%
```
* * For the Cluster Check Runner
```
➜  datadog-dev git:(main) ✗ k exec -it deployments/datadog-cluster-checks-runner -- curl http://localhost:5555/startup
Defaulted container "agent" out of: agent, init-config (init)
{"Healthy":["healthcheck","collector-queue-10s","ad-servicelistening","aggregator","workloadmeta-store","workloadmeta-puller","ad-config-provider-cluster-checks","collector-queue-15s"],"Unhealthy":null}%
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
