### PR TITLE
Use `unknown` tool version when env var is not set (#1345)

### DIFF
--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -477,7 +477,7 @@ func buildInstallInfoConfigMap(dda metav1.Object) *corev1.ConfigMap {
 }
 
 func getInstallInfoValue() string {
-	toolVersion := "datadog-operator"
+	toolVersion := "unknown"
 	if envVar := os.Getenv(apicommon.InstallInfoToolVersion); envVar != "" {
 		toolVersion = envVar
 	}

--- a/controllers/datadogagent/feature/enabledefault/feature_test.go
+++ b/controllers/datadogagent/feature/enabledefault/feature_test.go
@@ -7,8 +7,9 @@ package enabledefault
 
 import (
 	"encoding/json"
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -41,7 +42,7 @@ func Test_getInstallInfoValue(t *testing.T) {
 		{
 			name:                   "Env var empty/unset (os.Getenv returns unset env var as empty string)",
 			toolVersionEnvVarValue: "",
-			expectedToolVersion:    "datadog-operator",
+			expectedToolVersion:    "unknown",
 		},
 		{
 			name:                   "Env var set",


### PR DESCRIPTION
### What does this PR do?

cherry-pick #1345 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
