### PR TITLE
Add minimal OTel Agent container

### DIFF
--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -231,6 +231,7 @@ const (
 
 	AgentCustomConfigVolumePath = "/etc/datadog-agent/datadog.yaml"
 	SystemProbeConfigVolumePath = "/etc/datadog-agent/system-probe.yaml"
+	OtelCustomConfigVolumePath  = "/etc/otel-agent/otel-config.yaml"
 
 	LogDatadogVolumeName                             = "logdatadog"
 	LogDatadogVolumePath                             = "/var/log/datadog"

--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -231,7 +231,7 @@ const (
 
 	AgentCustomConfigVolumePath = "/etc/datadog-agent/datadog.yaml"
 	SystemProbeConfigVolumePath = "/etc/datadog-agent/system-probe.yaml"
-	OtelCustomConfigVolumePath  = "/etc/otel-agent/otel-config.yaml"
+	OtelCustomConfigVolumePath  = "/etc/datadog-agent/otel-config.yaml"
 
 	LogDatadogVolumeName                             = "logdatadog"
 	LogDatadogVolumePath                             = "/var/log/datadog"

--- a/apis/datadoghq/common/v1/types.go
+++ b/apis/datadoghq/common/v1/types.go
@@ -89,6 +89,8 @@ const (
 	// SystemProbeContainerName is the name of the System Probe container
 	SystemProbeContainerName AgentContainerName = "system-probe"
 	// AllContainers is used internally to reference all containers in the pod
+	OtelAgent AgentContainerName = "otel-agent"
+	// AllContainers is used internally to reference all containers in the pod
 	AllContainers AgentContainerName = "all"
 	// ClusterAgentContainerName is the name of the Cluster Agent container
 	ClusterAgentContainerName AgentContainerName = "cluster-agent"

--- a/apis/datadoghq/common/v1/types.go
+++ b/apis/datadoghq/common/v1/types.go
@@ -88,7 +88,7 @@ const (
 	SecurityAgentContainerName AgentContainerName = "security-agent"
 	// SystemProbeContainerName is the name of the System Probe container
 	SystemProbeContainerName AgentContainerName = "system-probe"
-	// AllContainers is used internally to reference all containers in the pod
+	// OtelAgent is the name of the OTel container
 	OtelAgent AgentContainerName = "otel-agent"
 	// AllContainers is used internally to reference all containers in the pod
 	AllContainers AgentContainerName = "all"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,10 +38,6 @@ spec:
         args:
         - --enable-leader-election
         - --pprof
-        # DON't MERGE
-        - --otelAgentEnabled
-        # Uncomment to tests with EDS
-        # - --supportExtendedDaemonset
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,10 @@ spec:
         args:
         - --enable-leader-election
         - --pprof
+        # DON't MERGE
+        - --otelAgentEnabled
+        # Uncomment to tests with EDS
+        # - --supportExtendedDaemonset
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -193,7 +193,8 @@ func otelAgentContainer(dda metav1.Object) corev1.Container {
 		Name:  string(common.OtelAgent),
 		Image: agentImage(),
 		Command: []string{
-			"otel-agent", fmt.Sprintf("--config=%s", apicommon.OtelCustomConfigVolumePath),
+			"/otel-agent",
+			fmt.Sprintf("--config=%s", apicommon.OtelCustomConfigVolumePath),
 		},
 		Env:          envVarsForOtelAgent(dda),
 		VolumeMounts: volumeMountsForOtelAgent(),

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -198,6 +198,20 @@ func otelAgentContainer(dda metav1.Object) corev1.Container {
 		},
 		Env:          envVarsForOtelAgent(dda),
 		VolumeMounts: volumeMountsForOtelAgent(),
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "grpc",
+				ContainerPort: 4317,
+				HostPort:      4317,
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
+				Name:          "http",
+				ContainerPort: 4318,
+				HostPort:      4318,
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
 	}
 }
 

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -140,6 +140,8 @@ func agentOptimizedContainers(dda metav1.Object, requiredContainers []common.Age
 			containers = append(containers, securityAgentContainer(dda))
 		case common.SystemProbeContainerName:
 			containers = append(containers, systemProbeContainer(dda))
+		case common.OtelAgent:
+			containers = append(containers, otelAgentContainer(dda))
 		}
 	}
 
@@ -183,6 +185,18 @@ func processAgentContainer(dda metav1.Object) corev1.Container {
 		},
 		Env:          commonEnvVars(dda),
 		VolumeMounts: volumeMountsForProcessAgent(),
+	}
+}
+
+func otelAgentContainer(dda metav1.Object) corev1.Container {
+	return corev1.Container{
+		Name:  string(common.OtelAgent),
+		Image: agentImage(),
+		Command: []string{
+			"otel-agent", fmt.Sprintf("--config=%s", apicommon.OtelCustomConfigVolumePath),
+		},
+		Env:          envVarsForOtelAgent(dda),
+		VolumeMounts: volumeMountsForOtelAgent(),
 	}
 }
 
