### PR TITLE
[profiles] Don't update status for default profile

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -266,11 +266,14 @@ func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment 
 }
 
 func (r *Reconciler) updateDAPStatus(logger logr.Logger, profile *datadoghqv1alpha1.DatadogAgentProfile) {
-	if err := r.client.Status().Update(context.TODO(), profile); err != nil {
-		if apierrors.IsConflict(err) {
-			logger.V(1).Info("unable to update DatadogAgentProfile status due to update conflict")
+	// update dap status for non-default profiles only
+	if !agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
+		if err := r.client.Status().Update(context.TODO(), profile); err != nil {
+			if apierrors.IsConflict(err) {
+				logger.V(1).Info("unable to update DatadogAgentProfile status due to update conflict")
+			}
+			logger.Error(err, "unable to update DatadogAgentProfile status")
 		}
-		logger.Error(err, "unable to update DatadogAgentProfile status")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix error:
```
{"level":"ERROR","ts":"2024-09-20T17:30:02.617Z","logger":"controllers.DatadogAgent","msg":"unable to update DatadogAgentProfile status","datadogagent":{"name":"datadog","namespace":"system"},"component":"nodeAgent","daemonset.Namespace":"system","daemonset.Name":"datadog-agent","error":"an empty namespace may not be set when a resource name is provided"}
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy the operator with [profiles enabled](https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md) and [create strategy enabled](https://github.com/DataDog/datadog-operator/blob/84b98e409bd0a1fdf272eaa28e9d082795490ea7/api/datadoghq/common/envvar.go#L189) in the operator
* Check that the above error doesn't occur

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
