### PR TITLE
feat(admission): add delete RBAC for datadog-webhook

### DIFF
--- a/internal/controller/datadogagent/feature/admissioncontroller/rbac.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/rbac.go
@@ -31,6 +31,7 @@ func getRBACClusterPolicyRules(webhookName string, cwsInstrumentationEnabled boo
 				rbac.ListVerb,
 				rbac.WatchVerb,
 				rbac.UpdateVerb,
+				rbac.DeleteVerb,
 			},
 		},
 		// ExtendedDaemonsetReplicaSets


### PR DESCRIPTION
### What does this PR do?

Adds the necessary RBACs for the Cluster Agent to `delete` the `datadog-webhook` Validating and Mutating webhook configurations.

### Motivation

This is needed to allow the Cluster Agent to delete its own Admission Webhooks.

### Minimum Agent Versions

Agent: v7.63.0
Cluster Agent: v7.63.0

### Describe your test plan

Build the Operator and validate that the new `datadog-cluster-agent` `clusterroles.rbac.authorization.k8s.io` has the following permissions:

```
➜ kubectl describe clusterroles.rbac.authorization.k8s.io datadog-cluster-agent
Name:         datadog-cluster-agent
[...]
  mutatingwebhookconfigurations.admissionregistration.k8s.io    []                 [datadog-webhook]                     [get list watch update delete]
  validatingwebhookconfigurations.admissionregistration.k8s.io  []                 [datadog-webhook]                     [get list watch update delete]
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
