### PR TITLE
(tooling) [devcontainer] Use gci lint + install tools

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,22 @@
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
 	},
 	"runArgs": ["--name", "datadog-operator-devenv", "-w", "/workspaces/datadog-operator"],
-	"postStartCommand": ["git", "config", "--global", "--add", "safe.directory", "/workspaces/datadog-operator"]
+	"postStartCommand": "git config --global --add safe.directory /workspaces/datadog-operator && make install-tools",
+	"customizations": {
+        "vscode": {
+            "settings": {
+                "go.lintTool": "golangci-lint",
+                "go.lintOnSave": "package",
+                "go.lintFlags": [
+                    "--config=/workspaces/datadog-operator/.golangci.toml"
+                ],
+                "[go]": {
+                    "editor.formatOnSave": true
+                }
+            },
+            "extensions": [
+                "golang.Go"
+            ]
+        }
+    },
 }


### PR DESCRIPTION
### What does this PR do?

* Adds `make install-tools` as post start + defaults linter to the one used in CI

### Motivation

https://github.com/DataDog/datadog-operator/pull/1671 enforces GCI, so let's ensure we use the right linter

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
