### PR TITLE
testing edit to generate-openapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,9 +283,9 @@ install-tools: bin/$(PLATFORM)/golangci-lint bin/$(PLATFORM)/operator-sdk bin/$(
 .PHONY: generate-openapi
 generate-openapi: bin/$(PLATFORM)/openapi-gen
 	@set -o pipefail; \
-	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v1alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v1alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v1alpha1 2>&1 | tee /dev/stderr | grep -q "warning" && { echo "Error: Warnings detected"; exit 1; } || true
+	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v1alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v1alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v1alpha1 2>&1 | tee /dev/stderr | grep -q "violation" && { echo "Error: Warnings detected"; exit 1; } || true
 	@set -o pipefail; \
-	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v2alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v2alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v2alpha1 2>&1 | tee /dev/stderr | grep -q "warning" && { echo "Error: Warnings detected"; exit 1; } || true
+	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v2alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v2alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v2alpha1 2>&1 | tee /dev/stderr | grep -q "violation" && { echo "Error: Warnings detected"; exit 1; } || true
 
 .PHONY: preflight-redhat-container
 preflight-redhat-container: bin/$(PLATFORM)/preflight

--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,10 @@ install-tools: bin/$(PLATFORM)/golangci-lint bin/$(PLATFORM)/operator-sdk bin/$(
 
 .PHONY: generate-openapi
 generate-openapi: bin/$(PLATFORM)/openapi-gen
-	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v1alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v1alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v1alpha1
-	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v2alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v2alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v2alpha1
+	@set -o pipefail; \
+	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v1alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v1alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v1alpha1 2>&1 | tee /dev/stderr | grep -q "warning" && { echo "Error: Warnings detected"; exit 1; } || true
+	@set -o pipefail; \
+	bin/$(PLATFORM)/openapi-gen --logtostderr --output-dir api/datadoghq/v2alpha1 --output-file zz_generated.openapi.go --output-pkg api/datadoghq/v2alpha1 --go-header-file ./hack/boilerplate.go.txt ./api/datadoghq/v2alpha1 2>&1 | tee /dev/stderr | grep -q "warning" && { echo "Error: Warnings detected"; exit 1; } || true
 
 .PHONY: preflight-redhat-container
 preflight-redhat-container: bin/$(PLATFORM)/preflight

--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -704,7 +704,6 @@ type OtelCollectorFeatureConfig struct {
 	// If not, this will lead to a port conflict.
 	// This limitation will be lifted once annotations support is removed.
 	// +optional
-	// +listType=atomic
 	Ports []*corev1.ContainerPort `json:"ports,omitempty"`
 
 	// OTelCollector Config Relevant to the Core agent

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -1418,11 +1418,6 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_OtelCollectorFeatureConfig(r
 						},
 					},
 					"ports": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Ports contains the ports for the otel-agent. Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317 or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http). If not, this will lead to a port conflict. This limitation will be lifted once annotations support is removed.",
 							Type:        []string{"array"},

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1411,7 +1411,6 @@ spec:
                               - containerPort
                             type: object
                           type: array
-                          x-kubernetes-list-type: atomic
                       type: object
                     otlp:
                       description: OTLP ingest configuration
@@ -8275,7 +8274,6 @@ spec:
                                   - containerPort
                                 type: object
                               type: array
-                              x-kubernetes-list-type: atomic
                           type: object
                         otlp:
                           description: OTLP ingest configuration

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1457,8 +1457,7 @@
                     ],
                     "type": "object"
                   },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
+                  "type": "array"
                 }
               },
               "type": "object"
@@ -8263,8 +8262,7 @@
                         ],
                         "type": "object"
                       },
-                      "type": "array",
-                      "x-kubernetes-list-type": "atomic"
+                      "type": "array"
                     }
                   },
                   "type": "object"


### PR DESCRIPTION
### What does this PR do?

**do not merge!!**
Testing edit to generate-openapi to cause error when warning occurs in the output of `make generate-openapi` command
I removed `// +listType=atomic` from `OtelCollectorFeatureConfig`'s `Ports` field in `api/datadoghq/v2alpha1/datadogagent_types.go` -> running `make generate` should lead to an `API rule violation` error

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
