### PR TITLE
[Dashboard] Replace DashboardLastForceSyncTime with LastForceSyncTime

### DIFF
--- a/api/datadoghq/v1alpha1/datadogdashboard_types.go
+++ b/api/datadoghq/v1alpha1/datadogdashboard_types.go
@@ -67,8 +67,8 @@ type DatadogDashboardStatus struct {
 	// CurrentHash tracks the hash of the current DatadogDashboardSpec to know
 	// if the Spec has changed and needs an update.
 	CurrentHash string `json:"currentHash,omitempty"`
-	// DashboardLastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource
-	LastForceSyncTime *metav1.Time `json:"dashboardLastForceSyncTime,omitempty"`
+	// LastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource
+	LastForceSyncTime *metav1.Time `json:"lastForceSyncTime,omitempty"`
 }
 
 type DatadogDashboardSyncStatus string

--- a/api/datadoghq/v1alpha1/datadogdashboard_types.go
+++ b/api/datadoghq/v1alpha1/datadogdashboard_types.go
@@ -67,7 +67,7 @@ type DatadogDashboardStatus struct {
 	// CurrentHash tracks the hash of the current DatadogDashboardSpec to know
 	// if the Spec has changed and needs an update.
 	CurrentHash string `json:"currentHash,omitempty"`
-	// LastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource
+	// LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
 	LastForceSyncTime *metav1.Time `json:"lastForceSyncTime,omitempty"`
 }
 

--- a/api/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -561,7 +561,7 @@ func schema__api_datadoghq_v1alpha1_DatadogDashboardStatus(ref common.ReferenceC
 					},
 					"lastForceSyncTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource",
+							Description: "LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},

--- a/api/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -559,9 +559,9 @@ func schema__api_datadoghq_v1alpha1_DatadogDashboardStatus(ref common.ReferenceC
 							Format:      "",
 						},
 					},
-					"dashboardLastForceSyncTime": {
+					"lastForceSyncTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DashboardLastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource",
+							Description: "LastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},

--- a/config/crd/bases/v1/datadoghq.com_datadogdashboards.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogdashboards.yaml
@@ -247,7 +247,7 @@ spec:
                   description: ID is the dashboard ID generated in Datadog.
                   type: string
                 lastForceSyncTime:
-                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the DatadogDashboard resource
                   format: date-time
                   type: string
                 syncStatus:

--- a/config/crd/bases/v1/datadoghq.com_datadogdashboards.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogdashboards.yaml
@@ -243,12 +243,12 @@ spec:
                     CurrentHash tracks the hash of the current DatadogDashboardSpec to know
                     if the Spec has changed and needs an update.
                   type: string
-                dashboardLastForceSyncTime:
-                  description: DashboardLastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource
-                  format: date-time
-                  type: string
                 id:
                   description: ID is the dashboard ID generated in Datadog.
+                  type: string
+                lastForceSyncTime:
+                  description: LastForceSyncTime is the last time the API dashboard was last force synced with the Datadogdashboard resource
+                  format: date-time
                   type: string
                 syncStatus:
                   description: SyncStatus shows the health of syncing the dashboard state to Datadog.


### PR DESCRIPTION
### What does this PR do?

* Replaces `DashboardLastForceSyncTime` with `LastForceSyncTime`

### Motivation

* Removes OpenAPI violation when using `make generate`
```
API rule violation: names_match,./api/datadoghq/v1alpha1,DatadogDashboardStatus,LastForceSyncTime
```

### Additional Notes

* Will be cherry-picked to `v1.9`

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* No Q/A needed, no functional change

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
