### PR TITLE
update podresources mount to only be in agent container

### DIFF
--- a/internal/controller/datadogagent/override/global.go
+++ b/internal/controller/datadogagent/override/global.go
@@ -287,31 +287,22 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 				})
 			}
 			if config.Kubelet.PodResourcesSocketPath != "" {
-				manager.EnvVar().AddEnvVar(&corev1.EnvVar{
+				manager.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 					Name:  DDKubernetesPodResourcesSocket,
 					Value: path.Join(config.Kubelet.PodResourcesSocketPath, "kubelet.sock"),
 				})
 
 				podResourcesVol, podResourcesMount := volume.GetVolumes(common.KubeletPodResourcesVolumeName, config.Kubelet.PodResourcesSocketPath, config.Kubelet.PodResourcesSocketPath, false)
 				if singleContainerStrategyEnabled {
-					manager.VolumeMount().AddVolumeMountToContainers(
+					manager.VolumeMount().AddVolumeMountToContainer(
 						&podResourcesMount,
-						[]apicommon.AgentContainerName{
-							apicommon.UnprivilegedSingleAgentContainerName,
-						},
+						apicommon.UnprivilegedSingleAgentContainerName,
 					)
 					manager.Volume().AddVolume(&podResourcesVol)
 				} else {
-					manager.VolumeMount().AddVolumeMountToContainers(
+					manager.VolumeMount().AddVolumeMountToContainer(
 						&podResourcesMount,
-						[]apicommon.AgentContainerName{
-							apicommon.CoreAgentContainerName,
-							apicommon.ProcessAgentContainerName,
-							apicommon.TraceAgentContainerName,
-							apicommon.SecurityAgentContainerName,
-							apicommon.AgentDataPlaneContainerName,
-							apicommon.SystemProbeContainerName,
-						},
+						apicommon.CoreAgentContainerName,
 					)
 					manager.Volume().AddVolume(&podResourcesVol)
 				}


### PR DESCRIPTION
### What does this PR do?

Update new podresources mount to be isolated to agent container

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Similar to https://github.com/DataDog/datadog-operator/pull/1650 , and also verify that the envvar (`DD_KUBERNETES_KUBELET_POD_RESOURCES_SOCKET `) and volumemount (`kubelet-pod-resources`) are only present in the Agent container.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
