### PR TITLE
Include golangci-lint in fmt Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,9 @@ all: build test ## Build test
 build: manager kubectl-datadog ## Builds manager + kubectl plugin
 
 .PHONY: fmt
-fmt: ## Run go fmt against code
+fmt: bin/$(PLATFORM)/golangci-lint ## Run formatters against code
 	go fmt ./...
+	bin/$(PLATFORM)/golangci-lint run ./... --fix
 
 .PHONY: vet
 vet: ## Run go vet against code
@@ -306,7 +307,7 @@ patch-crds: bin/$(PLATFORM)/yq ## Patch-crds
 	hack/patch-crds.sh
 
 .PHONY: lint
-lint: bin/$(PLATFORM)/golangci-lint fmt vet ## Lint
+lint: bin/$(PLATFORM)/golangci-lint vet ## Lint
 	bin/$(PLATFORM)/golangci-lint run ./...
 
 .PHONY: licenses


### PR DESCRIPTION
### What does this PR do?

Currently, there's no easy way to run `golangci-lint run ./... --fix` for formatting. It would be more convenient and intuitive if we could execute it via the fmt Make target.

Thanks for your review!

### Motivation

Running `golangci-lint run ./... --fix` easier.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
