### PR TITLE
[gitlab] add support for multiarch images in redhat

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,42 +173,6 @@ build_bundle_image:
     - if [ -n "$CI_COMMIT_TAG" ]; then docker buildx imagetools create $TARGET_IMAGE --tag $RELEASE_IMAGE; fi
 
 
-preflight_redhat_image_amd64:
-  stage: test-image
-  rules:
-    - if: $CI_COMMIT_TAG
-      when: on_success
-    - when: never
-  tags:
-    - "arch:amd64"
-  image: $JOB_DOCKER_IMAGE
-  variables:
-    IMG: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
-  script:
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - export IMG_PLATFORM=linux/amd64
-    - make preflight-redhat-container
-
-
-preflight_redhat_image_arm64:
-  stage: test-image
-  rules:
-    - if: $CI_COMMIT_TAG
-      when: on_success
-    - when: never
-  tags:
-    - "arch:amd64"
-  image: $JOB_DOCKER_IMAGE
-  variables:
-    IMG: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
-  script:
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - export IMG_PLATFORM=linux/arm64
-    - make preflight-redhat-container
-
-
 publish_public_main:
   stage: release
   rules:
@@ -247,9 +211,6 @@ publish_redhat_public_tag:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  needs:
-    - "preflight_redhat_image_amd64"
-    - "preflight_redhat_image_arm64"
   trigger:
     project: DataDog/public-images
     branch: main
@@ -283,9 +244,6 @@ publish_redhat_public_latest:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  needs:
-    - "preflight_redhat_image_amd64"
-    - "preflight_redhat_image_arm64"
   trigger:
     project: DataDog/public-images
     branch: main
@@ -439,7 +397,8 @@ e2e:
     - IMAGE_PULL_PASSWORD=$(aws ecr get-login-password) IMG=$TARGET_IMAGE make e2e-tests
 
 
-submit_preflight_redhat_image_amd64:
+# Preflight now supports multiarch image checks
+submit_preflight_redhat_image:
   stage: post-release
   rules:
     - if: $CI_COMMIT_TAG
@@ -454,25 +413,6 @@ submit_preflight_redhat_image_amd64:
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-    - export IMG_PLATFORM=linux/amd64
-    - make preflight-redhat-container-submit
-
-submit_preflight_redhat_image_arm64:
-  stage: post-release
-  rules:
-    - if: $CI_COMMIT_TAG
-      when: manual
-    - when: never
-  needs:
-    - "publish_redhat_public_tag"
-  tags: ["runner:docker", "size:large"]
-  image: $JOB_DOCKER_IMAGE
-  script:
-    - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
-    - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-    - export IMG_PLATFORM=linux/arm64
     - make preflight-redhat-container-submit
 
 publish_community_operators:
@@ -482,8 +422,7 @@ publish_community_operators:
         when: manual
       - when: never
   needs:
-    - "submit_preflight_redhat_image_amd64"
-    - "submit_preflight_redhat_image_arm64"
+    - "submit_preflight_redhat_image"
   tags: [ "runner:docker", "size:large" ]
   image: $JOB_DOCKER_IMAGE
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,6 +187,25 @@ preflight_redhat_image_amd64:
   script:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - export ARCH=linux/amd64
+    - make preflight-redhat-container
+
+
+preflight_redhat_image_arm64:
+  stage: test-image
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: on_success
+    - when: never
+  tags:
+    - "arch:amd64"
+  image: $JOB_DOCKER_IMAGE
+  variables:
+    IMG: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
+  script:
+    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
+    - export ARCH=linux/arm64
     - make preflight-redhat-container
 
 
@@ -222,7 +241,6 @@ publish_public_tag:
     IMG_DESTINATIONS_REGEX_REPL: ':'
     IMG_SIGNING: "false"
 
-# RedHat does not support multi-arch images. Use docker commands in lieu of DataDog/public-images until they do.
 publish_redhat_public_tag:
   stage: release
   rules:
@@ -231,30 +249,18 @@ publish_redhat_public_tag:
     - when: never
   needs:
     - "preflight_redhat_image_amd64"
-  tags: ["runner:docker", "size:large"]
-  image: $JOB_DOCKER_IMAGE
-  script:
-    - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
-    # Docker login to pull build image
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-    # Docker login to push image to Redhat
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
-    - docker push $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-
-  # Save for future use with public-images.
-  # trigger:
-  #   project: DataDog/public-images
-  #   branch: main
-  #   strategy: depend
-  # variables:
-  #   IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-  #   IMG_DESTINATIONS: operator:$CI_COMMIT_TAG
-  #   IMG_DESTINATIONS_REGEX: ':v'
-  #   IMG_DESTINATIONS_REGEX_REPL: ':'
-  #   IMG_REGISTRIES: redhat-operator
+    - "preflight_redhat_image_arm64"
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
+    IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:$CI_COMMIT_TAG
+    IMG_DESTINATIONS_REGEX: ':v'
+    IMG_DESTINATIONS_REGEX_REPL: ':'
+    IMG_REGISTRIES: redhat-operator
+    IMG_SIGNING: "false"
 
 publish_public_latest:
   stage: release
@@ -271,7 +277,6 @@ publish_public_latest:
     IMG_DESTINATIONS: operator:latest
     IMG_SIGNING: "false"
 
-# RedHat does not support multi-arch images. Use docker commands in lieu of DataDog/public-images until they do.
 publish_redhat_public_latest:
   stage: release
   rules:
@@ -280,18 +285,16 @@ publish_redhat_public_latest:
     - when: never
   needs:
     - "preflight_redhat_image_amd64"
