### PR TITLE
[Tooling] Bump golangci-lint to 1.61.0 and devcontainer to Go 1.23

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/go:dev-1.22",
+	"image": "mcr.microsoft.com/devcontainers/go:1.23",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
 	},

--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ bin/$(PLATFORM)/yq: Makefile
 	hack/install-yq.sh v4.31.2
 
 bin/$(PLATFORM)/golangci-lint: Makefile
-	hack/golangci-lint.sh -b "bin/$(PLATFORM)" v1.59.1
+	hack/golangci-lint.sh -b "bin/$(PLATFORM)" v1.61.0
 
 bin/$(PLATFORM)/operator-sdk: Makefile
 	hack/install-operator-sdk.sh v1.34.1


### PR DESCRIPTION
### What does this PR do?

* Bump the version of `golangci-lint` to `1.61.0` : 
    * `1.60.x` is required for Go `1.23.x` release : https://github.com/golangci/golangci-lint/pull/4836
* Bump the devcontainer to Go 1.23

### Motivation

* https://github.com/DataDog/datadog-operator/pull/1402 modified the go version to 1.22.7. Latest `1.22` devcontainer is using Go `1.22.6`, so need to update to `1.23` instead

### Additional Notes

With this `golangci-lint` bump comes a warning on a deprecated linter : 
```shell
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```
### Describe your test plan

* Run `make lint` without errors
* Run `make build` without errors

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
