### PR TITLE
Generate EKS controlplane RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -306,6 +306,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - metrics.eks.amazonaws.com
+  resources:
+  - kcm/metrics
+  - ksh/metrics
+  verbs:
+  - get
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -124,6 +124,10 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
+// EKS control plane metrics
+// +kubebuilder:rbac:groups="metrics.eks.amazonaws.com",resources=kcm/metrics,verbs=get
+// +kubebuilder:rbac:groups="metrics.eks.amazonaws.com",resources=ksh/metrics,verbs=get
+
 // Orchestrator explorer
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch


### PR DESCRIPTION
### What does this PR do?

* Adds EKS controlplane RBAC generation

### Motivation

https://github.com/DataDog/datadog-operator/pull/1666: following this merge, components cannot be reconciled since the operator itself does not have the RBAC to grant this rule
```json
{"level":"ERROR","ts":"2025-02-07T09:59:07.699Z","logger":"controllers.DatadogAgent","msg":"store.store Create","datadogagent":{"name":"datadog","namespace":"system"},"obj.namespace":"","obj.name":"datadog-agent","error":"clusterroles.rbac.authorization.k8s.io \"datadog-agent\" is forbidden: user \"system:serviceaccount:system:datadog-operator-controller-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"metrics.eks.amazonaws.com\"], Resources:[\"kcm/metrics\"], Verbs:[\"get\"]}\n{APIGroups:[\"metrics.eks.amazonaws.com\"], Resources:[\"ksh/metrics\"], Verbs:[\"get\"]}"}
{"level":"ERROR","ts":"2025-02-07T09:59:07.700Z","logger":"controllers.DatadogAgent","msg":"store.store Create","datadogagent":{"name":"datadog","namespace":"system"},"obj.namespace":"","obj.name":"datadog-agent","error":"clusterroles.rbac.authorization.k8s.io \"datadog-agent\" not found"}
{"level":"ERROR","ts":"2025-02-07T09:59:07.716Z","msg":"Reconciler error","controller":"datadogagent","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgent","DatadogAgent":{"name":"datadog","namespace":"system"},"namespace":"system","name":"datadog","reconcileID":"484fce12-4f57-4ce2-91e0-e9688b4246f9","error":"[clusterroles.rbac.authorization.k8s.io \"datadog-agent\" is forbidden: user \"system:serviceaccount:system:datadog-operator-controller-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"metrics.eks.amazonaws.com\"], Resources:[\"kcm/metrics\"], Verbs:[\"get\"]}\n{APIGroups:[\"metrics.eks.amazonaws.com\"], Resources:[\"ksh/metrics\"], Verbs:[\"get\"]}, clusterroles.rbac.authorization.k8s.io \"datadog-agent\" not found]","errorCauses":[{"error":"clusterroles.rbac.authorization.k8s.io \"datadog-agent\" is forbidden: user \"system:serviceaccount:system:datadog-operator-controller-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:system\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"metrics.eks.amazonaws.com\"], Resources:[\"kcm/metrics\"], Verbs:[\"get\"]}\n{APIGroups:[\"metrics.eks.amazonaws.com\"], Resources:[\"ksh/metrics\"], Verbs:[\"get\"]}"},{"error":"clusterroles.rbac.authorization.k8s.io \"datadog-agent\" not found"}]}
```
Rules coming from https://docs.aws.amazon.com/eks/latest/userguide/view-raw-metrics.html#deploy-prometheus-scraper

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Deploy with `make deploy`, ensure the operator clusterrole has the necessary permissions:
```shell
╰─❯ k get clusterrole datadog-operator-manager-role -oyaml | grep eks -A 5
  - metrics.eks.amazonaws.com
  resources:
  - kcm/metrics
  - ksh/metrics
  verbs:
  - get
```
Deploy a `DatadogAgent` basic manifest, ensure the `datadog-agent` (name depends on your DDA) clusterrole has same permissions:
```shell
╰─❯ k get clusterrole datadog-agent -oyaml | grep eks -A 5
  - metrics.eks.amazonaws.com
  resources:
  - kcm/metrics
  - ksh/metrics
  verbs:
  - get
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
