### PR TITLE
Fix parsing group resource to allow groups with periods

### DIFF
--- a/internal/controller/datadogagent/feature/enabledefault/rbac.go
+++ b/internal/controller/datadogagent/feature/enabledefault/rbac.go
@@ -350,7 +350,6 @@ func getKubernetesResourceMetadataAsTagsPolicyRules(resourcesLabelsAsTags, resou
 				APIGroups: []string{group},
 				Resources: []string{resource},
 				Verbs: []string{
-					rbac.GetVerb,
 					rbac.ListVerb,
 					rbac.WatchVerb,
 				},

--- a/internal/controller/datadogagent/feature/enabledefault/rbac_test.go
+++ b/internal/controller/datadogagent/feature/enabledefault/rbac_test.go
@@ -45,7 +45,6 @@ func TestGetKubernetesResourceMetadataAsTagsPolicyRules(t *testing.T) {
 			APIGroups: []string{""},
 			Resources: []string{"pods"},
 			Verbs: []string{
-				rbac.GetVerb,
 				rbac.ListVerb,
 				rbac.WatchVerb,
 			},
@@ -54,7 +53,6 @@ func TestGetKubernetesResourceMetadataAsTagsPolicyRules(t *testing.T) {
 			APIGroups: []string{"apps"},
 			Resources: []string{"deployments"},
 			Verbs: []string{
-				rbac.GetVerb,
 				rbac.ListVerb,
 				rbac.WatchVerb,
 			},
@@ -63,7 +61,6 @@ func TestGetKubernetesResourceMetadataAsTagsPolicyRules(t *testing.T) {
 			APIGroups: []string{"custom.metrics.group"},
 			Resources: []string{"metrics"},
 			Verbs: []string{
-				rbac.GetVerb,
 				rbac.ListVerb,
 				rbac.WatchVerb,
 			},

--- a/internal/controller/datadogagent/feature/enabledefault/rbac_test.go
+++ b/internal/controller/datadogagent/feature/enabledefault/rbac_test.go
@@ -23,6 +23,10 @@ func TestGetKubernetesResourceMetadataAsTagsPolicyRules(t *testing.T) {
 			"foo": "baz",
 			"bar": "bar",
 		},
+		"metrics.custom.metrics.group": {
+			"foo": "baz",
+			"bar": "bar",
+		},
 	}
 
 	annotationsAsTags := map[string]map[string]string{
@@ -49,6 +53,15 @@ func TestGetKubernetesResourceMetadataAsTagsPolicyRules(t *testing.T) {
 		{
 			APIGroups: []string{"apps"},
 			Resources: []string{"deployments"},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.ListVerb,
+				rbac.WatchVerb,
+			},
+		},
+		{
+			APIGroups: []string{"custom.metrics.group"},
+			Resources: []string{"metrics"},
 			Verbs: []string{
 				rbac.GetVerb,
 				rbac.ListVerb,


### PR DESCRIPTION
### What does this PR do?

Fixes bug in parsing group resource parsing that prevented parsing groups containing periods correctly.

### Motivation

Fix the issue.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Same testing plan as [this](https://github.com/DataDog/datadog-operator/pull/1379)

But, here we should test with a resource of which the api group contains periods.

You should add the labels/annotations as tags configuration for ingresses. For example:

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: system
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
    kubelet:
      tlsVerify: false
    kubernetesResourcesLabelsAsTags:
      ingresses.networking.k8s.io:
        foo: foo
        bar: bar

    kubernetesResourcesAnnotationsAsTags:
      daemonsets.apps:
        agent.datadoghq.com/agentspechash: hash
      ingresses.networking.k8s.io:
        test.test: test
        test: test2
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: example-ingress
  namespace: system
  annotations:
    test.test: hello
    test: hello2
  labels:
    foo: bar
    bar: baz
spec:
  rules:
    - host: example.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: example-service
                port:
                  number: 80
```

Then check the that the tags are found in the cluster agent tagger with `agent tagger-list`:

```
=== Entity kubernetes_metadata://networking.k8s.io/ingresses/system/example-ingress ===
== Source workloadmeta-kubernetes_metadata =
=Tags: [bar:baz foo:bar test2:hello2 test:hello]
===
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
