### PR TITLE
Update check_preflight_redhat_image image tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -532,7 +532,7 @@ check_preflight_redhat_image:
     - apt-get update && apt-get -y install --no-install-recommends build-essential git awscli && apt-get -y clean && rm -rf /var/lib/apt/lists/*
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$RH_PARTNER_REGISTRY_USER" --password-stdin "$RH_PARTNER_REGISTRY"
     - export RH_PARTNER_API_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_API_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:$CI_COMMIT_TAG
+    - export IMG=$RH_PARTNER_REGISTRY/$RH_PARTNER_PROJECT_ID:${CI_COMMIT_TAG:1}
     - make preflight-redhat-container
   
 


### PR DESCRIPTION
### What does this PR do?

Update check_preflight_redhat_image image tag to remove the `v` (ex: `v1.13.0-rc.2` should be `1.13.0-rc.2`) 

### Motivation

Running this test on v1.13.0-rc.2 pipeline [failed](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/824637698) because the check was trying to find an image with a tag that didn't exist

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
