### PR TITLE
feat(admission controller): add ValidatingWebhookConfigurations RBAC

### DIFF
--- a/bundle/manifests/datadog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/datadog-operator.clusterserviceversion.yaml
@@ -441,16 +441,10 @@ spec:
             - apiGroups:
                 - admissionregistration.k8s.io
               resources:
+                - validatingwebhookconfigurations
                 - mutatingwebhookconfigurations
               verbs:
                 - '*'
-            - apiGroups:
-                - admissionregistration.k8s.io
-              resources:
-                - validatingwebhookconfigurations
-              verbs:
-                - list
-                - watch
             - apiGroups:
                 - apiregistration.k8s.io
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -199,15 +199,9 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
-  verbs:
-  - '*'
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
   - validatingwebhookconfigurations
   verbs:
-  - list
-  - watch
+  - '*'
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/controllers/datadogagent/controller_test.go
+++ b/controllers/datadogagent/controller_test.go
@@ -100,12 +100,13 @@ func hasWpaRbacs(policyRules []rbacv1.PolicyRule) bool {
 
 func hasAdmissionRbacResources(clusterPolicyRules []rbacv1.PolicyRule, policyRules []rbacv1.PolicyRule) bool {
 	clusterLevelResources := map[string]bool{
-		"mutatingwebhookconfigurations": true,
-		"replicasets":                   true,
-		"deployments":                   true,
-		"statefulsets":                  true,
-		"cronjobs":                      true,
-		"jobs":                          true,
+		"validatingwebhookconfigurations": true,
+		"mutatingwebhookconfigurations":   true,
+		"replicasets":                     true,
+		"deployments":                     true,
+		"statefulsets":                    true,
+		"cronjobs":                        true,
+		"jobs":                            true,
 	}
 	roleResources := map[string]bool{
 		"secrets": true,

--- a/controllers/datadogagent/feature/admissioncontroller/rbac.go
+++ b/controllers/datadogagent/feature/admissioncontroller/rbac.go
@@ -14,17 +14,17 @@ import (
 
 func getRBACClusterPolicyRules(webhookName string, cwsInstrumentationEnabled bool, cwsInstrumentationMode string) []rbacv1.PolicyRule {
 	clusterPolicyRules := []rbacv1.PolicyRule{
-		// MutatingWebhooksConfigs
+		// ValidatingWebhooksConfigs and MutatingWebhooksConfigs
 		{
 			APIGroups: []string{rbac.AdmissionAPIGroup},
-			Resources: []string{rbac.MutatingConfigResource},
+			Resources: []string{rbac.ValidatingConfigResource, rbac.MutatingConfigResource},
 			Verbs: []string{
 				rbac.CreateVerb,
 			},
 		},
 		{
 			APIGroups:     []string{rbac.AdmissionAPIGroup},
-			Resources:     []string{rbac.MutatingConfigResource},
+			Resources:     []string{rbac.ValidatingConfigResource, rbac.MutatingConfigResource},
 			ResourceNames: []string{webhookName},
 			Verbs: []string{
 				rbac.GetVerb,

--- a/controllers/datadogagent_controller.go
+++ b/controllers/datadogagent_controller.go
@@ -70,7 +70,7 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=pods/exec,verbs=create
 
 // Configure Admission Controller
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=*
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations;mutatingwebhookconfigurations,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get
@@ -172,7 +172,6 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=list;watch
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=list;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=list;watch
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=list;watch
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=list;watch
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses;volumeattachments,verbs=list;watch

--- a/pkg/equality/equality.go
+++ b/pkg/equality/equality.go
@@ -39,6 +39,8 @@ func IsEqualObject(kind kubernetes.ObjectKind, a, b client.Object) bool {
 		return IsEqualRoles(a, b)
 	case kubernetes.RoleBindingKind:
 		return IsEqualRoleBinding(a, b)
+	case kubernetes.ValidatingWebhookConfigurationsKind:
+		return IsEqualValidatingWebhookConfigurations(a, b)
 	case kubernetes.MutatingWebhookConfigurationsKind:
 		return IsEqualMutatingWebhookConfigurations(a, b)
 	case kubernetes.APIServiceKind:
@@ -114,6 +116,16 @@ func IsEqualRoleBinding(objA, objB client.Object) bool {
 	b, okB := objB.(*rbacv1.RoleBinding)
 	if okA && okB && a != nil && b != nil {
 		return apiequality.Semantic.DeepEqual(a.RoleRef, b.RoleRef) && apiequality.Semantic.DeepEqual(a.Subjects, b.Subjects)
+	}
+	return false
+}
+
+// IsEqualValidatingWebhookConfigurations return true if the two ValidatingWebhookConfigurations are equal
+func IsEqualValidatingWebhookConfigurations(objA, objB client.Object) bool {
+	a, okA := objA.(*admissionregistrationv1.ValidatingWebhookConfiguration)
+	b, okB := objB.(*admissionregistrationv1.ValidatingWebhookConfiguration)
+	if okA && okB && a != nil && b != nil {
+		return apiequality.Semantic.DeepEqual(a.Webhooks, b.Webhooks)
 	}
 	return false
 }

--- a/pkg/kubernetes/const.go
+++ b/pkg/kubernetes/const.go
@@ -34,6 +34,8 @@ const (
 	RolesKind = "roles"
 	// RoleBindingKind RoleBinding resource kind
 	RoleBindingKind = "rolebindings"
+	// ValidatingWebhookConfigurationsKind ValidatingWebhookConfigurations resource kind
+	ValidatingWebhookConfigurationsKind = "validatingwebhookconfigurations"
 	// MutatingWebhookConfigurationsKind MutatingWebhookConfigurations resource kind
 	MutatingWebhookConfigurationsKind = "mutatingwebhookconfigurations"
 	// APIServiceKind APIService resource kind
@@ -64,6 +66,7 @@ func getResourcesKind(withCiliumResources, withPodSecurityPolicy bool) []ObjectK
 		ClusterRoleBindingKind,
 		RolesKind,
 		RoleBindingKind,
+		ValidatingWebhookConfigurationsKind,
 		MutatingWebhookConfigurationsKind,
 		APIServiceKind,
 		SecretsKind,

--- a/pkg/kubernetes/objects.go
+++ b/pkg/kubernetes/objects.go
@@ -30,6 +30,8 @@ func ObjectFromKind(kind ObjectKind, platformInfo PlatformInfo) client.Object {
 		return &rbacv1.Role{}
 	case RoleBindingKind:
 		return &rbacv1.RoleBinding{}
+	case ValidatingWebhookConfigurationsKind:
+		return &admissionregistrationv1.ValidatingWebhookConfiguration{}
 	case MutatingWebhookConfigurationsKind:
 		return &admissionregistrationv1.MutatingWebhookConfiguration{}
 	case APIServiceKind:

--- a/pkg/kubernetes/objectslist.go
+++ b/pkg/kubernetes/objectslist.go
@@ -30,6 +30,8 @@ func ObjectListFromKind(kind ObjectKind, platformInfo PlatformInfo) client.Objec
 		return &rbacv1.RoleList{}
 	case RoleBindingKind:
 		return &rbacv1.RoleBindingList{}
+	case ValidatingWebhookConfigurationsKind:
+		return &admissionregistrationv1.ValidatingWebhookConfigurationList{}
 	case MutatingWebhookConfigurationsKind:
 		return &admissionregistrationv1.MutatingWebhookConfigurationList{}
 	case APIServiceKind:


### PR DESCRIPTION
### What does this PR do?

Adds the necessary RBACs for the Cluster Agent to modify the `ValidatingWebhookConfigurations`.

### Motivation

This is needed to support the new `ValidatingAdmissionWebhook` controller in the Agent's Admission Controller.

### Minimum Agent Versions

Agent: v7.58.0
Cluster Agent: v7.58.0

### Describe your test plan

Build the Operator and validate that the new `ValidatingAdmissionWebhook` is created with the new Agent.

```
➜ k describe validatingwebhookconfigurations.admissionregistration.k8s.io datadog-webhook
Name:         datadog-webhook
Namespace:
Labels:       <none>
Annotations:  <none>
API Version:  admissionregistration.k8s.io/v1
Kind:         ValidatingWebhookConfiguration
Metadata:
  Creation Timestamp:  2024-08-28T09:07:22Z
  Generation:          1
  Resource Version:    832
  UID:                 efd5e35d-8257-46ba-bdc7-b35268bf7c15
Events:                <none>
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
