### PR TITLE
[gitlab] small fixes for gitlab job rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,7 +64,8 @@ stages:
         - "*.md"
       compare_to: "refs/heads/main"
     when: never
-  - if: $CI_COMMIT_BRANCH
+  # Temporarily disable on Conductor-triggered jobs
+  - if: '$DDR != "true"'
     when: manual
   - when: never
 
@@ -80,6 +81,10 @@ build:
 unit_tests:
   stage: test
   tags: ["runner:main", "size:large"]
+  rules:
+    - if: '$DDR == "true"'
+      when: never
+    - when: on_success
   before_script:
     - mkdir -p .cache
     - make install-tools
@@ -89,6 +94,10 @@ unit_tests:
 generate_code:
   stage: test
   tags: ["runner:main", "size:large"]
+  rules:
+    - if: '$DDR == "true"'
+      when: never
+    - when: on_success
   before_script:
     - mkdir -p .cache
     - make install-tools
@@ -177,7 +186,7 @@ build_bundle_image:
 publish_public_main:
   stage: release
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" && $DDR != "true"'
       when: on_success
     - when: never
   trigger:
@@ -294,7 +303,7 @@ trigger_internal_operator_check_image:
 trigger_internal_operator_nightly_image:
   stage: release
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main" && $CONDUCTOR_TARGET == "nightly-build"'
+    - if: '$CI_COMMIT_BRANCH == "main" && $DDR == "true" && $CONDUCTOR_TARGET == "nightly-build"'
       when: on_success
     - when: never
   trigger:
@@ -313,7 +322,7 @@ trigger_internal_operator_nightly_image:
 trigger_internal_operator_check_nightly_image:
   stage: release
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main" && $CONDUCTOR_TARGET == "nightly-build"'
+    - if: '$CI_COMMIT_BRANCH == "main" && $DDR == "true" && $CONDUCTOR_TARGET == "nightly-build"'
       when: on_success
     - when: never
   trigger:
@@ -482,6 +491,7 @@ publish_nightly_workflow:
     SKIP_PLAN_CHECK: "true"
     ENVIRONMENTS: "experimental"
     CHART: "datadog-operator"
+    OPTION_AUTOMATIC_ROLLOUT: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_operator.operator_nightly.publish"
     BAZEL_TARGET: $BAZEL_TARGET
     DDR: $DDR


### PR DESCRIPTION
### What does this PR do?

- Don't run `test` or `e2e` stages when triggered by Conductor
- Don't publish `main` image when triggered by Conductor
- Set automatic rollout on Conductor trigger of child k8s-datadog-agent-ops pipeline

### Motivation

Trim time spent running Conductor job
Don't use e2e tests which currently error
Automatically start workload publishing without manual intervention

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
