### PR TITLE
Regenerate stale datadogpodautoscalers CRD

### DIFF
--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -263,6 +263,13 @@
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
                 },
+                "stabilizationWindowSeconds": {
+                  "description": "StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations\nbefore deciding to apply a new one. Defaults to 0.",
+                  "format": "int32",
+                  "maximum": 1800,
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "strategy": {
                   "description": "Strategy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
                   "enum": [
@@ -339,6 +346,13 @@
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
+                },
+                "stabilizationWindowSeconds": {
+                  "description": "StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations\nbefore deciding to apply a new one. Defaults to 0.",
+                  "format": "int32",
+                  "maximum": 1800,
+                  "minimum": 0,
+                  "type": "integer"
                 },
                 "strategy": {
                   "description": "Strategy is used to specify which policy should be used.\nIf not set, the default value Max is used.",


### PR DESCRIPTION
### What does this PR do?

Fix stale CRD manifest from #1519 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
