### PR TITLE
[tooling][gitlab] automatically trigger release candidate workflow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -529,12 +529,11 @@ publish_nightly_workflow:
     CONDUCTOR_TARGET: $CONDUCTOR_TARGET
     DDR_WORKFLOW_ID: $DDR_WORKFLOW_ID
 
-# On success, this will cause CNAB to trigger a Deployment to Release Candidate clusters
+# On success, this will cause CNAB to trigger a Deployment to Release Candidate clusters and open a corresponding pull request
 publish_release_candidate_workflow:
   stage: deploy
   rules:
     - if: $CI_COMMIT_TAG
-      when: manual # TODO: change this to on_success when feeling confident
     - when: never
   needs:
     - trigger_internal_operator_image


### PR DESCRIPTION
### What does this PR do?

Automatically trigger release candidate workflow for tag pipelines

It was initially set to require a manual trigger so it could be tested

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
