### PR TITLE
chore(devcontainer): improve devcontainer and upgrade Go version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,8 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-	"name": "Go",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:0-1.19",
+	"image": "mcr.microsoft.com/devcontainers/go:1.21-bookworm",
 	"features": {
-		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
-		"ghcr.io/devcontainers-contrib/features/kubectx-kubens": {},
-		"ghcr.io/mpriscella/features/kind": {}
-	}
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "go version",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+	},
+	"runArgs": ["--name", "datadog-operator-devenv", "-w", "/workspaces/datadog-operator"],
+	"postStartCommand": ["git", "config", "--global", "--add", "safe.directory", "/workspaces/datadog-operator"]
 }


### PR DESCRIPTION
### What does this PR do?

Fixes and updates the Development Container to the current Go version and add some configurations to ease development process.

### Motivation

The current dev container does not work with the following error messages:
```
bin/linux-aarch64/openapi-gen: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by bin/linux-aarch64/openapi-gen)
bin/linux-aarch64/openapi-gen: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by bin/linux-aarch64/openapi-gen)
```

It is also out-dated.

### Describe your test plan

Build the devcontainer
```
➜  datadog-operator git:(wassim.dhif/devcontainer) devcontainer up --workspace-folder .
[1 ms] @devcontainers/cli 0.64.0. Node.js v22.2.0. darwin 23.5.0 arm64.
[312 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/docker-outside-of-docker:1'...
[1209 ms] Soft-dependency 'ghcr.io/devcontainers/features/common-utils' is not required.  Removing from installation order...
[1480 ms] Start: Run: docker buildx build --load --build-context dev_containers_feature_content_source=/var/folders/b2/5s4rmrnj0q75ppwfh2kx_hwr0000gq/T/devcontainercli/container-features/0.64.0-1718791249376 --build-arg _DEV_CONTAINERS_BASE_IMAGE=mcr.microsoft.com/devcontainers/go:1.21-bookworm --build-arg _DEV_CONTAINERS_IMAGE_USER=root --build-arg _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp --target dev_containers_target_stage -f /var/folders/b2/5s4rmrnj0q75ppwfh2kx_hwr0000gq/T/devcontainercli/container-features/0.64.0-1718791249376/Dockerfile.extended -t vsc-datadog-operator-9c5538ef92da03806392d41aeb049ec4df76619fcb08febfdbbd476fa6ec9248-features /var/folders/b2/5s4rmrnj0q75ppwfh2kx_hwr0000gq/T/devcontainercli/empty-folder
[+] Building 0.6s (15/15) FINISHED                                                                                                       docker:desktop-linux
 => [internal] load build definition from Dockerfile.extended                                                                                            0.0s
 => => transferring dockerfile: 2.79kB                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1.4                                                                              0.4s
 => CACHED docker-image://docker.io/docker/dockerfile:1.4@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc                        0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 => [internal] load metadata for mcr.microsoft.com/devcontainers/go:1.21-bookworm                                                                        0.0s
 => [context dev_containers_feature_content_source] load .dockerignore                                                                                   0.0s
 => => transferring dev_containers_feature_content_source: 2B                                                                                            0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                     0.0s
 => => transferring dev_containers_feature_content_source: 39.64kB                                                                                       0.0s
 => [dev_containers_feature_content_normalize 1/3] FROM mcr.microsoft.com/devcontainers/go:1.21-bookworm                                                 0.0s
 => CACHED [dev_containers_target_stage 2/5] RUN mkdir -p /tmp/dev-container-features                                                                    0.0s
 => CACHED [dev_containers_feature_content_normalize 2/3] COPY --from=dev_containers_feature_content_source devcontainer-features.builtin.env /tmp/buil  0.0s
 => CACHED [dev_containers_feature_content_normalize 3/3] RUN chmod -R 0755 /tmp/build-features/                                                         0.0s
 => CACHED [dev_containers_target_stage 3/5] COPY --from=dev_containers_feature_content_normalize /tmp/build-features/ /tmp/dev-container-features       0.0s
 => CACHED [dev_containers_target_stage 4/5] RUN echo "_CONTAINER_USER_HOME=$( (command -v getent >/dev/null 2>&1 && getent passwd 'root' || grep -E '^  0.0s
 => CACHED [dev_containers_target_stage 5/5] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=docker-outside-of-docker_0,target=  0.0s
 => exporting to image                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                  0.0s
 => => writing image sha256:f57782e9ccf9f019fcdcba1aa31f1f0bc0e9947ea1e6244dda38a29f676ab3d4                                                             0.0s
 => => naming to docker.io/library/vsc-datadog-operator-9c5538ef92da03806392d41aeb049ec4df76619fcb08febfdbbd476fa6ec9248-features                        0.0s
[2288 ms] Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,source=/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator,target=/workspaces/datadog-operator,consistency=cached --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker-host.sock -l devcontainer.local_folder=/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator -l devcontainer.config_file=/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator/.devcontainer/devcontainer.json --name datadog-operator-devenv -w /workspaces/datadog-operator --init --cap-add SYS_PTRACE --security-opt seccomp=unconfined --entrypoint /bin/sh vsc-datadog-operator-9c5538ef92da03806392d41aeb049ec4df76619fcb08febfdbbd476fa6ec9248-features -c echo Container started
Container started
Running the postAttachCommand from devcontainer.json...


What's next?
  Try Docker Debug for seamless, persistent debugging tools in any container or image → docker debug 987c00a5d8b6e5298bad558eb9f23caeee70d43ae7654959737aaf00b370cdad
  Learn more at https://docs.docker.com/go/debug-cli/
{"outcome":"success","containerId":"987c00a5d8b6e5298bad558eb9f23caeee70d43ae7654959737aaf00b370cdad","remoteUser":"vscode","remoteWorkspaceFolder":"/workspaces/datadog-operator"}
```

