### PR TITLE
Watch nodes if profiles or introspection is enabled

### DIFF
--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -205,7 +205,7 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Watch nodes and reconcile all DatadogAgents for node creation, node deletion, and node label change events
-	if r.Options.V2Enabled {
+	if r.Options.V2Enabled && (r.Options.DatadogAgentProfileEnabled || r.Options.IntrospectionEnabled) {
 		builder.Watches(
 			&corev1.Node{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueRequestsForAllDDAs()),

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.52.0
 	github.com/DataDog/datadog-agent/pkg/config/remote v0.52.0
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.52.0
+	github.com/prometheus/client_golang v1.16.0
 )
 
 require (
@@ -120,7 +121,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect


### PR DESCRIPTION
### What does this PR do?

Adds more conditionals to make make watch nodes more restrictive since we only need it for introspection or profiles

### Motivation

https://datadoghq.atlassian.net/browse/CECO-1267

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

* Deploy the operator with either introspection or profiles enabled
* Changing node labels should cause an extra reconcile
* Deploy the operator without introspection and profiles enabled
* Changing node labels shouldn't cause a reconcile

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
