### PR TITLE
Fix daemonset status duplication in DDA when DS can't be created

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -204,8 +204,8 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 	return r.createOrUpdateDaemonset(daemonsetLogger, dda, daemonset, newStatus, updateDSStatusV2WithAgent, profile)
 }
 
-func updateDSStatusV2WithAgent(ds *appsv1.DaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string) {
-	newStatus.AgentList = condition.UpdateDaemonSetStatus(ds, newStatus.AgentList, &updateTime)
+func updateDSStatusV2WithAgent(dsName string, ds *appsv1.DaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string) {
+	newStatus.AgentList = condition.UpdateDaemonSetStatus(dsName, ds, newStatus.AgentList, &updateTime)
 	condition.UpdateDatadogAgentStatusConditions(newStatus, updateTime, datadoghqv2alpha1.AgentReconcileConditionType, status, reason, message, true)
 	newStatus.Agent = condition.UpdateCombinedDaemonSetStatus(newStatus.AgentList)
 }

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -148,46 +148,47 @@ func UpdateDeploymentStatus(dep *appsv1.Deployment, depStatus *v2alpha1.Deployme
 }
 
 // UpdateDaemonSetStatus updates a daemonset's DaemonSetStatus
-func UpdateDaemonSetStatus(ds *appsv1.DaemonSet, dsStatus []*v2alpha1.DaemonSetStatus, updateTime *metav1.Time) []*v2alpha1.DaemonSetStatus {
+func UpdateDaemonSetStatus(dsName string, ds *appsv1.DaemonSet, dsStatus []*v2alpha1.DaemonSetStatus, updateTime *metav1.Time) []*v2alpha1.DaemonSetStatus {
 	if dsStatus == nil {
 		dsStatus = []*v2alpha1.DaemonSetStatus{}
 	}
+
+	var newStatus v2alpha1.DaemonSetStatus
 	if ds == nil {
-		dsStatus = append(dsStatus, &v2alpha1.DaemonSetStatus{
-			State:  string(DatadogAgentStateFailed),
-			Status: string(DatadogAgentStateFailed),
-		})
-		return dsStatus
-	}
+		newStatus = v2alpha1.DaemonSetStatus{
+			State:         string(DatadogAgentStateFailed),
+			Status:        string(DatadogAgentStateFailed),
+			DaemonsetName: dsName,
+		}
+	} else {
+		newStatus = v2alpha1.DaemonSetStatus{
+			Desired:       ds.Status.DesiredNumberScheduled,
+			Current:       ds.Status.CurrentNumberScheduled,
+			Ready:         ds.Status.NumberReady,
+			Available:     ds.Status.NumberAvailable,
+			UpToDate:      ds.Status.UpdatedNumberScheduled,
+			DaemonsetName: ds.ObjectMeta.Name,
+		}
+		if updateTime != nil {
+			newStatus.LastUpdate = updateTime
+		}
+		if hash, ok := ds.Annotations[v2alpha1.MD5AgentDeploymentAnnotationKey]; ok {
+			newStatus.CurrentHash = hash
+		}
 
-	newStatus := v2alpha1.DaemonSetStatus{
-		Desired:       ds.Status.DesiredNumberScheduled,
-		Current:       ds.Status.CurrentNumberScheduled,
-		Ready:         ds.Status.NumberReady,
-		Available:     ds.Status.NumberAvailable,
-		UpToDate:      ds.Status.UpdatedNumberScheduled,
-		DaemonsetName: ds.ObjectMeta.Name,
-	}
+		var deploymentState DatadogAgentState
+		switch {
+		case newStatus.UpToDate != newStatus.Desired:
+			deploymentState = DatadogAgentStateUpdating
+		case newStatus.Ready == 0 && newStatus.Desired != 0:
+			deploymentState = DatadogAgentStateProgressing
+		default:
+			deploymentState = DatadogAgentStateRunning
+		}
 
-	if updateTime != nil {
-		newStatus.LastUpdate = updateTime
+		newStatus.State = fmt.Sprintf("%v", deploymentState)
+		newStatus.Status = fmt.Sprintf("%v (%d/%d/%d)", deploymentState, newStatus.Desired, newStatus.Ready, newStatus.UpToDate)
 	}
-	if hash, ok := ds.Annotations[v2alpha1.MD5AgentDeploymentAnnotationKey]; ok {
-		newStatus.CurrentHash = hash
-	}
-
-	var deploymentState DatadogAgentState
-	switch {
-	case newStatus.UpToDate != newStatus.Desired:
-		deploymentState = DatadogAgentStateUpdating
-	case newStatus.Ready == 0 && newStatus.Desired != 0:
-		deploymentState = DatadogAgentStateProgressing
-	default:
-		deploymentState = DatadogAgentStateRunning
-	}
-
-	newStatus.State = fmt.Sprintf("%v", deploymentState)
-	newStatus.Status = fmt.Sprintf("%v (%d/%d/%d)", deploymentState, newStatus.Desired, newStatus.Ready, newStatus.UpToDate)
 
 	// match ds name to ds status
 	found := false

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -7,9 +7,12 @@ package condition
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	assert "github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -107,4 +110,12 @@ func TestDeleteDatadogAgentStatusCondition(t *testing.T) {
 			assert.True(t, apiutils.IsEqualStruct(tt.args.status, tt.expectedStatus), "status \ndiff = %s", cmp.Diff(tt.args.status, tt.expectedStatus))
 		})
 	}
