### PR TITLE
Pin kube-openapi version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ bin/$(PLATFORM)/preflight: Makefile
 
 bin/$(PLATFORM)/openapi-gen:
 	mkdir -p $(ROOT)/bin/$(PLATFORM)
-	GOBIN=$(ROOT)/bin/$(PLATFORM) go install k8s.io/kube-openapi/cmd/openapi-gen
+	GOBIN=$(ROOT)/bin/$(PLATFORM) go install k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20230717233707-2695361300d9
 
 bin/$(PLATFORM)/kubebuilder:
 	./hack/install-kubebuilder.sh 3.13.0 ./bin/$(PLATFORM)


### PR DESCRIPTION
### What does this PR do?

Pin version of kube-openapi. Dependabot is installing a newer version that doesn't have some of the flags used for our current build command:
```
k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
```
Other PRs use this version:
```
k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9
```
Seeing if pinning the version to the older one helps dependabot

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
