### PR TITLE
chore(lint): fix FromAsCasing warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.4 as builder
+FROM golang:1.22.4 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.4 as builder
+FROM golang:1.22.4 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
### What does this PR do?

Fixes [FromAsCasing](https://docs.docker.com/reference/build-checks/from-as-casing/) warnings for `operator` and `check-operator` Dockerfiles.

### Describe your test plan

Before
```
docker build . -t wdhifdatadog/operator --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=579a07c8b61d2e00c785748c7661578f59697e07 -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.8.0-rc.4_579a07c8 -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-08-28/08:32:38" --build-arg GOARCH=""
[...]
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
 
docker build . -t wdhifdatadog/check-operator -f check-operator.Dockerfile --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=579a07c8b61d2e00c785748c7661578f59697e07 -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.8.0-rc.4_579a07c8 -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-08-28/08:33:38" --build-arg GOARCH=""
[...]
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```

After
```
docker build . -t wdhifdatadog/operator --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=bd1e5f552089b37be01e9ce6a03ea96f1019a18f -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.8.0-rc.4_bd1e5f55 -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-08-28/08:40:55" --build-arg GOARCH=""
[NO WARNING]

docker build . -t wdhifdatadog/check-operator -f check-operator.Dockerfile --build-arg LDFLAGS="-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=bd1e5f552089b37be01e9ce6a03ea96f1019a18f -X github.com/DataDog/datadog-operator/pkg/version.Version=v1.8.0-rc.4_bd1e5f55 -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2024-08-28/08:41:20" --build-arg GOARCH=""
[NO WARNING]
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
