### PR TITLE
[CONTINT-4500] Add EKS Clusterrole Rule for EKS control plane metrics 

### DIFF
--- a/internal/controller/datadogagent/feature/enabledefault/rbac.go
+++ b/internal/controller/datadogagent/feature/enabledefault/rbac.go
@@ -26,6 +26,7 @@ func getDefaultAgentClusterRolePolicyRules(excludeNonResourceRules bool) []rbacv
 		getKubeletPolicyRule(),
 		getEndpointsPolicyRule(),
 		getLeaderElectionPolicyRule(),
+		getEKSControlPlaneMetricsPolicyRule(),
 	}
 
 	if !excludeNonResourceRules {
@@ -33,6 +34,19 @@ func getDefaultAgentClusterRolePolicyRules(excludeNonResourceRules bool) []rbacv
 	}
 
 	return policyRule
+}
+
+func getEKSControlPlaneMetricsPolicyRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups: []string{rbac.EKSMetricsAPIGroup},
+		Resources: []string{
+			rbac.EKSKubeControllerManagerMetrics,
+			rbac.EKSKubeSchedulerMetrics,
+		},
+		Verbs: []string{
+			rbac.GetVerb,
+		},
+	}
 }
 
 func getMetricsEndpointPolicyRule() rbacv1.PolicyRule {
@@ -286,6 +300,8 @@ func getDefaultClusterChecksRunnerClusterRolePolicyRules(dda metav1.Object, excl
 				rbac.GetVerb,
 			},
 		},
+		// EKS kube_scheduler and kube_controller_manager control plane metrics
+		getEKSControlPlaneMetricsPolicyRule(),
 	}
 
 	if !excludeNonResourceRules {

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -30,6 +30,7 @@ const (
 	RbacAPIGroup             = "rbac.authorization.k8s.io"
 	RegistrationAPIGroup     = "apiregistration.k8s.io"
 	StorageAPIGroup          = "storage.k8s.io"
+	EKSMetricsAPIGroup       = "metrics.eks.amazonaws.com"
 
 	// Resources
 
@@ -85,6 +86,8 @@ const (
 	VolumeAttachments                   = "volumeattachments"
 	VPAResource                         = "verticalpodautoscalers"
 	WpaResource                         = "watermarkpodautoscalers"
+	EKSKubeControllerManagerMetrics     = "kcm/metrics"
+	EKSKubeSchedulerMetrics             = "ksh/metrics"
 
 	// Non resource URLs
 


### PR DESCRIPTION
This PR is the same as #1651 but all commits are signed.

### What does this PR do?

This PR adds a clusterrole rule necessary to allow the agent to query the EKS metrics API as described in the official [AWS blog post](https://aws.amazon.com/blogs/containers/amazon-eks-enhances-kubernetes-control-plane-observability/).

### Motivation

Functional control plane metric reporting.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

The testing documentation is found in the description of https://github.com/DataDog/helm-charts/pull/1687.

I deployed the operator
I used the operator to deploy the agent
I validated that the appropriate rules were granted to both the datadog-agent and datadog-cluster-checks-runner clusterroles.

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
