### PR TITLE
Add a workflow action to mark and autoclose stale issues

### DIFF
--- a/.github/workflows/staler.yaml
+++ b/.github/workflows/staler.yaml
@@ -1,0 +1,18 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is marked as stale since there has not been any activity in over a year. It will be closed in 10 days'
+          close-issue-message: 'This issue has been closed after being marked stale for more than 10 days'
+          days-before-issue-stale: 365
+          days-before-issue-close: 10
+          exempt-issue-labels: no stale,enhancement,feature request,bug,feature/datadog-monitor,feature/slo
+          stale-issue-label: stale
+          close-issue-label: autoclosed


### PR DESCRIPTION
### What does this PR do?

Issues without any of these labels `no stale,enhancement,feature request,bug,feature/datadog-monitor,feature/slo` which haven't been for 1 year will be marked as `stale` and autoclosed after 14 days (workflow run every Monday) unless there is a user activity.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
