### PR TITLE
[BARX-512] Set Registry to Azure if site is us3

### DIFF
--- a/api/datadoghq/common/const.go
+++ b/api/datadoghq/common/const.go
@@ -84,6 +84,7 @@ const (
 	DefaultAgentImageName        string = "agent"
 	DefaultClusterAgentImageName string = "cluster-agent"
 	DefaultImageRegistry         string = "gcr.io/datadoghq"
+	DefaultAzureImageRegistry    string = "datadoghq.azurecr.io"
 	DefaultEuropeImageRegistry   string = "eu.gcr.io/datadoghq"
 	DefaultAsiaImageRegistry     string = "asia.gcr.io/datadoghq"
 	DefaultGovImageRegistry      string = "public.ecr.aws/datadog"

--- a/api/datadoghq/v2alpha1/datadogagent_default.go
+++ b/api/datadoghq/v2alpha1/datadogagent_default.go
@@ -16,6 +16,7 @@ const (
 	defaultSite       string = "datadoghq.com"
 	defaultEuropeSite string = "datadoghq.eu"
 	defaultAsiaSite   string = "ap1.datadoghq.com"
+	defaultAzureSite  string = "us3.datadoghq.com"
 	defaultGovSite    string = "ddog-gov.com"
 	defaultLogLevel   string = "info"
 
@@ -141,6 +142,8 @@ func defaultGlobalConfig(ddaSpec *DatadogAgentSpec) {
 			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultEuropeImageRegistry)
 		case defaultAsiaSite:
 			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultAsiaImageRegistry)
+		case defaultAzureSite:
+			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultAzureImageRegistry)
 		case defaultGovSite:
 			ddaSpec.Global.Registry = apiutils.NewStringPointer(apicommon.DefaultGovImageRegistry)
 		default:

--- a/api/datadoghq/v2alpha1/datadogagent_default_test.go
+++ b/api/datadoghq/v2alpha1/datadogagent_default_test.go
@@ -70,6 +70,21 @@ func Test_defaultGlobal(t *testing.T) {
 			},
 		},
 		{
+			name: "test registry defaulting based on site - Azure",
+			ddaSpec: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site: apiutils.NewStringPointer(defaultAzureSite),
+				},
+			},
+			want: &DatadogAgentSpec{
+				Global: &GlobalConfig{
+					Site:     apiutils.NewStringPointer(defaultAzureSite),
+					Registry: apiutils.NewStringPointer(apicommon.DefaultAzureImageRegistry),
+					LogLevel: apiutils.NewStringPointer(defaultLogLevel),
+				},
+			},
+		},
+		{
 			name: "test registry defaulting based on site - Gov",
 			ddaSpec: &DatadogAgentSpec{
 				Global: &GlobalConfig{

--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -1158,6 +1158,10 @@ type GlobalConfig struct {
 
 	// Registry is the image registry to use for all Agent images.
 	// Use 'public.ecr.aws/datadog' for AWS ECR.
+	// Use 'datadoghq.azurecr.io' for Azure Container Registry.
+	// Use 'gcr.io/datadoghq' for Google Container Registry.
+	// Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
+	// Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
 	// Use 'docker.io/datadog' for DockerHub.
 	// Default: 'gcr.io/datadoghq'
 	// +optional

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -2050,6 +2050,10 @@ spec:
                       description: |-
                         Registry is the image registry to use for all Agent images.
                         Use 'public.ecr.aws/datadog' for AWS ECR.
+                        Use 'datadoghq.azurecr.io' for Azure Container Registry.
+                        Use 'gcr.io/datadoghq' for Google Container Registry.
+                        Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
+                        Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
                         Use 'docker.io/datadog' for DockerHub.
                         Default: 'gcr.io/datadoghq'
                       type: string

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -222,7 +222,7 @@ spec:
 | global.originDetectionUnified.enabled | Enabled enables unified mechanism for origin detection. Default: false |
 | global.podAnnotationsAsTags | Provide a mapping of Kubernetes Annotations to Datadog Tags. <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY> |
 | global.podLabelsAsTags | Provide a mapping of Kubernetes Labels to Datadog Tags. <KUBERNETES_LABEL>: <DATADOG_TAG_KEY> |
-| global.registry | Registry is the image registry to use for all Agent images. Use 'public.ecr.aws/datadog' for AWS ECR. Use 'docker.io/datadog' for DockerHub. Default: 'gcr.io/datadoghq' |
+| global.registry | Registry is the image registry to use for all Agent images. Use 'public.ecr.aws/datadog' for AWS ECR. Use 'datadoghq.azurecr.io' for Azure Container Registry. Use 'gcr.io/datadoghq' for Google Container Registry. Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region. Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region. Use 'docker.io/datadog' for DockerHub. Default: 'gcr.io/datadoghq' |
 | global.site | Site is the Datadog intake site Agent data are sent to. Set to 'datadoghq.com' to send data to the US1 site (default). Set to 'datadoghq.eu' to send data to the EU site. Set to 'us3.datadoghq.com' to send data to the US3 site. Set to 'us5.datadoghq.com' to send data to the US5 site. Set to 'ddog-gov.com' to send data to the US1-FED site. Set to 'ap1.datadoghq.com' to send data to the AP1 site. Default: 'datadoghq.com' |
 | global.tags | Tags contains a list of tags to attach to every metric, event and service check collected. Learn more about tagging: https://docs.datadoghq.com/tagging/ |
 | override | Override the default configurations of the agents |


### PR DESCRIPTION
### What does this PR do?

This PR sets the registry to Azure if the site used is us3. Implemented in helm: https://github.com/DataDog/helm-charts/pull/1537

### Motivation

Azure users can benefit from the ACR.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
