### PR TITLE
Update CODEOWNERS remove container-integrations from owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 # and another the rest of the directory.
 
 # All your base
-*                   @DataDog/container-integrations @DataDog/container-ecosystems
+*                   @DataDog/container-ecosystems
 
 # Documentation
-README.md             @DataDog/documentation @DataDog/container-integrations @DataDog/container-ecosystems
-/docs/                @DataDog/documentation @DataDog/container-integrations @DataDog/container-ecosystems
+README.md             @DataDog/documentation @DataDog/container-ecosystems
+/docs/                @DataDog/documentation @DataDog/container-ecosystems

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,11 @@
 # Documentation
 README.md             @DataDog/documentation @DataDog/container-ecosystems
 /docs/                @DataDog/documentation @DataDog/container-ecosystems
+
+
+# Features owners
+/controllers/datadogagent/feature/admissioncontroller/*    @DataDog/container-platform
+/controllers/datadogagent/feature/prometheusscrape/*       @DataDog/container-platform
+/controllers/datadogagent/feature/clusterchecks/*          @DataDog/container-platform
+/controllers/datadogagent/feature/kubernetesstatecore/*    @DataDog/container-integrations
+/controllers/datadogagent/feature/helmcheck/*              @DataDog/container-integrations


### PR DESCRIPTION
### What does this PR do?

Remove @DataDog/container-integrations from CODEOWNERS

### Motivation

The split between @DataDog/container-integrations and @DataDog/container-ecosystems is done since 2 years now.

I think it is time to remove the #container-integrations for the owner of this repository. Thanks to this change it will be more clear who is mandatory to review the pull request.

### Additional Notes

I think we should start to add each product team as in the CODEOWNERS of each features. So they get automatically added to the code review if someone modify their code.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
