### PR TITLE
[CSV bundle] fixes replaces as 1.11.0 bundle was not released

### DIFF
--- a/bundle/manifests/datadog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/datadog-operator.clusterserviceversion.yaml
@@ -759,4 +759,4 @@ spec:
   provider:
     name: Datadog
   version: 1.11.1
-  replaces: datadog-operator.v1.11.0
+  replaces: datadog-operator.v1.10.0


### PR DESCRIPTION
### What does this PR do?

Correct replace version

### Motivation

When I used the `make bundle` command, I put `1.11.0` as the latest released version, but technically, this was false, 1.11.0 bundle was never released, only operator 1.11.0. The `replaces` needs to be the latest public bundle, otherwise, it cannot be added to the index. Example failure https://gist.github.com/rh-operator-bundle-bot/f9ba3c7e65838d62f7d6795a4b18ab79#file-operator-hosted-pipeline-run2jktz-log-L806 (from https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/941):
```shell
[add-bundle-to-index : add-bundle-to-index] 2024-12-31 15:16:27,719 [operator-cert] INFO Reason: Failed to add the bundles to the index image: Invalid bundle datadog-operator.v1.11.1, replaces nonexistent bundle datadog-operator.v1.11.0
```

This was manually fixed on the RedHat PRs, so fixing in release branch before merging updated bundle in `main`

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Tested by correcting the RedHat PRs and getting CI green as a result: https://github.com/redhat-openshift-ecosystem/redhat-marketplace-operators/pull/941/commits/40b1993abbd49c216a22e9853dbd7e0f0c66dddc

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
