### PR TITLE
[CECO-1441] Use fully-qualified domain name finalizer

### DIFF
--- a/internal/controller/datadogdashboard/finalizer.go
+++ b/internal/controller/datadogdashboard/finalizer.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	datadogDashboardFinalizer = "finalizer.dashboard.datadoghq.com"
+	datadogDashboardFinalizer = "finalizer.datadoghq.com/dashboard"
 )
 
 func (r *Reconciler) handleFinalizer(logger logr.Logger, db *datadoghqv1alpha1.DatadogDashboard) (ctrl.Result, error) {


### PR DESCRIPTION
### What does this PR do?

* Uses fully-qualified domain name on dashboard CRD per k8s convention : https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers

> Identifiers of custom finalizers consist of a domain name, a forward slash and the name of the finalizer. Any controller can add a finalizer to any object's list of finalizers.
### Motivation

* https://datadoghq.atlassian.net/browse/CECO-1441

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Covered by tests, but apply dashboard CR, ensure there are no logs from `KubeAPIWarningLogger` in the operator, then delete the CR with `kubectl delete` and ensure the CR is properly deleted

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
