### PR TITLE
[datadogpodautoscalers] Add stabilization window to scaling policy

### DIFF
--- a/api/datadoghq/v1alpha1/datadogpodautoscaler_types.go
+++ b/api/datadoghq/v1alpha1/datadogpodautoscaler_types.go
@@ -191,6 +191,11 @@ type DatadogPodAutoscalerScalingPolicy struct {
 	// +listType=atomic
 	// +optional
 	Rules []DatadogPodAutoscalerScalingRule `json:"rules,omitempty"`
+
+	// StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+	// before deciding to apply a new one. Default to 0.
+	// +optional
+	StabilizationWindowSeconds int32 `json:"stabilizationWindowSeconds,omitempty"`
 }
 
 // DatadogPodAutoscalerScalingRuleType defines how scaling rule value should be interpreted.

--- a/config/crd/bases/v1beta1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_datadogpodautoscalers.yaml
@@ -207,6 +207,11 @@ spec:
                         - Min
                         - Disabled
                       type: string
+                    stabilizationWindowSeconds:
+                      description: StabilizationWindowSeconds is used to specify the number of seconds to wait before 
+                      format: int32
+                      minimum: 0
+                      type: integer
                   type: object
                 update:
                   description: Update defines the policy to update target resource.
@@ -263,6 +268,11 @@ spec:
                         - Min
                         - Disabled
                       type: string
+                    stabilizationWindowSeconds:
+                      description: StabilizationWindowSeconds is used to specify the number of seconds to wait before 
+                      format: int32
+                      minimum: 0
+                      type: integer
                   type: object
               type: object
             remoteVersion:


### PR DESCRIPTION
### What does this PR do?

Add stabilization window to scaling policy in `DatadogPodAutoscalers` CRD

### Motivation

We want to support stabilizing recommendations and allow users to configure how long they would like the stabilization windows to be.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