Exec into the devcontainer
```
➜  datadog-operator git:(wassim.dhif/devcontainer) docker exec -it datadog-operator-devenv bash
root ➜ /workspaces/datadog-operator $ make
Usage: make <OPTIONS> ... <TARGETS>

Available targets are:


Usage:
  make <target>

Development
  all                        Build test
  build                      Builds manager + kubectl plugin
  fmt                        Run go fmt against code
  vet                        Run go vet against code
  echo-img                   Use `make -s echo-img` to get image string for other shell commands

Tools

Deploy
  manager                    Build manager binary
  managergobuild             Builds only manager go binary

Deploy
  manager                    Build manager binary
  run                        Run against the configured Kubernetes cluster in ~/.kube/config
  install                    Install CRDs into a cluster
  uninstall                  Uninstall CRDs from a cluster
  deploy                     Deploy controller in the configured Kubernetes cluster in ~/.kube/config
  undeploy                   Undeploy controller from the K8s cluster specified in ~/.kube/config.
  manifests                  Generate manifestcd s e.g. CRD, RBAC etc.
  generate                   Generate code

Test
  test                       Run unit tests and E2E tests
  integration-tests          Run tests.
  integration-tests-v2       Run tests with reconciler V2
  bundle                     Generate bundle manifests and metadata, then validate generated files.
  bundle-build-push          Build and load the bundle image.
  opm                        Download opm locally if necessary.
  catalog-build              Build a catalog image.
  catalog-push               Push a catalog image.

Datadog Custom part
  patch-crds                 Patch-crds
  lint                       Lint
  verify-licenses            Verify licenses
  tidy                       Run go tidy
  publish-community-bundles  Publish bundles to community repositories
  help                       Show this help screen.
```

