### PR TITLE
[profiles] Wait to update profile DS when canary present

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -287,11 +287,6 @@ rules:
   - datadoghq.com
   resources:
   - extendeddaemonsetreplicasets
-  verbs:
-  - get
-- apiGroups:
-  - datadoghq.com
-  resources:
   - watermarkpodautoscalers
   verbs:
   - get

--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -493,8 +493,9 @@ func (r *Reconciler) shouldUpdateProfileDaemonSet(profile *v1alpha1.DatadogAgent
 		}
 
 		// eds canary was validated manually
-		if eds.Annotations[edsv1alpha1.ExtendedDaemonSetCanaryValidAnnotationKey] == ers.Name {
-			r.log.Info("Updating profile DaemonSet because the canary was validated")
+		if eds.Annotations[edsv1alpha1.ExtendedDaemonSetCanaryValidAnnotationKey] == ers.Name &&
+			eds.Annotations[datadoghqv2alpha1.MD5AgentDeploymentAnnotationKey] == ers.Annotations[datadoghqv2alpha1.MD5AgentDeploymentAnnotationKey] {
+			r.log.Info("Updating profile DaemonSet because the canary was validated and EDS and ERS hashes match")
 			return true, nil
 		}
 
@@ -506,6 +507,7 @@ func (r *Reconciler) shouldUpdateProfileDaemonSet(profile *v1alpha1.DatadogAgent
 
 		// if eds and ers agentspechash match, canary was successful
 		if eds.Annotations[datadoghqv2alpha1.MD5AgentDeploymentAnnotationKey] == ers.Annotations[datadoghqv2alpha1.MD5AgentDeploymentAnnotationKey] {
+			r.log.Info("Updating profile DaemonSet because the EDS and ERS hashes match")
 			return true, nil
 		}
 	}

--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -7,13 +7,16 @@ package datadogagent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
@@ -23,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -156,7 +160,7 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 	}
 
 	if alreadyExists {
-		now := metav1.NewTime(time.Now())
+		now := metav1.Now()
 		if agentprofile.CreateStrategyEnabled() {
 			if profile.Status.CreateStrategy != nil {
 				profile.Status.CreateStrategy.PodsReady = currentDaemonset.Status.NumberReady
@@ -226,8 +230,6 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 			return reconcile.Result{}, nil
 		}
 
-		logger.Info("Updating Daemonset")
-
 		// TODO: these parameters can be added to the override.PodTemplateSpec. (It exists in v1alpha1)
 		keepAnnotationsFilter := ""
 		keepLabelsFilter := ""
@@ -241,14 +243,25 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 		// won't filter labels with "datadoghq.com" in the key
 		delete(updateDaemonset.Labels, agentprofile.OldProfileLabelKey)
 
-		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateDaemonset, currentDaemonset.ObjectMeta)
+		var updateProfileDS bool
+		ddaLastSpecUpdate := getDDALastUpdatedTime(dda.ManagedFields, dda.CreationTimestamp)
+		updateProfileDS, err = r.shouldUpdateProfileDaemonSet(profile, ddaLastSpecUpdate, now)
 		if err != nil {
-			updateStatusFunc(updateDaemonset.Name, updateDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to update Daemonset")
-			return reconcile.Result{}, err
+			return result, err
 		}
-		event := buildEventInfo(updateDaemonset.Name, updateDaemonset.Namespace, kubernetes.DaemonSetKind, datadog.UpdateEvent)
-		r.recordEvent(dda, event)
-		updateStatusFunc(updateDaemonset.Name, updateDaemonset, newStatus, now, metav1.ConditionTrue, updateSucceeded, "Daemonset updated")
+
+		if updateProfileDS {
+			logger.Info("Updating Daemonset")
+
+			err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateDaemonset, currentDaemonset.ObjectMeta)
+			if err != nil {
+				updateStatusFunc(updateDaemonset.Name, updateDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to update Daemonset")
+				return reconcile.Result{}, err
+			}
+			event := buildEventInfo(updateDaemonset.Name, updateDaemonset.Namespace, kubernetes.DaemonSetKind, datadog.UpdateEvent)
+			r.recordEvent(dda, event)
+			updateStatusFunc(updateDaemonset.Name, updateDaemonset, newStatus, now, metav1.ConditionTrue, updateSucceeded, "Daemonset updated")
+		}
 	} else {
 		// From here the PodTemplateSpec should be ready, we can generate the hash that will be added to this daemonset.
 		_, err = comparison.SetMD5DatadogAgentGenerationAnnotation(&daemonset.ObjectMeta, daemonset.Spec)
@@ -256,7 +269,8 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 			return result, err
 		}
 
-		now := metav1.NewTime(time.Now())
+		now := metav1.Now()
+		logger.Info("Creating Daemonset")
 
 		err = r.client.Create(context.TODO(), daemonset)
 		if err != nil {
@@ -267,8 +281,6 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 		r.recordEvent(dda, event)
 		updateStatusFunc(daemonset.Name, daemonset, newStatus, now, metav1.ConditionTrue, createSucceeded, "Daemonset created")
 	}
-
-	logger.Info("Creating Daemonset")
 
 	return result, err
 }
