### PR TITLE
[OpenShift] Doc update following 1.8.0 release

### DIFF
--- a/docs/install-openshift.md
+++ b/docs/install-openshift.md
@@ -60,6 +60,20 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
         # This is needed if the kubelet certificate is self-signed.
         # Alternatively, the CA certificate used to sign the kubelet certificate can be mounted.
         tlsVerify: false
+    features:
+      apm:
+        enabled: true
+        hostPortConfig:
+          enabled: true
+        # Unix Domain Socket uses a `hostPath` volume, prevented by OpenShift default SecurityContextConstraints for applicative pods.
+        # More information: https://docs.datadoghq.com/containers/troubleshooting/admission-controller/?tab=datadogoperator#openshift
+        unixDomainSocketConfig:
+          enabled: false
+      dogstatsd:
+        hostPortConfig:
+          enabled: true
+        unixDomainSocketConfig:
+          enabled: false
     override:
       nodeAgent:
         # In OpenShift 4.0+, set the hostNetwork parameter to allow access to your cloud provider metadata API endpoint.
@@ -75,6 +89,14 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
             type: spc_t
             user: system_u
         serviceAccountName: datadog-agent-scc
+        # Tolerations matching OpenShift default taints on master nodes
+        tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/infra
+          operator: Exists
+          effect: NoSchedule
       clusterAgent:
         serviceAccountName: datadog-agent-scc
         replicas: 2 # High-availability

--- a/docs/install-openshift.md
+++ b/docs/install-openshift.md
@@ -55,6 +55,7 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
         appSecret:
           keyName: app-key
           secretName: datadog-secret
+      clusterName: <CLUSTER_NAME>
       criSocketPath: /var/run/crio/crio.sock
       kubelet:
         # This is needed if the kubelet certificate is self-signed.

--- a/docs/install-openshift.md
+++ b/docs/install-openshift.md
@@ -80,8 +80,6 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
         # In OpenShift 4.0+, set the hostNetwork parameter to allow access to your cloud provider metadata API endpoint.
         # This is necessary to retrieve host tags and aliases collected by Datadog cloud provider integrations. 
         hostNetwork: true
-        image:
-          name: gcr.io/datadoghq/agent:latest
         securityContext:
           runAsUser: 0
           seLinuxOptions:
@@ -101,8 +99,6 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
       clusterAgent:
         serviceAccountName: datadog-agent-scc
         replicas: 2 # High-availability
-        image:
-          name: gcr.io/datadoghq/cluster-agent:latest
   ```
 
 Setting the `serviceAccountName` in the `nodeAgent` and `clusterAgent` `override` section ensures that these pods are associated with the necessary `SecurityContextConstraints` and RBACs.

--- a/docs/install-openshift.md
+++ b/docs/install-openshift.md
@@ -65,6 +65,8 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
         # In OpenShift 4.0+, set the hostNetwork parameter to allow access to your cloud provider metadata API endpoint.
         # This is necessary to retrieve host tags and aliases collected by Datadog cloud provider integrations. 
         hostNetwork: true
+        image:
+          name: gcr.io/datadoghq/agent:latest
         securityContext:
           runAsUser: 0
           seLinuxOptions:
@@ -75,11 +77,9 @@ The following is the simplest recommended configuration for the `DatadogAgent` i
         serviceAccountName: datadog-agent-scc
       clusterAgent:
         serviceAccountName: datadog-agent-scc
-        replicas: 2
-        containers:
-          cluster-agent:
-            securityContext:
-              readOnlyRootFilesystem: false
+        replicas: 2 # High-availability
+        image:
+          name: gcr.io/datadoghq/cluster-agent:latest
   ```
 
 Setting the `serviceAccountName` in the `nodeAgent` and `clusterAgent` `override` section ensures that these pods are associated with the necessary `SecurityContextConstraints` and RBACs.


### PR DESCRIPTION
### What does this PR do?
* Updates OpenShift instructions following `1.8.0` release
* Matching doc PR : https://github.com/DataDog/documentation/pull/24901

### Motivation

* Operator `1.8.0` was released containing https://github.com/DataDog/datadog-operator/pull/1296. This fixes the issue that was requiring the previous workaround of disabling the rootonlyfs for the DCA to get access to `agent` CLI in the DCA
* Adds default tolerations required for master nodes
* Disables UDS by default to rely on `hostIP` communication from the admission controller instead of `hostPath` volumes

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
