### PR TITLE
[profiles] Add update strategy overrides to profiles

### DIFF
--- a/apis/datadoghq/v1alpha1/datadogagentprofile_types.go
+++ b/apis/datadoghq/v1alpha1/datadogagentprofile_types.go
@@ -7,6 +7,7 @@ package v1alpha1
 
 import (
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +48,10 @@ type Override struct {
 	// default.
 	// +optional
 	PriorityClassName *string `json:"priorityClassName,omitempty"`
+
+	// The deployment strategy to use to replace existing pods with new ones.
+	// +optional
+	UpdateStrategy *v2alpha1.UpdateStrategy `json:"updateStrategy,omitempty"`
 
 	// Labels provide labels that are added to the Datadog Agent pods.
 	// +optional

--- a/apis/datadoghq/v1alpha1/datadogagentprofile_types.go
+++ b/apis/datadoghq/v1alpha1/datadogagentprofile_types.go
@@ -7,7 +7,6 @@ package v1alpha1
 
 import (
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
-	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +50,7 @@ type Override struct {
 
 	// The deployment strategy to use to replace existing pods with new ones.
 	// +optional
-	UpdateStrategy *v2alpha1.UpdateStrategy `json:"updateStrategy,omitempty"`
+	UpdateStrategy *commonv1.UpdateStrategy `json:"updateStrategy,omitempty"`
 
 	// Labels provide labels that are added to the Datadog Agent pods.
 	// +optional

--- a/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -12,6 +12,7 @@ package v1alpha1
 import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
+	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -1452,6 +1453,11 @@ func (in *Override) DeepCopyInto(out *Override) {
 		in, out := &in.PriorityClassName, &out.PriorityClassName
 		*out = new(string)
 		**out = **in
+	}
+	if in.UpdateStrategy != nil {
+		in, out := &in.UpdateStrategy, &out.UpdateStrategy
+		*out = new(v2alpha1.UpdateStrategy)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels

--- a/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -12,7 +12,6 @@ package v1alpha1
 import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
-	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -1456,7 +1455,7 @@ func (in *Override) DeepCopyInto(out *Override) {
 	}
 	if in.UpdateStrategy != nil {
 		in, out := &in.UpdateStrategy, &out.UpdateStrategy
-		*out = new(v2alpha1.UpdateStrategy)
+		*out = new(commonv1.UpdateStrategy)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Labels != nil {

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -244,6 +244,36 @@ spec:
                               If not specified, the pod priority will be default or zero if there is no
                               default.
                             type: string
+                          updateStrategy:
+                            description: The deployment strategy to use to replace existing pods with new ones.
+                            properties:
+                              rollingUpdate:
+                                description: Configure the rolling update strategy of the Deployment or DaemonSet.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      MaxSurge behaves differently based on the Kubernetes resource. Refer to the
+                                      Kubernetes API documentation for additional details.
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      The maximum number of pods that can be unavailable during the update.
+                                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                      Refer to the Kubernetes API documentation for additional details..
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: |-
+                                  Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
+                                  or "Recreate" for Deployments
+                                type: string
+                            type: object
                         type: object
                       type: object
                   type: object

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -350,9 +350,9 @@ func TestOverrideFromProfile(t *testing.T) {
 					},
 				},
 				PriorityClassName: apiutils.NewStringPointer("foo"),
-				UpdateStrategy: &v2alpha1.UpdateStrategy{
+				UpdateStrategy: &common.UpdateStrategy{
 					Type: "RollingUpdate",
-					RollingUpdate: &v2alpha1.RollingUpdate{
+					RollingUpdate: &common.RollingUpdate{
 						MaxUnavailable: &intstr.IntOrString{
 							IntVal: 10,
 						},
@@ -623,9 +623,9 @@ func configWithAllOverrides(cpuRequest string) *v1alpha1.Config {
 		Override: map[v1alpha1.ComponentName]*v1alpha1.Override{
 			v1alpha1.NodeAgentComponentName: {
 				PriorityClassName: apiutils.NewStringPointer("foo"),
-				UpdateStrategy: &v2alpha1.UpdateStrategy{
+				UpdateStrategy: &common.UpdateStrategy{
 					Type: "RollingUpdate",
-					RollingUpdate: &v2alpha1.RollingUpdate{
+					RollingUpdate: &common.RollingUpdate{
 						MaxUnavailable: &intstr.IntOrString{
 							IntVal: 10,
 						},

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -380,7 +380,7 @@ func TestOverrideFromProfile(t *testing.T) {
 			},
 		},
 		{
-			name:    "default profile",
+			name:    "default profile, no overrides applied",
 			profile: exampleDefaultProfile(),
 			expectedOverride: v2alpha1.DatadogAgentComponentOverride{
 				Name: apiutils.NewStringPointer(""),

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -10,18 +10,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	apicommon "github.com/DataDog/datadog-operator/apis/datadoghq/common"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const testNamespace = "default"
@@ -347,6 +349,15 @@ func TestOverrideFromProfile(t *testing.T) {
 						},
 					},
 				},
+				PriorityClassName: apiutils.NewStringPointer("foo"),
+				UpdateStrategy: &v2alpha1.UpdateStrategy{
+					Type: "RollingUpdate",
+					RollingUpdate: &v2alpha1.RollingUpdate{
+						MaxUnavailable: &intstr.IntOrString{
+							IntVal: 10,
+						},
+					},
+				},
 				Containers: map[common.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{
 					common.CoreAgentContainerName: {
 						Resources: &v1.ResourceRequirements{
@@ -354,10 +365,56 @@ func TestOverrideFromProfile(t *testing.T) {
 								v1.ResourceCPU: resource.MustParse("100m"),
 							},
 						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "foo",
+								Value: "bar",
+							},
+						},
 					},
 				},
 				Labels: map[string]string{
 					"agent.datadoghq.com/datadogagentprofile": "linux",
+					"foo": "bar",
+				},
+			},
+		},
+		{
+			name:    "default profile",
+			profile: exampleDefaultProfile(),
+			expectedOverride: v2alpha1.DatadogAgentComponentOverride{
+				Name: apiutils.NewStringPointer(""),
+				Affinity: &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{
+								{
+									MatchExpressions: []v1.NodeSelectorRequirement{
+										{
+											Key:      ProfileLabelKey,
+											Operator: v1.NodeSelectorOpDoesNotExist,
+										},
+									},
+								},
+							},
+						},
+					},
+					PodAntiAffinity: &v1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      apicommon.AgentDeploymentComponentLabelKey,
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"agent"},
+										},
+									},
+								},
+								TopologyKey: v1.LabelHostname,
+							},
+						},
+					},
 				},
 			},
 		},
@@ -397,85 +454,6 @@ func TestDaemonSetName(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expectedDaemonSetName, DaemonSetName(test.profileNamespacedName))
-		})
-	}
-}
-
-func Test_priorityClassNameOverride(t *testing.T) {
-	tests := []struct {
-		name                  string
-		profile               v1alpha1.DatadogAgentProfile
-		expectedpriorityClass *string
-	}{
-		{
-			name:                  "empty profile",
-			profile:               v1alpha1.DatadogAgentProfile{},
-			expectedpriorityClass: nil,
-		},
-		{
-			name: "profile with no priority class set",
-			profile: v1alpha1.DatadogAgentProfile{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
-					Name:      "foo",
-				},
-				Spec: v1alpha1.DatadogAgentProfileSpec{
-					Config: &v1alpha1.Config{
-						Override: map[v1alpha1.ComponentName]*v1alpha1.Override{
-							v1alpha1.NodeAgentComponentName: {
-								Containers: map[common.AgentContainerName]*v1alpha1.Container{},
-							},
-						},
-					},
-				},
-			},
-			expectedpriorityClass: nil,
-		},
-		{
-			name: "profile with empty priority class set",
-			profile: v1alpha1.DatadogAgentProfile{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
-					Name:      "foo",
-				},
-				Spec: v1alpha1.DatadogAgentProfileSpec{
-					Config: &v1alpha1.Config{
-						Override: map[v1alpha1.ComponentName]*v1alpha1.Override{
-							v1alpha1.NodeAgentComponentName: {
-								Containers:        map[common.AgentContainerName]*v1alpha1.Container{},
-								PriorityClassName: apiutils.NewStringPointer(""),
-							},
-						},
-					},
-				},
-			},
-			expectedpriorityClass: apiutils.NewStringPointer(""),
-		},
-		{
-			name: "profile with priority class set",
-			profile: v1alpha1.DatadogAgentProfile{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
-					Name:      "foo",
-				},
-				Spec: v1alpha1.DatadogAgentProfileSpec{
-					Config: &v1alpha1.Config{
-						Override: map[v1alpha1.ComponentName]*v1alpha1.Override{
-							v1alpha1.NodeAgentComponentName: {
-								Containers:        map[common.AgentContainerName]*v1alpha1.Container{},
-								PriorityClassName: apiutils.NewStringPointer("bar"),
-							},
-						},
-					},
-				},
-			},
-			expectedpriorityClass: apiutils.NewStringPointer("bar"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expectedpriorityClass, priorityClassNameOverride(&test.profile))
 		})
 	}
 }
