### PR TITLE
Add PodResources mount to agent

### DIFF
--- a/api/datadoghq/v2alpha1/const.go
+++ b/api/datadoghq/v2alpha1/const.go
@@ -181,7 +181,6 @@ const (
 	KubeletAgentCAPath            = "/var/run/host-kubelet-ca.crt"
 	KubeletCAVolumeName           = "kubelet-ca"
 	KubeletPodResourcesVolumeName = "kubelet-pod-resources"
-	DefaultKubeletPodResourcesSocket = "/var/lib/kubelet/pod-resources/kubelet.sock"
 
 	APMSocketName = "apm.socket"
 

--- a/api/datadoghq/v2alpha1/const.go
+++ b/api/datadoghq/v2alpha1/const.go
@@ -178,8 +178,9 @@ const (
 	CriSocketVolumeName     = "runtimesocketdir"
 	RuntimeDirVolumePath    = "/var/run"
 
-	KubeletAgentCAPath  = "/var/run/host-kubelet-ca.crt"
-	KubeletCAVolumeName = "kubelet-ca"
+	KubeletAgentCAPath            = "/var/run/host-kubelet-ca.crt"
+	KubeletCAVolumeName           = "kubelet-ca"
+	KubeletPodResourcesVolumeName = "kubelet-pod-resources"
 
 	APMSocketName = "apm.socket"
 

--- a/api/datadoghq/v2alpha1/const.go
+++ b/api/datadoghq/v2alpha1/const.go
@@ -181,6 +181,7 @@ const (
 	KubeletAgentCAPath            = "/var/run/host-kubelet-ca.crt"
 	KubeletCAVolumeName           = "kubelet-ca"
 	KubeletPodResourcesVolumeName = "kubelet-pod-resources"
+	DefaultKubeletPodResourcesSocket = "/var/lib/kubelet/pod-resources/kubelet.sock"
 
 	APMSocketName = "apm.socket"
 

--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -1079,6 +1079,11 @@ type KubeletConfig struct {
 	// Default: '/var/run/host-kubelet-ca.crt' if hostCAPath is set, else '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
 	// +optional
 	AgentCAPath string `json:"agentCAPath,omitempty"`
+
+	// PodResourcesSocket is the path to the pod resources socket, to be used to read pod resource assignments
+	// Default: `/var/lib/kubelet/pod-resources/kubelet.sock`
+	// +optional
+	PodResourcesSocket string `json:"podResourcesSocket,omitempty"`
 }
 
 // HostPortConfig contains host port configuration.

--- a/api/datadoghq/v2alpha1/envvar.go
+++ b/api/datadoghq/v2alpha1/envvar.go
@@ -44,6 +44,7 @@ const (
 	DDKubeResourcesNamespace               = "DD_KUBE_RESOURCES_NAMESPACE"
 	DDKubernetesResourcesLabelsAsTags      = "DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS"
 	DDKubernetesResourcesAnnotationsAsTags = "DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS"
+	DDKubernetesPodResourcesSocket         = "DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET"
 	DDLeaderElection                       = "DD_LEADER_ELECTION"
 	DDLogsEnabled                          = "DD_LOGS_ENABLED"
 	DDNamespaceLabelsAsTags                = "DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS"

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -2149,6 +2149,11 @@ spec:
                         hostCAPath:
                           description: HostCAPath is the host path where the kubelet CA certificate is stored.
                           type: string
+                        podResourcesSocket:
+                          description: |-
+                            PodResourcesSocket is the path to the pod resources socket, to be used to read pod resource assignments
+                            Default: `/var/lib/kubelet/pod-resources/kubelet.sock`
+                          type: string
                         tlsVerify:
                           description: |-
                             TLSVerify toggles kubelet TLS verification.

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -2300,6 +2300,10 @@
                   "description": "HostCAPath is the host path where the kubelet CA certificate is stored.",
                   "type": "string"
                 },
+                "podResourcesSocket": {
+                  "description": "PodResourcesSocket is the path to the pod resources socket, to be used to read pod resource assignments\nDefault: `/var/lib/kubelet/pod-resources/kubelet.sock`",
+                  "type": "string"
+                },
                 "tlsVerify": {
                   "description": "TLSVerify toggles kubelet TLS verification.\nDefault: true",
                   "type": "boolean"

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -228,6 +228,7 @@ spec:
 | global.kubelet.host.secretKeyRef.name | Of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names |
 | global.kubelet.host.secretKeyRef.optional | Specify whether the Secret or its key must be defined |
 | global.kubelet.hostCAPath | HostCAPath is the host path where the kubelet CA certificate is stored. |
+| global.kubelet.podResourcesSocket | PodResourcesSocket is the path to the pod resources socket, to be used to read pod resource assignments Default: `/var/lib/kubelet/pod-resources/kubelet.sock` |
 | global.kubelet.tlsVerify | TLSVerify toggles kubelet TLS verification. Default: true |
 | global.kubernetesResourcesAnnotationsAsTags | Provide a mapping of Kubernetes Resource Groups to annotations mapping to Datadog Tags. <KUBERNETES_RESOURCE_GROUP>: 		<KUBERNETES_ANNOTATION>: <DATADOG_TAG_KEY> KUBERNETES_RESOURCE_GROUP should be in the form `{resource}.{group}` or `{resource}` (example: deployments.apps, pods) |
 | global.kubernetesResourcesLabelsAsTags | Provide a mapping of Kubernetes Resource Groups to labels mapping to Datadog Tags. <KUBERNETES_RESOURCE_GROUP>: 		<KUBERNETES_LABEL>: <DATADOG_TAG_KEY> KUBERNETES_RESOURCE_GROUP should be in the form `{resource}.{group}` or `{resource}` (example: deployments.apps, pods) |

--- a/internal/controller/datadogagent/defaults/datadogagent_default.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default.go
@@ -115,6 +115,7 @@ const (
 
 	// defaultKubeletAgentCAPath            = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	// defaultKubeletAgentCAPathHostPathSet = "/var/run/host-kubelet-ca.crt"
+	defaultKubeletPodResourcesSocket = "/var/lib/kubelet/pod-resources/kubelet.sock"
 
 	defaultContainerStrategy = v2alpha1.OptimizedContainerStrategy
 
@@ -190,6 +191,14 @@ func defaultGlobalConfig(ddaSpec *v2alpha1.DatadogAgentSpec) {
 		apiutils.DefaultInt32IfUnset(&ddaSpec.Global.FIPS.Port, defaultFIPSPort)
 		apiutils.DefaultInt32IfUnset(&ddaSpec.Global.FIPS.PortRange, defaultFIPSPortRange)
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Global.FIPS.UseHTTPS, defaultFIPSUseHTTPS)
+	}
+
+	if ddaSpec.Global.Kubelet == nil {
+		ddaSpec.Global.Kubelet = &v2alpha1.KubeletConfig{}
+	}
+
+	if ddaSpec.Global.Kubelet.PodResourcesSocket == "" {
+		ddaSpec.Global.Kubelet.PodResourcesSocket = defaultKubeletPodResourcesSocket
 	}
 
 	apiutils.DefaultBooleanIfUnset(&ddaSpec.Global.RunProcessChecksInCoreAgent, defaultRunProcessChecksInCoreAgent)

--- a/internal/controller/datadogagent/override/global.go
+++ b/internal/controller/datadogagent/override/global.go
@@ -305,6 +305,11 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 						&podResourcesMount,
 						[]apicommon.AgentContainerName{
 							apicommon.CoreAgentContainerName,
+							apicommon.ProcessAgentContainerName,
+							apicommon.TraceAgentContainerName,
+							apicommon.SecurityAgentContainerName,
+							apicommon.AgentDataPlaneContainerName,
+							apicommon.SystemProbeContainerName,
 						},
 					)
 					manager.Volume().AddVolume(&podResourcesVol)

--- a/internal/controller/datadogagent/override/global.go
+++ b/internal/controller/datadogagent/override/global.go
@@ -285,6 +285,31 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 					Value: agentCAPath,
 				})
 			}
