### PR TITLE
[sdp] adjust cron schedule for nightly

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -47,7 +47,7 @@ extensions:
           parent_environments: 
             - "staging"
           branch: "main"
-          schedule: "10 3 * * SUN-THU"
+          schedule: "30 23 * * SUN-THU"
           workflows:
             - "k8s-datadog-agent-ops/workflows/deploy_operator.operator_nightly"
           options:


### PR DESCRIPTION
### What does this PR do?

Adjusting the CRON schedule for the nightly job. There appears to be a bug when setting time zone in the downstream job, so seeing if adjusting to earlier in the evening (`23` is 7p EST) helps.

`30 23 * * SUN-THU` -> 11:30pm UTC Sunday through Thursday

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
