### PR TITLE
Add network policies for admission controller feature

### DIFF
--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -7,15 +7,19 @@ package admissioncontroller
 
 import (
 	"encoding/json"
+	"strconv"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	componentdca "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusteragent"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/objects"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -38,6 +42,7 @@ type admissionControllerFeature struct {
 	registry               string
 	serviceAccountName     string
 	owner                  metav1.Object
+	networkPolicy          v2alpha1.NetworkPolicyFlavor
 
 	cwsInstrumentationEnabled bool
 	cwsInstrumentationMode    string
@@ -117,6 +122,8 @@ func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqC
 			f.cwsInstrumentationEnabled = true
 			f.cwsInstrumentationMode = apiutils.StringValue(ac.CWSInstrumentation.Mode)
 		}
+
+		_, f.networkPolicy = v2alpha1.IsNetworkPolicyEnabled(dda)
 
 		sidecarConfig := dda.Spec.Features.AdmissionController.AgentSidecarInjection
 		if shouldEnablesidecarInjection(sidecarConfig) {
@@ -224,7 +231,62 @@ func (f *admissionControllerFeature) ManageDependencies(managers feature.Resourc
 	if err := managers.RBACManager().AddClusterPolicyRules(ns, rbacName, f.serviceAccountName, getRBACClusterPolicyRules(f.webhookName, f.cwsInstrumentationEnabled, f.cwsInstrumentationMode)); err != nil {
 		return err
 	}
-	return managers.RBACManager().AddPolicyRules(ns, rbacName, f.serviceAccountName, getRBACPolicyRules())
+	if err := managers.RBACManager().AddPolicyRules(ns, rbacName, f.serviceAccountName, getRBACPolicyRules()); err != nil {
+		return err
+	}
+
+	if f.networkPolicy != "" {
+		policyName, podSelector := objects.GetNetworkPolicyMetadata(f.owner, v2alpha1.ClusterAgentComponentName)
+		switch f.networkPolicy {
+		case v2alpha1.NetworkPolicyFlavorKubernetes:
+			ingressRules := []netv1.NetworkPolicyIngressRule{
+				{
+					Ports: []netv1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								Type:   intstr.Int,
+								IntVal: v2alpha1.DefaultAdmissionControllerTargetPort,
+							},
+						},
+					},
+				},
+			}
+			return managers.NetworkPolicyManager().AddKubernetesNetworkPolicy(
+				policyName,
+				f.owner.GetNamespace(),
+				podSelector,
+				nil,
+				ingressRules,
+				nil,
+			)
+		case v2alpha1.NetworkPolicyFlavorCilium:
+			policySpecs := []cilium.NetworkPolicySpec{
+				{
+					Description:      "Ingress from API server for admission controller",
+					EndpointSelector: podSelector,
+					Ingress: []cilium.IngressRule{
+						{
+							FromEntities: []cilium.Entity{
+								"kube-apiserver",
+							},
+							ToPorts: []cilium.PortRule{
+								{
+									Ports: []cilium.PortProtocol{
+										{
+											Port:     strconv.Itoa(v2alpha1.DefaultAdmissionControllerTargetPort),
+											Protocol: cilium.ProtocolTCP,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			return managers.CiliumPolicyManager().AddCiliumPolicy(policyName, f.owner.GetNamespace(), policySpecs)
+		}
+	}
+	return nil
 }
 
 func (f *admissionControllerFeature) ManageClusterAgent(managers feature.PodTemplateManagers) error {


### PR DESCRIPTION
### What does this PR do?

Add network policies for the admission controller feature

### Motivation

https://github.com/DataDog/datadog-operator/issues/1490
https://datadoghq.atlassian.net/browse/CECO-1741

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Create a cluster with a network plugin enabled
2. Deploy the operator
3. Deploy a DDA with network policies and the admission controller feature enabled
```yaml
    networkPolicy:
      create: true
      flavor: <kubernetes or cilium>
```
4. Deploy an app that the admission controller should mutate. Example label and annotation below adds an init container that installs the python tracer to the app pod
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis
  labels:
    app: redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
        admission.datadoghq.com/enabled: "true"
      annotations:
        admission.datadoghq.com/python-lib.version: "v2.16.0"
    spec:
      containers:
        - name: redis
          imagePullPolicy: IfNotPresent
          image: redis:latest
          resources: {}
```
5. Ensure the app is mutated. The example above should start the app pod with the init container `datadog-lib-python-init`. If not mutated successfully, there won't be an init container


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