+			if config.Kubelet.PodResourcesSocket != "" {
+				manager.EnvVar().AddEnvVar(&corev1.EnvVar{
+					Name:  v2alpha1.DDKubernetesPodResourcesSocket,
+					Value: config.Kubelet.PodResourcesSocket,
+				})
+
+				podResourcesVol, podResourcesMount := volume.GetVolumes(v2alpha1.KubeletPodResourcesVolumeName, config.Kubelet.PodResourcesSocket, config.Kubelet.PodResourcesSocket, false)
+				if singleContainerStrategyEnabled {
+					manager.VolumeMount().AddVolumeMountToContainers(
+						&podResourcesMount,
+						[]apicommon.AgentContainerName{
+							apicommon.UnprivilegedSingleAgentContainerName,
+						},
+					)
+					manager.Volume().AddVolume(&podResourcesVol)
+				} else {
+					manager.VolumeMount().AddVolumeMountToContainers(
+						&podResourcesMount,
+						[]apicommon.AgentContainerName{
+							apicommon.CoreAgentContainerName,
+						},
+					)
+					manager.Volume().AddVolume(&podResourcesVol)
+				}
+			}
 		}
 
 		var runtimeVol corev1.Volume

--- a/internal/controller/datadogagent/override/global_test.go
+++ b/internal/controller/datadogagent/override/global_test.go
@@ -327,16 +327,16 @@ func getExpectedVolumes(configs ...volumeConfig) []*corev1.Volume {
 	if slices.Contains(configs, kubeletCAVolumes) {
 		volumes = append(volumes, &corev1.Volume{
 			Name: v2alpha1.KubeletCAVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: hostCAPath,
-					},
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: hostCAPath,
 				},
+			},
 		})
 	}
 
 	if slices.Contains(configs, defaultVolumes) {
-		volumes = append(volumes,  &corev1.Volume{
+		volumes = append(volumes, &corev1.Volume{
 			Name: v2alpha1.KubeletPodResourcesVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
@@ -351,8 +351,8 @@ func getExpectedVolumes(configs ...volumeConfig) []*corev1.Volume {
 			Name: v2alpha1.CriSocketVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-						Path: dockerSocketPath,
-					},
+					Path: dockerSocketPath,
+				},
 			},
 		})
 	}
