### PR TITLE
add generation changed predicate to dda controller

### DIFF
--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -254,7 +254,7 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}))
 	}
 
-	if err := builder.For(&datadoghqv2alpha1.DatadogAgent{}, builderOptions...).Complete(r); err != nil {
+	if err := builder.For(&datadoghqv2alpha1.DatadogAgent{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).Complete(r); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add GenerationChanged predicate to DatadogAgent controller to prevent Status updates from triggering reconciles on the resource.

### Motivation

Before change (two reconcilers per period):

```
{"level":"INFO","ts":"2024-10-25T11:41:39.377Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
{"level":"INFO","ts":"2024-10-25T11:41:39.743Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
{"level":"INFO","ts":"2024-10-25T11:41:54.377Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
{"level":"INFO","ts":"2024-10-25T11:41:54.743Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
{"level":"INFO","ts":"2024-10-25T11:42:09.743Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
{"level":"INFO","ts":"2024-10-25T11:42:09.864Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
```

After (1 reconcile per period):

```
{"level":"INFO","ts":"2024-10-25T11:51:46.344Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
{"level":"INFO","ts":"2024-10-25T11:52:01.465Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
{"level":"INFO","ts":"2024-10-25T11:52:16.553Z","logger":"controllers.DatadogAgent","msg":"Reconciling DatadogAgent","datadogagent":{"name":"datadog","namespace":"system"}}
```
### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

- Deploy the latest Datadog Operator and apply a DatadogAgent manifest

- View the logs to see reconcile frequency (`Reconciling DatadogAgent`). It is expected to be at least twice per second, every 15s.

- Deploy the test image

- Check the reconcile frequency. The number of reconciles should be reduced (in my test environment, it went down to once every 15s).

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
