### PR TITLE
fix: specify 'run' subcommand to ADP binary

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -265,6 +265,7 @@ func agentDataPlaneContainer(dda metav1.Object) corev1.Container {
 		Image: agentImage(),
 		Command: []string{
 			"agent-data-plane",
+			"run",
 			fmt.Sprintf("--config=%s", apicommon.AgentCustomConfigVolumePath),
 		},
 		Env:            commonEnvVars(dda),


### PR DESCRIPTION
### What does this PR do?

Updates the ADP container command to specify a `run` subcommand to the `agent-data-plane` instead of relying on it being a default.

### Motivation

We're making changes to ADP's CLI argument handling and need to specify the specific subcommand to use to run ADP.

### Additional Notes

N/A

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Ran Operator locally in a Kind cluster and observed that it used the updated command arguments when creating the ADP container.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