@@ -396,7 +396,6 @@ func getExpectedVolumeMounts(configs ...volumeConfig) []*corev1.VolumeMount {
 			ReadOnly:  true,
 		})
 	}
-
 
 	return mounts
 }

--- a/internal/controller/datadogagent/override/global_test.go
+++ b/internal/controller/datadogagent/override/global_test.go
@@ -33,7 +33,7 @@ import (
 const (
 	hostCAPath           = "/host/ca/path/ca.crt"
 	agentCAPath          = "/agent/ca/path/ca.crt"
-	podResourcesSocket   = v2alpha1.DefaultKubeletPodResourcesSocket
+	podResourcesSocket   = "/var/lib/kubelet/pod-resources/kubelet.sock"
 	dockerSocketPath     = "/docker/socket/path/docker.sock"
 	secretBackendCommand = "foo.sh"
 	secretBackendArgs    = "bar baz"
@@ -307,7 +307,7 @@ func getExpectedEnvVars(addedEnvVars ...*corev1.EnvVar) []*corev1.EnvVar {
 	if !containsPodResourcesEnvVar {
 		defaultEnvVars = append(defaultEnvVars, &corev1.EnvVar{
 			Name:  v2alpha1.DDKubernetesPodResourcesSocket,
-			Value: v2alpha1.DefaultKubeletPodResourcesSocket,
+			Value: podResourcesSocket,
 		})
 	}
 

--- a/pkg/testutils/builder.go
+++ b/pkg/testutils/builder.go
@@ -834,11 +834,12 @@ func (builder *DatadogAgentBuilder) WithHelmCheckValuesAsTags(valuesAsTags map[s
 
 // Global Kubelet
 
-func (builder *DatadogAgentBuilder) WithGlobalKubeletConfig(hostCAPath, agentCAPath string, tlsVerify bool) *DatadogAgentBuilder {
+func (builder *DatadogAgentBuilder) WithGlobalKubeletConfig(hostCAPath, agentCAPath string, tlsVerify bool, podResourcesSocket string) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Global.Kubelet = &v2alpha1.KubeletConfig{
-		TLSVerify:   apiutils.NewBoolPointer(tlsVerify),
-		HostCAPath:  hostCAPath,
-		AgentCAPath: agentCAPath,
+		TLSVerify:          apiutils.NewBoolPointer(tlsVerify),
+		HostCAPath:         hostCAPath,
+		AgentCAPath:        agentCAPath,
+		PodResourcesSocket: podResourcesSocket,
 	}
 	return builder
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the mount for the PodResources socket.

### Motivation

The pod resources API is necessary for correctly assigning pods to GPU devices in GPU monitoring.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.62

### Describe your test plan

Tested locally by deploying the operator in a cluster, deploying an agent with default settings and ensuring that:
- The agent container has a mount for `/var/lib/kubelet/pod-resources/kubelet.sock` 
- The environment variable `DD_KUBERNETES_KUBELET_POD_RESOURCES_SOCKET` is correctly set to `/var/lib/kubelet/pod-resources/kubelet.sock`.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
