### PR TITLE
Use validation rules to validate DatadogMonitorSpec

### DIFF
--- a/api/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/api/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -13,6 +13,10 @@ import (
 
 // DatadogMonitorSpec defines the desired state of DatadogMonitor
 // +k8s:openapi-gen=true
+// +kubebuilder:validation:XValidation:rule="has(self.name) && size(self.name) > 0",message="spec.Name must be defined"
+// +kubebuilder:validation:XValidation:rule="has(self.message) && size(self.message) > 0",message="spec.Message must be defined"
+// +kubebuilder:validation:XValidation:rule="has(self.query) && size(self.query) > 0",message="spec.Query must be defined"
+// +kubebuilder:validation:XValidation:rule="has(self.type) && size(self.type) > 0",message="spec.Type must be defined"
 type DatadogMonitorSpec struct {
 	// Name is the monitor name
 	Name string `json:"name,omitempty"`

--- a/api/datadoghq/v1alpha1/datadogmonitor_validation.go
+++ b/api/datadoghq/v1alpha1/datadogmonitor_validation.go
@@ -13,6 +13,8 @@ import (
 
 // IsValidDatadogMonitor use to check if a DatadogMonitorSpec is valid by checking
 // that the required fields are defined
+// Deprecated: Use CRD validation rules for input validation
+// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules
 func IsValidDatadogMonitor(spec *DatadogMonitorSpec) error {
 	var errs []error
 	if spec.Query == "" {

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -223,6 +223,15 @@ spec:
                   description: Type is the monitor type
                   type: string
               type: object
+              x-kubernetes-validations:
+                - message: spec.Name must be defined
+                  rule: has(self.name) && size(self.name) > 0
+                - message: spec.Message must be defined
+                  rule: has(self.message) && size(self.message) > 0
+                - message: spec.Query must be defined
+                  rule: has(self.query) && size(self.query) > 0
+                - message: spec.Type must be defined
+                  rule: has(self.type) && size(self.type) > 0
             status:
               description: DatadogMonitorStatus defines the observed state of DatadogMonitor
               properties:

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors_v1alpha1.json
@@ -206,7 +206,25 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "spec.Name must be defined",
+          "rule": "has(self.name) \u0026\u0026 size(self.name) \u003e 0"
+        },
+        {
+          "message": "spec.Message must be defined",
+          "rule": "has(self.message) \u0026\u0026 size(self.message) \u003e 0"
+        },
+        {
+          "message": "spec.Query must be defined",
+          "rule": "has(self.query) \u0026\u0026 size(self.query) \u003e 0"
+        },
+        {
+          "message": "spec.Type must be defined",
+          "rule": "has(self.type) \u0026\u0026 size(self.type) \u003e 0"
+        }
+      ]
     },
     "status": {
       "additionalProperties": false,


### PR DESCRIPTION
### What does this PR do?

This PR implements validation rules for validation rules for DatadogMonitorSpec. Thanks for your review!

### Motivation

Currently, the Datadog Operator does not implement validating webhooks and validates inputs during reconciliation. I assume this is to simplify the operator setup, but from a user experience perspective, it’s not ideal since users can only discover issues after applying their manifests.  

Kubernetes now offers a feature called [validation rules](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules), which allows input validation using CEL without requiring webhooks. I believe this would enhance the user experience by enabling users to identify errors before creating the resource.

### Additional Notes

- Kubernetes 1.23 or earlier does not seem to support the `x-kubernetes-validations` field in CRDs. However, I assume this isn’t a major issue since the operator uses Kubernetes libraries around v0.31, and no one should expect it to work on a Kubernetes 1.23 cluster anyway.  
- This PR is primarily intended to propose and demonstrate the use of validation rules. However, if this approach looks good, I’d be happy to implement validation rules for other resources as well.


### Describe your test plan

I've tested it in my local kind cluster v1.32.

```
$ cat monitor.yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMonitor
metadata:
  name: datadog-monitor-test
spec:
  # query: "avg(last_10m):avg:system.disk.in_use{*} by {host} > 0.5"
  # type: "metric alert"
  name: "Test monitor made from DatadogMonitor"
  message: "We are running out of disk space!"
  tags:
    - "test:datadog"
```

```
$ k apply -f monitor.yaml 
The DatadogMonitor "datadog-monitor-test" is invalid:
* spec: Invalid value: "object": spec.Query must be defined
* spec: Invalid value: "object": spec.Type must be defined
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
