### PR TITLE
APM instrumentation: increase default memory limit

### DIFF
--- a/api/datadoghq/common/envvar.go
+++ b/api/datadoghq/common/envvar.go
@@ -31,6 +31,7 @@ const (
 	DDAdmissionControllerAppsecEnabled                   = "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_ENABLED"
 	DDAdmissionControllerAppsecSCAEnabled                = "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_APPSEC_SCA_ENABLED"
 	DDAdmissionControllerIASTEnabled                     = "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_IAST_ENABLED"
+	DDAdmissionControllerAutoInstrumentationInitMem      = "DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY"
 	DDAPIKey                                             = "DD_API_KEY"
 	DDAPMEnabled                                         = "DD_APM_ENABLED"
 	DDAPMInstrumentationInstallTime                      = "DD_INSTRUMENTATION_INSTALL_TIME"

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -275,6 +275,13 @@ func (f *apmFeature) ManageClusterAgent(managers feature.PodTemplateManagers) er
 			Value: apiutils.BoolToString(&f.singleStepInstrumentation.enabled),
 		})
 
+		if f.singleStepInstrumentation.enabled {
+			managers.EnvVar().AddEnvVarToContainer(apicommonv1.ClusterAgentContainerName, &corev1.EnvVar{
+				Name:  apicommon.DDAdmissionControllerAutoInstrumentationInitMem,
+				Value: "128Mi",
+			})
+		}
+
 		if f.shouldEnableLanguageDetection() {
 			managers.EnvVar().AddEnvVarToContainer(apicommonv1.ClusterAgentContainerName, &corev1.EnvVar{
 				Name:  apicommon.DDLanguageDetectionEnabled,

--- a/internal/controller/datadogagent/feature/apm/feature_test.go
+++ b/internal/controller/datadogagent/feature/apm/feature_test.go
@@ -531,6 +531,10 @@ func testAPMInstrumentationFull() *test.ComponentTest {
 					Value: "true",
 				},
 				{
+					Name:  apiCommon.DDAdmissionControllerAutoInstrumentationInitMem,
+					Value: "128Mi",
+				},
+				{
 					Name:  apicommon.DDAPMInstrumentationDisabledNamespaces,
 					Value: "[\"foo\",\"bar\"]",
 				},
@@ -605,6 +609,10 @@ func testAPMInstrumentation() *test.ComponentTest {
 					Name:  apicommon.DDAPMInstrumentationEnabled,
 					Value: "true",
 				},
+				{
+					Name:  apiCommon.DDAdmissionControllerAutoInstrumentationInitMem,
+					Value: "128Mi",
+				},
 			}
 			assert.True(
 				t,
@@ -626,6 +634,10 @@ func testAPMInstrumentationWithLanguageDetectionEnabledForClusterAgent() *test.C
 				{
 					Name:  apicommon.DDAPMInstrumentationEnabled,
 					Value: "true",
+				},
+				{
+					Name:  apiCommon.DDAdmissionControllerAutoInstrumentationInitMem,
+					Value: "128Mi",
 				},
 				{
 					Name:  apicommon.DDLanguageDetectionEnabled,
@@ -695,6 +707,10 @@ func testAgentHostPortUDS(agentContainerName apicommonv1.AgentContainerName, hos
 				{
 					Name:  apicommon.DDAPMEnabled,
 					Value: "true",
+				},
+				{
+					Name:  apiCommon.DDAdmissionControllerAutoInstrumentationInitMem,
+					Value: "128Mi",
 				},
 				{
 					Name:  apicommon.DDAPMNonLocalTraffic,


### PR DESCRIPTION
Increase the default memory limit for APM instrumentation InitContainers to 128Mi.

The [default chosen](https://github.com/DataDog/datadog-agent/blob/e141eadad35bdf8f82b253bea45a6a71eaf3a471/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go#L44) (20MB) in 7.57.0 of the agent is too low which results in OOMKills for some of the APM library InitContainers. This is likely due to a regression in the size of the APM libraries. Once a fix is merged upstream in the Agent we should add a version gate on this setting so it only applies to the versions affected.

64Mi was successfully tested in a default GKE cluster and a local minikube. Since we'd like to mitigate the issue immediately 128Mi should be more than safe enough given that 64Mi worked to protect against any further regressions in the library InitContainers.

[](https://datadoghq.atlassian.net/browse/APMON-1472)

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
