### PR TITLE
fix(kustomization): fix deploy file

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
 - manager.yaml
 images:
 - name: controller
- newName: gcr.io/datadoghq/operator
+  newName: gcr.io/datadoghq/operator
   newTag: 1.4.0
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
### What does this PR do?

The `config/manager/kustomization.yaml` seems malformed therefor it causes this issue when trying to deploy:

```
Error: accumulating resources: accumulation err='accumulating resources from '../manager': '/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator/config/manager' must resolve to a file': couldn't make target for path '/Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator/config/manager': error converting YAML to JSON: yaml: line 4: did not find expected key
```

### Motivation

Fix `make deploy` issue.

### Describe your test plan

Run the `make deploy` command

```
➜  datadog-operator git:(dev/wassim.dhif/upgrade-devcontainer) ✗ make IMG=wdhifdatadog/operator IMG_CHECK=wdhifdatadog/operator-check deploy && kubectl create secret generic datadog-secret --from-literal api-key=$DD_API_KEY --from-literal app-key=$DD_APP_KEY --namespace system && kubectl config set-context --current --namespace=system
bin/darwin-arm64/controller-gen crd:crdVersions=v1 rbac:roleName=manager-role paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1
hack/patch-crds.sh
dcd config/manager && /Users/wassim.dhif/go/src/github.com/DataDog/datadog-operator//bin/darwin-arm64/kustomize edit set image controller=wdhifdatadog/operator
bin/darwin-arm64/kustomize build config/default | kubectl apply --force-conflicts --server-side -f -
namespace/system serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogagentprofiles.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogagents.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogmetrics.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogmonitors.datadoghq.com serverside-applied
customresourcedefinition.apiextensions.k8s.io/datadogslos.datadoghq.com serverside-applied
serviceaccount/datadog-operator-controller-manager serverside-applied
role.rbac.authorization.k8s.io/datadog-operator-leader-election-role serverside-applied
clusterrole.rbac.authorization.k8s.io/datadog-operator-manager-role serverside-applied
rolebinding.rbac.authorization.k8s.io/datadog-operator-leader-election-rolebinding serverside-applied
clusterrolebinding.rbac.authorization.k8s.io/datadog-operator-manager-rolebinding serverside-applied
deployment.apps/datadog-operator-manager serverside-applied
secret/datadog-secret created
Context "wassim-minikube" modified.
```

```
➜  datadog-operator git:(dev/wassim.dhif/upgrade-devcontainer) ✗ k get pod
NAME                                        READY   STATUS    RESTARTS   AGE
datadog-operator-manager-68dbb6bb7c-m899w   1/1     Running   0          49s
➜  datadog-operator git:(dev/wassim.dhif/upgrade-devcontainer) ✗ k describe pod datadog-operator-manager-68dbb6bb7c-m899w
Name:             datadog-operator-manager-68dbb6bb7c-m899w
Namespace:        system
Priority:         0
Service Account:  datadog-operator-controller-manager
Node:             wassim-minikube/192.168.49.2
Start Time:       Mon, 08 Jul 2024 17:59:39 +0200
Labels:           app.kubernetes.io/name=datadog-operator
                  pod-template-hash=68dbb6bb7c
Annotations:      ad.datadoghq.com/manager.check_names: ["openmetrics"]
                  ad.datadoghq.com/manager.init_configs: [{}]
                  ad.datadoghq.com/manager.instances:
                    [{
                      "prometheus_url": "http://%%host%%:8080/metrics",
                      "namespace": "datadog.operator",
                      "metrics": ["*"]
                    }]
Status:           Running
IP:               10.244.0.4
IPs:
  IP:           10.244.0.4
Controlled By:  ReplicaSet/datadog-operator-manager-68dbb6bb7c
Containers:
  manager:
    Container ID:  docker://baf1001c29b89d9209cf645507e98d27b20f2872bf160c40477a021b455b0cf1
    Image:         wdhifdatadog/operator:latest
    Image ID:      docker-pullable://wdhifdatadog/operator@sha256:933ff3506cba732ad7918be268fea1fec20a4a92ddb8d35c14c9de685ba64081
    Port:          8080/TCP
    Host Port:     0/TCP
    Command:
      /manager
    Args:
      --enable-leader-election
      --pprof
    State:          Running
      Started:      Mon, 08 Jul 2024 17:59:46 +0200
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  250Mi
    Requests:
      cpu:     100m
      memory:  250Mi
    Liveness:  http-get http://:8081/healthz/ delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      POD_NAME:         datadog-operator-manager-68dbb6bb7c-m899w (v1:metadata.name)
      WATCH_NAMESPACE:  system (v1:metadata.namespace)
      DD_TOOL_VERSION:  datadog-operator
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-bz6qj (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
Volumes:
  kube-api-access-bz6qj:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Guaranteed
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  54s   default-scheduler  Successfully assigned system/datadog-operator-manager-68dbb6bb7c-m899w to wassim-minikube
  Normal  Pulling    53s   kubelet            Pulling image "wdhifdatadog/operator:latest"
  Normal  Pulled     47s   kubelet            Successfully pulled image "wdhifdatadog/operator:latest" in 6.463s (6.463s including waiting). Image size: 159497716 bytes.
  Normal  Created    47s   kubelet            Created container manager
  Normal  Started    47s   kubelet            Started container manager
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
