### PR TITLE
[profiles] Use deepcopy for patch

### DIFF
--- a/controllers/datadogagent/controller_reconcile_agent.go
+++ b/controllers/datadogagent/controller_reconcile_agent.go
@@ -309,13 +309,10 @@ func (r *Reconciler) labelNodesWithProfiles(ctx context.Context, profilesByNode 
 			return nil
 		}
 
-		patch := corev1.Node{
-			TypeMeta:   node.TypeMeta,
-			ObjectMeta: node.ObjectMeta,
-		}
-		patch.Labels = newLabels
+		modifiedNode := node.DeepCopy()
+		modifiedNode.Labels = newLabels
 
-		err := r.client.Patch(ctx, &patch, client.MergeFrom(node))
+		err := r.client.Patch(ctx, modifiedNode, client.MergeFrom(node))
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}

--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -180,13 +180,10 @@ func (r *Reconciler) profilesCleanup() error {
 			newLabels[k] = v
 		}
 
-		patch := corev1.Node{
-			TypeMeta:   node.TypeMeta,
-			ObjectMeta: node.ObjectMeta,
-		}
+		patch := node.DeepCopy()
 		patch.Labels = newLabels
 
-		err := r.client.Patch(context.TODO(), &patch, client.MergeFrom(&node))
+		err := r.client.Patch(context.TODO(), patch, client.MergeFrom(&node))
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}

--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -180,10 +180,10 @@ func (r *Reconciler) profilesCleanup() error {
 			newLabels[k] = v
 		}
 
-		patch := node.DeepCopy()
-		patch.Labels = newLabels
+		modifiedNode := node.DeepCopy()
+		modifiedNode.Labels = newLabels
 
-		err := r.client.Patch(context.TODO(), patch, client.MergeFrom(&node))
+		err := r.client.Patch(context.TODO(), modifiedNode, client.MergeFrom(&node))
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

Deepcopy the node instead of adding only typemeta and objectmeta. On some nodes, the patch request would try to patch in an empty node status instead of only the modified labels. This attempts to prevent empty node statuses from being a part of the patch request

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy the operator with profiles enabled
* Spin up a profile and check that the nodes targeted by the profile have the `agent.datadoghq.com/datadogagentprofile` label on them

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