-  tags: ["runner:docker", "size:large"]
-  image: $JOB_DOCKER_IMAGE
-  script:
-    - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
-    # Docker login to pull build image
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - docker pull --platform linux/amd64 $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-    - docker tag $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64 $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:latest
-    # Docker login to push image to Redhat
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login -u "$RH_PARTNER_REGISTRY_USER" quay.io --password-stdin
-    - docker push $RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:latest
+    - "preflight_redhat_image_arm64"
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
+    IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:latest
+    IMG_REGISTRIES: redhat-operator
+    IMG_SIGNING: "false"
 
 trigger_internal_operator_image:
   stage: release
@@ -435,7 +438,8 @@ e2e:
   script:
     - IMAGE_PULL_PASSWORD=$(aws ecr get-login-password) IMG=$TARGET_IMAGE make e2e-tests
 
-submit_preflight_redhat_public_tag:
+
+submit_preflight_redhat_image_amd64:
   stage: post-release
   rules:
     - if: $CI_COMMIT_TAG
@@ -450,8 +454,26 @@ submit_preflight_redhat_public_tag:
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
+    - export ARCH=linux/amd64
     - make preflight-redhat-container-submit
 
+submit_preflight_redhat_image_arm64:
+  stage: post-release
+  rules:
+    - if: $CI_COMMIT_TAG
+      when: manual
+    - when: never
+  needs:
+    - "publish_redhat_public_tag"
+  tags: ["runner:docker", "size:large"]
+  image: $JOB_DOCKER_IMAGE
+  script:
+    - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
+    - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
+    - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
+    - export ARCH=linux/arm64
+    - make preflight-redhat-container-submit
 
 publish_community_operators:
   stage: post-release
@@ -460,7 +482,8 @@ publish_community_operators:
         when: manual
       - when: never
   needs:
-    - "submit_preflight_redhat_public_tag"
+    - "submit_preflight_redhat_image_amd64"
+    - "submit_preflight_redhat_image_arm64"
   tags: [ "runner:docker", "size:large" ]
   image: $JOB_DOCKER_IMAGE
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,7 +187,7 @@ preflight_redhat_image_amd64:
   script:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - export ARCH=linux/amd64
+    - export IMG_PLATFORM=linux/amd64
     - make preflight-redhat-container
 
 
@@ -205,7 +205,7 @@ preflight_redhat_image_arm64:
   script:
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
-    - export ARCH=linux/arm64
+    - export IMG_PLATFORM=linux/arm64
     - make preflight-redhat-container
 
 
@@ -454,7 +454,7 @@ submit_preflight_redhat_image_amd64:
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-    - export ARCH=linux/amd64
+    - export IMG_PLATFORM=linux/amd64
     - make preflight-redhat-container-submit
 
 submit_preflight_redhat_image_arm64:
@@ -472,7 +472,7 @@ submit_preflight_redhat_image_arm64:
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
-    - export ARCH=linux/arm64
+    - export IMG_PLATFORM=linux/arm64
     - make preflight-redhat-container-submit
 
 publish_community_operators:

--- a/Makefile
+++ b/Makefile
@@ -294,12 +294,12 @@ generate-openapi: bin/$(PLATFORM)/openapi-gen
 
 .PHONY: preflight-redhat-container
 preflight-redhat-container: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${IMG_PLATFORM} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} -d ~/.docker/config.json
 
 # Runs only on Linux and requires `docker login` to scan.connect.redhat.com
 .PHONY: preflight-redhat-container-submit
 preflight-redhat-container-submit: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${IMG_PLATFORM} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
 
 .PHONY: patch-crds
 patch-crds: bin/$(PLATFORM)/yq ## Patch-crds
@@ -349,7 +349,7 @@ bin/$(PLATFORM)/operator-manifest-tools: Makefile
 	hack/install-operator-manifest-tools.sh 0.6.0
 
 bin/$(PLATFORM)/preflight: Makefile
-	hack/install-openshift-preflight.sh 1.9.4
+	hack/install-openshift-preflight.sh 1.9.9
 
 bin/$(PLATFORM)/openapi-gen:
 	mkdir -p $(ROOT)/bin/$(PLATFORM)

--- a/Makefile
+++ b/Makefile
@@ -294,12 +294,12 @@ generate-openapi: bin/$(PLATFORM)/openapi-gen
 
 .PHONY: preflight-redhat-container
 preflight-redhat-container: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${ARCH} -d ~/.docker/config.json
 
 # Runs only on Linux and requires `docker login` to scan.connect.redhat.com
 .PHONY: preflight-redhat-container-submit
 preflight-redhat-container-submit: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${ARCH} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
 
 .PHONY: patch-crds
 patch-crds: bin/$(PLATFORM)/yq ## Patch-crds

--- a/Makefile
+++ b/Makefile
@@ -294,12 +294,12 @@ generate-openapi: bin/$(PLATFORM)/openapi-gen
 
 .PHONY: preflight-redhat-container
 preflight-redhat-container: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${ARCH} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${IMG_PLATFORM} -d ~/.docker/config.json
 
 # Runs only on Linux and requires `docker login` to scan.connect.redhat.com
 .PHONY: preflight-redhat-container-submit
 preflight-redhat-container-submit: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${ARCH} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --platform=${IMG_PLATFORM} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
 
 .PHONY: patch-crds
 patch-crds: bin/$(PLATFORM)/yq ## Patch-crds

--- a/config/manifests/bases/datadog-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/datadog-operator.clusterserviceversion.yaml
@@ -11,6 +11,10 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/DataDog/datadog-operator
+  labels:
+    operatorframework.io/os.linux: supported
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
   name: datadog-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
### What does this PR do?

- Update publish redhat jobs to use public-images tool
- Consolidate preflight checks into one. This now supports a multiarch image, so we will run the check/submit together with the pushed Redhat image after it's been pushed.
- Update CSV labels to indicate arch support


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
