### PR TITLE
Mount /usr/lib/sysimage/rpm when using host SBOM feature

### DIFF
--- a/api/datadoghq/common/const.go
+++ b/api/datadoghq/common/const.go
@@ -82,6 +82,10 @@ const (
 	RpmDirVolumePath = "/var/lib/rpm"
 	RpmDirMountPath  = "/host/var/lib/rpm"
 
+	SysimageRpmDirVolumeName = "host-sysimage-rpm-dir"
+	SysimageRpmDirVolumePath = "/usr/lib/sysimage/rpm"
+	SysimageRpmDirMountPath  = "/host/usr/lib/sysimage/rpm"
+
 	RedhatReleaseVolumeName = "etc-redhat-release"
 	RedhatReleaseVolumePath = "/etc/redhat-release"
 	RedhatReleaseMountPath  = "/host/etc/redhat-release"

--- a/internal/controller/datadogagent/feature/sbom/feature.go
+++ b/internal/controller/datadogagent/feature/sbom/feature.go
@@ -222,6 +222,10 @@ func (f *sbomFeature) ManageNodeAgent(managers feature.PodTemplateManagers, prov
 		volMountMgr.AddVolumeMountToContainer(&hostRpmVolMount, apicommon.CoreAgentContainerName)
 		volMgr.AddVolume(&hostRpmVol)
 
+		hostSysimageRpmVol, hostSysimageRpmVolMount := volume.GetVolumes(apicommon.SysimageRpmDirVolumeName, apicommon.SysimageRpmDirVolumePath, apicommon.SysimageRpmDirMountPath, true)
+		volMountMgr.AddVolumeMountToContainer(&hostSysimageRpmVolMount, apicommonv1.CoreAgentContainerName)
+		volMgr.AddVolume(&hostSysimageRpmVol)
+
 		hostRedhatReleaseVol, hostRedhatReleaseVolMount := volume.GetVolumes(apicommon.RedhatReleaseVolumeName, apicommon.RedhatReleaseVolumePath, apicommon.RedhatReleaseMountPath, true)
 		volMountMgr.AddVolumeMountToContainer(&hostRedhatReleaseVolMount, apicommon.CoreAgentContainerName)
 		volMgr.AddVolume(&hostRedhatReleaseVol)

--- a/internal/controller/datadogagent/feature/sbom/feature_test.go
+++ b/internal/controller/datadogagent/feature/sbom/feature_test.go
@@ -176,6 +176,11 @@ func Test_sbomFeature_Configure(t *testing.T) {
 				ReadOnly:  true,
 			},
 			{
+				Name:      apicommon.SysimageRpmDirVolumeName,
+				MountPath: apicommon.SysimageRpmDirMountPath,
+				ReadOnly:  true,
+			},
+			{
 				Name:      apicommon.RedhatReleaseVolumeName,
 				MountPath: apicommon.RedhatReleaseMountPath,
 				ReadOnly:  true,


### PR DESCRIPTION
### What does this PR do?

Mount /usr/lib/sysimage/rpm when using host SBOM feature

### Motivation

Amazon Linux 2023 use /usr/lib/sysimage/rpm instead of /var/lib/rpm

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
