### PR TITLE
Use emptyDir for auth_token in Cluster Agent (aligned with Agent)

### DIFF
--- a/controllers/datadogagent/clusteragent_test.go
+++ b/controllers/datadogagent/clusteragent_test.go
@@ -58,6 +58,7 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 					{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 					{Name: "tmp", ReadOnly: false, MountPath: "/tmp"},
 					{Name: "certificates", ReadOnly: false, MountPath: "/etc/datadog-agent/certificates"},
+					{Name: "datadog-agent-auth", MountPath: "/etc/datadog-agent/auth"},
 				},
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
@@ -111,6 +112,12 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
+			{
+				Name: "datadog-agent-auth",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
 		},
 		// To be uncommented when the cluster-agent Dockerfile will be updated to use a non-root user by default
 		// SecurityContext: &corev1.PodSecurityContext{
@@ -143,6 +150,10 @@ func clusterAgentPodSpectWithConfd(configDirSpec *datadoghqv1alpha1.ConfigDirSpe
 
 func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 	return []corev1.EnvVar{
+		{
+			Name:  "DD_AUTH_TOKEN_FILE_PATH",
+			Value: "/etc/datadog-agent/auth/token",
+		},
 		{
 			Name: "DD_POD_NAME",
 			ValueFrom: &corev1.EnvVarSource{

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -7,6 +7,7 @@ package clusteragent
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -49,6 +50,7 @@ func NewDefaultClusterAgentPodTemplateSpec(dda metav1.Object) *corev1.PodTemplat
 		component.GetVolumeForConfd(),
 		component.GetVolumeForLogs(),
 		component.GetVolumeForCertificates(),
+		component.GetVolumeForAuth(),
 
 		// /tmp is needed because some versions of the DCA (at least until
 		// 1.19.0) write to it.
@@ -65,6 +67,7 @@ func NewDefaultClusterAgentPodTemplateSpec(dda metav1.Object) *corev1.PodTemplat
 		component.GetVolumeMountForConfd(),
 		component.GetVolumeMountForLogs(),
 		component.GetVolumeMountForCertificates(),
+		component.GetVolumeMountForAuth(false),
 		component.GetVolumeMountForTmp(),
 	}
 
@@ -159,6 +162,10 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 		{
 			Name:  apicommon.DDAPMInstrumentationInstallType,
 			Value: component.DefaultAgentInstallType,
+		},
+		{
+			Name:  apicommon.DDAuthTokenFilePath,
+			Value: filepath.Join(apicommon.AuthVolumePath, "token"),
 		},
 	}
 

--- a/controllers/datadogagent/component/clusteragent/default_test.go
+++ b/controllers/datadogagent/component/clusteragent/default_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
-	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1/test"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/component"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
-
+	"github.com/DataDog/datadog-operator/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -28,40 +28,49 @@ func defaultDatadogAgent() *datadoghqv2alpha1.DatadogAgent {
 	dda := &datadoghqv2alpha1.DatadogAgent{}
 	dda.SetName("foo")
 	dda.SetNamespace("bar")
+	dda.SetCreationTimestamp(metav1.Now())
 	return dda
 }
 
 func Test_defaultClusterAgentDeployment(t *testing.T) {
 	dda := defaultDatadogAgent()
 	deployment := NewDefaultClusterAgentDeployment(dda)
-	deployment.Spec.Template = *clusterAgentDefaultPodTemplateSpec()
+	expectedDeployment := clusterAgentExpectedPodTemplate(dda)
 
-	assert.Equal(t, clusterAgentDefaultPodTemplateSpec(), &deployment.Spec.Template)
+	assert.Empty(t, testutils.CompareKubeResource(&deployment.Spec.Template, expectedDeployment))
 }
 
-func clusterAgentDefaultPodTemplateSpec() *corev1.PodTemplateSpec {
+func clusterAgentExpectedPodTemplate(dda *datadoghqv2alpha1.DatadogAgent) *corev1.PodTemplateSpec {
 	podTemplate := &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      make(map[string]string),
+			Labels: map[string]string{
+				"agent.datadoghq.com/component": "cluster-agent",
+				"agent.datadoghq.com/name":      "foo",
+				"app.kubernetes.io/component":   "cluster-agent",
+				"app.kubernetes.io/instance":    "foo-cluster-agent",
+				"app.kubernetes.io/managed-by":  "datadog-operator",
+				"app.kubernetes.io/name":        "datadog-agent-deployment",
+				"app.kubernetes.io/part-of":     "bar-foo",
+				"app.kubernetes.io/version":     "",
+			},
 			Annotations: make(map[string]string),
 		},
-		Spec: clusterAgentDefaultPodSpec(),
+		Spec: clusterAgentDefaultPodSpec(dda),
 	}
 
 	return podTemplate
 }
 
