### PR TITLE
[cleanup] shuffle constants in pkg/config

### DIFF
--- a/api/datadoghq/common/envvar.go
+++ b/api/datadoghq/common/envvar.go
@@ -65,6 +65,7 @@ const (
 	DDContainerCollectionEnabled                         = "DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED"
 	DDCriSocketPath                                      = "DD_CRI_SOCKET_PATH"
 	DDddURL                                              = "DD_DD_URL"
+	DDURL                                                = "DD_URL"
 	DDDogstatsdEnabled                                   = "DD_USE_DOGSTATSD"
 	DDDogstatsdMapperProfiles                            = "DD_DOGSTATSD_MAPPER_PROFILES"
 	DDDogstatsdNonLocalTraffic                           = "DD_DOGSTATSD_NON_LOCAL_TRAFFIC"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 )
 
+// These constants are only used within pkg/config
 const (
 	// AgentWatchNamespaceEnvVar is a comma-separated list of namespaces watched by the DatadogAgent controller.
 	agentWatchNamespaceEnvVar = "DD_AGENT_WATCH_NAMESPACE"
@@ -38,16 +39,6 @@ const (
 	// WatchNamespaceEnvVar is a comma-separated list of namespaces watched by all controllers, unless a controller-specific configuration is provided.
 	// An empty value means the operator is running with cluster scope.
 	watchNamespaceEnvVar = "WATCH_NAMESPACE"
-	// DDAPIKeyEnvVar is the constant for the env variable DD_API_KEY which is the fallback
-	// API key to use if a resource does not have it defined in its spec.
-	DDAPIKeyEnvVar = "DD_API_KEY"
-	// DDAppKeyEnvVar is the constant for the env variable DD_APP_KEY which is the fallback
-	// App key to use if a resource does not have it defined in its spec.
-	DDAppKeyEnvVar = "DD_APP_KEY"
-	// DDURLEnvVar is the constant for the env variable DD_URL which is the
-	// host of the Datadog intake server to send data to.
-	DDURLEnvVar = "DD_URL"
-	// TODO consider moving DDSite here as well
 )
 
 var (

--- a/pkg/config/creds.go
+++ b/pkg/config/creds.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -53,8 +54,8 @@ func (cm *CredentialManager) GetCredentials() (Creds, error) {
 		return creds, nil
 	}
 
-	apiKey := os.Getenv(DDAPIKeyEnvVar)
-	appKey := os.Getenv(DDAppKeyEnvVar)
+	apiKey := os.Getenv(apicommon.DDAPIKey)
+	appKey := os.Getenv(apicommon.DDAppKey)
 
 	if apiKey == "" || appKey == "" {
 		return Creds{}, errors.New("empty API key and/or App key")

--- a/pkg/datadogclient/client.go
+++ b/pkg/datadogclient/client.go
@@ -111,8 +111,10 @@ func setupAuth(logger logr.Logger, creds config.Creds) (context.Context, error) 
 	)
 
 	apiURL := ""
-	if os.Getenv(config.DDURLEnvVar) != "" {
-		apiURL = os.Getenv(config.DDURLEnvVar)
+	if os.Getenv(apicommon.DDddURL) != "" {
+		apiURL = os.Getenv(apicommon.DDddURL)
+	} else if os.Getenv(apicommon.DDURL) != "" {
+		apiURL = os.Getenv(apicommon.DDURL)
 	} else if site := os.Getenv(apicommon.DDSite); site != "" {
 		apiURL = prefix + strings.TrimSpace(site)
 	}


### PR DESCRIPTION
### What does this PR do?

A small cleanup-related change for constants defined in pkg/config . Remove duplicate envvars and move one envvar to apicommon

Also, incorporate DD_DD_URL envvar option into datadog client setup

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Make sure operator builds and runs as expected

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