@@ -406,4 +418,111 @@ func shouldCheckCreateStrategyStatus(profile *v1alpha1.DatadogAgentProfile) bool
 	}
 
 	return profile.Status.CreateStrategy.Status != v1alpha1.CompletedStatus
+}
+
+// shouldUpdateProfileDaemonSet determines if we should update a daemonset
+// created from a profile based on the canary status, if one exists
+// * true causes the daemonset to be updated immediately
+// * false causes the reconcile to skip updating the daemonset
+func (r *Reconciler) shouldUpdateProfileDaemonSet(profile *v1alpha1.DatadogAgentProfile, ddaLastUpdateTime metav1.Time, now metav1.Time) (bool, error) {
+	// eds needs to be enabled
+	if !r.options.ExtendedDaemonsetOptions.Enabled {
+		return true, nil
+	}
+
+	// profiles need to be enabled
+	if !r.options.DatadogAgentProfileEnabled {
+		return true, nil
+	}
+
+	// profile should not be nil or the default profile
+	if profile == nil {
+		return true, nil
+	}
+	if agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
+		return true, nil
+	}
+
+	// TODO: check that EDS is for a specific DDA
+	edsList := edsv1alpha1.ExtendedDaemonSetList{}
+	if err := r.client.List(context.TODO(), &edsList, client.MatchingLabels{
+		apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+		kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+	}); err != nil {
+		return false, err
+	}
+
+	for _, eds := range edsList.Items {
+		// eds canary was paused
+		if eds.Annotations[edsv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey] == "true" {
+			r.log.Info("Waiting to update profile DaemonSet because the canary was paused")
+			return false, nil
+		}
+
+		// wait if eds has an active canary
+		if eds.Status.Canary != nil {
+			r.log.Info("Waiting to update profile DaemonSet because of an active canary")
+			return false, nil
+		}
+		// get ers associated with eds
+		ersList := edsv1alpha1.ExtendedDaemonSetReplicaSetList{}
+		if err := r.client.List(context.TODO(), &ersList, client.MatchingLabels{
+			edsv1alpha1.ExtendedDaemonSetNameLabelKey: eds.Name,
+		}); err != nil {
+			return false, err
+		}
+		// there should be at least 1 ers
+		if len(ersList.Items) == 0 {
+			return false, errors.New("there must exist at least 1 ExtendedDaemonSetReplicaSet")
+		}
+		// wait for canary ers to be cleaned up if there are multiple ers
+		if len(ersList.Items) > 1 {
+			r.log.Info("Waiting to update profile DaemonSet until unused ExtendedDaemonSetReplicaSets are cleaned up")
+			return false, nil
+		}
+		ers := ersList.Items[0]
+		// the eds's active ers should match the ers name
+		if eds.Status.ActiveReplicaSet != ers.Name {
+			return false, errors.New("ExtendedDaemonSetReplicaSet name does not match ExtendedDaemonSet's active replicaset")
+		}
+
+		// add reconcile requeue time buffer to allow eds time to update before making a decision
+		if ddaLastUpdateTime.Add(defaultRequeuePeriod).After(now.Time) {
+			r.log.Info("Waiting to update profile DaemonSet after DatadogAgent update", "last update", ddaLastUpdateTime, "wait period", defaultRequeuePeriod)
+			return false, nil
+		}
+
+		// eds canary was validated manually
+		if eds.Annotations[edsv1alpha1.ExtendedDaemonSetCanaryValidAnnotationKey] == ers.Name {
+			r.log.Info("Updating profile DaemonSet because the canary was validated")
+			return true, nil
+		}
+
+		// wait for canary duration to elapse
+		if ddaLastUpdateTime.Add(r.options.ExtendedDaemonsetOptions.CanaryDuration).After(now.Time) {
+			r.log.Info("Waiting to update profile DaemonSet because the canary duration has not yet elapsed")
+			return false, nil
+		}
+
+		// if eds and ers agentspechash match, canary was successful
+		if eds.Annotations[datadoghqv2alpha1.MD5AgentDeploymentAnnotationKey] == ers.Annotations[datadoghqv2alpha1.MD5AgentDeploymentAnnotationKey] {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getDDALastUpdatedTime returns the latest timestamp from managedFields
+// ignoring the `status` subresource. If there are no managed fields, it uses
+// the creation timestamp
+func getDDALastUpdatedTime(managedFields []metav1.ManagedFieldsEntry, creationTimestamp metav1.Time) metav1.Time {
+	lastUpdateTime := creationTimestamp
+	for _, mf := range managedFields {
+		if mf.Subresource != "status" {
+			if mf.Time != nil && mf.Time.After(lastUpdateTime.Time) {
+				lastUpdateTime = *mf.Time
+			}
+		}
+	}
+	return lastUpdateTime
 }

--- a/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
@@ -1,13 +1,26 @@
 package datadogagent
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 
 	assert "github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -217,6 +230,586 @@ func Test_shouldCheckCreateStrategyStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(common.CreateStrategyEnabled, tt.CreateStrategy)
 			actual := shouldCheckCreateStrategyStatus(tt.profile)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func Test_shouldUpdateProfileDaemonSet(t *testing.T) {
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	_ = edsdatadoghqv1alpha1.AddToScheme(sch)
+
+	testNS := "test"
+	now := metav1.Now()
+	now5MinBefore := metav1.NewTime(now.Add(-5 * time.Minute))
+	now15MinBefore := metav1.NewTime(now.Add(-15 * time.Minute))
+	testProfile := v1alpha1.DatadogAgentProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-profile",
+			Namespace: testNS,
+		},
+	}
+	testEDSLabels := map[string]string{
+		apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+		kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+	}
+	testERSLabels := map[string]string{
+		edsv1alpha1.ExtendedDaemonSetNameLabelKey: "test-eds",
+	}
+
+	tests := []struct {
+		name                 string
+		reconcilerOptions    ReconcilerOptions
+		profile              *v1alpha1.DatadogAgentProfile
+		ddaLastUpdateTime    metav1.Time
+		now                  metav1.Time
+		existingObjects      []client.Object
+		expectedShouldUpdate bool
+		errorMessage         error
+	}{
+		{
+			name: "EDS not enabled",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: false,
+				},
+			},
+			profile:              &testProfile,
+			ddaLastUpdateTime:    now,
+			now:                  now,
+			existingObjects:      nil,
+			expectedShouldUpdate: true,
+			errorMessage:         nil,
+		},
+		{
+			name: "Profiles not enabled",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: false,
+			},
+			profile:              &testProfile,
+			ddaLastUpdateTime:    now,
+			now:                  now,
+			existingObjects:      nil,
+			expectedShouldUpdate: true,
+			errorMessage:         nil,
+		},
+		{
+			name: "Profiles nil",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:              nil,
+			ddaLastUpdateTime:    now,
+			now:                  now,
+			existingObjects:      nil,
+			expectedShouldUpdate: true,
+			errorMessage:         nil,
+		},
+		{
+			name: "Default profile",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile: &v1alpha1.DatadogAgentProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "",
+				},
+			},
+			ddaLastUpdateTime:    now,
+			now:                  now,
+			existingObjects:      nil,
+			expectedShouldUpdate: true,
+			errorMessage:         nil,
+		},
+		{
+			name: "No EDSs exist",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:              &testProfile,
+			ddaLastUpdateTime:    now,
+			now:                  now,
+			existingObjects:      []client.Object{},
+			expectedShouldUpdate: false,
+			errorMessage:         nil,
+		},
+		{
+			name: "Canary paused",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Annotations: map[string]string{
+							edsv1alpha1.ExtendedDaemonSetCanaryPausedAnnotationKey: "true",
+						},
+						Labels: testEDSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         nil,
+		},
+		{
+			name: "Active canary",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						Canary: &edsv1alpha1.ExtendedDaemonSetStatusCanary{},
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         nil,
+		},
+		{
+			name: "No ERS",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         errors.New("there must exist at least 1 ExtendedDaemonSetReplicaSet"),
+		},
+		{
+			name: "More than 1 ERS",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-2",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         nil,
+		},
+		{
+			name: "ERS name and active replicaSet name don't match",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						ActiveReplicaSet: "",
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         errors.New("ExtendedDaemonSetReplicaSet name does not match ExtendedDaemonSet's active replicaset"),
+		},
+		{
+			name: "DDA was just updated",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						ActiveReplicaSet: "test-ers-1",
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         nil,
+		},
+		{
+			name: "Canary validated annotation present but name doesn't match",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now5MinBefore,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Annotations: map[string]string{
+							edsv1alpha1.ExtendedDaemonSetCanaryValidAnnotationKey: "test-ers-2",
+						},
+						Labels: testEDSLabels,
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						ActiveReplicaSet: "test-ers-1",
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: true,
+			errorMessage:         nil,
+		},
+		{
+			name: "Canary validated",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled: true,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now5MinBefore,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Annotations: map[string]string{
+							edsv1alpha1.ExtendedDaemonSetCanaryValidAnnotationKey: "test-ers-1",
+						},
+						Labels: testEDSLabels,
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						ActiveReplicaSet: "test-ers-1",
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: true,
+			errorMessage:         nil,
+		},
+		{
+			name: "Canary duration hasn't passed",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled:        true,
+					CanaryDuration: 10 * time.Minute,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now5MinBefore,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						ActiveReplicaSet: "test-ers-1",
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         nil,
+		},
+		{
+			name: "Agent spec hash for EDS and ERS doesn't match",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled:        true,
+					CanaryDuration: 10 * time.Minute,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now15MinBefore,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+						Annotations: map[string]string{
+							v2alpha1.MD5AgentDeploymentAnnotationKey: "12345",
+						},
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						ActiveReplicaSet: "test-ers-1",
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+						Annotations: map[string]string{
+							v2alpha1.MD5AgentDeploymentAnnotationKey: "67890",
+						},
+					},
+				},
+			},
+			expectedShouldUpdate: false,
+			errorMessage:         nil,
+		},
+		{
+			name: "Agent spec hash for EDS and ERS match",
+			reconcilerOptions: ReconcilerOptions{
+				ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+					Enabled:        true,
+					CanaryDuration: 10 * time.Minute,
+				},
+				DatadogAgentProfileEnabled: true,
+			},
+			profile:           &testProfile,
+			ddaLastUpdateTime: now15MinBefore,
+			now:               now,
+			existingObjects: []client.Object{
+				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-eds",
+						Namespace: testNS,
+						Labels:    testEDSLabels,
+						Annotations: map[string]string{
+							v2alpha1.MD5AgentDeploymentAnnotationKey: "12345",
+						},
+					},
+					Status: edsv1alpha1.ExtendedDaemonSetStatus{
+						ActiveReplicaSet: "test-ers-1",
+					},
+				},
+				&edsdatadoghqv1alpha1.ExtendedDaemonSetReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-ers-1",
+						Namespace: testNS,
+						Labels:    testERSLabels,
+						Annotations: map[string]string{
+							v2alpha1.MD5AgentDeploymentAnnotationKey: "12345",
+						},
+					},
+				},
+			},
+			expectedShouldUpdate: true,
+			errorMessage:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(tt.existingObjects...).Build()
+
+			r := &Reconciler{
+				client:  fakeClient,
+				log:     logf.Log.WithName(tt.name),
+				options: tt.reconcilerOptions,
+			}
+
+			actual, err := r.shouldUpdateProfileDaemonSet(tt.profile, tt.ddaLastUpdateTime, tt.now)
+			assert.Equal(t, tt.expectedShouldUpdate, actual)
+			assert.Equal(t, tt.errorMessage, err)
+		})
+	}
+}
+
+func Test_getDDALastUpdatedTime(t *testing.T) {
+	now := metav1.Now()
+	now5MinLater := metav1.NewTime(now.Add(5 * time.Minute))
+	now15MinLater := metav1.NewTime(now.Add(15 * time.Minute))
+	tests := []struct {
+		name              string
+		managedFields     []metav1.ManagedFieldsEntry
+		creationTimestamp metav1.Time
+		expected          metav1.Time
+	}{
+		{
+			name:              "no managed field entries",
+			managedFields:     []metav1.ManagedFieldsEntry{},
+			creationTimestamp: now,
+			expected:          now,
+		},
+		{
+			name: "one new entry",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Time: &now15MinLater,
+				},
+			},
+			creationTimestamp: now,
+			expected:          now15MinLater,
+		},
+		{
+			name: "multiple entries",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Time: &now15MinLater,
+				},
+				{
+					Time: &now5MinLater,
+				},
+				{
+					Time: &now,
+				},
+			},
+			creationTimestamp: now,
+			expected:          now15MinLater,
+		},
+		{
+			name: "ignore status entry",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Subresource: "status",
+					Time:        &now15MinLater,
+				},
+				{
+					Time: &now5MinLater,
+				},
+				{
+					Time: &now,
+				},
+			},
+			creationTimestamp: now,
+			expected:          now5MinLater,
+		},
+		{
+			name: "nil time entry",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{
+					Time: &now15MinLater,
+				},
+				{
+					Manager: "test",
+				},
+				{
+					Time: &now,
+				},
+			},
+			creationTimestamp: now,
+			expected:          now15MinLater,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := getDDALastUpdatedTime(tt.managedFields, tt.creationTimestamp)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -94,7 +94,7 @@ type DatadogAgentReconciler struct {
 
 // Use ExtendedDaemonSet
 // +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsetreplicasets,verbs=get
+// +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsetreplicasets,verbs=get;list;watch
 
 // Use CiliumNetworkPolicy
 // +kubebuilder:rbac:groups=cilium.io,resources=ciliumnetworkpolicies,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
### What does this PR do?

When using EDS and profiles and a canary, the profile DaemonSet is immediately updated while the EDS goes through a canary phase. This PR prevents profile DSs from being updated until the canary is successful.

### Motivation

https://datadoghq.atlassian.net/browse/CECO-1947

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Example setup:
* kind cluster with at least 2 nodes, e.g. 1 control plane + 1 worker, 1 control plane + multiple workers
* EDS controller setup: `helm repo update && helm install eds datadog/extendeddaemonset`
  * Double check that the `ExtendedDaemonSet` and `ExtendedDaemonSetReplicaSet` CRDs are present in the cluster
  * Install the EDS plugin, follow the [EDS readme instructions](https://github.com/DataDog/extendeddaemonset?tab=readme-ov-file#kubectl-plugin). `make kubectl-eds` will install the plugin in the `bin` folder in the extendeddaemonset repo so you can run commands using `./bin/kubectl-eds canary pause <eds-name>`
* Operator setup:
  * Double check the operator can get, list, and watch ExtendedDaemonSetReplicaSets:
```yaml
- apiGroups:
  - datadoghq.com
  resources:
  - extendeddaemonsetreplicasets
  verbs:
  - get
  - list
  - watch
```
  * Enable/disable profiles using [datadogAgentProfile.enabled](https://github.com/DataDog/helm-charts/blob/c65f22450ed666129286c2123d0de864d3b26a90/charts/datadog-operator/values.yaml#L70-L72) or [datadogAgentProfileEnabled](https://github.com/DataDog/datadog-operator/blob/63b056f22e5e283381172616508238879ac83ac0/cmd/main.go#L161)
  * Enable/disable EDS support using [supportExtendedDaemonset](https://github.com/DataDog/helm-charts/blob/c65f22450ed666129286c2123d0de864d3b26a90/charts/datadog-operator/values.yaml#L73-L74) or [supportExtendedDaemonset](https://github.com/DataDog/datadog-operator/blob/63b056f22e5e283381172616508238879ac83ac0/cmd/main.go#L167)
* Example DDA
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog-agent
spec:
  global:
    kubelet:
      tlsVerify: false
    credentials:
      <credentials>
  override:
    nodeAgent:
      tolerations:
        # optional: allow node agents to be scheduled on the control plane node
        - key: node-role.kubernetes.io/control-plane
          operator: Exists
          effect: NoSchedule
      containers:
        agent:
          env:
            - name: FOO
              value: "foo"

```

Tests:
Make sure changes to the DDA are immediately reflected in the DS/EDS as normal when:
  * EDS is not enabled but profiles are enabled
  * Profiles are not enabled but EDS is enabled

With EDS and profiles enabled and an active profile DS applied:
Check that profile DSs aren't updated until after a canary is finished:
  * Change the DDA's spec so that a canary is created (`kubectl get ers`). Ensure that the profile DS does not update to the new spec while the canary is active (`kubectl describe ds <profile-ds>`). In the operator logs, you should see the log `Waiting to update profile DaemonSet because of an active canary`
  * While the canary is active, pause it using the kubectl-eds plugin (`./bin/kubectl-eds canary pause <eds>`) and check the operator logs for the line `Waiting to update profile DaemonSet because the canary was paused`
  * Unpause the canary using `./bin/kubectl-eds canary unpause <eds>` and check that the profile DS is still not updated
  * After the canary duration (default 10min) is over and the canary is successful, check that the profile DS is updated
With EDS and profiles

Check that 1) profile DSs are updated when the EDS is manually validated, 2) subsequent DDA updates don't trigger immediate profile DS updates, and 3) subsequent canary failures don't update the profile DS:
* Change the DDA's spec so that a canary is created. The profile DS should not update yet
* Manually validate the EDS using `./bin/kubectl-eds canary validate <eds>`
* The profile DS should update soon with the operator log `Updating profile DaemonSet because the canary was validated`
* Change the DDA spec again and ensure that the profile DS does not update the new DDA spec immediately. The log `Waiting to update profile DaemonSet after DatadogAgent update` should be present in the operator
* After the previous canary is finished, change the DDA's spec again. The profile DS should not update yet
* Fail the canary: `./bin/kubectl-eds canary fail <eds>`
* Ensure the profile DS does not update even after the canary duration (default 10min)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
