### PR TITLE
[conductor] disable failure notifications for now

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -35,7 +35,7 @@ integrations:
 extensions:
   datadoghq.com/sdp:
     conductor:
-      slack: "container-ecosystems"
+      slack: "datadog-operator"
       options:
         rollout_strategy: "installation"
       targets:
@@ -50,6 +50,8 @@ extensions:
           schedule: "10 3 * * SUN-THU"
           workflows:
             - "k8s-datadog-agent-ops/workflows/deploy_operator.operator_nightly"
+          options:
+            disable_failure_notifications: true
         - name: "conductor-test"
           ci_pipeline: "//fake_placeholder:fake_placeholder"
           # Test branch


### PR DESCRIPTION
### What does this PR do?

Disable failure notifications for now as it isn't working as expected
Also adjust the notification slack channel 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
