### PR TITLE
fix: include ADP container in certain pod-wide volume mount overrides

### DIFF
--- a/internal/controller/datadogagent/override/global.go
+++ b/internal/controller/datadogagent/override/global.go
@@ -311,6 +311,7 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 							apicommon.ProcessAgentContainerName,
 							apicommon.TraceAgentContainerName,
 							apicommon.SecurityAgentContainerName,
+							apicommon.AgentDataPlaneContainerName,
 						},
 					)
 					manager.Volume().AddVolume(&kubeletVol)

--- a/internal/controller/datadogagent/override/global.go
+++ b/internal/controller/datadogagent/override/global.go
@@ -360,6 +360,7 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 						apicommon.ProcessAgentContainerName,
 						apicommon.TraceAgentContainerName,
 						apicommon.SecurityAgentContainerName,
+						apicommon.AgentDataPlaneContainerName,
 					},
 				)
 				manager.Volume().AddVolume(&runtimeVol)


### PR DESCRIPTION
### What does this PR do?

This PR adds the Agent Data Plane container to the list of containers which receive an overridden `runtimesocketdir` and `kubelet-ca` volume mount.

### Motivation

This is needed to ensure ADP can access the proper socket paths on the host.

### Additional Notes

N/A

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Ran Operator locally in Kind cluster and observed the ADP container got the same `runtimesocketdir` and `kubelet-ca` volume mounts as other containers in Agent pod.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
