### PR TITLE
[profiles] Do not error if pod needing deletion is not found

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -379,7 +380,9 @@ func (r *Reconciler) cleanupPodsForProfilesThatNoLongerApply(ctx context.Context
 				},
 			}
 			if err = r.client.Delete(ctx, &toDelete); err != nil {
-				return err
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Occasionally, when we need to delete existing agent pods that don't match a node's affinity, there's a chance that some pods are already deleted between the time the cached list of pods the operator queries is updated and the operator sends the deletion request. When that happens, the operator receives a pod not found error from the deletion request. Instead of causing a reconciler error, this PR ignores the not found error.

### Motivation

CECO-1383

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

This PR is difficult to test since the issue only happens sporadically. It was reported when a new DatadogAgentProfile was created that triggered the operator to delete existing agent pods for not meeting the updated nodeaffinity requirements and affected approximately 1 out of 8 agent pods in that instance.

One way to test could be to create a DatadogAgentProfile in staging and ensuring you don't see a reconcile error log similar to the following during rollout of the profile:

```
{"level":"ERROR","ts":"2024-08-08T19:46:12.565Z","msg":"Reconciler error","controller":"datadogagent","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgent","DatadogAgent":{"name":"datadog-agent","namespace":"datadog-agent"},"namespace":"datadog-agent","name":"datadog-agent","reconcileID":"xxx","error":"pods \"datadog-agent-xxxxx-xxxxx\" not found"}
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
