### PR TITLE
[profiles] Remove validation for container resource

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagentprofile_validation.go
+++ b/apis/datadoghq/v1alpha1/datadogagentprofile_validation.go
@@ -29,21 +29,6 @@ func ValidateDatadogAgentProfileSpec(spec *DatadogAgentProfileSpec) error {
 	if spec.Config.Override == nil {
 		return fmt.Errorf("config override must be defined")
 	}
-	if spec.Config.Override[NodeAgentComponentName] == nil {
-		return fmt.Errorf("node agent override must be defined")
-	}
-	if spec.Config.Override[NodeAgentComponentName].Containers == nil {
-		return fmt.Errorf("node agent container must be defined")
-	}
-	containsAtLeastOneContainerResourceOverride := false
-	for _, container := range spec.Config.Override[NodeAgentComponentName].Containers {
-		if container.Resources != nil {
-			containsAtLeastOneContainerResourceOverride = true
-		}
-	}
-	if !containsAtLeastOneContainerResourceOverride {
-		return fmt.Errorf("at least one container resource must be defined")
-	}
 
 	return nil
 }

--- a/apis/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
+++ b/apis/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
@@ -70,56 +70,6 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 			},
 		},
 	}
-	missingResources := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
-		},
-		Config: &Config{
-			Override: map[ComponentName]*Override{
-				NodeAgentComponentName: {
-					Containers: map[commonv1.AgentContainerName]*Container{
-						commonv1.CoreAgentContainerName: {},
-					},
-				},
-			},
-		},
-	}
-	missingContainer := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
-		},
-		Config: &Config{
-			Override: map[ComponentName]*Override{
-				NodeAgentComponentName: {},
-			},
-		},
-	}
-	missingComponent := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
-		},
-		Config: &Config{
-			Override: map[ComponentName]*Override{},
-		},
-	}
 	missingOverride := &DatadogAgentProfileSpec{
 		ProfileAffinity: &ProfileAffinity{
 			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
@@ -165,21 +115,6 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 		{
 			name: "valid dap, resources specified in one container only",
 			spec: validResourceOverrideInOneContainerOnly,
-		},
-		{
-			name:    "missing resources",
-			spec:    missingResources,
-			wantErr: "at least one container resource must be defined",
-		},
-		{
-			name:    "missing container",
-			spec:    missingContainer,
-			wantErr: "node agent container must be defined",
-		},
-		{
-			name:    "missing component",
-			spec:    missingComponent,
-			wantErr: "node agent override must be defined",
 		},
 		{
 			name:    "missing override",


### PR DESCRIPTION
### What does this PR do?

Remove validation that requires container resources to be configured in a profile. It should be possible to use profiles to override priorityClassName or env vars without needing to specify a container resource

### Motivation

https://datadoghq.atlassian.net/browse/CECO-1276

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

* Deploy a profile with only priorityClassName or env var overrides set. There shouldn't be a validation error in the logs and the profile should be applied with the proper override

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
