### PR TITLE
Update the default (cluster-)Agent version to 7.60.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.59.0"
+	AgentLatestVersion = "7.60.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.59.0"
+	ClusterAgentLatestVersion = "7.60.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.6"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry


### PR DESCRIPTION
### What does this PR do?

* Update default Agent and cluster Agent to `7.60.0`

### Motivation

https://github.com/DataDog/datadog-agent/releases/tag/7.60.0 was released

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
