### PR TITLE
Set LeaderElectionResourceLock to `leases` and remove `leader-election-resource` parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,7 +106,6 @@ type options struct {
 
 	// Leader Election options
 	enableLeaderElection        bool
-	leaderElectionResourceLock  string
 	leaderElectionLeaseDuration time.Duration
 
 	// Controllers options
@@ -149,7 +148,6 @@ func (opts *options) Parse() {
 	// Leader Election options flags
 	flag.BoolVar(&opts.enableLeaderElection, "enable-leader-election", true,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&opts.leaderElectionResourceLock, "leader-election-resource", resourcelock.ConfigMapsLeasesResourceLock, "determines which resource lock to use for leader election. option:[configmapsleases|endpointsleases|leases]")
 	flag.DurationVar(&opts.leaderElectionLeaseDuration, "leader-election-lease-duration", 60*time.Second, "Define LeaseDuration as well as RenewDeadline (leaseDuration / 2) and RetryPeriod (leaseDuration / 4)")
 
 	// Custom flags
@@ -242,7 +240,7 @@ func run(opts *options) error {
 		Port:                       9443,
 		LeaderElection:             opts.enableLeaderElection,
 		LeaderElectionID:           "datadog-operator-lock",
-		LeaderElectionResourceLock: opts.leaderElectionResourceLock,
+		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              &opts.leaderElectionLeaseDuration,
 		RenewDeadline:              &renewDeadline,
 		RetryPeriod:                &retryPeriod,


### PR DESCRIPTION
### What does this PR do?

In Operator v1.8 we will upgrade `controller-runtime` and Kubernetes API dependencies which only supports `leases` as leader election resource lock.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
