### PR TITLE
Fixes for operator release (openshift preflight version, docker maintainer label)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ LABEL summary="The Datadog Operator aims at providing a new way to deploy the Da
 LABEL description="Datadog provides a modern monitoring and analytics platform. Gather \
       metrics, logs and traces for full observability of your Kubernetes cluster with \
       Datadog Operator."
+LABEL maintainer="Datadog Inc."
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ preflight-redhat-container: bin/$(PLATFORM)/preflight
 # Runs only on Linux and requires `docker login` to scan.connect.redhat.com
 .PHONY: preflight-redhat-container-submit
 preflight-redhat-container-submit: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
 
 .PHONY: patch-crds
 patch-crds: bin/$(PLATFORM)/yq ## Patch-crds

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ bin/$(PLATFORM)/operator-manifest-tools: Makefile
 	hack/install-operator-manifest-tools.sh 0.6.0
 
 bin/$(PLATFORM)/preflight: Makefile
-	hack/install-openshift-preflight.sh 1.10.1
+	hack/install-openshift-preflight.sh 1.11.1
 
 bin/$(PLATFORM)/openapi-gen:
 	mkdir -p $(ROOT)/bin/$(PLATFORM)

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ preflight-redhat-container: bin/$(PLATFORM)/preflight
 # Runs only on Linux and requires `docker login` to scan.connect.redhat.com
 .PHONY: preflight-redhat-container-submit
 preflight-redhat-container-submit: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
 
 .PHONY: patch-crds
 patch-crds: bin/$(PLATFORM)/yq ## Patch-crds


### PR DESCRIPTION
### What does this PR do?

- Update openshift preflight version to v1.11.1
- Update docker `maintainer` label to `Datadog Inc.` due to redhat trademark error in preflight checks

### Motivation

`time="2025-02-04T22:11:54Z" level=error msg=release-url error="invalid preflight version, please download the latest version and re-submit"
Error: could not submit to pyxis: could not create test results: status code: 400: body: {"type": "about:blank", "title": "Bad Request", "detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.10.1' is not supported. Supported versions are: ['1.11.0', '1.11.1']", "status": 400, "trace_id": "0xe42cec93d3e34e6fbb91c99e80009941"}`

`time="2025-02-05T16:15:52Z" level=debug msg="running check" check=HasRequiredLabel
time="2025-02-05T16:15:52Z" level=debug msg="labels violate Red Hat trademark" check=HasRequiredLabel trademarkViolationLabels="[\"maintainer\"]"`

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
Used this [image](https://console.cloud.google.com/artifacts/docker/datadog-sandbox/us/fanny-sandbox/operator?invt=Abo3Tg&project=datadog-sandbox&rapt=AEjHL4MTqZ1Yn80gUr-FPaPvXsgBn7Dr2JZOE0iyv_G4P_dQslTtPMznxv52yz14RvGAMwJPnQkR_OOm3fUyPazn3C8cFv145BbDV0CNInLiKFkebO51vKk) which included the updated label in Dockerfile. Manually published it to the redhat registry under the tag `test`. Ran preflight checks and the previously failing trademark test is now passing; output of the preflight checks is below. 

<img width="2498" alt="image" src="https://github.com/user-attachments/assets/ad27dd08-b578-4098-87fe-b7eef18750bb" />


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
