### PR TITLE
chore(devcontainer): bump Go version to 1.22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/go:1.21-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:dev-1.22",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 	},

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,9 @@
 # All your base
 *                   @DataDog/container-integrations @DataDog/container-ecosystems
 
+# Dev Container
+/.devcontainer          @DataDog/container-ecosystems @DataDog/container-platform
+
 # Documentation
 README.md             @DataDog/documentation @DataDog/container-integrations @DataDog/container-ecosystems
 /docs/                @DataDog/documentation @DataDog/container-integrations @DataDog/container-ecosystems


### PR DESCRIPTION
### What does this PR do?

Upgrade devcontainer to Go `1.22` after https://github.com/DataDog/datadog-operator/pull/1247.
It also changes the `CODEOWNERS` file to have this being managed by @DataDog/container-platform and @DataDog/container-ecosystems.

### Motivation

Needed to keep building the Operator using the devcontainer.

### Describe your test plan

* Building the devcontainer
```
➜  datadog-operator git:(dev/wassim.dhif/upgrade-devcontainer) ✗ devcontainer up --workspace-folder .
[1 ms] @devcontainers/cli 0.65.0. Node.js v22.3.0. darwin 23.5.0 arm64.
[830 ms] Resolving Feature dependencies for 'ghcr.io/devcontainers/features/docker-outside-of-docker:1'...
[2029 ms] Soft-dependency 'ghcr.io/devcontainers/features/common-utils' is not required.  Removing from installation order...
[2350 ms] Start: Run: docker buildx build --load --build-context dev_containers_feature_content_source=/var/folders/b2/5s4rmrnj0q75ppwfh2kx_hwr0000gq/T/devcontainercli/container-features/0.65.0-1720447281331 --build-arg _DEV_CONTAINERS_BASE_IMAGE=mcr.microsoft.com/devcontainers/go:dev-1.22 --build-arg _DEV_CONTAINERS_IMAGE_USER=root --build-arg _DEV_CONTAINERS_FEATURE_CONTENT_SOURCE=dev_container_feature_content_temp --target dev_containers_target_stage -f /var/folders/b2/5s4rmrnj0q75ppwfh2kx_hwr0000gq/T/devcontainercli/container-features/0.65.0-1720447281331/Dockerfile.extended -t vsc-datadog-operator-9c5538ef92da03806392d41aeb049ec4df76619fcb08febfdbbd476fa6ec9248-features /var/folders/b2/5s4rmrnj0q75ppwfh2kx_hwr0000gq/T/devcontainercli/empty-folder
[+] Building 1.1s (16/16) FINISHED                                                                                                       docker:desktop-linux
 => [internal] load build definition from Dockerfile.extended                                                                                            0.0s
 => => transferring dockerfile: 2.81kB                                                                                                                   0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1.4                                                                              0.9s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                                                         0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1.4@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc                        0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 => [internal] load metadata for mcr.microsoft.com/devcontainers/go:dev-1.22                                                                             0.0s
 => [context dev_containers_feature_content_source] load .dockerignore                                                                                   0.0s
 => => transferring dev_containers_feature_content_source: 2B                                                                                            0.0s
 => [dev_containers_feature_content_normalize 1/3] FROM mcr.microsoft.com/devcontainers/go:dev-1.22                                                      0.0s
 => [context dev_containers_feature_content_source] load from client                                                                                     0.0s
 => => transferring dev_containers_feature_content_source: 39.66kB                                                                                       0.0s
 => CACHED [dev_containers_target_stage 2/5] RUN mkdir -p /tmp/dev-container-features                                                                    0.0s
 => CACHED [dev_containers_feature_content_normalize 2/3] COPY --from=dev_containers_feature_content_source devcontainer-features.builtin.env /tmp/buil  0.0s
 => CACHED [dev_containers_feature_content_normalize 3/3] RUN chmod -R 0755 /tmp/build-features/                                                         0.0s
 => CACHED [dev_containers_target_stage 3/5] COPY --from=dev_containers_feature_content_normalize /tmp/build-features/ /tmp/dev-container-features       0.0s
 => CACHED [dev_containers_target_stage 4/5] RUN echo "_CONTAINER_USER_HOME=$( (command -v getent >/dev/null 2>&1 && getent passwd 'root' || grep -E '^  0.0s
 => CACHED [dev_containers_target_stage 5/5] RUN --mount=type=bind,from=dev_containers_feature_content_source,source=docker-outside-of-docker_0,target=  0.0s
 => exporting to image                                                                                                                                   0.0s
 => => exporting layers                                                                                                                                  0.0s
 => => writing image sha256:a282429cc1e7ecd4e8f597c8b978786591abe8e484c946b6e398087cae4de0bd                                                             0.0s
 => => naming to docker.io/library/vsc-datadog-operator-9c5538ef92da03806392d41aeb049ec4df76619fcb08febfdbbd476fa6ec9248-features                        0.0s
[3729 ms] Start: Run: docker run --sig-proxy=false -a STDOUT -a STDERR --mount type=bind,source=/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator,target=/workspaces/datadog-operator,consistency=cached --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker-host.sock -l devcontainer.local_folder=/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator -l devcontainer.config_file=/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator/.devcontainer/devcontainer.json --name datadog-operator-devenv -w /workspaces/datadog-operator --init --cap-add SYS_PTRACE --security-opt seccomp=unconfined --entrypoint /bin/sh vsc-datadog-operator-9c5538ef92da03806392d41aeb049ec4df76619fcb08febfdbbd476fa6ec9248-features -c echo Container started
Container started
Running the postStartCommand from devcontainer.json...

{"outcome":"success","containerId":"016a4c2f5a4dfb576a5e50ad2ff2bcf3f6490200ff8cc0cd927a14d499d0ff62","remoteUser":"vscode","remoteWorkspaceFolder":"/workspaces/datadog-operator"}
➜  datadog-operator git:(dev/wassim.dhif/upgrade-devcontainer) ✗ ddoe
root ➜ /workspaces/datadog-operator $ go version
go version go1.22.4 linux/arm64
```

