### PR TITLE
[cleanup] rename dependencies package to store

### DIFF
--- a/controllers/datadogagent/controller_reconcile_v2.go
+++ b/controllers/datadogagent/controller_reconcile_v2.go
@@ -14,9 +14,9 @@ import (
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/override"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/controllers/metrics"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
@@ -106,14 +106,14 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	// -----------------------
 	// Manage dependencies
 	// -----------------------
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		SupportCilium: r.options.SupportCilium,
 		VersionInfo:   r.versionInfo,
 		PlatformInfo:  r.platformInfo,
 		Logger:        logger,
 		Scheme:        r.scheme,
 	}
-	depsStore := dependencies.NewStore(instance, storeOptions)
+	depsStore := store.NewStore(instance, storeOptions)
 	resourceManagers := feature.NewResourceManagers(depsStore)
 
 	var errs []error

--- a/controllers/datadogagent/feature/apm/feature_test.go
+++ b/controllers/datadogagent/feature/apm/feature_test.go
@@ -15,10 +15,10 @@ import (
 	v2alpha1test "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1/test"
 	"github.com/DataDog/datadog-operator/apis/utils"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	"github.com/google/go-cmp/cmp"
@@ -256,7 +256,7 @@ func TestAPMFeature(t *testing.T) {
 				Build(),
 			WantConfigure: true,
 			ClusterAgent:  testAPMInstrumentationFull(),
-			WantDependenciesFunc: func(t testing.TB, store dependencies.StoreClient) {
+			WantDependenciesFunc: func(t testing.TB, store store.StoreClient) {
 				_, found := store.Get(kubernetes.ClusterRoleBindingKind, "", "-apm-cluster-agent")
 				if found {
 					t.Error("Should not have created proper RBAC for language detection because language detection is not enabled.")
@@ -313,7 +313,7 @@ func TestAPMFeature(t *testing.T) {
 			FeatureOptions: &feature.Options{ProcessChecksInCoreAgentEnabled: false},
 			ClusterAgent:   testAPMInstrumentationWithLanguageDetectionEnabledForClusterAgent(),
 			Agent:          testAPMInstrumentationWithLanguageDetectionForNodeAgent(true, false),
-			WantDependenciesFunc: func(t testing.TB, store dependencies.StoreClient) {
+			WantDependenciesFunc: func(t testing.TB, store store.StoreClient) {
 				_, found := store.Get(kubernetes.ClusterRoleBindingKind, "", "-apm-cluster-agent")
 				if !found {
 					t.Error("Should have created proper RBAC for language detection")
@@ -332,7 +332,7 @@ func TestAPMFeature(t *testing.T) {
 			WantConfigure: true,
 			ClusterAgent:  testAPMInstrumentation(),
 			Agent:         testAPMInstrumentationWithLanguageDetectionForNodeAgent(false, false),
-			WantDependenciesFunc: func(t testing.TB, store dependencies.StoreClient) {
+			WantDependenciesFunc: func(t testing.TB, store store.StoreClient) {
 				_, found := store.Get(kubernetes.ClusterRoleBindingKind, "", "-apm-cluster-agent")
 				if found {
 					t.Error("Should not have created RBAC for language detection")
@@ -359,7 +359,7 @@ func TestAPMFeature(t *testing.T) {
 			FeatureOptions: &feature.Options{ProcessChecksInCoreAgentEnabled: true},
 			ClusterAgent:   testAPMInstrumentationWithLanguageDetectionEnabledForClusterAgent(),
 			Agent:          testAPMInstrumentationWithLanguageDetectionForNodeAgent(true, true),
-			WantDependenciesFunc: func(t testing.TB, store dependencies.StoreClient) {
+			WantDependenciesFunc: func(t testing.TB, store store.StoreClient) {
 				_, found := store.Get(kubernetes.ClusterRoleBindingKind, "", "-apm-cluster-agent")
 				if !found {
 					t.Error("Should have created proper RBAC for language detection")

--- a/controllers/datadogagent/feature/autoscaling/feature_test.go
+++ b/controllers/datadogagent/feature/autoscaling/feature_test.go
@@ -13,10 +13,10 @@ import (
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -78,7 +78,7 @@ func newAgent(enabled bool, admissionEnabled bool) *v2alpha1.DatadogAgent {
 	}
 }
 
-func testRBACResources(t testing.TB, store dependencies.StoreClient) {
+func testRBACResources(t testing.TB, store store.StoreClient) {
 	// RBAC
 	rbacName := fmt.Sprintf("%s-%s", ddaName, "cluster-agent-autoscaling")
 

--- a/controllers/datadogagent/feature/eventcollection/feature_test.go
+++ b/controllers/datadogagent/feature/eventcollection/feature_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	v2alpha1test "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1/test"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	"github.com/google/go-cmp/cmp"
@@ -93,7 +93,7 @@ func eventCollectionClusterAgentWantFunc(t testing.TB, mgrInterface feature.PodT
 	assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, want), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, want))
 }
 
-func unbundledEventsDependencies(t testing.TB, store dependencies.StoreClient) {
+func unbundledEventsDependencies(t testing.TB, store store.StoreClient) {
 	// validate clusterRole policy rules
 	crObj, found := store.Get(kubernetes.ConfigMapKind, "", "ddaDCA-kube-apiserver-config")
 	if !found {

--- a/controllers/datadogagent/feature/externalmetrics/feature_test.go
+++ b/controllers/datadogagent/feature/externalmetrics/feature_test.go
@@ -12,10 +12,10 @@ import (
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,7 +73,7 @@ func TestExternalMetricsFeature(t *testing.T) {
 			Name:          "external metrics enabled, secrets set, registerAPIService enabled",
 			DDA:           newAgent(true, true, true, false, secret),
 			WantConfigure: true,
-			WantDependenciesFunc: func(t testing.TB, store dependencies.StoreClient) {
+			WantDependenciesFunc: func(t testing.TB, store store.StoreClient) {
 				apiServiceName := "v1beta1.external.metrics.k8s.io"
 				ns := ""
 
@@ -88,7 +88,7 @@ func TestExternalMetricsFeature(t *testing.T) {
 			Name:          "external metrics enabled, secrets set, registerAPIService disabled",
 			DDA:           newAgent(true, false, true, false, secret),
 			WantConfigure: true,
-			WantDependenciesFunc: func(t testing.TB, store dependencies.StoreClient) {
+			WantDependenciesFunc: func(t testing.TB, store store.StoreClient) {
 				apiServiceName := "v1beta1.external.metrics.k8s.io"
 				ns := ""
 

--- a/controllers/datadogagent/feature/helmcheck/feature_test.go
+++ b/controllers/datadogagent/feature/helmcheck/feature_test.go
@@ -20,11 +20,11 @@ import (
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	v2alpha1test "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1/test"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/test"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object/configmap"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -72,8 +72,8 @@ func Test_helmCheckFeature_Configure(t *testing.T) {
 	tests.Run(t, buildHelmCheckFeature)
 }
 
-func helmCheckWantDepsFunc(ccr bool, collectEvents bool, valuesAsTags map[string]string, rbacSuffix string) func(t testing.TB, store dependencies.StoreClient) {
-	return func(t testing.TB, store dependencies.StoreClient) {
+func helmCheckWantDepsFunc(ccr bool, collectEvents bool, valuesAsTags map[string]string, rbacSuffix string) func(t testing.TB, store store.StoreClient) {
+	return func(t testing.TB, store store.StoreClient) {
 		// validate configMap
 		configMapName := fmt.Sprintf("%s-%s", resourcesName, apicommon.DefaultHelmCheckConf)
 

--- a/controllers/datadogagent/feature/test/testsuite.go
+++ b/controllers/datadogagent/feature/test/testsuite.go
@@ -5,9 +5,9 @@ import (
 
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	testutils "github.com/DataDog/datadog-operator/controllers/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
@@ -35,8 +35,8 @@ type FeatureTest struct {
 	Options        *Options
 	FeatureOptions *feature.Options
 	// Dependencies Store
-	StoreOption        *dependencies.StoreOptions
-	StoreInitFunc      func(store dependencies.StoreClient)
+	StoreOption        *store.StoreOptions
+	StoreInitFunc      func(store store.StoreClient)
 	RequiredComponents feature.RequiredComponents
 	// Test configuration
 	Agent               *ComponentTest
@@ -45,7 +45,7 @@ type FeatureTest struct {
 	// Want
 	WantConfigure             bool
 	WantManageDependenciesErr bool
-	WantDependenciesFunc      func(testing.TB, dependencies.StoreClient)
+	WantDependenciesFunc      func(testing.TB, store.StoreClient)
 }
 
 // Options use to provide some option to the test.
@@ -155,9 +155,9 @@ func runTest(t *testing.T, tt FeatureTest) {
 	}
 }
 
-func initDependencies(tt FeatureTest, logger logr.Logger, dda metav1.Object) (*dependencies.Store, feature.ResourceManagers) {
+func initDependencies(tt FeatureTest, logger logr.Logger, dda metav1.Object) (*store.Store, feature.ResourceManagers) {
 	if tt.StoreOption == nil {
-		tt.StoreOption = &dependencies.StoreOptions{
+		tt.StoreOption = &store.StoreOptions{
 			Logger: logger,
 		}
 	}
@@ -165,7 +165,7 @@ func initDependencies(tt FeatureTest, logger logr.Logger, dda metav1.Object) (*d
 		tt.StoreOption.Scheme = testutils.TestScheme()
 	}
 
-	store := dependencies.NewStore(dda, tt.StoreOption)
+	store := store.NewStore(dda, tt.StoreOption)
 	if tt.StoreInitFunc != nil {
 		tt.StoreInitFunc(store)
 	}

--- a/controllers/datadogagent/feature/types.go
+++ b/controllers/datadogagent/feature/types.go
@@ -10,8 +10,8 @@ import (
 	apicommonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/merger"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -162,7 +162,7 @@ type BuildFunc func(options *Options) Feature
 
 // ResourceManagers used to access the different resources manager.
 type ResourceManagers interface {
-	Store() dependencies.StoreClient
+	Store() store.StoreClient
 	RBACManager() merger.RBACManager
 	PodSecurityManager() merger.PodSecurityManager
 	SecretManager() merger.SecretManager
@@ -174,7 +174,7 @@ type ResourceManagers interface {
 }
 
 // NewResourceManagers return new instance of the ResourceManagers interface
-func NewResourceManagers(store dependencies.StoreClient) ResourceManagers {
+func NewResourceManagers(store store.StoreClient) ResourceManagers {
 	return &resourceManagersImpl{
 		store:         store,
 		rbac:          merger.NewRBACManager(store),
@@ -189,7 +189,7 @@ func NewResourceManagers(store dependencies.StoreClient) ResourceManagers {
 }
 
 type resourceManagersImpl struct {
-	store         dependencies.StoreClient
+	store         store.StoreClient
 	rbac          merger.RBACManager
 	podSecurity   merger.PodSecurityManager
 	secret        merger.SecretManager
@@ -200,7 +200,7 @@ type resourceManagersImpl struct {
 	apiService    merger.APIServiceManager
 }
 
-func (impl *resourceManagersImpl) Store() dependencies.StoreClient {
+func (impl *resourceManagersImpl) Store() store.StoreClient {
 	return impl.store
 }
 

--- a/controllers/datadogagent/finalizer.go
+++ b/controllers/datadogagent/finalizer.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/override"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -81,13 +81,13 @@ func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) err
 	features, requiredComponents := feature.BuildFeatures(
 		dda, reconcilerOptionsToFeatureOptions(&r.options, reqLogger))
 
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		SupportCilium: r.options.SupportCilium,
 		Logger:        reqLogger,
 		Scheme:        r.scheme,
 		PlatformInfo:  r.platformInfo,
 	}
-	depsStore := dependencies.NewStore(dda, storeOptions)
+	depsStore := store.NewStore(dda, storeOptions)
 	resourceManagers := feature.NewResourceManagers(depsStore)
 
 	var errs []error

--- a/controllers/datadogagent/merger/apiservice.go
+++ b/controllers/datadogagent/merger/apiservice.go
@@ -8,7 +8,7 @@ package merger
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -20,7 +20,7 @@ type APIServiceManager interface {
 }
 
 // NewAPIServiceManager returns a new APIServiceManager instance
-func NewAPIServiceManager(store dependencies.StoreClient) APIServiceManager {
+func NewAPIServiceManager(store store.StoreClient) APIServiceManager {
 	manager := &apiServiceManagerImpl{
 		store: store,
 	}
@@ -29,7 +29,7 @@ func NewAPIServiceManager(store dependencies.StoreClient) APIServiceManager {
 
 // apiServiceManagerImpl is used to manage service resources.
 type apiServiceManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 }
 
 // AddAPIService creates or updates service

--- a/controllers/datadogagent/merger/cilium.go
+++ b/controllers/datadogagent/merger/cilium.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -22,7 +22,7 @@ type CiliumPolicyManager interface {
 }
 
 // NewCiliumPolicyManager returns a new CiliumPolicyManager instance
-func NewCiliumPolicyManager(store dependencies.StoreClient) CiliumPolicyManager {
+func NewCiliumPolicyManager(store store.StoreClient) CiliumPolicyManager {
 	manager := &ciliumPolicyManagerImpl{
 		store: store,
 	}
@@ -31,7 +31,7 @@ func NewCiliumPolicyManager(store dependencies.StoreClient) CiliumPolicyManager 
 
 // ciliumPolicyManagerImpl is used to manage cilium policy resources.
 type ciliumPolicyManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 }
 
 // AddCiliumPolicy creates a cilium network policy or adds policy specs to a cilium network policy

--- a/controllers/datadogagent/merger/cilium_test.go
+++ b/controllers/datadogagent/merger/cilium_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
@@ -87,7 +87,7 @@ func TestCiliumPolicyManager_AddCiliumPolicy(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -105,21 +105,21 @@ func TestCiliumPolicyManager_AddCiliumPolicy(t *testing.T) {
 	}
 	tests := []struct {
 		name         string
-		store        *dependencies.Store
+		store        *store.Store
 		args         args
 		wantErr      bool
-		validateFunc func(*testing.T, *dependencies.Store)
+		validateFunc func(*testing.T, *store.Store)
 	}{
 		{
 			name:  "empty store",
-			store: dependencies.NewStore(owner, storeOptions),
+			store: store.NewStore(owner, storeOptions),
 			args: args{
 				namespace:  ns,
 				name:       name1,
 				policySpec: policySpec1,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.CiliumNetworkPoliciesKind, ns, name1); !found {
 					t.Errorf("missing CiliumPolicy %s/%s", ns, name1)
 				}
@@ -127,14 +127,14 @@ func TestCiliumPolicyManager_AddCiliumPolicy(t *testing.T) {
 		},
 		{
 			name:  "another CiliumPolicy already exists",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.CiliumNetworkPoliciesKind, unstructuredPolicy),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.CiliumNetworkPoliciesKind, unstructuredPolicy),
 			args: args{
 				namespace:  ns,
 				name:       name1,
 				policySpec: policySpec1,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.CiliumNetworkPoliciesKind, ns, name1); !found {
 					t.Errorf("missing CiliumPolicy %s/%s", ns, name1)
 				}
@@ -142,14 +142,14 @@ func TestCiliumPolicyManager_AddCiliumPolicy(t *testing.T) {
 		},
 		{
 			name:  "update existing CiliumPolicy",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.CiliumNetworkPoliciesKind, unstructuredPolicy),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.CiliumNetworkPoliciesKind, unstructuredPolicy),
 			args: args{
 				namespace:  ns,
 				name:       name2,
 				policySpec: policySpec1,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				obj, found := store.Get(kubernetes.CiliumNetworkPoliciesKind, ns, name2)
 				if !found {
 					t.Errorf("missing CiliumPolicy %s/%s", ns, name2)

--- a/controllers/datadogagent/merger/configmap.go
+++ b/controllers/datadogagent/merger/configmap.go
@@ -8,7 +8,7 @@ package merger
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +20,7 @@ type ConfigMapManager interface {
 }
 
 // NewConfigMapManager returns a new ConfigMapManager instance
-func NewConfigMapManager(store dependencies.StoreClient) ConfigMapManager {
+func NewConfigMapManager(store store.StoreClient) ConfigMapManager {
 	manager := &configMapManagerImpl{
 		store: store,
 	}
@@ -29,7 +29,7 @@ func NewConfigMapManager(store dependencies.StoreClient) ConfigMapManager {
 
 // configMapManagerImpl is used to manage configmap resources.
 type configMapManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 }
 
 // AddConfigMap creates or updates a kubernetes network policy

--- a/controllers/datadogagent/merger/configmap_test.go
+++ b/controllers/datadogagent/merger/configmap_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,7 +39,7 @@ func TestConfigMapManager_AddConfigMap(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -57,21 +57,21 @@ func TestConfigMapManager_AddConfigMap(t *testing.T) {
 	}
 	tests := []struct {
 		name         string
-		store        *dependencies.Store
+		store        *store.Store
 		args         args
 		wantErr      bool
-		validateFunc func(*testing.T, *dependencies.Store)
+		validateFunc func(*testing.T, *store.Store)
 	}{
 		{
 			name:  "empty store",
-			store: dependencies.NewStore(owner, storeOptions),
+			store: store.NewStore(owner, storeOptions),
 			args: args{
 				namespace: ns,
 				name:      name1,
 				data:      cmData,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.ConfigMapKind, ns, name1); !found {
 					t.Errorf("missing ConfigMap %s/%s", ns, name1)
 				}
@@ -79,14 +79,14 @@ func TestConfigMapManager_AddConfigMap(t *testing.T) {
 		},
 		{
 			name:  "another ConfigMap already exists",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ConfigMapKind, &existingConfigMap),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ConfigMapKind, &existingConfigMap),
 			args: args{
 				namespace: ns,
 				name:      name1,
 				data:      cmData,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.ConfigMapKind, ns, name1); !found {
 					t.Errorf("missing ConfigMap %s/%s", ns, name1)
 				}
@@ -94,14 +94,14 @@ func TestConfigMapManager_AddConfigMap(t *testing.T) {
 		},
 		{
 			name:  "update existing ConfigMap",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ConfigMapKind, &existingConfigMap),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ConfigMapKind, &existingConfigMap),
 			args: args{
 				namespace: ns,
 				name:      name2,
 				data:      cmData,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				obj, found := store.Get(kubernetes.ConfigMapKind, ns, name2)
 				if !found {
 					t.Errorf("missing ConfigMap %s/%s", ns, name2)

--- a/controllers/datadogagent/merger/network_policy.go
+++ b/controllers/datadogagent/merger/network_policy.go
@@ -8,7 +8,7 @@ package merger
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	netv1 "k8s.io/api/networking/v1"
@@ -21,7 +21,7 @@ type NetworkPolicyManager interface {
 }
 
 // NewNetworkPolicyManager returns a new NetworkPolicyManager instance
-func NewNetworkPolicyManager(store dependencies.StoreClient) NetworkPolicyManager {
+func NewNetworkPolicyManager(store store.StoreClient) NetworkPolicyManager {
 	manager := &networkPolicyManagerImpl{
 		store: store,
 	}
@@ -30,7 +30,7 @@ func NewNetworkPolicyManager(store dependencies.StoreClient) NetworkPolicyManage
 
 // networkPolicyManagerImpl is used to manage network policy resources.
 type networkPolicyManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 }
 
 // AddKubernetesNetworkPolicy creates or updates a kubernetes network policy

--- a/controllers/datadogagent/merger/network_policy_test.go
+++ b/controllers/datadogagent/merger/network_policy_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	netv1 "k8s.io/api/networking/v1"
@@ -92,7 +92,7 @@ func TestNetworkPolicyManager_AddKubernetesNetworkPolicy(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -113,14 +113,14 @@ func TestNetworkPolicyManager_AddKubernetesNetworkPolicy(t *testing.T) {
 	}
 	tests := []struct {
 		name         string
-		store        *dependencies.Store
+		store        *store.Store
 		args         args
 		wantErr      bool
-		validateFunc func(*testing.T, *dependencies.Store)
+		validateFunc func(*testing.T, *store.Store)
 	}{
 		{
 			name:  "empty store",
-			store: dependencies.NewStore(owner, storeOptions),
+			store: store.NewStore(owner, storeOptions),
 			args: args{
 				namespace:   ns,
 				name:        name1,
@@ -130,7 +130,7 @@ func TestNetworkPolicyManager_AddKubernetesNetworkPolicy(t *testing.T) {
 				egress:      egress1,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.NetworkPoliciesKind, ns, name1); !found {
 					t.Errorf("missing NetworkPolicy %s/%s", ns, name1)
 				}
@@ -138,7 +138,7 @@ func TestNetworkPolicyManager_AddKubernetesNetworkPolicy(t *testing.T) {
 		},
 		{
 			name:  "another NetworkPolicy already exists",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.NetworkPoliciesKind, &existingPolicy),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.NetworkPoliciesKind, &existingPolicy),
 			args: args{
 				namespace:   ns,
 				name:        name1,
@@ -148,7 +148,7 @@ func TestNetworkPolicyManager_AddKubernetesNetworkPolicy(t *testing.T) {
 				egress:      egress1,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.NetworkPoliciesKind, ns, name1); !found {
 					t.Errorf("missing NetworkPolicy %s/%s", ns, name1)
 				}
@@ -156,7 +156,7 @@ func TestNetworkPolicyManager_AddKubernetesNetworkPolicy(t *testing.T) {
 		},
 		{
 			name:  "update existing NetworkPolicy",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.NetworkPoliciesKind, &existingPolicy),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.NetworkPoliciesKind, &existingPolicy),
 			args: args{
 				namespace:   ns,
 				name:        name2,
@@ -166,7 +166,7 @@ func TestNetworkPolicyManager_AddKubernetesNetworkPolicy(t *testing.T) {
 				egress:      egress1,
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				obj, found := store.Get(kubernetes.NetworkPoliciesKind, ns, name2)
 				if !found {
 					t.Errorf("missing NetworkPolicy %s/%s", ns, name2)

--- a/controllers/datadogagent/merger/pod_security.go
+++ b/controllers/datadogagent/merger/pod_security.go
@@ -6,7 +6,7 @@
 package merger
 
 import (
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 )
@@ -20,7 +20,7 @@ type PodSecurityManager interface {
 }
 
 // NewPodSecurityManager return new PodSecurityManager instance
-func NewPodSecurityManager(store dependencies.StoreClient) PodSecurityManager {
+func NewPodSecurityManager(store store.StoreClient) PodSecurityManager {
 	manager := &podSecurityManagerImpl{
 		store: store,
 	}
@@ -29,7 +29,7 @@ func NewPodSecurityManager(store dependencies.StoreClient) PodSecurityManager {
 
 // podSecurityManagerImpl is used to manage pod security resources.
 type podSecurityManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 }
 
 func (m *podSecurityManagerImpl) GetPodSecurityPolicy(namespace string, pspName string) (psp *policyv1beta1.PodSecurityPolicy, err error) {

--- a/controllers/datadogagent/merger/rbac.go
+++ b/controllers/datadogagent/merger/rbac.go
@@ -8,7 +8,7 @@ package merger
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
 
@@ -33,7 +33,7 @@ type RBACManager interface {
 }
 
 // NewRBACManager return new RBACManager instance
-func NewRBACManager(store dependencies.StoreClient) RBACManager {
+func NewRBACManager(store store.StoreClient) RBACManager {
 	manager := &rbacManagerImpl{
 		store:                     store,
 		serviceAccountByComponent: make(map[string][]string),
@@ -45,7 +45,7 @@ func NewRBACManager(store dependencies.StoreClient) RBACManager {
 
 // rbacManagerImpl use to manage RBAC resources.
 type rbacManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 
 	serviceAccountByComponent map[string][]string
 	roleByComponent           map[string][]string

--- a/controllers/datadogagent/merger/rbac_test.go
+++ b/controllers/datadogagent/merger/rbac_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -59,7 +59,7 @@ func TestRBACManager_AddPolicyRules(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -78,14 +78,14 @@ func TestRBACManager_AddPolicyRules(t *testing.T) {
 	}
 	tests := []struct {
 		name         string
-		store        *dependencies.Store
+		store        *store.Store
 		args         args
 		wantErr      bool
-		validateFunc func(*testing.T, *dependencies.Store)
+		validateFunc func(*testing.T, *store.Store)
 	}{
 		{
 			name:  "empty store",
-			store: dependencies.NewStore(owner, storeOptions),
+			store: store.NewStore(owner, storeOptions),
 			args: args{
 				namespace: ns,
 				saName:    name + "sa",
@@ -95,7 +95,7 @@ func TestRBACManager_AddPolicyRules(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.RolesKind, ns, name+"role"); !found {
 					t.Errorf("missing Role %s/%s", ns, name+"role")
 				}
@@ -107,7 +107,7 @@ func TestRBACManager_AddPolicyRules(t *testing.T) {
 		},
 		{
 			name:  "another Role already exist",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.RolesKind, role1),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.RolesKind, role1),
 			args: args{
 				namespace: ns,
 				saName:    name + "sa",
@@ -117,7 +117,7 @@ func TestRBACManager_AddPolicyRules(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.RolesKind, ns, name+"role"); !found {
 					t.Errorf("missing Role %s/%s", ns, name+"role")
 				}
@@ -129,7 +129,7 @@ func TestRBACManager_AddPolicyRules(t *testing.T) {
 		},
 		{
 			name:  "update existing Role",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.RolesKind, role2),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.RolesKind, role2),
 			args: args{
 				namespace: ns,
 				saName:    name + "sa",
@@ -139,7 +139,7 @@ func TestRBACManager_AddPolicyRules(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				obj, found := store.Get(kubernetes.RolesKind, ns, name+"role")
 				if !found {
 					t.Errorf("missing Role %s/%s", ns, name+"role")
@@ -193,7 +193,7 @@ func TestRBACManager_AddClusterPolicyRules(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -212,14 +212,14 @@ func TestRBACManager_AddClusterPolicyRules(t *testing.T) {
 	}
 	tests := []struct {
 		name         string
-		store        *dependencies.Store
+		store        *store.Store
 		args         args
 		wantErr      bool
-		validateFunc func(*testing.T, *dependencies.Store)
+		validateFunc func(*testing.T, *store.Store)
 	}{
 		{
 			name:  "empty store",
-			store: dependencies.NewStore(owner, storeOptions),
+			store: store.NewStore(owner, storeOptions),
 			args: args{
 				namespace: ns,
 				saName:    name + "sa",
@@ -229,7 +229,7 @@ func TestRBACManager_AddClusterPolicyRules(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.ClusterRolesKind, "", name+"role"); !found {
 					t.Errorf("missing ClusterRole %s", name+"role")
 				}
@@ -241,7 +241,7 @@ func TestRBACManager_AddClusterPolicyRules(t *testing.T) {
 		},
 		{
 			name:  "another ClusterRole already exist",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.RolesKind, role1),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.RolesKind, role1),
 			args: args{
 				namespace: ns,
 				saName:    name + "sa",
@@ -251,7 +251,7 @@ func TestRBACManager_AddClusterPolicyRules(t *testing.T) {
 				},
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.ClusterRolesKind, "", name+"role"); !found {
 					t.Errorf("missing ClusterRole %s", name+"role")
 				}

--- a/controllers/datadogagent/merger/secret.go
+++ b/controllers/datadogagent/merger/secret.go
@@ -10,8 +10,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/go-logr/logr"
 )
@@ -23,7 +23,7 @@ type SecretManager interface {
 }
 
 // NewSecretManager return new SecretManager instance
-func NewSecretManager(store dependencies.StoreClient) SecretManager {
+func NewSecretManager(store store.StoreClient) SecretManager {
 	manager := &secretManagerImpl{
 		store: store,
 	}
@@ -31,7 +31,7 @@ func NewSecretManager(store dependencies.StoreClient) SecretManager {
 }
 
 type secretManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 }
 
 func (m *secretManagerImpl) AddSecret(secretNamespace, secretName, key, value string) error {

--- a/controllers/datadogagent/merger/secret_test.go
+++ b/controllers/datadogagent/merger/secret_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/object"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +35,7 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -58,14 +58,14 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 	}
 	tests := []struct {
 		name         string
-		store        *dependencies.Store
+		store        *store.Store
 		args         args
 		wantErr      bool
-		validateFunc func(*testing.T, *dependencies.Store)
+		validateFunc func(*testing.T, *store.Store)
 	}{
 		{
 			name:  "empty Store",
-			store: dependencies.NewStore(owner, storeOptions),
+			store: store.NewStore(owner, storeOptions),
 			args: args{
 				secretNamespace: secretNs,
 				secretName:      secretName,
@@ -73,7 +73,7 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 				value:           "secret-value",
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				if _, found := store.Get(kubernetes.SecretsKind, secretNs, secretName); !found {
 					t.Errorf("missing Secret %s/%s", secretNs, secretName)
 				}
@@ -81,7 +81,7 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 		},
 		{
 			name:  "secret already exist",
-			store: dependencies.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.SecretsKind, secret1),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.SecretsKind, secret1),
 			args: args{
 				secretNamespace: secretNs,
 				secretName:      secretName,
@@ -89,7 +89,7 @@ func Test_secretManagerImpl_AddSecret(t *testing.T) {
 				value:           "secret-value",
 			},
 			wantErr: false,
-			validateFunc: func(t *testing.T, store *dependencies.Store) {
+			validateFunc: func(t *testing.T, store *store.Store) {
 				obj, found := store.Get(kubernetes.SecretsKind, secretNs, secretName)
 				secret, ok := obj.(*corev1.Secret)
 				if !ok {

--- a/controllers/datadogagent/merger/service.go
+++ b/controllers/datadogagent/merger/service.go
@@ -8,7 +8,7 @@ package merger
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,7 +20,7 @@ type ServiceManager interface {
 }
 
 // NewServiceManager returns a new ServiceManager instance
-func NewServiceManager(store dependencies.StoreClient) ServiceManager {
+func NewServiceManager(store store.StoreClient) ServiceManager {
 	manager := &serviceManagerImpl{
 		store: store,
 	}
@@ -29,7 +29,7 @@ func NewServiceManager(store dependencies.StoreClient) ServiceManager {
 
 // serviceManagerImpl is used to manage service resources.
 type serviceManagerImpl struct {
-	store dependencies.StoreClient
+	store store.StoreClient
 }
 
 // AddService creates or updates service

--- a/controllers/datadogagent/override/dependencies_test.go
+++ b/controllers/datadogagent/override/dependencies_test.go
@@ -11,8 +11,8 @@ import (
 	commonv1 "github.com/DataDog/datadog-operator/apis/datadoghq/common/v1"
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,7 +24,7 @@ func TestDependencies(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -129,7 +129,7 @@ func TestDependencies(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store := dependencies.NewStore(&test.dda, storeOptions)
+			store := store.NewStore(&test.dda, storeOptions)
 			manager := feature.NewResourceManagers(store)
 
 			errs := Dependencies(testLogger, manager, &test.dda)

--- a/controllers/datadogagent/override/fips_test.go
+++ b/controllers/datadogagent/override/fips_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1"
 	v2alpha1test "github.com/DataDog/datadog-operator/apis/datadoghq/v2alpha1/test"
 	apiutils "github.com/DataDog/datadog-operator/apis/utils"
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	"github.com/google/go-cmp/cmp"
@@ -32,7 +32,7 @@ func Test_ApplyFIPSConfig(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -69,7 +69,7 @@ defaults
 		name            string
 		dda             *v2alpha1.DatadogAgent
 		existingManager func() *fake.PodTemplateManagers
-		want            func(t testing.TB, manager *fake.PodTemplateManagers, store *dependencies.Store)
+		want            func(t testing.TB, manager *fake.PodTemplateManagers, store *store.Store)
 	}{
 		{
 			name: "FIPS enabled",
@@ -85,7 +85,7 @@ defaults
 					},
 				})
 			},
-			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *dependencies.Store) {
+			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *store.Store) {
 				// fips env var
 				checkFIPSContainerEnvVars(t, mgr)
 				// fips port
@@ -117,7 +117,7 @@ defaults
 					},
 				})
 			},
-			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *dependencies.Store) {
+			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *store.Store) {
 				// fips env var
 				checkFIPSContainerEnvVars(t, mgr)
 				// fips port
@@ -149,7 +149,7 @@ defaults
 					},
 				})
 			},
-			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *dependencies.Store) {
+			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *store.Store) {
 				// fips env var
 				checkFIPSContainerEnvVars(t, mgr)
 				// fips port
@@ -190,7 +190,7 @@ defaults
 					},
 				})
 			},
-			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *dependencies.Store) {
+			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *store.Store) {
 				// fips env var
 				checkFIPSContainerEnvVars(t, mgr)
 				// fips port
@@ -222,7 +222,7 @@ defaults
 					},
 				})
 			},
-			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *dependencies.Store) {
+			want: func(t testing.TB, mgr *fake.PodTemplateManagers, store *store.Store) {
 				// fips env var
 				checkFIPSContainerEnvVars(t, mgr)
 				// fips port
@@ -250,7 +250,7 @@ defaults
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			podTemplateManager := tt.existingManager()
-			store := dependencies.NewStore(tt.dda, storeOptions)
+			store := store.NewStore(tt.dda, storeOptions)
 			resourcesManager := feature.NewResourceManagers(store)
 
 			applyFIPSConfig(logger, podTemplateManager, tt.dda, resourcesManager)

--- a/controllers/datadogagent/override/global_test.go
+++ b/controllers/datadogagent/override/global_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-operator/controllers/datadogagent/dependencies"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/controllers/datadogagent/feature/fake"
+	"github.com/DataDog/datadog-operator/controllers/datadogagent/store"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,7 +36,7 @@ func TestNodeAgentComponenGlobalSettings(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	testScheme.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
-	storeOptions := &dependencies.StoreOptions{
+	storeOptions := &store.StoreOptions{
 		Scheme: testScheme,
 	}
 
@@ -121,7 +121,7 @@ func TestNodeAgentComponenGlobalSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			podTemplateManager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
-			store := dependencies.NewStore(tt.dda, storeOptions)
+			store := store.NewStore(tt.dda, storeOptions)
 			resourcesManager := feature.NewResourceManagers(store)
 
 			ApplyGlobalSettingsNodeAgent(logger, podTemplateManager, tt.dda, resourcesManager, tt.singleContainerStrategyEnabled)

--- a/controllers/datadogagent/store/doc.go
+++ b/controllers/datadogagent/store/doc.go
@@ -3,5 +3,5 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package dependencies provides a store use to manage deployment dependencies.
-package dependencies
+// Package store provides a store use to manage deployment dependencies.
+package store

--- a/controllers/datadogagent/store/store.go
+++ b/controllers/datadogagent/store/store.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package dependencies
+package store
 
 import (
 	"context"
@@ -211,7 +211,7 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 			objAPIServer := kubernetes.ObjectFromKind(kind, ds.platformInfo)
 			err := k8sClient.Get(ctx, objNSName, objAPIServer)
 			if err != nil && apierrors.IsNotFound(err) {
-				ds.logger.V(2).Info("dependencies.store Add object to create", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
+				ds.logger.V(2).Info("store.store Add object to create", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
 				objsToCreate = append(objsToCreate, objStore)
 				continue
 			} else if err != nil {
@@ -231,25 +231,25 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 			}
 
 			if !equality.IsEqualObject(kind, objStore, objAPIServer) {
-				ds.logger.V(2).Info("dependencies.store Add object to update", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
+				ds.logger.V(2).Info("store.store Add object to update", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
 				objsToUpdate = append(objsToUpdate, objStore)
 				continue
 			}
 		}
 	}
 
-	ds.logger.V(2).Info("dependencies.store objsToCreate", "nb", len(objsToCreate))
+	ds.logger.V(2).Info("store.store objsToCreate", "nb", len(objsToCreate))
 	for _, obj := range objsToCreate {
 		if err := k8sClient.Create(ctx, obj); err != nil {
-			ds.logger.Error(err, "dependencies.store Create", "obj.namespace", obj.GetNamespace(), "obj.name", obj.GetName())
+			ds.logger.Error(err, "store.store Create", "obj.namespace", obj.GetNamespace(), "obj.name", obj.GetName())
 			errs = append(errs, err)
 		}
 	}
 
-	ds.logger.V(2).Info("dependencies.store objsToUpdate", "nb", len(objsToUpdate))
+	ds.logger.V(2).Info("store.store objsToUpdate", "nb", len(objsToUpdate))
 	for _, obj := range objsToUpdate {
 		if err := k8sClient.Update(ctx, obj); err != nil {
-			ds.logger.Error(err, "dependencies.store Update", "obj.namespace", obj.GetNamespace(), "obj.name", obj.GetName())
+			ds.logger.Error(err, "store.store Update", "obj.namespace", obj.GetNamespace(), "obj.name", obj.GetName())
 			errs = append(errs, err)
 		}
 	}

--- a/controllers/datadogagent/store/store_test.go
+++ b/controllers/datadogagent/store/store_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package dependencies
+package store
 
 import (
 	"context"


### PR DESCRIPTION
### What does this PR do?

Small PR to rename `controllers/datadogagent/dependencies` to `controllers/datadogagent/store`, since this code houses the `Store` object and there is a different meaning for `dependencies` in the agent controller elsewhere.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
