### PR TITLE
Improve resource.Quantity to float conversion for SLOs

### DIFF
--- a/controllers/datadogslo/slo.go
+++ b/controllers/datadogslo/slo.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
@@ -73,12 +74,13 @@ func buildThreshold(sloSpec v1alpha1.DatadogSLOSpec) []datadogV1.SLOThreshold {
 
 	var warningThreshold *float64
 	if sloSpec.WarningThreshold != nil {
-		approxFloat := sloSpec.WarningThreshold.AsApproximateFloat64()
-		warningThreshold = &approxFloat
+		convertedFloat, _ := strconv.ParseFloat(sloSpec.WarningThreshold.AsDec().String(), 64)
+		warningThreshold = &convertedFloat
 	}
 
+	convertedFloat, _ := strconv.ParseFloat(sloSpec.TargetThreshold.AsDec().String(), 64)
 	threshold := datadogV1.SLOThreshold{
-		Target:    sloSpec.TargetThreshold.AsApproximateFloat64(),
+		Target:    convertedFloat,
 		Timeframe: *timeframe,
 		Warning:   warningThreshold,
 	}

--- a/controllers/datadogslo/slo_test.go
+++ b/controllers/datadogslo/slo_test.go
@@ -27,11 +27,11 @@ func Test_buildThreshold(t *testing.T) {
 			mockSpec: v1alpha1.DatadogSLOSpec{
 				Name:            "test",
 				Timeframe:       "7d",
-				TargetThreshold: resource.MustParse("99.9"),
+				TargetThreshold: resource.MustParse("99990m"),
 			},
 			expectedResult: []datadogV1.SLOThreshold{
 				{
-					Target:    99.9,
+					Target:    99.99,
 					Timeframe: datadogV1.SLOTimeframe("7d"),
 				},
 			},
@@ -41,14 +41,14 @@ func Test_buildThreshold(t *testing.T) {
 			mockSpec: v1alpha1.DatadogSLOSpec{
 				Name:             "test",
 				Timeframe:        "30d",
-				TargetThreshold:  resource.MustParse("99.9"),
-				WarningThreshold: ptrResourceQuantity(resource.MustParse("95.9")),
+				TargetThreshold:  resource.MustParse("99.999"),
+				WarningThreshold: ptrResourceQuantity(resource.MustParse("95.010001")),
 			},
 			expectedResult: []datadogV1.SLOThreshold{
 				{
-					Target:    99.9,
+					Target:    99.999,
 					Timeframe: datadogV1.SLOTimeframe("30d"),
-					Warning:   float64Ptr(95.9),
+					Warning:   float64Ptr(95.010001),
 				},
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

CONS-6488

`Quantity.AsApproximateFloat64` does some math to convert Quantity to `float64` needed for SLO API input so some floats may appear with additional decimals. Instead we convert Quantity to Decimal string and then parse as float. This may still have edge cases were string representation doesn't have exact `float64` so conversion isn't 1-to-1.

This impl ignores string to float parsing errors, assuming decimal string obtain from Quantity would be valid.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Enabled SLO CRD using `datadogSLOEnabled`
2. Apply SLO manifest and confirm in the app number match (to see warningThreshold clone the SLO in UI)
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogSLO
metadata:
  name: test-slo
  namespace: system
spec:
  description: Error SLO for test-xyz
  name: Error SLO for test-xyz
  query:
    denominator: sum:trace.pyramid.request.hits{service:test-xyz, env:test}.as_count()
    numerator: sum:trace.pyramid.request.hits{service:test-xyz, env:test}.as_count()
      - sum:trace.pyramid.request.errors{service:test-xyz, env:test}.as_count()
  tags:
  - integration:kubernetes
  - service:test-xyz
  - env:test
  - team:sre
  - generated:kubernetes
  targetThreshold: "0.001"
  warningThreshold: "99.999"
  timeframe: 7d
  type: metric
```

Tested on user-reported combinations
```
* "99.95" produces 99.95%
* "99.99" produces "error updating SLO" in k8s
* "99.990" produces "error updating SLO" in k8s
* "99.991" produces 99.991%
* 99950m produces 99.95%
* 99990m produces "error updating SLO" in k8s
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
