### PR TITLE
[CECO-2017] DDAI flag to enable controller + nits

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,6 +116,7 @@ type options struct {
 	edsCanaryAutoPauseMaxSlowStartDuration time.Duration
 	supportCilium                          bool
 	datadogAgentEnabled                    bool
+	datadogAgentInternalEnabled            bool
 	datadogMonitorEnabled                  bool
 	datadogSLOEnabled                      bool
 	operatorMetricsEnabled                 bool
@@ -160,6 +161,9 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.remoteConfigEnabled, "remoteConfigEnabled", false, "Enable RemoteConfig capabilities in the Operator (beta)")
 	flag.BoolVar(&opts.datadogDashboardEnabled, "datadogDashboardEnabled", false, "Enable the DatadogDashboard controller")
 	flag.BoolVar(&opts.datadogGenericResourceEnabled, "datadogGenericResourceEnabled", false, "Enable the DatadogGenericResource controller")
+
+	// DatadogAgentInternal
+	flag.BoolVar(&opts.datadogAgentInternalEnabled, "datadogAgentInternalEnabled", false, "Enable the DatadogAgentInternal controller")
 
 	// ExtendedDaemonset configuration
 	flag.BoolVar(&opts.supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
@@ -256,6 +260,7 @@ func run(opts *options) error {
 		RetryPeriod:                &retryPeriod,
 		Cache: config.CacheOptions(setupLog, config.WatchOptions{
 			DatadogAgentEnabled:           opts.datadogAgentEnabled,
+			DatadogAgentInternalEnabled:   opts.datadogAgentInternalEnabled,
 			DatadogMonitorEnabled:         opts.datadogMonitorEnabled,
 			DatadogSLOEnabled:             opts.datadogSLOEnabled,
 			DatadogAgentProfileEnabled:    opts.datadogAgentProfileEnabled,
@@ -307,6 +312,7 @@ func run(opts *options) error {
 		SupportCilium:                 opts.supportCilium,
 		Creds:                         creds,
 		DatadogAgentEnabled:           opts.datadogAgentEnabled,
+		DatadogAgentInternalEnabled:   opts.datadogAgentInternalEnabled,
 		DatadogMonitorEnabled:         opts.datadogMonitorEnabled,
 		DatadogSLOEnabled:             opts.datadogSLOEnabled,
 		OperatorMetricsEnabled:        opts.operatorMetricsEnabled,

--- a/internal/controller/datadogagentinternal/controller.go
+++ b/internal/controller/datadogagentinternal/controller.go
@@ -10,31 +10,25 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// DatadogAgentInternalReconciler reconciles a DatadogAgentInternal object
-type DatadogAgentInternalReconciler struct {
+// Reconciler reconciles a DatadogAgentInternal object
+type Reconciler struct {
 	client client.Client
 	scheme *runtime.Scheme
 	log    logr.Logger
 }
 
-//+kubebuilder:rbac:groups=datadoghq.com,resources=datadogagentinternals,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=datadoghq.com,resources=datadogagentinternals/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=datadoghq.com,resources=datadogagentinternals/finalizers,verbs=update
-
 // NewReconciler returns a new Reconciler object
-func NewReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger) (*DatadogAgentInternalReconciler, error) {
-	return &DatadogAgentInternalReconciler{
+func NewReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger) *Reconciler {
+	return &Reconciler{
 		client: client,
 		scheme: scheme,
 		log:    log,
-	}, nil
+	}
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -46,17 +40,10 @@ func NewReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
-func (r *DatadogAgentInternalReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	_ = log.FromContext(ctx)
 
 	// TODO(user): your logic here
 
-	return ctrl.Result{}, nil
-}
-
-// SetupWithManager sets up the controller with the Manager.
-func (r *DatadogAgentInternalReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&datadoghqv1alpha1.DatadogAgentInternal{}).
-		Complete(r)
+	return reconcile.Result{}, nil
 }

--- a/internal/controller/datadogagentinternal_controller.go
+++ b/internal/controller/datadogagentinternal_controller.go
@@ -24,7 +24,7 @@ type DatadogAgentInternalReconciler struct {
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
-	internal *ddai.DatadogAgentInternalReconciler
+	internal *ddai.Reconciler
 }
 
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadogagentinternals,verbs=get;list;watch;create;update;patch;delete
@@ -38,16 +38,14 @@ func (r *DatadogAgentInternalReconciler) Reconcile(ctx context.Context, req ctrl
 
 // SetupWithManager creates a new DatadogAgentInternal controller.
 func (r *DatadogAgentInternalReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	internal, err := ddai.NewReconciler(r.Client, r.Scheme, r.Log)
-	if err != nil {
-		return err
-	}
-	r.internal = internal
+	r.internal = ddai.NewReconciler(r.Client, r.Scheme, r.Log)
 
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.DatadogAgentInternal{})
+		// TODO: Possibly only watch for spec changes, not status changes.
+		// .WithEventFilter(predicate.GenerationChangedPredicate{})
 
-	err = builder.Complete(r)
+	err := builder.Complete(r)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	agentControllerName           = "DatadogAgent"
+	agentInternalControllerName   = "DatadogAgentInternal"
 	monitorControllerName         = "DatadogMonitor"
 	sloControllerName             = "DatadogSLO"
 	profileControllerName         = "DatadogAgentProfile"
@@ -40,6 +41,7 @@ type SetupOptions struct {
 	SupportCilium                 bool
 	Creds                         config.Creds
 	DatadogAgentEnabled           bool
+	DatadogAgentInternalEnabled   bool
 	DatadogMonitorEnabled         bool
 	DatadogSLOEnabled             bool
 	OperatorMetricsEnabled        bool
@@ -70,6 +72,7 @@ type starterFunc func(logr.Logger, manager.Manager, kubernetes.PlatformInfo, Set
 
 var controllerStarters = map[string]starterFunc{
 	agentControllerName:           startDatadogAgent,
+	agentInternalControllerName:   startDatadogAgentInternal,
 	monitorControllerName:         startDatadogMonitor,
 	sloControllerName:             startDatadogSLO,
 	profileControllerName:         startDatadogAgentProfiles,
@@ -163,6 +166,20 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, pInfo kubernetes
 			DatadogAgentProfileEnabled: options.DatadogAgentProfileEnabled,
 		},
 	}).SetupWithManager(mgr, metricForwardersMgr)
+}
+
+func startDatadogAgentInternal(logger logr.Logger, mgr manager.Manager, pInfo kubernetes.PlatformInfo, options SetupOptions, metricForwardersMgr datadog.MetricForwardersManager) error {
+	if !options.DatadogAgentInternalEnabled {
+		logger.Info("Feature disabled, not starting the controller", "controller", agentInternalControllerName)
+		return nil
+	}
+
+	return (&DatadogAgentInternalReconciler{
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName(agentInternalControllerName),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor(agentInternalControllerName),
+	}).SetupWithManager(mgr)
 }
 
 func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, pInfo kubernetes.PlatformInfo, options SetupOptions, metricForwardersMgr datadog.MetricForwardersManager) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,7 @@ var (
 
 type WatchOptions struct {
 	DatadogAgentEnabled           bool
+	DatadogAgentInternalEnabled   bool
 	DatadogMonitorEnabled         bool
 	DatadogSLOEnabled             bool
 	DatadogAgentProfileEnabled    bool


### PR DESCRIPTION
### What does this PR do?

* Controls the DDAI controller with flag `datadogAgentInternalEnabled`
* Removes some kubebuilder markers and SetupWithManager that were duplicated

### Describe your test plan

Tested locally:
```shell
╰─❯ k describe pod datadog-operator-manager-58b4594958-wg6dm | grep -i agentinternal -A2 -B2
      --enable-leader-election
      --pprof
      -datadogAgentInternalEnabled=true
    State:          Running
      Started:      Tue, 18 Feb 2025 11:25:51 +0100
╭─ ~/dd/datadog-operator tbavelier/ddai/ceco-2017                                                                                                                                     ⎈ kind-local-k8s/system 11:39:20
╰─❯ k logs datadog-operator-manager-58b4594958-wg6dm | grep -i agentinternal
{"level":"INFO","ts":"2025-02-18T10:27:19.992Z","msg":"Starting EventSource","controller":"datadogagentinternal","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgentInternal","source":"kind source: *v1alpha1.DatadogAgentInternal"}
{"level":"INFO","ts":"2025-02-18T10:27:19.992Z","msg":"Starting Controller","controller":"datadogagentinternal","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgentInternal"}
{"level":"INFO","ts":"2025-02-18T10:27:20.466Z","msg":"Starting workers","controller":"datadogagentinternal","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgentInternal","worker count":1}
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
