### PR TITLE
Add beta support for Agent Data Plane.

### DIFF
--- a/apis/datadoghq/common/common.go
+++ b/apis/datadoghq/common/common.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// GetDefaultLivenessProbe creates a defaulted LivenessProbe
-func GetDefaultLivenessProbe() *corev1.Probe {
+// GetDefaultLivenessProbeWithPort creates a liveness probe with defaulted values, using the provided port
+func GetDefaultLivenessProbeWithPort(port int32) *corev1.Probe {
 	livenessProbe := &corev1.Probe{
 		InitialDelaySeconds: DefaultLivenessProbeInitialDelaySeconds,
 		PeriodSeconds:       DefaultLivenessProbePeriodSeconds,
@@ -24,14 +24,14 @@ func GetDefaultLivenessProbe() *corev1.Probe {
 	livenessProbe.HTTPGet = &corev1.HTTPGetAction{
 		Path: DefaultLivenessProbeHTTPPath,
 		Port: intstr.IntOrString{
-			IntVal: DefaultAgentHealthPort,
+			IntVal: port,
 		},
 	}
 	return livenessProbe
 }
 
-// GetDefaultReadinessProbe creates a defaulted ReadinessProbe
-func GetDefaultReadinessProbe() *corev1.Probe {
+// GetDefaultReadinessProbeWithPort creates a readiness probe with defaulted values, using the provided port
+func GetDefaultReadinessProbeWithPort(port int32) *corev1.Probe {
 	readinessProbe := &corev1.Probe{
 		InitialDelaySeconds: DefaultReadinessProbeInitialDelaySeconds,
 		PeriodSeconds:       DefaultReadinessProbePeriodSeconds,
@@ -42,14 +42,14 @@ func GetDefaultReadinessProbe() *corev1.Probe {
 	readinessProbe.HTTPGet = &corev1.HTTPGetAction{
 		Path: DefaultReadinessProbeHTTPPath,
 		Port: intstr.IntOrString{
-			IntVal: DefaultAgentHealthPort,
+			IntVal: port,
 		},
 	}
 	return readinessProbe
 }
 
-// GetDefaultStartupProbe creates a defaulted StartupProbe
-func GetDefaultStartupProbe() *corev1.Probe {
+// GetDefaultStartupProbeWithPort creates a startup probe with defaulted values, using the provided port
+func GetDefaultStartupProbeWithPort(port int32) *corev1.Probe {
 	startupProbe := &corev1.Probe{
 		InitialDelaySeconds: DefaultStartupProbeInitialDelaySeconds,
 		PeriodSeconds:       DefaultStartupProbePeriodSeconds,
@@ -60,10 +60,35 @@ func GetDefaultStartupProbe() *corev1.Probe {
 	startupProbe.HTTPGet = &corev1.HTTPGetAction{
 		Path: DefaultStartupProbeHTTPPath,
 		Port: intstr.IntOrString{
-			IntVal: DefaultAgentHealthPort,
+			IntVal: port,
 		},
 	}
 	return startupProbe
+}
+
+// GetAgentLivenessProbe creates a liveness probe configured for the core Agent
+func GetAgentLivenessProbe() *corev1.Probe {
+	return GetDefaultLivenessProbeWithPort(DefaultAgentHealthPort)
+}
+
+// GetAgentLivenessProbe creates a readiness probe configured for the core Agent
+func GetAgentReadinessProbe() *corev1.Probe {
+	return GetDefaultReadinessProbeWithPort(DefaultAgentHealthPort)
+}
+
+// GetAgentStartupProbe creates a startup probe configured for the core Agent
+func GetAgentStartupProbe() *corev1.Probe {
+	return GetDefaultStartupProbeWithPort(DefaultAgentHealthPort)
+}
+
+// GetAgentDataPlaneLivenessProbe creates a liveness probe configured for the Agent Data Plane
+func GetAgentDataPlaneLivenessProbe() *corev1.Probe {
+	return GetDefaultLivenessProbeWithPort(DefaultAgentDataPlanetHealthPort)
+}
+
+// GetAgentDataPlaneLivenessProbe creates a readiness probe configured for the Agent Data Plane
+func GetAgentDataPlaneReadinessProbe() *corev1.Probe {
+	return GetDefaultReadinessProbeWithPort(DefaultAgentDataPlanetHealthPort)
 }
 
 // GetDefaultTraceAgentProbe creates a defaulted liveness/readiness probe for the Trace Agent

--- a/apis/datadoghq/common/const.go
+++ b/apis/datadoghq/common/const.go
@@ -84,6 +84,9 @@ const (
 	// DefaultAgentHealthPort default agent health port
 	DefaultAgentHealthPort int32 = 5555
 
+	// DefaultAgentHealthPort default ADP health port
+	DefaultAgentDataPlanetHealthPort int32 = 9999
+
 	// Liveness probe default config
 	DefaultLivenessProbeInitialDelaySeconds int32 = 15
 	DefaultLivenessProbePeriodSeconds       int32 = 15

--- a/apis/datadoghq/common/v1/types.go
+++ b/apis/datadoghq/common/v1/types.go
@@ -90,6 +90,8 @@ const (
 	SystemProbeContainerName AgentContainerName = "system-probe"
 	// OtelAgent is the name of the OTel container
 	OtelAgent AgentContainerName = "otel-agent"
+	// AgentDataPlaneContainerName is the name of the ADP container
+	AgentDataPlaneContainerName AgentContainerName = "agent-data-plane"
 	// AllContainers is used internally to reference all containers in the pod
 	AllContainers AgentContainerName = "all"
 	// ClusterAgentContainerName is the name of the Cluster Agent container

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,6 @@ spec:
         args:
         - --enable-leader-election
         - --pprof
-        - --agentDataPlaneEnabled
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,6 +38,7 @@ spec:
         args:
         - --enable-leader-election
         - --pprof
+        - --agentDataPlaneEnabled
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -153,6 +153,8 @@ func agentOptimizedContainers(dda metav1.Object, requiredContainers []commonv1.A
 			containers = append(containers, systemProbeContainer(dda))
 		case commonv1.OtelAgent:
 			containers = append(containers, otelAgentContainer(dda))
+		case common.AgentDataPlaneContainerName:
+			containers = append(containers, agentDataPlaneContainer(dda))
 		}
 	}
 
@@ -255,6 +257,18 @@ func systemProbeContainer(dda metav1.Object) corev1.Container {
 				LocalhostProfile: apiutils.NewStringPointer(apicommon.SystemProbeSeccompProfileName),
 			},
 		},
+	}
+}
+
+func agentDataPlaneContainer(dda metav1.Object) corev1.Container {
+	return corev1.Container{
+		Name:           string(common.OtelAgent),
+		Image:          agentImage(),
+		Command:        []string{"agent-data-plane"},
+		Env:            envVarsForAgentDataPlane(dda),
+		VolumeMounts:   volumeMountsForAgentDataPlane(),
+		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
+		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
 	}
 }
 
@@ -387,6 +401,14 @@ func envVarsForOtelAgent(dda metav1.Object) []corev1.EnvVar {
 	return append(envs, commonEnvVars(dda)...)
 }
 
+func envVarsForAgentDataPlane(dda metav1.Object) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
+		// TODO: add additional env vars here
+	}
+
+	return append(envs, commonEnvVars(dda)...)
+}
+
 func volumeMountsForInitConfig() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		common.GetVolumeMountForLogs(),
@@ -496,6 +518,18 @@ func volumeMountsForOtelAgent() []corev1.VolumeMount {
 		common.GetVolumeMountForDogstatsdSocket(false),
 		common.GetVolumeMountForRuntimeSocket(true),
 		common.GetVolumeMountForProc(),
+	}
+}
+
+func volumeMountsForAgentDataPlane() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		common.GetVolumeMountForLogs(),
+		common.GetVolumeMountForAuth(true),
+		common.GetVolumeMountForConfig(),
+		common.GetVolumeMountForDogstatsdSocket(false),
+		common.GetVolumeMountForRuntimeSocket(true),
+		common.GetVolumeMountForProc(),
+		common.GetVolumeMountForCgroups(),
 	}
 }
 

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -403,7 +403,10 @@ func envVarsForOtelAgent(dda metav1.Object) []corev1.EnvVar {
 
 func envVarsForAgentDataPlane(dda metav1.Object) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
-		// TODO: add additional env vars here
+		{
+			Name:  "DD_API_LISTEN_ADDRESS",
+			Value: "tcp://0.0.0.0:9999",
+		},
 	}
 
 	return append(envs, commonEnvVars(dda)...)

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -153,7 +153,7 @@ func agentOptimizedContainers(dda metav1.Object, requiredContainers []commonv1.A
 			containers = append(containers, systemProbeContainer(dda))
 		case commonv1.OtelAgent:
 			containers = append(containers, otelAgentContainer(dda))
-		case common.AgentDataPlaneContainerName:
+		case commonv1.AgentDataPlaneContainerName:
 			containers = append(containers, agentDataPlaneContainer(dda))
 		}
 	}
@@ -262,7 +262,7 @@ func systemProbeContainer(dda metav1.Object) corev1.Container {
 
 func agentDataPlaneContainer(dda metav1.Object) corev1.Container {
 	return corev1.Container{
-		Name:           string(common.OtelAgent),
+		Name:           string(commonv1.AgentDataPlaneContainerName),
 		Image:          agentImage(),
 		Command:        []string{"agent-data-plane"},
 		Env:            envVarsForAgentDataPlane(dda),

--- a/controllers/datadogagent/component/agent/default.go
+++ b/controllers/datadogagent/component/agent/default.go
@@ -125,8 +125,8 @@ func agentSingleContainer(dda metav1.Object) []corev1.Container {
 		Image:          agentImage(),
 		Env:            envVarsForCoreAgent(dda),
 		VolumeMounts:   volumeMountsForCoreAgent(),
-		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+		LivenessProbe:  apicommon.GetAgentLivenessProbe(),
+		ReadinessProbe: apicommon.GetAgentReadinessProbe(),
 	}
 
 	containers := []corev1.Container{
@@ -168,9 +168,9 @@ func coreAgentContainer(dda metav1.Object) corev1.Container {
 		Command:        []string{"agent", "run"},
 		Env:            envVarsForCoreAgent(dda),
 		VolumeMounts:   volumeMountsForCoreAgent(),
-		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
-		StartupProbe:   apicommon.GetDefaultStartupProbe(),
+		LivenessProbe:  apicommon.GetAgentLivenessProbe(),
+		ReadinessProbe: apicommon.GetAgentReadinessProbe(),
+		StartupProbe:   apicommon.GetAgentStartupProbe(),
 	}
 }
 
@@ -267,8 +267,8 @@ func agentDataPlaneContainer(dda metav1.Object) corev1.Container {
 		Command:        []string{"agent-data-plane"},
 		Env:            envVarsForAgentDataPlane(dda),
 		VolumeMounts:   volumeMountsForAgentDataPlane(),
-		LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-		ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
+		LivenessProbe:  apicommon.GetAgentDataPlaneLivenessProbe(),
+		ReadinessProbe: apicommon.GetAgentDataPlaneReadinessProbe(),
 	}
 }
 

--- a/controllers/datadogagent/component/clusteragent/default.go
+++ b/controllers/datadogagent/component/clusteragent/default.go
@@ -121,9 +121,9 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				},
 				Env:            envVars,
 				VolumeMounts:   volumeMounts,
-				LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-				ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
-				StartupProbe:   apicommon.GetDefaultStartupProbe(),
+				LivenessProbe:  apicommon.GetAgentLivenessProbe(),
+				ReadinessProbe: apicommon.GetAgentReadinessProbe(),
+				StartupProbe:   apicommon.GetAgentStartupProbe(),
 				Command:        nil,
 				Args:           nil,
 				SecurityContext: &corev1.SecurityContext{

--- a/controllers/datadogagent/component/clusterchecksrunner/default.go
+++ b/controllers/datadogagent/component/clusterchecksrunner/default.go
@@ -115,9 +115,9 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				Args: []string{
 					"agent run",
 				},
-				LivenessProbe:  apicommon.GetDefaultLivenessProbe(),
-				ReadinessProbe: apicommon.GetDefaultReadinessProbe(),
-				StartupProbe:   apicommon.GetDefaultStartupProbe(),
+				LivenessProbe:  apicommon.GetAgentLivenessProbe(),
+				ReadinessProbe: apicommon.GetAgentReadinessProbe(),
+				StartupProbe:   apicommon.GetAgentStartupProbe(),
 				SecurityContext: &corev1.SecurityContext{
 					ReadOnlyRootFilesystem:   apiutils.NewBoolPointer(true),
 					AllowPrivilegeEscalation: apiutils.NewBoolPointer(false),

--- a/controllers/datadogagent/controller.go
+++ b/controllers/datadogagent/controller.go
@@ -65,6 +65,7 @@ type ReconcilerOptions struct {
 	DatadogAgentProfileEnabled      bool
 	ProcessChecksInCoreAgentEnabled bool
 	OtelAgentEnabled                bool
+	AgentDataPlaneEnabled           bool
 }
 
 // Reconciler is the internal reconciler for Datadog Agent
@@ -112,6 +113,7 @@ func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logg
 		Logger:                          logger,
 		ProcessChecksInCoreAgentEnabled: opts.ProcessChecksInCoreAgentEnabled,
 		OtelAgentEnabled:                opts.OtelAgentEnabled,
+		AgentDataPlaneEnabled:           opts.AgentDataPlaneEnabled,
 	}
 }
 

--- a/controllers/datadogagent/feature/enabledefault/feature.go
+++ b/controllers/datadogagent/feature/enabledefault/feature.go
@@ -52,6 +52,7 @@ func buildDefaultFeature(options *feature.Options) feature.Feature {
 	if options != nil {
 		dF.logger = options.Logger
 		dF.otelAgentEnabled = options.OtelAgentEnabled
+		dF.agentDataPlaneEnabled = options.AgentDataPlaneEnabled
 	}
 
 	return dF

--- a/controllers/datadogagent/feature/types.go
+++ b/controllers/datadogagent/feature/types.go
@@ -154,6 +154,7 @@ type Options struct {
 
 	ProcessChecksInCoreAgentEnabled bool
 	OtelAgentEnabled                bool
+	AgentDataPlaneEnabled           bool
 }
 
 // BuildFunc function type used by each Feature during its factory registration.

--- a/controllers/datadogagent/merger/utils.go
+++ b/controllers/datadogagent/merger/utils.go
@@ -10,12 +10,13 @@ import commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 // AllAgentContainers is a map of all agent containers
 var AllAgentContainers = map[commonv1.AgentContainerName]struct{}{
 	// Node agent containers
-	commonv1.CoreAgentContainerName:     {},
-	commonv1.TraceAgentContainerName:    {},
-	commonv1.ProcessAgentContainerName:  {},
-	commonv1.SecurityAgentContainerName: {},
-	commonv1.SystemProbeContainerName:   {},
-	commonv1.OtelAgent:                  {},
+	commonv1.CoreAgentContainerName:      {},
+	commonv1.TraceAgentContainerName:     {},
+	commonv1.ProcessAgentContainerName:   {},
+	commonv1.SecurityAgentContainerName:  {},
+	commonv1.SystemProbeContainerName:    {},
+	commonv1.OtelAgent:                   {},
+	commonv1.AgentDataPlaneContainerName: {},
 	// DCA containers
 	commonv1.ClusterAgentContainerName: {},
 	// CCR container name is equivalent to core agent container name

--- a/controllers/datadogagent/override/global.go
+++ b/controllers/datadogagent/override/global.go
@@ -300,6 +300,7 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 						apicommonv1.ProcessAgentContainerName,
 						apicommonv1.TraceAgentContainerName,
 						apicommonv1.SecurityAgentContainerName,
+						apicommonv1.AgentDataPlaneContainerName,
 					},
 				)
 				manager.Volume().AddVolume(&runtimeVol)

--- a/controllers/setup.go
+++ b/controllers/setup.go
@@ -47,6 +47,7 @@ type SetupOptions struct {
 	DatadogAgentProfileEnabled      bool
 	ProcessChecksInCoreAgentEnabled bool
 	OtelAgentEnabled                bool
+	AgentDataPlaneEnabled           bool
 }
 
 // ExtendedDaemonsetOptions defines ExtendedDaemonset options
@@ -155,6 +156,7 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, vInfo *version.I
 			DatadogAgentProfileEnabled:      options.DatadogAgentProfileEnabled,
 			ProcessChecksInCoreAgentEnabled: options.ProcessChecksInCoreAgentEnabled,
 			OtelAgentEnabled:                options.OtelAgentEnabled,
+			AgentDataPlaneEnabled:           options.AgentDataPlaneEnabled,
 		},
 	}).SetupWithManager(mgr)
 }

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ type options struct {
 	remoteConfigEnabled                    bool
 	processChecksInCoreAgentEnabled        bool
 	otelAgentEnabled                       bool
+	agentDataPlaneEnabled                  bool
 
 	// Secret Backend options
 	secretBackendCommand string
@@ -157,6 +158,7 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.remoteConfigEnabled, "remoteConfigEnabled", false, "Enable RemoteConfig capabilities in the Operator (beta)")
 	flag.BoolVar(&opts.processChecksInCoreAgentEnabled, "processChecksInCoreAgentEnabled", false, "Enable running process checks in the core agent (beta)")
 	flag.BoolVar(&opts.otelAgentEnabled, "otelAgentEnabled", false, "Enable the OTel agent container (beta)")
