### PR TITLE
Clean up integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,5 +34,5 @@ jobs:
       - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: cover.out,cover_integration_v1.out,cover_integration_v2.out
+          files: cover.out,cover_integration.out
           flags: unittests

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ IMG ?= gcr.io/datadoghq/operator:$(IMG_VERSION)
 IMG_CHECK ?= gcr.io/datadoghq/operator-check:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24
+ENVTEST_K8S_VERSION = 1.30
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -190,19 +190,15 @@ docker-push-check-img:
 ##@ Test
 
 .PHONY: test
-test: build manifests generate fmt vet verify-licenses gotest integration-tests integration-tests-v2 ## Run unit tests and integration tests
+test: build manifests generate fmt vet verify-licenses gotest integration-tests ## Run unit tests and integration tests
 
 .PHONY: gotest
 gotest:
 	go test ./... -coverprofile cover.out
 
 .PHONY: integration-tests
-integration-tests: $(ENVTEST) ## Run tests.
-	KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test --tags=integration github.com/DataDog/datadog-operator/internal/controller -coverprofile cover_integration_v1.out
-
-.PHONY: integration-tests-v2
-integration-tests-v2: $(ENVTEST) ## Run tests with reconciler V2
-	KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test --tags=integration_v2 github.com/DataDog/datadog-operator/internal/controller -coverprofile cover_integration_v2.out
+integration-tests: $(ENVTEST) ## Run integration tests with reconciler
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ROOT)/bin/$(PLATFORM) -p path)" go test --tags=integration github.com/DataDog/datadog-operator/internal/controller -coverprofile cover_integration.out
 
 .PHONY: e2e-tests
 e2e-tests: ## Run E2E tests and destroy environment stacks after tests complete. To run locally, complete pre-reqs (see docs/how-to-contribute.md) and prepend command with `aws-vault exec sso-agent-sandbox-account-admin --`. E.g. `aws-vault exec sso-agent-sandbox-account-admin -- make e2e-tests`.

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -93,11 +93,8 @@ If the golang version is used in a new file (for example in a new `Dockefile`) t
 # Run unit tests and integration tests
 $ make test
 
-# Run v1 integration tests
+# Run integration tests
 $ make integration-tests
-
-# Run v2 integration tests
-$ make integration-tests-v2
 ```
 
 ### End-to-End Tests

--- a/internal/controller/datadogagent_controller_profiles_test.go
+++ b/internal/controller/datadogagent_controller_profiles_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build integration_v2
-// +build integration_v2
+//go:build integration
+// +build integration
 
 package controller
 

--- a/internal/controller/datadogagent_controller_test.go
+++ b/internal/controller/datadogagent_controller_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build integration_v2
-// +build integration_v2
+//go:build integration
+// +build integration
 
 package controller
 

--- a/internal/controller/suite_v2_test.go
+++ b/internal/controller/suite_v2_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build integration_v2 && !integration
-// +build integration_v2,!integration
+//go:build integration
+// +build integration
 
 // Note: This is very similar to "suite_test.go". The only differences are that
 // here we patch the CRDs to store and serve v2alpha1 and configure the


### PR DESCRIPTION
### What does this PR do?

I've fixed the following two issues related to the integration tests:

1. Currently, users need to manually install Kubernetes binaries using setup-envtest to run the integration tests. It would be better if these binaries were installed automatically when needed.
2. The Makefile has two targets related to integration tests: integration and integration_v2. However, there don't seem to be any tests associated with the integration tag. So, I promoted integration_v2 to integration and removed the integration_v2 target.

Thanks for your review!

### Motivation

Cleaning up integration tests and making it easier to run them.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
