### PR TITLE
Do not rebuild image during merge-queue workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,11 @@ stages:
     when: manual
   - when: never
 
+.on_build_images:
+  - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
+    when: never
+  - when: always
+
 build:
   stage: build
   tags: ["runner:main", "size:large"]
@@ -109,6 +114,7 @@ generate_code:
 
 build_operator_image_amd64:
   stage: image
+  rules: !reference [.on_build_images]
   tags:
     - "arch:amd64"
   image: $JOB_DOCKER_IMAGE
@@ -125,6 +131,7 @@ build_operator_image_amd64:
 
 build_operator_image_arm64:
   stage: image
+  rules: !reference [.on_build_images]
   tags:
     - "arch:arm64"
   image: $JOB_DOCKER_IMAGE
@@ -141,6 +148,7 @@ build_operator_image_arm64:
 
 build_operator_check_image_amd64:
   stage: image
+  rules: !reference [.on_build_images]
   tags:
     - "arch:amd64"
   image: $JOB_DOCKER_IMAGE
@@ -157,6 +165,7 @@ build_operator_check_image_amd64:
 
 build_operator_check_image_arm64:
   stage: image
+  rules: !reference [.on_build_images]
   tags:
     - "arch:arm64"
   image: $JOB_DOCKER_IMAGE


### PR DESCRIPTION
### What does this PR do?

Do not rebuild the container images during merge-queue pipeline execution

### Motivation

The goal of this PR is not optimise the merge-queue duration by removing unnecessary job from the workload.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