+	flag.BoolVar(&opts.agentDataPlaneEnabled, "agentDataPlaneEnabled", false, "Enable the Agent Data Plane container (beta)")
 
 	// ExtendedDaemonset configuration
 	flag.BoolVar(&opts.supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
@@ -298,6 +300,7 @@ func run(opts *options) error {
 		DatadogAgentProfileEnabled:      opts.datadogAgentProfileEnabled,
 		ProcessChecksInCoreAgentEnabled: opts.processChecksInCoreAgentEnabled,
 		OtelAgentEnabled:                opts.otelAgentEnabled,
+		AgentDataPlaneEnabled:           opts.agentDataPlaneEnabled,
 	}
 
 	if err = controllers.SetupControllers(setupLog, mgr, options); err != nil {


### PR DESCRIPTION
### What does this PR do?

Adds support for the experimental Agent Data Plane project. This follows a similar path to #1269 where only an experimental CLI flag is exposed for enabling ADP support, and we're leaving the CRDs alone.

### Motivation

The ADP deployment model is based around a new container, so Operator changes are necessary for internal testing.

### Additional Notes

N/A

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

Not tied to a standard Agent version, as this depends on a custom internal-only Datadog Agent build.

### Describe your test plan

- Deploy the custom Operator image to a designated staging cluster, and enable the newly-added CLI flag.
- Update that cluster to use an ADP-specific image for the Datadog Agent.
- Observe that the new container for ADP is created.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label