### PR TITLE
Remove IsReadOnly from dashboard

### DIFF
--- a/internal/controller/datadogdashboard/dashboard.go
+++ b/internal/controller/datadogdashboard/dashboard.go
@@ -22,6 +22,9 @@ func buildDashboard(logger logr.Logger, ddb *v1alpha1.DatadogDashboard) *datadog
 	json.Unmarshal([]byte(ddb.Spec.Widgets), widgetList)
 
 	dashboard := datadogV1.NewDashboard(layoutType, ddb.Spec.Title, *widgetList)
+	// isReadOnly is deprecated
+	// TODO: remove once NewDashboard in datadog-api-client-go is updated
+	dashboard.IsReadOnly = nil
 
 	if ddb.Spec.Description != "" {
 		dashboard.SetDescription(ddb.Spec.Description)

--- a/internal/controller/datadogdashboard/dashboard_test.go
+++ b/internal/controller/datadogdashboard/dashboard_test.go
@@ -73,6 +73,7 @@ func TestBuildDashboard(t *testing.T) {
 	assert.Equal(t, datadogV1.DashboardReflowType(*db.Spec.ReflowType), dashboard.GetReflowType(), "discrepancy found in parameter: ReflowType")
 	assert.Equal(t, db.Spec.Tags, dashboard.GetTags(), "discrepancy found in parameter: Tags")
 	assert.Equal(t, db.Spec.Title, dashboard.GetTitle(), "discrepancy found in parameter: Title")
+	assert.Nil(t, dashboard.IsReadOnly, "discrepancy found in parameter: IsReadOnly")
 }
 
 func Test_getDashboard(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Remove `IsReadOnly` from dashboards since it is deprecated and being removed from the backend, which causes API calls to error

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Check that whichever org you're testing in prevents `is_read_only` API calls
* Deploy operator with [dashboards enabled](https://github.com/DataDog/helm-charts/blob/643aedf8cd8b400cf8f15da9cf698873e92e9064/charts/datadog-operator/values.yaml#L87-L89)
* Create a `DatadogDashboard` and check that it is created and doesn't cause any error logs in the operator. [Example dashboard](https://github.com/DataDog/datadog-operator/blob/main/examples/datadogdashboard/simple-dashboard.yaml)
* Update the dashboard in k8s and check that it is updated in the UI

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
