### PR TITLE
bump kustomize to 5.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ $(CONTROLLER_GEN): Makefile  ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = bin/$(PLATFORM)/kustomize
 $(KUSTOMIZE): Makefile  ## Download kustomize locally if necessary.
-	$(call go-get-tool,$@,sigs.k8s.io/kustomize/kustomize/v5@v5.4.3)
+	$(call go-get-tool,$@,sigs.k8s.io/kustomize/kustomize/v5@v5.6.0)
 
 ENVTEST = bin/$(PLATFORM)/setup-envtest
 $(ENVTEST): Makefile ## Download envtest-setup locally if necessary.


### PR DESCRIPTION
### What does this PR do?

Bump kustomize version to 5.6.0 following go version bump

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
