### PR TITLE
Implement label and annotation equality checking

### DIFF
--- a/pkg/equality/equality.go
+++ b/pkg/equality/equality.go
@@ -238,12 +238,10 @@ func IsEqualOperatorObjectMeta(a, b metav1.Object) bool {
 
 // IsEqualOperatorAnnotations use to check if Operator annotations are equal between 2 Objects
 func IsEqualOperatorAnnotations(a, b metav1.Object) bool {
-	// TODO compare Operator annotations only
-	return true
+	return apiequality.Semantic.DeepEqual(a.GetAnnotations(), b.GetAnnotations())
 }
 
 // IsEqualOperatorLabels use to check if Operator labels are equal between 2 Objects
 func IsEqualOperatorLabels(a, b metav1.Object) bool {
-	// TODO compare Operator labels only
-	return true
+	return apiequality.Semantic.DeepEqual(a.GetLabels(), b.GetLabels())
 }

--- a/pkg/equality/equality_test.go
+++ b/pkg/equality/equality_test.go
@@ -128,7 +128,7 @@ func TestIsEqualOperatorLabels(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "objs not equal, but annotations equal",
+			name: "objs not equal, but labels equal",
 			objA: &metav1.ObjectMeta{
 				Name: "foo",
 				Annotations: map[string]string{

--- a/pkg/equality/equality_test.go
+++ b/pkg/equality/equality_test.go
@@ -1,0 +1,162 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package equality
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsEqualOperatorAnnotations(t *testing.T) {
+	tests := []struct {
+		name string
+		objA metav1.Object
+		objB metav1.Object
+		want bool
+	}{
+		{
+			name: "obj annotations equal",
+			objA: &metav1.ObjectMeta{
+				Name: "foo",
+				Annotations: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			objB: &metav1.ObjectMeta{
+				Name: "foo2",
+				Annotations: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "objs not equal",
+			objA: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			objB: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"foo":  "bar",
+					"one2": "two",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "objs not equal, but annotations equal",
+			objA: &metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+				Annotations: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			objB: &metav1.ObjectMeta{
+				Name: "foo2",
+				Labels: map[string]string{
+					"foo2": "bar",
+					"one2": "two",
+				},
+				Annotations: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsEqualOperatorAnnotations(tt.objA, tt.objB))
+		})
+	}
+}
+func TestIsEqualOperatorLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		objA metav1.Object
+		objB metav1.Object
+		want bool
+	}{
+		{
+			name: "obj labels equal",
+			objA: &metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			objB: &metav1.ObjectMeta{
+				Name: "foo2",
+				Labels: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "objs not equal",
+			objA: &metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			objB: &metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo":  "bar",
+					"one2": "two",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "objs not equal, but annotations equal",
+			objA: &metav1.ObjectMeta{
+				Name: "foo",
+				Annotations: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+				Labels: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			objB: &metav1.ObjectMeta{
+				Name: "foo2",
+				Annotations: map[string]string{
+					"foo2": "bar",
+					"one2": "two",
+				},
+				Labels: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsEqualOperatorLabels(tt.objA, tt.objB))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Implements checking for differences in annotations and labels for objects.

### Motivation

Unable to update service account annotations when qa'ing https://github.com/DataDog/datadog-operator/pull/1425 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
