### PR TITLE
Update operator-manifest-tools args for 0.6.0

### DIFF
--- a/hack/redhat-bundle.sh
+++ b/hack/redhat-bundle.sh
@@ -26,7 +26,7 @@ eval $SED \'s#containerImage: gcr.io/datadoghq/operator:#containerImage: registr
 $YQ -i "(.spec.install.spec.deployments[] | select(.name == \"datadog-operator-manager\") | .spec.template.spec.containers[] | select(.name == \"manager\") | .env[] | select(.name == \"DD_TOOL_VERSION\") | .value) = \"redhat\"" $RH_BUNDLE_PATH/manifests/datadog-operator.clusterserviceversion.yaml
 
 # Pin images
-$ROOT/bin/$PLATFORM/operator-manifest-tools pinning pin "$RH_BUNDLE_PATH/manifests" -a ~/.redhat/auths.json
+$ROOT/bin/$PLATFORM/operator-manifest-tools pinning pin "$RH_BUNDLE_PATH/manifests" -a ~/.redhat/auths.json -r skopeo
 
 # Remove tests folder as unused
 rm -rf "$RH_BUNDLE_PATH/tests"


### PR DESCRIPTION
### What does this PR do?

`make bundle-redhat` broke after `operator-manifest-tools` upgrade from 0.2.0 to 0.6.0. Issue is new version using `crane` as a default resolver (from the error output) and our script fails with authentication error

>   -r, --resolver string                The resolver to use; valid values are [script, skopeo, crane] (default "crane")

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
