### PR TITLE
[chore] Fix alignment of Reconciler struct init in SLO controller

### DIFF
--- a/internal/controller/datadogslo/controller.go
+++ b/internal/controller/datadogslo/controller.go
@@ -56,8 +56,8 @@ func NewReconciler(client client.Client, ddClient datadogclient.DatadogSLOClient
 		client:        client,
 		datadogClient: ddClient.Client,
 		datadogAuth:   ddClient.Auth,
-		log:      log,
-		recorder: recorder,
+		log:           log,
+		recorder:      recorder,
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

* No-op change

### Motivation

* Running `make build` on `main` currently produces a diff for this file while it should not. This is linked to https://github.com/DataDog/datadog-operator/pull/1436/files#diff-c70a44743985a8fd8164e0cd7af09a1d2a0479201796e987f4d4bdc08150987dL61-L63 that changed the alignment for parameters that remained

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