Build the datadog-operator
```
root ➜ /workspaces/datadog-operator (wassim.dhif/upgrade-devcontainer) $ make IMG=wdhifdatadog/operator:test IMG_CHECK=wdhifdatadog/check-operator:test docker-build
bin/linux-aarch64/openapi-gen --logtostderr=true -o "./" -i ./apis/datadoghq/v1alpha1 -O zz_generated.openapi -p ./apis/datadoghq/v1alpha1 -h ./hack/boilerplate.go.txt -r "-"
API rule violation: list_type_missing,./apis/datadoghq/v1alpha1,DatadogMonitorOptions,NotifyBy
API rule violation: names_match,./apis/datadoghq/v1alpha1,DatadogMonitorDowntimeStatus,DowntimeID
API rule violation: names_match,./apis/datadoghq/v1alpha1,DatadogMonitorStatus,MonitorStateSyncStatus
bin/linux-aarch64/openapi-gen --logtostderr=true -o "./" -i ./apis/datadoghq/v2alpha1 -O zz_generated.openapi -p ./apis/datadoghq/v2alpha1 -h ./hack/boilerplate.go.txt -r "-"
bin/linux-aarch64/controller-gen "crd:preserveUnknownFields=false",crdVersions=v1 rbac:roleName=manager-role webhook paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1
bin/linux-aarch64/controller-gen "crd:preserveUnknownFields=false",crdVersions=v1beta1 rbac:roleName=manager-role webhook paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1beta1
hack/patch-crds.sh
go run ./hack/generate-docs.go
bin/linux-aarch64/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./apis/.."
docker build . -t wdhifdatadog/operator:test --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=3c42990b210b2834055232cd5a7f968a587ae819 -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.7.0-rc.3_3c42990b -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-06-19/11:41:26" --build-arg GOARCH=""
[+] Building 69.0s (27/27) FINISHED                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 1.51kB                                                                                                                   0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi-minimal:latest                                                                      0.4s
 => [internal] load metadata for docker.io/library/golang:1.21                                                                                           1.6s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 66B                                                                                                                         0.0s
 => [internal] load build context                                                                                                                        0.1s
 => => transferring context: 649.95kB                                                                                                                    0.1s
 => [builder  1/12] FROM docker.io/library/golang:1.21@sha256:2eb85b8942c29145b4a5bed2d0f3dc1a3ba2f823aec74afe16751da108a585e1                          28.9s
 => => resolve docker.io/library/golang:1.21@sha256:2eb85b8942c29145b4a5bed2d0f3dc1a3ba2f823aec74afe16751da108a585e1                                     0.0s
 => => sha256:1e60a453843e00d6f3d4242dbd696365f0894e3ca2f02f4ce1ab098d7ff7907f 49.61MB / 49.61MB                                                        21.2s
 => => sha256:aec3010487a0b12c3d3f9f816fa02885bf77adc808c51f1537f86535ce7630ae 2.33kB / 2.33kB                                                           0.0s
 => => sha256:ee55db4bbb11b34c961dc0ee45e08eed865d8dace8dba8c5b804ccf8c0a9bdc1 2.86kB / 2.86kB                                                           0.0s
 => => sha256:4dadad3edfd860d6d4fd52d4cbf17e7431a88d64161c62654786e60f331343a8 23.59MB / 23.59MB                                                         3.6s
 => => sha256:51cd5f8f608f832afd85dc82fbac4aea05183fd7fccf555dd4a53a4bbe06b013 63.99MB / 63.99MB                                                        21.6s
 => => sha256:2eb85b8942c29145b4a5bed2d0f3dc1a3ba2f823aec74afe16751da108a585e1 9.75kB / 9.75kB                                                           0.0s
 => => sha256:a8df69f15c51d1fa8f80fac8aa3783284f02e1cb10fb38d294be12a39a814e30 86.25MB / 86.25MB                                                        12.5s
 => => sha256:f25e25a1338cd9a74320d3614da987b4eee0d8fb2408a8d4ffdfe3322d412fd4 64.11MB / 64.11MB                                                        20.4s
 => => sha256:8bf1f3ab454abe873b1a5ce2cd1c82cf92990da3831b93035475749cb99e15e8 127B / 127B                                                              20.7s
 => => sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B                                                                20.9s
 => => extracting sha256:1e60a453843e00d6f3d4242dbd696365f0894e3ca2f02f4ce1ab098d7ff7907f                                                                1.4s
 => => extracting sha256:4dadad3edfd860d6d4fd52d4cbf17e7431a88d64161c62654786e60f331343a8                                                                0.4s
 => => extracting sha256:51cd5f8f608f832afd85dc82fbac4aea05183fd7fccf555dd4a53a4bbe06b013                                                                1.5s
 => => extracting sha256:a8df69f15c51d1fa8f80fac8aa3783284f02e1cb10fb38d294be12a39a814e30                                                                1.3s
 => => extracting sha256:f25e25a1338cd9a74320d3614da987b4eee0d8fb2408a8d4ffdfe3322d412fd4                                                                2.7s
 => => extracting sha256:8bf1f3ab454abe873b1a5ce2cd1c82cf92990da3831b93035475749cb99e15e8                                                                0.0s
 => => extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1                                                                0.0s
 => CACHED [stage-1 1/9] FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5  0.0s
 => [builder  2/12] WORKDIR /workspace                                                                                                                   0.6s
 => [builder  3/12] COPY go.mod go.mod                                                                                                                   0.0s
 => [builder  4/12] COPY go.sum go.sum                                                                                                                   0.0s
 => [builder  5/12] RUN go mod download                                                                                                                 18.2s
 => [builder  6/12] COPY main.go main.go                                                                                                                 0.0s
 => [builder  7/12] COPY apis/ apis/                                                                                                                     0.0s
 => [builder  8/12] COPY controllers/ controllers/                                                                                                       0.0s
 => [builder  9/12] COPY pkg/ pkg/                                                                                                                       0.0s
 => [builder 10/12] COPY cmd/helpers/ cmd/helpers/                                                                                                       0.0s
 => [builder 11/12] RUN CGO_ENABLED=0 GOOS=linux GOARCH= GO111MODULE=on go build -a -ldflags "-w -s -X github.com/DataDog/datadog-operator/pkg/version  15.1s
 => [builder 12/12] RUN CGO_ENABLED=0 GOOS=linux GOARCH= GO111MODULE=on go build -a -ldflags "-w -s -X github.com/DataDog/datadog-operator/pkg/version.  3.8s
 => [stage-1 2/9] COPY --from=builder /workspace/manager .                                                                                               0.1s
 => [stage-1 3/9] COPY --from=builder /workspace/helpers .                                                                                               0.1s
 => [stage-1 4/9] COPY scripts/readsecret.sh .                                                                                                           0.0s
 => [stage-1 5/9] RUN chmod 550 readsecret.sh && chmod 550 helpers                                                                                       0.1s
 => [stage-1 6/9] RUN mkdir -p /licences                                                                                                                 0.1s
 => [stage-1 7/9] COPY ./LICENSE ./LICENSE-3rdparty.csv /licenses/                                                                                       0.0s
 => [stage-1 8/9] RUN chmod -R 755 /licences                                                                                                             0.1s
 => exporting to image                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                  0.1s
 => => writing image sha256:a341ae71e958c5adf285dd43d4611dad1245a19c03061b1d79da0d0db8327ca2                                                             0.0s
 => => naming to docker.io/wdhifdatadog/operator:test                                                                                                    0.0s
docker build . -t wdhifdatadog/check-operator:test -f check-operator.Dockerfile --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=3c42990b210b2834055232cd5a7f968a587ae819 -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.7.0-rc.3_3c42990b -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-06-19/11:42:36" --build-arg GOARCH=""
[+] Building 13.9s (17/17) FINISHED                                                                                                            docker:default
 => [internal] load build definition from check-operator.Dockerfile                                                                                      0.0s
 => => transferring dockerfile: 808B                                                                                                                     0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:latest                                                                      0.2s
 => [internal] load metadata for docker.io/library/golang:1.21                                                                                           0.4s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 66B                                                                                                                         0.0s
 => [builder 1/9] FROM docker.io/library/golang:1.21@sha256:2eb85b8942c29145b4a5bed2d0f3dc1a3ba2f823aec74afe16751da108a585e1                             0.0s
 => CACHED [stage-1 1/3] FROM registry.access.redhat.com/ubi8/ubi-minimal:latest@sha256:5f1cd3422d5d46aea35dac80825dbcbd58213eef49c317f42a394345fb4e8ff  0.0s
 => [internal] load build context                                                                                                                        0.0s
 => => transferring context: 23.55kB                                                                                                                     0.0s
 => CACHED [builder 2/9] WORKDIR /workspace                                                                                                              0.0s
 => CACHED [builder 3/9] COPY go.mod go.mod                                                                                                              0.0s
 => CACHED [builder 4/9] COPY go.sum go.sum                                                                                                              0.0s
 => CACHED [builder 5/9] RUN go mod download                                                                                                             0.0s
 => [builder 6/9] COPY cmd/check-operator/ cmd/check-operator/                                                                                           0.0s
 => [builder 7/9] COPY apis/ apis/                                                                                                                       0.0s
 => [builder 8/9] COPY pkg/ pkg/                                                                                                                         0.0s
 => [builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH= GO111MODULE=on go build -a -ldflags "-w -s -X github.com/DataDog/datadog-operator/pkg/version.C  13.2s
 => [stage-1 2/3] COPY --from=builder /workspace/check-operator .                                                                                        0.0s
 => exporting to image                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                  0.1s
 => => writing image sha256:260be1de84d0a820a8bbec891b1afabf4ff0166b7e8a5affde99ccb4acddc002                                                             0.0s
 => => naming to docker.io/wdhifdatadog/check-operator:test                                                                                              0.0s
root ➜ /workspaces/datadog-operator (wassim.dhif/upgrade-devcontainer) $ make IMG=wdhifdatadog/operator:test IMG_CHECK=wdhifdatadog/check-operator:test dock
er-push
docker push wdhifdatadog/operator:test
The push refers to repository [docker.io/wdhifdatadog/operator]
074089eb9746: Layer already exists
858463ba7119: Layer already exists
f89bb9abef63: Layer already exists
985c6c030816: Layer already exists
32b70e74850d: Layer already exists
d7ae63e615f8: Layer already exists
53ce7ccd4662: Layer already exists
test: digest: sha256:9348de7421790bbfdfcdbaa5e482159a2ef13d349559119e1c498d94331e2783 size: 1990
docker push wdhifdatadog/check-operator:test
The push refers to repository [docker.io/wdhifdatadog/check-operator]
9584deaf4383: Layer already exists
816dd1ed75e1: Layer already exists
test: digest: sha256:253155ca7199a0d9c56154456767dc48af2b023be038ecc89b70ff5c633c8dab size: 741
```

