### PR TITLE
Remove XValidation rule in DPA as requires K8S >= 1.25

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogpodautoscaler_types.go
+++ b/apis/datadoghq/v1alpha1/datadogpodautoscaler_types.go
@@ -78,7 +78,6 @@ const (
 // DatadogPodAutoscalerSpec defines the desired state of DatadogPodAutoscaler
 type DatadogPodAutoscalerSpec struct {
 	// TargetRef is the reference to the resource to scale.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Modifying the targetRef is not allowed. Please delete and re-create the DatadogPodAutoscaler object."
 	TargetRef autoscalingv2.CrossVersionObjectReference `json:"targetRef"`
 
 	// Owner defines the source of truth for this object (local or remote)

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -324,9 +324,6 @@ spec:
                     - kind
                     - name
                   type: object
-                  x-kubernetes-validations:
-                    - message: Modifying the targetRef is not allowed. Please delete and re-create the DatadogPodAutoscaler object.
-                      rule: self == oldSelf
                 targets:
                   description: |-
                     Targets are objectives to reach and maintain for the target resource.


### PR DESCRIPTION
### What does this PR do?

Remove XValidation rule in DPA as requires K8S >= 1.25

### Motivation

Bugfix.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