@@ -587,7 +565,7 @@ func exampleProfileForLinux() v1alpha1.DatadogAgentProfile {
 					},
 				},
 			},
-			Config: configWithCPURequestOverrideForCoreAgent("100m"),
+			Config: configWithAllOverrides("100m"),
 		},
 	}
 }
@@ -608,7 +586,7 @@ func exampleProfileForWindows() v1alpha1.DatadogAgentProfile {
 					},
 				},
 			},
-			Config: configWithCPURequestOverrideForCoreAgent("200m"),
+			Config: configWithAllOverrides("200m"),
 		},
 	}
 }
@@ -621,19 +599,49 @@ func exampleInvalidProfile() v1alpha1.DatadogAgentProfile {
 		},
 		Spec: v1alpha1.DatadogAgentProfileSpec{
 			// missing ProfileAffinity
-			Config: configWithCPURequestOverrideForCoreAgent("200m"),
+			Config: configWithAllOverrides("200m"),
 		},
 	}
 }
 
-// configWithCPURequestOverrideForCoreAgent returns a config with a CPU request
-// for the core agent container.
-func configWithCPURequestOverrideForCoreAgent(cpuRequest string) *v1alpha1.Config {
+func exampleDefaultProfile() v1alpha1.DatadogAgentProfile {
+	return v1alpha1.DatadogAgentProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "",
+			Name:      "default",
+		},
+		Spec: v1alpha1.DatadogAgentProfileSpec{
+			Config: configWithAllOverrides("200m"),
+		},
+	}
+}
+
+// configWithAllOverrides returns a config with all available overrides for the
+// core agent container.
+func configWithAllOverrides(cpuRequest string) *v1alpha1.Config {
 	return &v1alpha1.Config{
 		Override: map[v1alpha1.ComponentName]*v1alpha1.Override{
 			v1alpha1.NodeAgentComponentName: {
+				PriorityClassName: apiutils.NewStringPointer("foo"),
+				UpdateStrategy: &v2alpha1.UpdateStrategy{
+					Type: "RollingUpdate",
+					RollingUpdate: &v2alpha1.RollingUpdate{
+						MaxUnavailable: &intstr.IntOrString{
+							IntVal: 10,
+						},
+					},
+				},
+				Labels: map[string]string{
+					"foo": "bar",
+				},
 				Containers: map[common.AgentContainerName]*v1alpha1.Container{
 					common.CoreAgentContainerName: {
+						Env: []corev1.EnvVar{
+							{
+								Name:  "foo",
+								Value: "bar",
+							},
+						},
 						Resources: &v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceCPU: resource.MustParse(cpuRequest),


### PR DESCRIPTION
### What does this PR do?

Adds update strategy overrides to profiles

### Motivation

https://datadoghq.atlassian.net/browse/CECO-1014

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy operator with [profiles enabled](https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md#enabling-datadogagentprofiles)
* Deploy DDA
* Create a profile with a custom update strategy that is different from what is set in the DDA
* Check the profile daemonset to see if the update strategy was overridden

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
