### PR TITLE
service discovery: Add missing cgroup mount

### DIFF
--- a/internal/controller/datadogagent/feature/servicediscovery/feature.go
+++ b/internal/controller/datadogagent/feature/servicediscovery/feature.go
@@ -71,6 +71,11 @@ func (f *serviceDiscoveryFeature) ManageNodeAgent(managers feature.PodTemplateMa
 	managers.VolumeMount().AddVolumeMountToContainer(&procdirMount, apicommon.SystemProbeContainerName)
 	managers.Volume().AddVolume(&procdirVol)
 
+	// Needed to resolve container information
+	cgroupsVol, cgroupsMount := volume.GetVolumes(v2alpha1.CgroupsVolumeName, v2alpha1.CgroupsHostPath, v2alpha1.CgroupsMountPath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&cgroupsMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&cgroupsVol)
+
 	socketVol, socketVolMount := volume.GetVolumesEmptyDir(v2alpha1.SystemProbeSocketVolumeName, v2alpha1.SystemProbeSocketVolumePath, false)
 	managers.Volume().AddVolume(&socketVol)
 	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommon.SystemProbeContainerName)

--- a/internal/controller/datadogagent/feature/servicediscovery/feature_test.go
+++ b/internal/controller/datadogagent/feature/servicediscovery/feature_test.go
@@ -64,6 +64,11 @@ func Test_serviceDiscoveryFeature_Configure(t *testing.T) {
 				ReadOnly:  true,
 			},
 			{
+				Name:      v2alpha1.CgroupsVolumeName,
+				MountPath: v2alpha1.CgroupsMountPath,
+				ReadOnly:  true,
+			},
+			{
 				Name:      v2alpha1.SystemProbeSocketVolumeName,
 				MountPath: v2alpha1.SystemProbeSocketVolumePath,
 				ReadOnly:  false,
@@ -83,6 +88,14 @@ func Test_serviceDiscoveryFeature_Configure(t *testing.T) {
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: v2alpha1.ProcdirHostPath,
+					},
+				},
+			},
+			{
+				Name: v2alpha1.CgroupsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: v2alpha1.CgroupsHostPath,
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Add a missing cgroup mount to system-probe which is required to get container information for service discovery. 
This was not required for earlier agent releases but will be from version 7.61 of the agent.

### Motivation

Bug found during manual testing of latest agent release.

### Additional Notes

The same mount is already added for other features like USM/NPM.

### Minimum Agent Versions

### Describe your test plan

Follow the instructions on https://github.com/datadog/datadog-operator/pull/1449 except use at least version `7.61.0-rc.10` of the agent. 
Run the following command in the system-probe container to check that the `container_id` is filled:

```
$ kubectl exec -it -n system datadog-agent-wh7nn -c system-probe -- /bin/bash
# curl --unix-socket /var/run/sysprobe/sysprobe.sock http://unix/discovery/services
.... ,"container_id":"2405b0f93c5ed4039223c7b5ac098f32b3e6ae7671a743bca4023e5ac2e75c59"}] ...
``` 

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
