### PR TITLE
Add gitlab workflows to publish fips images (#1732)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -265,6 +265,12 @@ publish_public_tag:
     IMG_DESTINATIONS_REGEX_REPL: ':'
     IMG_SIGNING: "false"
 
+publish_public_tag_fips:
+  extends: publish_public_tag
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: operator:$CI_COMMIT_TAG-fips
+
 publish_redhat_public_tag:
   stage: release
   rules:
@@ -283,6 +289,12 @@ publish_redhat_public_tag:
     IMG_REGISTRIES: redhat-operator
     IMG_SIGNING: "false"
 
+publish_redhat_public_tag_fips:
+  extends: publish_redhat_public_tag
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:$CI_COMMIT_TAG-fips
+
 publish_public_latest:
   stage: release
   rules:
@@ -297,6 +309,12 @@ publish_public_latest:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:latest
     IMG_SIGNING: "false"
+
+publish_public_latest_fips:
+  extends: publish_public_latest
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: operator:latest-fips
 
 publish_redhat_public_latest:
   stage: release
@@ -313,6 +331,12 @@ publish_redhat_public_latest:
     IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:latest
     IMG_REGISTRIES: redhat-operator
     IMG_SIGNING: "false"
+
+publish_redhat_public_latest_fips:
+  extends: publish_redhat_public_latest
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:latest-fips
 
 trigger_internal_operator_image:
   stage: release

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMG_VERSION?=$(if $(VERSION),$(VERSION),latest)
 VERSION?=$(if $(GIT_TAG),$(GIT_TAG),$(TAG_HASH))
 GIT_COMMIT?=$(shell git rev-parse HEAD)
 DATE=$(shell date +%Y-%m-%d/%H:%M:%S )
-LDFLAGS=-X ${BUILDINFOPKG}.Commit=${GIT_COMMIT} -X ${BUILDINFOPKG}.Version=${VERSION} -X ${BUILDINFOPKG}.BuildTime=${DATE}
+LDFLAGS=-w -s -X ${BUILDINFOPKG}.Commit=${GIT_COMMIT} -X ${BUILDINFOPKG}.Version=${VERSION} -X ${BUILDINFOPKG}.BuildTime=${DATE}
 CHANNELS=stable
 DEFAULT_CHANNEL=stable
 GOARCH?=


### PR DESCRIPTION
* Add gitlab workflows to publish fips images

* Add back -w -s ldflags

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
