### PR TITLE
bump default agent images to 7.63.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.62.2"
+	AgentLatestVersion = "7.63.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.62.2"
+	ClusterAgentLatestVersion = "7.63.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.7"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Run Datadog Operator with the a minimum DatadogAgent. Make sure the agent and cluster agent images are 7.63.0 .

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
