### PR TITLE
Stop generating `v1beta1` CRD versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,6 @@ manifests: generate-manifests patch-crds ## Generate manifestcd s e.g. CRD, RBAC
 .PHONY: generate-manifests
 generate-manifests: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) $(CRD_OPTIONS),crdVersions=v1 rbac:roleName=manager-role paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1
-	$(CONTROLLER_GEN) $(CRD_OPTIONS),crdVersions=v1beta1 rbac:roleName=manager-role paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1beta1
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) generate-openapi generate-docs ## Generate code


### PR DESCRIPTION
### What does this PR do?

With this change Operator will stop updating `v1beta1` versions of the CRDs but they will be kept in the repo.

`v1beta1` CRD versions will be removed in the Operator v1.10. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