@@ -339,6 +353,14 @@ func envVarsForSecurityAgent(dda metav1.Object) []corev1.EnvVar {
 	return append(envs, commonEnvVars(dda)...)
 }
 
+func envVarsForOtelAgent(dda metav1.Object) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
+		// TODO: add additional env vars here
+	}
+
+	return append(envs, commonEnvVars(dda)...)
+}
+
 func volumeMountsForInitConfig() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForLogs(),
@@ -436,6 +458,18 @@ func volumeMountsForSeccompSetup() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		component.GetVolumeMountForSecurity(),
 		component.GetVolumeMountForSeccomp(),
+	}
+}
+
+func volumeMountsForOtelAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		// TODO: add/remove volume mounts
+		component.GetVolumeMountForLogs(),
+		component.GetVolumeMountForAuth(true),
+		component.GetVolumeMountForConfig(),
+		component.GetVolumeMountForDogstatsdSocket(false),
+		component.GetVolumeMountForRuntimeSocket(true),
+		component.GetVolumeMountForProc(),
 	}
 }
 

--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -74,6 +74,7 @@ type ReconcilerOptions struct {
 	IntrospectionEnabled            bool
 	DatadogAgentProfileEnabled      bool
 	ProcessChecksInCoreAgentEnabled bool
+	OtelAgentEnabled                bool
 }
 
 // Reconciler is the internal reconciler for Datadog Agent
@@ -169,6 +170,7 @@ func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logg
 		SupportExtendedDaemonset:        opts.ExtendedDaemonsetOptions.Enabled,
 		Logger:                          logger,
 		ProcessChecksInCoreAgentEnabled: opts.ProcessChecksInCoreAgentEnabled,
