### PR TITLE
fix generated controller manager rbacs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ manifests: generate-manifests patch-crds ## Generate manifestcd s e.g. CRD, RBAC
 
 .PHONY: generate-manifests
 generate-manifests: $(CONTROLLER_GEN)
-	$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=manager-role paths="./apis/..." output:crd:artifacts:config=config/crd/bases/v1
+	$(CONTROLLER_GEN) crd:crdVersions=v1 rbac:roleName=manager-role paths="./apis/..." paths="./controllers/..." output:crd:artifacts:config=config/crd/bases/v1
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) generate-openapi generate-docs ## Generate code

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -740,13 +740,6 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
   - volumeattachments
   verbs:
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,13 +1,14 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - nonResourceURLs:
   - /metrics
+  verbs:
+  - get
+- nonResourceURLs:
   - /metrics/slis
   verbs:
   - get
@@ -85,8 +86,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
   - patch
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -201,11 +202,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apiregistration.k8s.io
   resources:
   - apiservices
   verbs:
   - '*'
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -294,6 +304,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - pods/exec
+  verbs:
+  - create
 - apiGroups:
   - authorization.k8s.io
   resources:
@@ -389,6 +405,38 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - datadogagentprofiles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogagentprofiles/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogagentprofiles/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - datadoghq.com
+  resources:
   - datadogagents
   verbs:
   - create
@@ -468,6 +516,38 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - datadogslos
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogslos/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadogslos/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - datadoghq.com
+  resources:
   - extendeddaemonsetreplicasets
   verbs:
   - get
@@ -489,6 +569,13 @@ rules:
   - watermarkpodautoscalers
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - customresourcedefinitions
+  verbs:
   - list
   - watch
 - apiGroups:
@@ -653,79 +740,14 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
   - volumeattachments
   verbs:
   - list
   - watch
-- apiGroups:
-  - extensions
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - list
-  - watch
-- apiGroups:
-    - datadoghq.com
-  resources:
-    - datadogslos
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - datadoghq.com
-  resources:
-    - datadogslos/finalizers
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - datadoghq.com
-  resources:
-    - datadogslos/status
-  verbs:
-    - get
-    - patch
-    - update
-- apiGroups:
-    - datadoghq.com
-  resources:
-    - datadogagentprofiles
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - datadoghq.com
-  resources:
-    - datadogagentprofiles/status
-  verbs:
-    - get
-    - patch
-    - update
-- apiGroups:
-    - datadoghq.com
-  resources:
-    - datadogagentprofiles/finalizers
-  verbs:
-    - update
-- apiGroups:
-    - ""
-  resources:
-    - pods/exec
-  verbs:
-    - create

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -99,6 +99,7 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=restricted,verbs=use
 
 // +kubebuilder:rbac:urls=/metrics,verbs=get
+// +kubebuilder:rbac:urls=/metrics/slis,verbs=get
 // +kubebuilder:rbac:groups="",resources=componentstatuses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes/metrics,verbs=get

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -143,7 +143,6 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=list;watch
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=ingresses,verbs=list;watch
 // +kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=list;watch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=list;watch
 
 // Kubernetes_state_core
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch


### PR DESCRIPTION
### What does this PR do?

Fix path for controller_gen generate-manifests. This fixes the RBACs configured for the controller manager
Adds one missing kubebuilder tag

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Deploy Datadog Operator with a DatadogAgent (most/all features enabled), ensure there are no RBAC errors in the logs.


### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
