### PR TITLE
Fix API violation from OTel Agent

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -704,6 +704,7 @@ type OtelCollectorFeatureConfig struct {
 	// If not, this will lead to a port conflict.
 	// This limitation will be lifted once annotations support is removed.
 	// +optional
+	// +listType=atomic
 	Ports []*corev1.ContainerPort `json:"ports,omitempty"`
 
 	// OTelCollector Config Relevant to the Core agent
@@ -718,15 +719,15 @@ type CoreConfig struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
-	// +optional
 	// Extension URL provides the URL of the ddflareextension to
 	// the core agent.
-	ExtensionURL *string `json:"extension_url,omitempty"`
-
 	// +optional
+	ExtensionURL *string `json:"extensionURL,omitempty"`
+
 	// Extension URL provides the timout of the ddflareextension to
 	// the core agent.
-	ExtensionTimeout *int `json:"extension_timeout,omitempty"`
+	// +optional
+	ExtensionTimeout *int `json:"extensionTimeout,omitempty"`
 }
 
 // AdmissionControllerFeatureConfig contains the Admission Controller feature configuration.

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -85,14 +85,14 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_CoreConfig(ref common.Refere
 							Format:      "",
 						},
 					},
-					"extension_url": {
+					"extensionURL": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Extension URL provides the URL of the ddflareextension to the core agent.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
-					"extension_timeout": {
+					"extensionTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Extension URL provides the timout of the ddflareextension to the core agent.",
 							Type:        []string{"integer"},
@@ -1418,6 +1418,11 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_OtelCollectorFeatureConfig(r
 						},
 					},
 					"ports": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Ports contains the ports for the otel-agent. Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317 or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http). If not, this will lead to a port conflict. This limitation will be lifted once annotations support is removed.",
 							Type:        []string{"array"},

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1352,12 +1352,12 @@ spec:
                             enabled:
                               description: Enabled marks otelcollector as enabled in core agent.
                               type: boolean
-                            extension_timeout:
+                            extensionTimeout:
                               description: |-
                                 Extension URL provides the timout of the ddflareextension to
                                 the core agent.
                               type: integer
-                            extension_url:
+                            extensionURL:
                               description: |-
                                 Extension URL provides the URL of the ddflareextension to
                                 the core agent.
@@ -1411,6 +1411,7 @@ spec:
                               - containerPort
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     otlp:
                       description: OTLP ingest configuration
@@ -8215,12 +8216,12 @@ spec:
                                 enabled:
                                   description: Enabled marks otelcollector as enabled in core agent.
                                   type: boolean
-                                extension_timeout:
+                                extensionTimeout:
                                   description: |-
                                     Extension URL provides the timout of the ddflareextension to
                                     the core agent.
                                   type: integer
-                                extension_url:
+                                extensionURL:
                                   description: |-
                                     Extension URL provides the URL of the ddflareextension to
                                     the core agent.
@@ -8274,6 +8275,7 @@ spec:
                                   - containerPort
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                         otlp:
                           description: OTLP ingest configuration

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1407,11 +1407,11 @@
                       "description": "Enabled marks otelcollector as enabled in core agent.",
                       "type": "boolean"
                     },
-                    "extension_timeout": {
+                    "extensionTimeout": {
                       "description": "Extension URL provides the timout of the ddflareextension to\nthe core agent.",
                       "type": "integer"
                     },
-                    "extension_url": {
+                    "extensionURL": {
                       "description": "Extension URL provides the URL of the ddflareextension to\nthe core agent.",
                       "type": "string"
                     }
@@ -1457,7 +1457,8 @@
                     ],
                     "type": "object"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object"
@@ -8212,11 +8213,11 @@
                           "description": "Enabled marks otelcollector as enabled in core agent.",
                           "type": "boolean"
                         },
-                        "extension_timeout": {
+                        "extensionTimeout": {
                           "description": "Extension URL provides the timout of the ddflareextension to\nthe core agent.",
                           "type": "integer"
                         },
-                        "extension_url": {
+                        "extensionURL": {
                           "description": "Extension URL provides the URL of the ddflareextension to\nthe core agent.",
                           "type": "string"
                         }
@@ -8262,7 +8263,8 @@
                         ],
                         "type": "object"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object"

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -146,8 +146,8 @@ spec:
 | features.otelCollector.conf.configMap.items | Maps a ConfigMap data `key` to a file `path` mount. |
 | features.otelCollector.conf.configMap.name | Is the name of the ConfigMap. |
 | features.otelCollector.coreConfig.enabled | Marks otelcollector as enabled in core agent. |
-| features.otelCollector.coreConfig.extension_timeout | Extension URL provides the timout of the ddflareextension to the core agent. |
-| features.otelCollector.coreConfig.extension_url | Extension URL provides the URL of the ddflareextension to the core agent. |
+| features.otelCollector.coreConfig.extensionTimeout | Extension URL provides the timout of the ddflareextension to the core agent. |
+| features.otelCollector.coreConfig.extensionURL | Extension URL provides the URL of the ddflareextension to the core agent. |
 | features.otelCollector.enabled | Enables the OTel Agent. Default: true |
 | features.otelCollector.ports | Contains the ports for the otel-agent. Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317 or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http). If not, this will lead to a port conflict. This limitation will be lifted once annotations support is removed. |
 | features.otlp.receiver.protocols.grpc.enabled | Enable the OTLP/gRPC endpoint. Host port is enabled by default and can be disabled. |


### PR DESCRIPTION
### What does this PR do?

Fixes API violation from https://github.com/DataDog/datadog-operator/pull/1559 

### Motivation

https://github.com/DataDog/datadog-operator/actions/runs/12434980195/job/34719814433#step:6:43 API rule violations occur when running `make generate`

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Verify that error has been resolved in CI: https://github.com/DataDog/datadog-operator/actions/runs/12659013902/job/35277172303?pr=1607 looks good

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
