### PR TITLE
Fix secret equality checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ docker-push-check-img:
 ##@ Test
 
 .PHONY: test
-test: build manifests generate fmt vet gotest integration-tests integration-tests-v2 ## Run unit tests and integration tests
+test: build manifests generate fmt vet verify-licenses gotest integration-tests integration-tests-v2 ## Run unit tests and integration tests
 
 .PHONY: gotest
 gotest:

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ docker-push-check-img:
 ##@ Test
 
 .PHONY: test
-test: build manifests generate fmt vet verify-licenses gotest integration-tests integration-tests-v2 ## Run unit tests and integration tests
+test: build manifests generate fmt vet gotest integration-tests integration-tests-v2 ## Run unit tests and integration tests
 
 .PHONY: gotest
 gotest:

--- a/pkg/equality/equality.go
+++ b/pkg/equality/equality.go
@@ -150,13 +150,13 @@ func IsEqualAPIService(objA, objB client.Object) bool {
 
 // IsEqualSecrets return true if the two Secrets are equal
 func IsEqualSecrets(a, b client.Object) bool {
-	sA, okA := a.(*corev1.ConfigMap)
-	sB, okB := b.(*corev1.ConfigMap)
+	sA, okA := a.(*corev1.Secret)
+	sB, okB := b.(*corev1.Secret)
 	if okA && okB && sA != nil && sB != nil {
 		if !apiutils.IsEqualStruct(sA.Data, sB.Data) {
 			return false
 		}
-		if !apiutils.IsEqualStruct(sA.BinaryData, sA.BinaryData) {
+		if !apiutils.IsEqualStruct(sA.StringData, sA.StringData) {
 			return false
 		}
 		return true

--- a/pkg/equality/equality.go
+++ b/pkg/equality/equality.go
@@ -153,13 +153,7 @@ func IsEqualSecrets(a, b client.Object) bool {
 	sA, okA := a.(*corev1.Secret)
 	sB, okB := b.(*corev1.Secret)
 	if okA && okB && sA != nil && sB != nil {
-		if !apiutils.IsEqualStruct(sA.Data, sB.Data) {
-			return false
-		}
-		if !apiutils.IsEqualStruct(sA.StringData, sA.StringData) {
-			return false
-		}
-		return true
+		return apiutils.IsEqualStruct(sA.Data, sB.Data)
 	}
 	return false
 }

--- a/pkg/equality/equality_test.go
+++ b/pkg/equality/equality_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestIsEqualOperatorAnnotations(t *testing.T) {
@@ -157,6 +159,114 @@ func TestIsEqualOperatorLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, IsEqualOperatorLabels(tt.objA, tt.objB))
+		})
+	}
+}
+func TestIsEqualSecrets(t *testing.T) {
+	tests := []struct {
+		name string
+		objA client.Object
+		objB client.Object
+		want bool
+	}{
+		{
+			name: "objs equal",
+			objA: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+				Data: map[string][]byte{
+					"foo": {1, 2, 3},
+				},
+				StringData: map[string]string{
+					"bar": "foo",
+				},
+			},
+			objB: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+				Data: map[string][]byte{
+					"foo": {1, 2, 3},
+				},
+				StringData: map[string]string{
+					"bar": "foo",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "objs not equal",
+			objA: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+				Data: map[string][]byte{
+					"foo": {1, 2, 3},
+				},
+				StringData: map[string]string{
+					"bar": "foo",
+				},
+			},
+			objB: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+				Data: map[string][]byte{
+					"foo": {3, 2, 1},
+				},
+				StringData: map[string]string{
+					"bar": "foo",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "objs not equal, but data and stringdata equal",
+			objA: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					"foo": {1, 2, 3},
+				},
+				StringData: map[string]string{
+					"bar": "foo",
+				},
+			},
+			objB: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+				Type: corev1.SecretTypeBootstrapToken,
+				Data: map[string][]byte{
+					"foo": {1, 2, 3},
+				},
+				StringData: map[string]string{
+					"bar": "foo",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "objs not secrets",
+			objA: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+			},
+			objB: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "secret-foo",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsEqualSecrets(tt.objA, tt.objB))
 		})
 	}
 }

--- a/pkg/equality/equality_test.go
+++ b/pkg/equality/equality_test.go
@@ -178,9 +178,6 @@ func TestIsEqualSecrets(t *testing.T) {
 				Data: map[string][]byte{
 					"foo": {1, 2, 3},
 				},
-				StringData: map[string]string{
-					"bar": "foo",
-				},
 			},
 			objB: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -188,9 +185,6 @@ func TestIsEqualSecrets(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					"foo": {1, 2, 3},
-				},
-				StringData: map[string]string{
-					"bar": "foo",
 				},
 			},
 			want: true,
@@ -204,9 +198,6 @@ func TestIsEqualSecrets(t *testing.T) {
 				Data: map[string][]byte{
 					"foo": {1, 2, 3},
 				},
-				StringData: map[string]string{
-					"bar": "foo",
-				},
 			},
 			objB: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -214,9 +205,6 @@ func TestIsEqualSecrets(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					"foo": {3, 2, 1},
-				},
-				StringData: map[string]string{
-					"bar": "foo",
 				},
 			},
 			want: false,
@@ -231,9 +219,6 @@ func TestIsEqualSecrets(t *testing.T) {
 				Data: map[string][]byte{
 					"foo": {1, 2, 3},
 				},
-				StringData: map[string]string{
-					"bar": "foo",
-				},
 			},
 			objB: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -242,9 +227,6 @@ func TestIsEqualSecrets(t *testing.T) {
 				Type: corev1.SecretTypeBootstrapToken,
 				Data: map[string][]byte{
 					"foo": {1, 2, 3},
-				},
-				StringData: map[string]string{
-					"bar": "foo",
 				},
 			},
 			want: true,


### PR DESCRIPTION
### What does this PR do?

When checking if secrets were the same to determine whether we needed to send an update request to k8s, the operator was checking that it was a configmap by mistake.

### Motivation

https://datadoghq.atlassian.net/browse/CECO-1697

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Once a new rc is deployed on staging, check the operator rollout dashboard in staging and confirm that the number of update requests for secrets is reduced in the `k8s requests by target object` widget

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
