### PR TITLE
Bump Go version in go.mod and Dockerfiles to 1.22.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.22.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/DataDog/datadog-operator
 
-go 1.22
-
-toolchain go1.22.4
+go 1.22.4
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.19.0


### PR DESCRIPTION
### What does this PR do?

Trying to address a [cve-2024-24790](https://avd.aquasec.com/nvd/2024/cve-2024-24790/), VULN-5906 by bumping Go to 1.22.4.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
