### PR TITLE
Update OTel agent image

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -105,8 +105,8 @@ func agentImage() string {
 }
 
 func otelAgentImage() string {
-	// todo(mackjmr): make this dynamic once we have otel agent image which releases with regular agent.
-	return fmt.Sprintf("%s:%s", defaulting.AgentDevImageName, defaulting.OTelAgentNightlyTag)
+	// todo(mackjmr): Update once OTel agent is GA (7.64.0), as the ot-beta tag will be discontinued.
+	return fmt.Sprintf("%s/%s:%s", defaulting.DefaultImageRegistry, defaulting.DefaultAgentImageName, defaulting.OTelAgentBetaTag)
 
 }
 

--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -39,8 +39,6 @@ const (
 	// Default Image names
 	DefaultAgentImageName        string = "agent"
 	DefaultClusterAgentImageName string = "cluster-agent"
-	AgentDevImageName                   = "datadog/agent-dev"
-	// Nightly dev image tag for otel agent
 	OTelAgentBetaTag = "7.63.0-ot-beta-jmx"
 )
 

--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -41,7 +41,7 @@ const (
 	DefaultClusterAgentImageName string = "cluster-agent"
 	AgentDevImageName                   = "datadog/agent-dev"
 	// Nightly dev image tag for otel agent
-	OTelAgentNightlyTag = "nightly-ot-beta-main"
+	OTelAgentBetaTag = "7.63.0-ot-beta-jmx"
 )
 
 // imageHasTag identifies whether an image string contains a tag suffix


### PR DESCRIPTION
### What does this PR do?

Use `7.63.0-ot-beta-jmx` instead of nightly image. This will need to be updated once OTel agent is GA (7.64.0), as the ot-beta image will be discontinued.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Run the OTel Collector feature, and ensure the otel agent starts/ works as expected. Confirm that the otel container image is `7.63.0-ot-beta-jmx`.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
