### PR TITLE
Fix CiliumNetworkPolicy not updating properly

### DIFF
--- a/internal/controller/datadogagent/store/store.go
+++ b/internal/controller/datadogagent/store/store.go
@@ -220,13 +220,8 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 				objStore.(*v1.Service).Spec.ClusterIPs = objAPIServer.(*v1.Service).Spec.ClusterIPs
 				objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
 			}
-			// The APIServiceKind resource version must be set.
-			if kind == kubernetes.APIServiceKind {
-				objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
-			}
-
-			// The CiliumNetworkPoliciesKind resource version must be set.
-			if kind == kubernetes.CiliumNetworkPoliciesKind {
+			// The APIServiceKind and CiliumNetworkPoliciesKind resource version must be set.
+			if kind == kubernetes.APIServiceKind || kind == kubernetes.CiliumNetworkPoliciesKind {
 				objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
 			}
 

--- a/internal/controller/datadogagent/store/store.go
+++ b/internal/controller/datadogagent/store/store.go
@@ -225,6 +225,11 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 				objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
 			}
 
+			// The CiliumNetworkPoliciesKind resource version must be set.
+			if kind == kubernetes.CiliumNetworkPoliciesKind {
+				objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
+			}
+
 			if !equality.IsEqualObject(kind, objStore, objAPIServer) {
 				ds.logger.V(2).Info("store.store Add object to update", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
 				objsToUpdate = append(objsToUpdate, objStore)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the operator where when updating the DatadogAgent with an pre-existing CiliumNetworkPolicy created by the operator does not update the CiliumNetworkPolicy. The following errors are returned repeatedly:
```
{"level":"ERROR","ts":"2024-10-08T17:11:28.580Z","msg":"Reconciler error","controller":"datadogagent","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgent","DatadogAgent":{"name":"datadog","namespace":"default"},"namespace":"default","name":"datadog","reconcileID":"8acb4181-dd52-433d-a67f-ca7cc7e0c7b1","error":"ciliumnetworkpolicies.cilium.io \"datadog-agent\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update","errorCauses":[{"error":"ciliumnetworkpolicies.cilium.io \"datadog-agent\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update"}]}
```
This sets the resource version for the `CiliumNetworkPolicy` object when it gets created/updated which removes the above errors and updates the `CiliumNetworkPolicy` appropriately.

### Motivation
CECO-1473

### Describe your test plan
Create a kind cluster, and follow this guide to install Cilium in your cluster: [Installation Using Kind — Cilium 1.16.2 documentation](https://docs.cilium.io/en/stable/installation/kind/) 

Deploy this DatadogAgent configuration:
```
spec:
  global:
    networkPolicy:
      create: true
      flavor: "cilium"
  features:
    apm:
      enabled: true
      hostPortConfig:
        enabled: true
```

Run a describe on the operator created CiliumNetworkPolicy, you should see:
```
  Description:  Ingress for APM trace
  Endpoint Selector:
    Match Labels:
      app.kubernetes.io/instance:  agent
      app.kubernetes.io/part-of:   system-datadog
  Ingress:
    From Endpoints:
    To Ports:
      Ports:
        Port:      8126
        Protocol:  TCP
  Description:     Egress to ECS agent port 51678
```

Then update it to:
```
spec:
  global:
    networkPolicy:
      create: true
      flavor: "cilium"
  features:
    apm:
      enabled: true
      hostPortConfig:
        enabled: true
        hostPort: 1234
```

un a describe on the operator created CiliumNetworkPolicy, you should see it update:
```
  Description:  Ingress for APM trace
  Endpoint Selector:
    Match Labels:
      app.kubernetes.io/instance:  agent
      app.kubernetes.io/part-of:   system-datadog
  Ingress:
    From Endpoints:
    To Ports:
      Ports:
        Port:      1234
        Protocol:  TCP
  Description:     Egress to ECS agent port 51678
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