+}
+
+func TestDSUpdateWhenNil(t *testing.T) {
+	var ds *appsv1.DaemonSet
+	dsStatus := UpdateDaemonSetStatus(ds, []*v2alpha1.DaemonSetStatus{}, &metav1.Time{Time: time.Now()})
+	dsStatus = UpdateDaemonSetStatus(ds, dsStatus, &metav1.Time{Time: time.Now()})
+	dsStatus = UpdateDaemonSetStatus(ds, dsStatus, &metav1.Time{Time: time.Now()})
+	assert.Equal(t, 1, len(dsStatus))
 }

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -112,10 +112,10 @@ func TestDeleteDatadogAgentStatusCondition(t *testing.T) {
 	}
 }
 
-func TestDSUpdateWhenNil(t *testing.T) {
+func TestUpdateWhenDSNil(t *testing.T) {
 	var ds *appsv1.DaemonSet
-	dsStatus := UpdateDaemonSetStatus(ds, []*v2alpha1.DaemonSetStatus{}, &metav1.Time{Time: time.Now()})
-	dsStatus = UpdateDaemonSetStatus(ds, dsStatus, &metav1.Time{Time: time.Now()})
-	dsStatus = UpdateDaemonSetStatus(ds, dsStatus, &metav1.Time{Time: time.Now()})
+	dsStatus := UpdateDaemonSetStatus("ds", ds, []*v2alpha1.DaemonSetStatus{}, &metav1.Time{Time: time.Now()})
+	dsStatus = UpdateDaemonSetStatus("ds", ds, dsStatus, &metav1.Time{Time: time.Now()})
+	dsStatus = UpdateDaemonSetStatus("ds", ds, dsStatus, &metav1.Time{Time: time.Now()})
 	assert.Equal(t, 1, len(dsStatus))
 }


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/DataDog/datadog-operator/issues/1561

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Install older version of Operator
2. Edit operator clusterrole and to restrict operator on Daemonsets - delete `daemonsets` in this definition:
```yaml
...
- apiGroups:
  - apps
  resources:
  - daemonsets
  - deployments
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
...
```
3. Apply minimal DDA and monitor status - observe DDA status with duplicates.
```yaml
  agentList:
  - available: 0
    current: 0
    desired: 0
    ready: 0
    state: Failed
    status: Failed
    upToDate: 0
  - available: 0
    current: 0
    desired: 0
    ready: 0
    state: Failed
    status: Failed
    upToDate: 0
...
```
5. Delete DDA.
6. Upgrade Operator and reapply DDA.
7. No duplicates in DDA status.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
