### PR TITLE
Update make bundle command to include `--apis-dir` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ e2e-tests-keep-stacks: manifests $(KUSTOMIZE) ## Run E2E tests and keep environm
 
 .PHONY: bundle
 bundle: bin/$(PLATFORM)/operator-sdk bin/$(PLATFORM)/yq $(KUSTOMIZE) manifests ## Generate bundle manifests and metadata, then validate generated files.
-	bin/$(PLATFORM)/operator-sdk generate kustomize manifests -q
+	bin/$(PLATFORM)/operator-sdk generate kustomize manifests --apis-dir ./apis -q
 	cd config/manager && $(ROOT)/$(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | bin/$(PLATFORM)/operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	hack/patch-bundle.sh


### PR DESCRIPTION
### What does this PR do?

Update make bundle command to include `--apis-dir` flag during the manifest generation step.

### Motivation

Since upgrading operator-sdk to `v1.34.1`, the `make bundle` command's manifest generation step removes the `displayName` and `description` for some CRDs. 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Run `make VERSION=x.y.z LATEST_VERSION=x.y.z bundle` and make sure the DatadogAgentProfile and DatadogSLO crds still have the `displayName` and `description` field under `spec.customresourcedefinitions.owned` in the `bundle/manifests/datadog-operator.clusterserviceversion.yaml` file. 

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
