### PR TITLE
add retry when getting the datadog agent in the rc updater

### DIFF
--- a/pkg/remoteconfig/updater.go
+++ b/pkg/remoteconfig/updater.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -241,7 +242,7 @@ func (r *RemoteConfigUpdater) agentConfigUpdateCallback(updates map[string]state
 		r.logger.Info("Merged", "update", mergedUpdate)
 	}
 
-	dda, err := r.getDatadogAgentInstance(ctx)
+	dda, err := r.getDatadogAgentWithRetry(ctx)
 	if err != nil {
 		r.logger.Error(err, "Failed to get updatable agents")
 		return
@@ -392,6 +393,34 @@ func (r *RemoteConfigUpdater) getDatadogAgentInstance(ctx context.Context) (v2al
 
 	// Return first DatadogAgent as only one is supported
 	return ddaList.Items[0], nil
+}
+
+func (r *RemoteConfigUpdater) getDatadogAgentWithRetry(ctx context.Context) (v2alpha1.DatadogAgent, error) {
+	var dda v2alpha1.DatadogAgent
+	var err error
+
+	operation := func() error {
+		dda, err = r.getDatadogAgentInstance(ctx)
+		if err != nil {
+			r.logger.Error(err, "Failed to get updatable agents, retrying...")
+			return err
+		}
+		return nil
+	}
+
+	// Create a backoff strategy
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = 1 * time.Second
+	expBackoff.MaxInterval = 10 * time.Second
+	expBackoff.MaxElapsedTime = 3 * time.Minute
+
+	err = backoff.Retry(operation, expBackoff)
+	if err != nil {
+		r.logger.Error(err, "Failed to get updatable agents after retries")
+		return dda, err
+	}
+
+	return dda, nil
 }
 
 func (r *RemoteConfigUpdater) updateInstanceStatus(dda v2alpha1.DatadogAgent, cfg DatadogAgentRemoteConfig) error {


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.
When getting we receive a new config, the dda might not be ready yet, so this allows a retry method to solve this issue.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
