### PR TITLE
Update agent / cluster-agent to 7.58.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.57.2"
+	AgentLatestVersion = "7.58.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.57.2"
+	ClusterAgentLatestVersion = "7.58.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.0.1"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry


### PR DESCRIPTION
### What does this PR do?

Bump default agent/cluster-agent to `7.58.0`

### Motivation

`7.58.0` was released

### Additional Notes

### Minimum Agent Versions

### Describe your test plan

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