+		OtelAgentEnabled:                opts.OtelAgentEnabled,
 	}
 }
 

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -53,6 +53,7 @@ func buildDefaultFeature(options *feature.Options) feature.Feature {
 
 	if options != nil {
 		dF.logger = options.Logger
+		dF.otelAgentEnabled = options.OtelAgentEnabled
 	}
 
 	return dF
@@ -68,6 +69,7 @@ type defaultFeature struct {
 	clusterChecksRunner     clusterChecksRunnerConfig
 	logger                  logr.Logger
 	disableNonResourceRules bool
+	otelAgentEnabled        bool
 
 	customConfigAnnotationKey   string
 	customConfigAnnotationValue string
@@ -184,14 +186,29 @@ func (f *defaultFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredC
 		f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(string(feature.DefaultIDType))
 	}
 
-	return feature.RequiredComponents{
-		ClusterAgent: feature.RequiredComponent{
-			IsRequired: &trueValue,
-		},
-		Agent: feature.RequiredComponent{
-			IsRequired: &trueValue,
-		},
+	if f.otelAgentEnabled {
+		return feature.RequiredComponents{
+			ClusterAgent: feature.RequiredComponent{
+				IsRequired: &trueValue,
+			},
+			Agent: feature.RequiredComponent{
+				IsRequired: &trueValue,
+				Containers: []commonv1.AgentContainerName{
+					commonv1.OtelAgent,
+				},
+			},
+		}
+	} else {
+		return feature.RequiredComponents{
+			ClusterAgent: feature.RequiredComponent{
+				IsRequired: &trueValue,
+			},
+			Agent: feature.RequiredComponent{
+				IsRequired: &trueValue,
+			},
+		}
 	}
+
 }
 
 func (f *defaultFeature) ConfigureV1(dda *v1alpha1.DatadogAgent) feature.RequiredComponents {

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -186,6 +186,9 @@ func (f *defaultFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredC
 		f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(string(feature.DefaultIDType))
 	}
 
+	//
+	// In Operator 1.9 OTel Agent will be configured through a feature.
+	// In the meantime we add the OTel Agent as a required component here, if the flag is enabled.
 	if f.otelAgentEnabled {
 		return feature.RequiredComponents{
 			ClusterAgent: feature.RequiredComponent{

--- a/controllers/datadogagent/feature/types.go
+++ b/controllers/datadogagent/feature/types.go
@@ -157,6 +157,7 @@ type Options struct {
 	Logger logr.Logger
 
 	ProcessChecksInCoreAgentEnabled bool
+	OtelAgentEnabled                bool
 }
 
 // BuildFunc function type used by each Feature during its factory registration.

--- a/controllers/datadogagent/merger/utils.go
+++ b/controllers/datadogagent/merger/utils.go
@@ -15,6 +15,7 @@ var AllAgentContainers = map[commonv1.AgentContainerName]struct{}{
 	commonv1.ProcessAgentContainerName:  {},
 	commonv1.SecurityAgentContainerName: {},
 	commonv1.SystemProbeContainerName:   {},
+	commonv1.OtelAgent:                  {},
 	// DCA containers
 	commonv1.ClusterAgentContainerName: {},
 	// CCR container name is equivalent to core agent container name

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -46,6 +46,7 @@ type SetupOptions struct {
 	IntrospectionEnabled            bool
 	DatadogAgentProfileEnabled      bool
 	ProcessChecksInCoreAgentEnabled bool
+	OtelAgentEnabled                bool
 }
 
 // ExtendedDaemonsetOptions defines ExtendedDaemonset options
@@ -154,6 +155,7 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 			IntrospectionEnabled:            options.IntrospectionEnabled,
 			DatadogAgentProfileEnabled:      options.DatadogAgentProfileEnabled,
 			ProcessChecksInCoreAgentEnabled: options.ProcessChecksInCoreAgentEnabled,
+			OtelAgentEnabled:                options.OtelAgentEnabled,
 		},
 	}).SetupWithManager(mgr)
 }

--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ type options struct {
 	datadogAgentProfileEnabled             bool
 	remoteConfigEnabled                    bool
 	processChecksInCoreAgentEnabled        bool
+	otelAgentEnabled                       bool
 
 	// Secret Backend options
 	secretBackendCommand string
@@ -161,6 +162,7 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.datadogAgentProfileEnabled, "datadogAgentProfileEnabled", false, "Enable DatadogAgentProfile controller (beta)")
 	flag.BoolVar(&opts.remoteConfigEnabled, "remoteConfigEnabled", false, "Enable RemoteConfig capabilities in the Operator (beta)")
 	flag.BoolVar(&opts.processChecksInCoreAgentEnabled, "processChecksInCoreAgentEnabled", false, "Enable running process checks in the core agent (beta)")
+	flag.BoolVar(&opts.otelAgentEnabled, "otelAgentEnabled", false, "Enable running process checks in the core agent (beta)")
 
 	// ExtendedDaemonset configuration
 	flag.BoolVar(&opts.supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
@@ -289,6 +291,7 @@ func run(opts *options) error {
 		IntrospectionEnabled:            opts.introspectionEnabled,
 		DatadogAgentProfileEnabled:      opts.datadogAgentProfileEnabled,
 		ProcessChecksInCoreAgentEnabled: opts.processChecksInCoreAgentEnabled,
+		OtelAgentEnabled:                opts.otelAgentEnabled,
 	}
 
 	if err = controllers.SetupControllers(setupLog, mgr, options); err != nil {

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.datadogAgentProfileEnabled, "datadogAgentProfileEnabled", false, "Enable DatadogAgentProfile controller (beta)")
 	flag.BoolVar(&opts.remoteConfigEnabled, "remoteConfigEnabled", false, "Enable RemoteConfig capabilities in the Operator (beta)")
 	flag.BoolVar(&opts.processChecksInCoreAgentEnabled, "processChecksInCoreAgentEnabled", false, "Enable running process checks in the core agent (beta)")
-	flag.BoolVar(&opts.otelAgentEnabled, "otelAgentEnabled", false, "Enable running process checks in the core agent (beta)")
+	flag.BoolVar(&opts.otelAgentEnabled, "otelAgentEnabled", false, "Enable the OTel agent container (beta)")
 
 	// ExtendedDaemonset configuration
 	flag.BoolVar(&opts.supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")


### PR DESCRIPTION
### What does this PR do?

This change adds minimal OTel agent container with minimal defaults in Operator. It's enabled by `otelAgentEnabled` argument (disabled by default).

To test locally off this branch you'll need a Kind cluster and Go 1.22:
```
# Create a local Kind cluster

# Add `- --otelAgentEnabled` to Operator args in `config/manager/manager.yaml`.

# build image
make build && make docker-build

# load image in the kind cluster
kind load docker-image --name mycluster $(make -s echo-img)

# deploy
make deploy

# switch to default installation namespace
kubens system

# create secret
kubectl create secret generic datadog-secret --from-literal api-key=API_KEY

# apply DatadogAgent manifest and config map (see below)
kubectl apply -f agent.yaml
kubectl apply -f otel-cm.yaml
```

### Motivation

Enabled internal testing while working on adding OTel feature and agent configs to the CRDs.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Verified that OTel agents starts and reaches running state using following DDA and ConfigMap manifests (mounted in the OTel container)

Sample manifest
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog-agent
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
    clusterName: kind
    kubelet:
      tlsVerify: false
  features:
    logCollection:
      enabled: true
  override:
    nodeAgent:
      image:
        name: dineshgurumurthydd/dd-otel-agent:7.56.1
      customConfigurations:
        otel-config.yaml:
          configMap:
            name: my-datadog-otel-config
            items:
              - key: otel-config.yaml
                path: otel-config.yaml
      containers:
        otel-agent:
          # command:
          #   - /otel-agent 
          #   - --config=file:/etc/datadog-agent/otel-config.yaml
          env:
            - name: DD_LOG_LEVEL
              value: "debug"
```

Mounted config map
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: my-datadog-otel-config
  labels:
    app.kubernetes.io/name: "my-datadog"
    app.kubernetes.io/version: "7"
data:
  otel-config.yaml: |-

    receivers:
      prometheus:
        config:
          scrape_configs:
            - job_name: "otel-agent"
              scrape_interval: 10s
              static_configs:
                - targets: ["0.0.0.0:8888"]
      otlp:
        protocols:
          grpc:
          http:
    exporters:
      debug:
        verbosity: detailed
      datadog:
        api:
          key: DD_API_KEY
    processors:
      infraattributes:
        cardinality: 2
      probabilistic_sampler:
        hash_seed: 22
        sampling_percentage: 15.3
      batch:
        timeout: 10s
    connectors:
      datadog/connector:
        traces:
          compute_top_level_by_span_kind: true
          peer_tags_aggregation: true
          compute_stats_by_span_kind: true
    extensions:
      health_check:
    service:
      extensions: [health_check]
      telemetry:
        logs:
          level: debug
      pipelines:
        traces:
          receivers: [otlp]
          processors: [batch]
          exporters: [datadog/connector]
        traces/sampled:
          receivers: [otlp]
          processors: [probabilistic_sampler, infraattributes, batch]
          exporters: [datadog]
        metrics:
          receivers: [otlp, datadog/connector, prometheus]
          processors: [infraattributes, batch]
          exporters: [datadog]
        logs:
          receivers: [otlp]
          processors: [infraattributes, batch]
          exporters: [datadog]
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
