### PR TITLE
[profiles] Fall back to EDS options if needed

### DIFF
--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"math/rand"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
 )
 
@@ -126,4 +127,10 @@ func YAMLToJSONString(yamlConfigs string) string {
 		return ""
 	}
 	return string(jsonValue)
+}
+
+// NewIntOrStringPointer converts a string value to an IntOrString pointer
+func NewIntOrStringPointer(str string) *intstr.IntOrString {
+	val := intstr.Parse(str)
+	return &val
 }

--- a/api/utils/utils_test.go
+++ b/api/utils/utils_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package agent
+package utils
 
 import (
 	"testing"
@@ -35,7 +35,7 @@ func Test_newIntOrStringPointer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			output := newIntOrStringPointer(tt.input)
+			output := NewIntOrStringPointer(tt.input)
 			if tt.want != *output {
 				t.Errorf("newIntOrStringPointer() result is %v but want %v", *output, tt.want)
 			}

--- a/internal/controller/datadogagent/component/agent/new.go
+++ b/internal/controller/datadogagent/component/agent/new.go
@@ -8,12 +8,12 @@ package agent
 import (
 	"time"
 
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // NewDaemonset use to generate the skeleton of a new daemonset based on few information
@@ -34,7 +34,7 @@ func NewDaemonset(owner metav1.Object, edsOptions *ExtendedDaemonsetOptions, com
 	if edsOptions != nil && edsOptions.MaxPodUnavailable != "" {
 		daemonset.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
 			RollingUpdate: &appsv1.RollingUpdateDaemonSet{
-				MaxUnavailable: newIntOrStringPointer(edsOptions.MaxPodUnavailable),
+				MaxUnavailable: apiutils.NewIntOrStringPointer(edsOptions.MaxPodUnavailable),
 			},
 		}
 	}
@@ -87,11 +87,11 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 	edsv1alpha1.DefaultExtendedDaemonSetSpec(&spec, edsv1alpha1.ExtendedDaemonSetSpecStrategyCanaryValidationModeAuto)
 
 	if options.MaxPodUnavailable != "" {
-		spec.Strategy.RollingUpdate.MaxUnavailable = newIntOrStringPointer(options.MaxPodUnavailable)
+		spec.Strategy.RollingUpdate.MaxUnavailable = apiutils.NewIntOrStringPointer(options.MaxPodUnavailable)
 	}
 
 	if options.MaxPodSchedulerFailure != "" {
-		spec.Strategy.RollingUpdate.MaxPodSchedulerFailure = newIntOrStringPointer(options.MaxPodSchedulerFailure)
+		spec.Strategy.RollingUpdate.MaxPodSchedulerFailure = apiutils.NewIntOrStringPointer(options.MaxPodSchedulerFailure)
 	}
 
 	if options.CanaryDuration != 0 {
@@ -99,7 +99,7 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 	}
 
 	if options.CanaryReplicas != "" {
-		spec.Strategy.Canary.Replicas = newIntOrStringPointer(options.CanaryReplicas)
+		spec.Strategy.Canary.Replicas = apiutils.NewIntOrStringPointer(options.CanaryReplicas)
 	}
 
 	spec.Strategy.Canary.AutoFail.Enabled = edsv1alpha1.NewBool(options.CanaryAutoFailEnabled)
@@ -116,9 +116,4 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseMaxRestarts)
 	}
 	return spec
-}
-
-func newIntOrStringPointer(str string) *intstr.IntOrString {
-	val := intstr.Parse(str)
-	return &val
 }

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -349,7 +349,7 @@ func (r *Reconciler) profilesToApply(ctx context.Context, logger logr.Logger, no
 
 	sortedProfiles := agentprofile.SortProfiles(profilesList.Items)
 	for _, profile := range sortedProfiles {
-		maxUnavailable := agentprofile.GetMaxUnavailable(logger, dda, &profile, len(nodeList))
+		maxUnavailable := agentprofile.GetMaxUnavailable(logger, dda, &profile, len(nodeList), &r.options.ExtendedDaemonsetOptions)
 		profileAppliedByNode, err = agentprofile.ApplyProfile(logger, &profile, nodeList, profileAppliedByNode, now, maxUnavailable)
 		r.updateDAPStatus(logger, &profile)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

If we don't set a max unavailable in the DAP or the DDA, try to use the [edsMaxPodUnavailable](https://github.com/DataDog/datadog-operator/blob/2a7b83cae17fb1cb6304832f9dde548c9e4fd75e/cmd/main.go#L166) value before falling back to the kubernetes default.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Spin up an operator pod with [DAP enabled](https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md#enabling-datadogagentprofiles) and [edsMaxPodUnavailable](https://github.com/DataDog/datadog-operator/blob/2a7b83cae17fb1cb6304832f9dde548c9e4fd75e/cmd/main.go#L166) set to different values
* Create a profile with a max unavailable set to a different value from the DDA and EDS option
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: dap-test
spec:
  profileAffinity:
    profileNodeAffinity:
      [...]
  config:
    override:
      nodeAgent:
        updateStrategy:
          type: "RollingUpdate"
          rollingUpdate:
            maxUnavailable: 5%
```
* The profile's `CreateStrategy.MaxUnavailable` should be using the calculated value from the profile, i.e. if there are 40 agent pods, 5% of that = `2`
* Remove the profile's `updateStrategy`. The `CreateStrategy.MaxUnavailable` should use the DDA's max unavailable value
* Delete the DDA's `updateStrategy`. The `CreateStrategy.MaxUnavailable` should use the `edsMaxPodUnavailable` value

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
