### PR TITLE
gpu: added cgroup mount to gpu feature

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -80,6 +80,10 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 	managers.VolumeMount().AddVolumeMountToContainer(&procdirMount, apicommon.SystemProbeContainerName)
 	managers.Volume().AddVolume(&procdirVol)
 
+	cgroupsVol, cgroupsMount := volume.GetVolumes(v2alpha1.CgroupsVolumeName, v2alpha1.CgroupsHostPath, v2alpha1.CgroupsMountPath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&cgroupsMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&cgroupsVol)
+
 	socketVol, socketVolMount := volume.GetVolumesEmptyDir(v2alpha1.SystemProbeSocketVolumeName, v2alpha1.SystemProbeSocketVolumePath, false)
 	managers.Volume().AddVolume(&socketVol)
 	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommon.SystemProbeContainerName)

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -70,6 +70,11 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				ReadOnly:  true,
 			},
 			{
+				Name:      v2alpha1.CgroupsVolumeName,
+				MountPath: v2alpha1.CgroupsMountPath,
+				ReadOnly:  true,
+			},
+			{
 				Name:      v2alpha1.SystemProbeSocketVolumeName,
 				MountPath: v2alpha1.SystemProbeSocketVolumePath,
 				ReadOnly:  false,
@@ -94,6 +99,14 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: v2alpha1.ProcdirHostPath,
+					},
+				},
+			},
+			{
+				Name: v2alpha1.CgroupsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: v2alpha1.CgroupsHostPath,
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

add a missing cgroup mount to gpu monitoring feature of system-probe

### Motivation

gpu-probe is using cgroups mount to adjust device cgroups

### Additional Notes

[Jira ticket](https://datadoghq.atlassian.net/browse/EBPF-646)

similar to this [PR](https://github.com/DataDog/datadog-operator/pull/1617) that adds the mount for the service-discovery feature and same mount already added for NPM/USM

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

Agent: v7.64.x for the GPU monitoring feature.
Cluster Agent: N/A

### Describe your test plan

1. Deploy the operator in a cluster
2. Deploy the agent resource with feature.gpu.enabled: yes and service_discovery, usm and npm are disabled.
3. Check that deployed agent has a cgroup mount in the system-probe container

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