-func clusterAgentDefaultPodSpec() corev1.PodSpec {
+func clusterAgentDefaultPodSpec(dda *datadoghqv2alpha1.DatadogAgent) corev1.PodSpec {
 	return corev1.PodSpec{
 		// from default
 		Affinity:           DefaultAffinity(),
 		ServiceAccountName: "foo-cluster-agent",
 		Containers: []corev1.Container{
 			{
-				Name:            "cluster-agent",
-				Image:           defaulting.GetLatestClusterAgentImage(),
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Resources:       corev1.ResourceRequirements{},
+				Name:      "cluster-agent",
+				Image:     defaulting.GetLatestClusterAgentImage(),
+				Resources: corev1.ResourceRequirements{},
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 5005,
@@ -69,14 +78,14 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 						Protocol:      "TCP",
 					},
 				},
-				Env: clusterAgentDefaultEnvVars(),
+				Env: clusterAgentDefaultEnvVars(dda),
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "installinfo", ReadOnly: true, SubPath: "install_info", MountPath: "/etc/datadog-agent/install_info"},
 					{Name: "confd", ReadOnly: true, MountPath: "/conf.d"},
-					{Name: "orchestrator-explorer-config", ReadOnly: true, MountPath: "/etc/datadog-agent/conf.d/orchestrator.d"},
 					{Name: "logdatadog", ReadOnly: false, MountPath: "/var/log/datadog"},
 					{Name: "tmp", ReadOnly: false, MountPath: "/tmp"},
 					{Name: "certificates", ReadOnly: false, MountPath: "/etc/datadog-agent/certificates"},
+					{Name: "datadog-agent-auth", MountPath: "/etc/datadog-agent/auth"},
 				},
 				LivenessProbe:  defaultLivenessProbe(),
 				ReadinessProbe: defaultReadinessProbe(),
@@ -103,16 +112,6 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 			},
 			{
-				Name: "orchestrator-explorer-config",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "foo-orchestrator-explorer-config",
-						},
-					},
-				},
-			},
-			{
 				Name: "logdatadog",
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
@@ -130,28 +129,12 @@ func clusterAgentDefaultPodSpec() corev1.PodSpec {
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
-		},
-	}
-}
-
-func authTokenValue() *corev1.EnvVarSource {
-	return &corev1.EnvVarSource{
-		SecretKeyRef: &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: testDdaName,
+			{
+				Name: "datadog-agent-auth",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
 			},
-			Key: "token",
-		},
-	}
-}
-
-func apiKeyValue() *corev1.EnvVarSource {
-	return &corev1.EnvVarSource{
-		SecretKeyRef: &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: testDdaName,
-			},
-			Key: "api_key",
 		},
 	}
 }
@@ -210,8 +193,12 @@ func defaultStartupProbe() *corev1.Probe {
 	}
 }
 
