### PR TITLE
Add gitlab workflows to publish fips images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -265,6 +265,12 @@ publish_public_tag:
     IMG_DESTINATIONS_REGEX_REPL: ':'
     IMG_SIGNING: "false"
 
+publish_public_tag_fips:
+  extends: publish_public_tag
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: operator:$CI_COMMIT_TAG-fips
+
 publish_redhat_public_tag:
   stage: release
   rules:
@@ -283,6 +289,12 @@ publish_redhat_public_tag:
     IMG_REGISTRIES: redhat-operator
     IMG_SIGNING: "false"
 
+publish_redhat_public_tag_fips:
+  extends: publish_redhat_public_tag
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:$CI_COMMIT_TAG-fips
+
 publish_public_latest:
   stage: release
   rules:
@@ -297,6 +309,12 @@ publish_public_latest:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:latest
     IMG_SIGNING: "false"
+
+publish_public_latest_fips:
+  extends: publish_public_latest
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: operator:latest-fips
 
 publish_redhat_public_latest:
   stage: release
@@ -313,6 +331,12 @@ publish_redhat_public_latest:
     IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:latest
     IMG_REGISTRIES: redhat-operator
     IMG_SIGNING: "false"
+
+publish_redhat_public_latest_fips:
+  extends: publish_redhat_public_latest
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:latest-fips
 
 trigger_internal_operator_image:
   stage: release

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMG_VERSION?=$(if $(VERSION),$(VERSION),latest)
 VERSION?=$(if $(GIT_TAG),$(GIT_TAG),$(TAG_HASH))
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 DATE=$(shell date +%Y-%m-%d/%H:%M:%S )
-LDFLAGS=-X ${BUILDINFOPKG}.Commit=${GIT_COMMIT} -X ${BUILDINFOPKG}.Version=${VERSION} -X ${BUILDINFOPKG}.BuildTime=${DATE}
+LDFLAGS=-w -s -X ${BUILDINFOPKG}.Commit=${GIT_COMMIT} -X ${BUILDINFOPKG}.Version=${VERSION} -X ${BUILDINFOPKG}.BuildTime=${DATE}
 CHANNELS=stable
 DEFAULT_CHANNEL=stable
 GOARCH?=


### PR DESCRIPTION
### What does this PR do?

Adds jobs to publish version tag and latest fips images to docker and RH.
Jobs are similar to the one added for `main` tag in https://github.com/DataDog/datadog-operator/pull/1731 and verified as follows:
```sh
$ docker pull datadog/operator:main-fips
main-fips: Pulling from datadog/operator
....
Digest: sha256:90d7e8df5126470fcabc7ecb5bb953eace778c31a0cfc3fb7a1f306f71023e39
Status: Downloaded newer image for datadog/operator:main-fips
docker.io/datadog/operator:main-fips
$ docker create --name operator-main-fips datadog/operator:main-fips
54df7908953a958acaeb5e99b6ce9b6eafa039aaf82371945540304fee6380c7
$ docker cp operator-main-fips:/manager ./manager-main-fips
Successfully copied 91.8MB to /workspaces/operator-2/manager-main-fips
$ go tool nm manager-main-fips | grep -i 'crypto/internal/boring/sig.FIPSOnly'
  539bc0 t crypto/internal/boring/sig.FIPSOnly.abi0
```


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