Deploy the datadog-operator
```
➜  datadog-operator git:(wassim.dhif/devcontainer) ✗ make IMG=wdhifdatadog/operator:test IMG_CHECK=wdhifdatadog/operator-check:test deploy && kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY --from-literal app-key=$DD_APP_KEY --namespace system && kubectl config set-context --current --namespace=system
bin/darwin-arm64/controller-gen "crd:preserveUnknownFields=false",crdVersions=v1 rbac:roleName=manager-role webhook paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1
bin/darwin-arm64/controller-gen "crd:preserveUnknownFields=false",crdVersions=v1beta1 rbac:roleName=manager-role webhook paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1beta1
hack/patch-crds.sh
cd config/manager && /Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator//bin/darwin-arm64/kustomize edit set image controller=wdhifdatadog/operator:test
bin/darwin-arm64/kustomize build config/default | kubectl apply --force-conflicts --server-side -f -
namespace/system serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogagentprofiles.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogagents.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogmetrics.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogmonitors.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogslos.datadoghq.com serverside-applied
serviceaccount/datadog-operator-controller-manager serverside-applied
role.rbac.authorization.k8s.io/datadog-operator-leader-election-role serverside-applied
clusterrole.rbac.authorization.k8s.io/datadog-operator-manager-role serverside-applied
rolebinding.rbac.authorization.k8s.io/datadog-operator-leader-election-rolebinding serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/datadog-operator-manager-rolebinding serverside-applied
deployment.apps/datadog-operator-manager serverside-applied
secret/datadog-secret created
Context "wassim-minikube" modified.
➜  datadog-operator git:(wassim.dhif/devcontainer) ✗ k get pod
NAME                                        READY   STATUS    RESTARTS   AGE
datadog-operator-manager-584b8d9498-jr7rw   1/1     Running   0          30s
```

### Additional Notes

The devcontainer does not have access to Minikube/Kind/Kubernetes for now as it needed more configurations that just adding the feature, deployment should be done from outside the devcontainer.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