-func clusterAgentDefaultEnvVars() []corev1.EnvVar {
+func clusterAgentDefaultEnvVars(dda *datadoghqv2alpha1.DatadogAgent) []corev1.EnvVar {
 	return []corev1.EnvVar{
+		{
+			Name:  "DD_AUTH_TOKEN_FILE_PATH",
+			Value: "/etc/datadog-agent/auth/token",
+		},
 		{
 			Name: "DD_POD_NAME",
 			ValueFrom: &corev1.EnvVarSource{
@@ -221,72 +208,32 @@ func clusterAgentDefaultEnvVars() []corev1.EnvVar {
 			},
 		},
 		{
-			Name:  "DD_CLUSTER_CHECKS_ENABLED",
-			Value: "false",
-		},
-		{
 			Name:  "DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME",
 			Value: fmt.Sprintf("%s-%s", testDdaName, apicommon.DefaultClusterAgentResourceSuffix),
-		},
-		{
-			Name:      "DD_CLUSTER_AGENT_AUTH_TOKEN",
-			ValueFrom: authTokenValue(),
 		},
 		{
 			Name:  "DD_LEADER_ELECTION",
 			Value: "true",
 		},
 		{
-			Name:  "DD_LEADER_LEASE_NAME",
-			Value: fmt.Sprintf("%s-leader-election", testDdaName),
-		},
-		{
-			Name:  "DD_COMPLIANCE_CONFIG_ENABLED",
-			Value: "false",
-		},
-		{
-			Name:  "DD_COLLECT_KUBERNETES_EVENTS",
-			Value: "false",
-		},
-		{
 			Name:  "DD_HEALTH_PORT",
 			Value: "5555",
-		},
-		{
-			Name:  "DD_LOG_LEVEL",
-			Value: "INFO",
-		},
-		{
-			Name:      "DD_API_KEY",
-			ValueFrom: apiKeyValue(),
-		},
-		{
-			Name:  "DD_ORCHESTRATOR_EXPLORER_ENABLED",
-			Value: "true",
-		},
-		{
-			Name:  "DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED",
-			Value: "true",
-		},
-		{
-			Name:  "DD_CLUSTER_AGENT_TOKEN_NAME",
-			Value: fmt.Sprintf("%stoken", testDdaName),
 		},
 		{
 			Name:  "DD_KUBE_RESOURCES_NAMESPACE",
 			Value: testDdaNamespace,
 		},
 		{
-			Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
-			Value: strconv.FormatInt(test.AgentInstallTime.Time.Unix(), 10),
-		},
-		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 			Value: component.DefaultAgentInstallType,
 		},
 		{
+			Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
+			Value: strconv.Itoa(int(dda.GetCreationTimestamp().Unix())),
+		},
+		{
 			Name:  "DD_INSTRUMENTATION_INSTALL_ID",
-			Value: string(test.AgentInstallId),
+			Value: "",
 		},
 	}
 }

--- a/controllers/datadogagent/feature/logcollection/feature.go
+++ b/controllers/datadogagent/feature/logcollection/feature.go
@@ -141,7 +141,6 @@ func (f *logCollectionFeature) ManageNodeAgent(managers feature.PodTemplateManag
 }
 
 func (f *logCollectionFeature) manageNodeAgent(agentContainerName apicommonv1.AgentContainerName, managers feature.PodTemplateManagers, provider string) error {
-
 	// pointerdir volume mount
 	pointerVol, pointerVolMount := volume.GetVolumes(apicommon.PointerVolumeName, f.tempStoragePath, apicommon.PointerVolumePath, false)
 	managers.VolumeMount().AddVolumeMountToContainer(&pointerVolMount, agentContainerName)


### PR DESCRIPTION
### What does this PR do?

Currently Cluster Agent is not aligned with Agent and write `auth_token` to default location (i.e. folder of `datadog.yaml`). This causes issues on read-only filesystem or containers running with random UID (e.g. not `dd-agent` or `root`).

### Motivation

Bugfix

### Additional Notes

### Minimum Agent Versions

### Describe your test plan

Deploy the Agent on OpenShift or with this security context:
```
  override:
    clusterAgent:
      containers:
        cluster-agent:
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: false
            runAsNonRoot: true
            runAsUser: 1000370000
```

Exec in the Cluster Agent POD, running `agent` commands should work `agent status`, for instance.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