* Building the Operator
```
bin/linux-aarch64/openapi-gen --logtostderr=true -o "./" -i ./apis/datadoghq/v1alpha1 -O zz_generated.openapi -p ./apis/datadoghq/v1alpha1 -h ./hack/boilerplate.go.txt -r "-"
API rule violation: list_type_missing,./apis/datadoghq/v1alpha1,DatadogMonitorOptions,NotifyBy
API rule violation: names_match,./apis/datadoghq/v1alpha1,DatadogMonitorDowntimeStatus,DowntimeID
API rule violation: names_match,./apis/datadoghq/v1alpha1,DatadogMonitorStatus,MonitorStateSyncStatus
bin/linux-aarch64/openapi-gen --logtostderr=true -o "./" -i ./apis/datadoghq/v2alpha1 -O zz_generated.openapi -p ./apis/datadoghq/v2alpha1 -h ./hack/boilerplate.go.txt -r "-"
bin/linux-aarch64/controller-gen crd:crdVersions=v1 rbac:roleName=manager-role paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1
hack/patch-crds.sh
go run ./hack/generate-docs.go
bin/linux-aarch64/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./apis/..."
docker build . -t wdhifdatadog/operator --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=16859187ac4cb0295081881f33b4b3a7fa07222c -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.7.0-rc.3_16859187 -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-07-08/14:29:44" --build-arg GOARCH=""
[+] Building 23.2s (27/27) FINISHED                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                     0.0s
 => => transferring dockerfile: 1.51kB                                                                                                                   0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi9/ubi-minimal:latest                                                                      0.2s
 => [internal] load metadata for docker.io/library/golang:1.22                                                                                           0.8s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 66B                                                                                                                         0.0s
 => [internal] load build context                                                                                                                        0.2s
 => => transferring context: 2.53MB                                                                                                                      0.2s
 => [builder  1/12] FROM docker.io/library/golang:1.22@sha256:fcae9e0e7313c6467a7c6632ebb5e5fab99bd39bd5eb6ee34a211353e647827a                           0.0s
 => => resolve docker.io/library/golang:1.22@sha256:fcae9e0e7313c6467a7c6632ebb5e5fab99bd39bd5eb6ee34a211353e647827a                                     0.0s
 => CACHED [stage-1 1/9] FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5  0.0s
 => CACHED [builder  2/12] WORKDIR /workspace                                                                                                            0.0s
 => CACHED [builder  3/12] COPY go.mod go.mod                                                                                                            0.0s
 => CACHED [builder  4/12] COPY go.sum go.sum                                                                                                            0.0s
 => CACHED [builder  5/12] RUN go mod download                                                                                                           0.0s
 => CACHED [builder  6/12] COPY main.go main.go                                                                                                          0.0s
 => CACHED [builder  7/12] COPY apis/ apis/                                                                                                              0.0s
 => CACHED [builder  8/12] COPY controllers/ controllers/                                                                                                0.0s
 => CACHED [builder  9/12] COPY pkg/ pkg/                                                                                                                0.0s
 => CACHED [builder 10/12] COPY cmd/helpers/ cmd/helpers/                                                                                                0.0s
 => [builder 11/12] RUN CGO_ENABLED=0 GOOS=linux GOARCH= GO111MODULE=on go build -a -ldflags "-w -s -X github.com/DataDog/datadog-operator/pkg/version  17.4s
 => [builder 12/12] RUN CGO_ENABLED=0 GOOS=linux GOARCH= GO111MODULE=on go build -a -ldflags "-w -s -X github.com/DataDog/datadog-operator/pkg/version.  4.0s
 => [stage-1 2/9] COPY --from=builder /workspace/manager .                                                                                               0.1s
 => [stage-1 3/9] COPY --from=builder /workspace/helpers .                                                                                               0.0s
 => [stage-1 4/9] COPY scripts/readsecret.sh .                                                                                                           0.1s
 => [stage-1 5/9] RUN chmod 550 readsecret.sh && chmod 550 helpers                                                                                       0.1s
 => [stage-1 6/9] RUN mkdir -p /licences                                                                                                                 0.1s
 => [stage-1 7/9] COPY ./LICENSE ./LICENSE-3rdparty.csv /licenses/                                                                                       0.0s
 => [stage-1 8/9] RUN chmod -R 755 /licences                                                                                                             0.1s
 => exporting to image                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                  0.1s
 => => writing image sha256:53e4125421b61682435fe69e6ea2de8f8f064c15aaefc484aa0ed4cdc1262787                                                             0.0s
 => => naming to docker.io/wdhifdatadog/operator                                                                                                         0.0s
docker build . -t wdhifdatadog/check-operator -f check-operator.Dockerfile --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=16859187ac4cb0295081881f33b4b3a7fa07222c -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.7.0-rc.3_16859187 -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-07-08/14:30:07" --build-arg GOARCH=""
[+] Building 16.4s (17/17) FINISHED                                                                                                            docker:default
 => [internal] load build definition from check-operator.Dockerfile                                                                                      0.0s
 => => transferring dockerfile: 808B                                                                                                                     0.0s
 => [internal] load metadata for registry.access.redhat.com/ubi8/ubi-minimal:latest                                                                      0.2s
 => [internal] load metadata for docker.io/library/golang:1.22                                                                                           0.4s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 66B                                                                                                                         0.0s
 => [builder 1/9] FROM docker.io/library/golang:1.22@sha256:fcae9e0e7313c6467a7c6632ebb5e5fab99bd39bd5eb6ee34a211353e647827a                             0.0s
 => => resolve docker.io/library/golang:1.22@sha256:fcae9e0e7313c6467a7c6632ebb5e5fab99bd39bd5eb6ee34a211353e647827a                                     0.0s
 => CACHED [stage-1 1/3] FROM registry.access.redhat.com/ubi8/ubi-minimal:latest@sha256:de2a0a20c1c3b39c3de829196de9694d09f97cd18fda1004de855ed2b4c841b  0.0s
 => [internal] load build context                                                                                                                        0.0s
 => => transferring context: 23.55kB                                                                                                                     0.0s
 => CACHED [builder 2/9] WORKDIR /workspace                                                                                                              0.0s
 => CACHED [builder 3/9] COPY go.mod go.mod                                                                                                              0.0s
 => CACHED [builder 4/9] COPY go.sum go.sum                                                                                                              0.0s
 => CACHED [builder 5/9] RUN go mod download                                                                                                             0.0s
 => CACHED [builder 6/9] COPY cmd/check-operator/ cmd/check-operator/                                                                                    0.0s
 => CACHED [builder 7/9] COPY apis/ apis/                                                                                                                0.0s
 => CACHED [builder 8/9] COPY pkg/ pkg/                                                                                                                  0.0s
 => [builder 9/9] RUN CGO_ENABLED=0 GOOS=linux GOARCH= GO111MODULE=on go build -a -ldflags "-w -s -X github.com/DataDog/datadog-operator/pkg/version.C  15.7s
 => [stage-1 2/3] COPY --from=builder /workspace/check-operator .                                                                                        0.1s
 => exporting to image                                                                                                                                   0.1s
 => => exporting layers                                                                                                                                  0.1s
 => => writing image sha256:3b5cf8b57bcb1d150748aeb4fd4f370a9922189f38e9b6bddcb971db302601fd                                                             0.0s
 => => naming to docker.io/wdhifdatadog/check-operator                                                                                                   0.0s
docker push wdhifdatadog/operator
Using default tag: latest
The push refers to repository [docker.io/wdhifdatadog/operator]
eadb4565a1ec: Pushed
73df041c6088: Pushed
c3a5894bd3a1: Pushed
985c6c030816: Layer already exists
e9159e26d84f: Pushed
e1a59ffc18ca: Pushed
53ce7ccd4662: Layer already exists
latest: digest: sha256:84162b1187055705500fd23ba21f2d258c2ebe86daef286e8e6458912e18b055 size: 1990
docker push wdhifdatadog/check-operator
Using default tag: latest
The push refers to repository [docker.io/wdhifdatadog/check-operator]
df3376a69d9e: Pushed
4f0bd1bd1b3f: Pushed
latest: digest: sha256:b69bb3d7e89f95f0f66b5e343dd53f6927566258dac8452be25640f2e8373cf1 size: 741
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
