### PR TITLE
[CECO-2016] Small controller reconcile v2 refactor

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -7,7 +7,6 @@ package datadogagent
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -16,7 +15,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -24,9 +22,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/defaults"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
-	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
@@ -38,60 +33,22 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, request reconcile.
 	reqLogger := r.log.WithValues("datadogagent", request.NamespacedName)
 	reqLogger.Info("Reconciling DatadogAgent")
 
-	// Fetch the DatadogAgent instance
-	instance := &datadoghqv2alpha1.DatadogAgent{}
-	var result reconcile.Result
-	err := r.client.Get(ctx, request.NamespacedName, instance)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return result, nil
-		}
-		// Error reading the object - requeue the request.
+	// 1. Fetch and validate the resource.
+	instance, result, err := r.fetchAndValidateDatadogAgent(ctx, request)
+	if utils.ShouldReturn(result, err) {
 		return result, err
 	}
 
-	if instance.Spec.Global == nil || instance.Spec.Global.Credentials == nil {
-		return result, fmt.Errorf("credentials not configured in the DatadogAgent, can't reconcile")
-	}
-
-	// check it the resource was properly decoded in v2
-	// if not it means it was a v1
-	/*if apiequality.Semantic.DeepEqual(instance.Spec, datadoghqv2alpha1.DatadogAgentSpec{}) {
-		instanceV1 := &datadoghqv1alpha1.DatadogAgent{}
-		if err = r.client.Get(ctx, request.NamespacedName, instanceV1); err != nil {
-			if apierrors.IsNotFound(err) {
-				// Request object not found, could have been deleted after reconcile request.
-				// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-				// Return and don't requeue
-				return result, nil
-			}
-			// Error reading the object - requeue the request.starting metrics server
-			return result, err
-		}
-		if err = datadoghqv1alpha1.ConvertTo(instanceV1, instance); err != nil {
-			reqLogger.Error(err, "unable to convert to v2alpha1")
-			return result, err
-		}
-	}*/
-
+	// 2. Handle finalizer logic.
 	if result, err = r.handleFinalizer(reqLogger, instance, r.finalizeDadV2); utils.ShouldReturn(result, err) {
 		return result, err
 	}
 
-	// TODO check if IsValideDatadogAgent function is needed for v2
-	/*
-		if err = datadoghqv2alpha1.IsValidDatadogAgent(&instance.Spec); err != nil {
-			reqLogger.V(1).Info("Invalid spec", "error", err)
-			return r.updateStatusIfNeeded(reqLogger, instance, &instance.Status, result, err)
-		}
-	*/
-
-	// Set default values for GlobalConfig and Features
+	// 3. Set default values for GlobalConfig and Features
 	instanceCopy := instance.DeepCopy()
 	defaults.DefaultDatadogAgent(instanceCopy)
+
+	// 4. Delegate to the main reconcile function.
 	return r.reconcileInstanceV2(ctx, reqLogger, instanceCopy)
 }
 
@@ -99,150 +56,62 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	var result reconcile.Result
 	newStatus := instance.Status.DeepCopy()
 	now := metav1.NewTime(time.Now())
+
 	features, requiredComponents := feature.BuildFeatures(instance, reconcilerOptionsToFeatureOptions(&r.options, logger))
 	// update list of enabled features for metrics forwarder
 	r.updateMetricsForwardersFeatures(instance, features)
 
-	// -----------------------
-	// Manage dependencies
-	// -----------------------
-	storeOptions := &store.StoreOptions{
-		SupportCilium: r.options.SupportCilium,
-		PlatformInfo:  r.platformInfo,
-		Logger:        logger,
-		Scheme:        r.scheme,
-	}
-	depsStore := store.NewStore(instance, storeOptions)
-	resourceManagers := feature.NewResourceManagers(depsStore)
+	// 1. Manage dependencies.
+	depsStore, resourceManagers := r.setupDependencies(instance, logger)
 
-	var errs []error
-
-	// Set up dependencies required by enabled features
-	for _, feat := range features {
-		logger.V(1).Info("Dependency ManageDependencies", "featureID", feat.ID())
-		if featErr := feat.ManageDependencies(resourceManagers, requiredComponents); featErr != nil {
-			errs = append(errs, featErr)
-		}
+	var err error
+	if err = r.manageFeatureDependencies(logger, features, requiredComponents, resourceManagers); err != nil {
+		return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
 	}
-	if len(errs) > 0 {
-		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, errors.NewAggregate(errs), now)
+	if err = r.overrideDependencies(logger, resourceManagers, instance); err != nil {
+		return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
 	}
 
-	// Examine user configuration to override any external dependencies (e.g. RBACs)
-	errs = override.Dependencies(logger, resourceManagers, instance)
-	if len(errs) > 0 {
-		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, errors.NewAggregate(errs), now)
-	}
-
+	// TODO: this feels like it should be moved somewhere else
 	userSpecifiedClusterAgentToken := instance.Spec.Global.ClusterAgentToken != nil || instance.Spec.Global.ClusterAgentTokenSecret != nil
 	if !userSpecifiedClusterAgentToken {
 		ensureAutoGeneratedTokenInStatus(instance, newStatus, resourceManagers, logger)
 	}
 
-	// -----------------------------
-	// Start reconcile Components
-	// -----------------------------
-
-	var err error
+	// 2. Reconcile each component.
+	// 2.a. Cluster Agent
 
 	result, err = r.reconcileV2ClusterAgent(logger, requiredComponents, features, instance, resourceManagers, newStatus)
 	if utils.ShouldReturn(result, err) {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
-	} else {
-		// Update the status to make it the ClusterAgentReconcileConditionType successful
-		condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.ClusterAgentReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
+	}
+	// Update the status to make it the ClusterAgentReconcileConditionType successful
+	condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.ClusterAgentReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
+
+	// 2.b. Node Agent and profiles
+	// TODO: ignore profiles and introspection for DDAI
+
+	if result, err = r.reconcileAgentProfiles(ctx, logger, instance, requiredComponents, features, resourceManagers, newStatus, now); utils.ShouldReturn(result, err) {
+		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
 	}
 
-	// Start with an "empty" profile and provider
-	// If profiles is disabled, reconcile the agent once using an empty profile
-	// If introspection is disabled, reconcile the agent once using the empty provider `LegacyProvider`
-	providerList := map[string]struct{}{kubernetes.LegacyProvider: {}}
-	profiles := []datadoghqv1alpha1.DatadogAgentProfile{{}}
-	metrics.IntrospectionEnabled.Set(metrics.FalseValue)
-	metrics.DAPEnabled.Set(metrics.FalseValue)
-
-	if r.options.DatadogAgentProfileEnabled || r.options.IntrospectionEnabled {
-		// Get a node list for profiles and introspection
-		nodeList, e := r.getNodeList(ctx)
-		if e != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newStatus, result, e, now)
-		}
-
-		if r.options.IntrospectionEnabled {
-			providerList = kubernetes.GetProviderListFromNodeList(nodeList, logger)
-			metrics.IntrospectionEnabled.Set(metrics.TrueValue)
-		}
-
-		if r.options.DatadogAgentProfileEnabled {
-			metrics.DAPEnabled.Set(metrics.TrueValue)
-			var profilesByNode map[string]types.NamespacedName
-			profiles, profilesByNode, e = r.profilesToApply(ctx, logger, nodeList, now, instance)
-			if err != nil {
-				return r.updateStatusIfNeededV2(logger, instance, newStatus, result, e, now)
-			}
-
-			if err = r.handleProfiles(ctx, profilesByNode, instance.Namespace); err != nil {
-				return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
-			}
-		}
-	}
-
-	for _, profile := range profiles {
-		for provider := range providerList {
-			result, err = r.reconcileV2Agent(logger, requiredComponents, features, instance, resourceManagers, newStatus, provider, providerList, &profile)
-			if utils.ShouldReturn(result, err) {
-				// If the agent reconcile failed, we should not continue with the other profiles
-				errs = append(errs, err)
-			}
-		}
-	}
-
-	if utils.ShouldReturn(result, errors.NewAggregate(errs)) {
-		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, errors.NewAggregate(errs), now)
-	} else {
-		// Update the status to set AgentReconcileConditionType to successful
-		condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.AgentReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
-	}
-
+	// 2.c. Cluster Checks Runner
 	result, err = r.reconcileV2ClusterChecksRunner(logger, requiredComponents, features, instance, resourceManagers, newStatus)
 	if utils.ShouldReturn(result, err) {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
-	} else {
-		// Update the status to set ClusterChecksRunnerReconcileConditionType to successful
-		condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.ClusterChecksRunnerReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
+	}
+	// Update the status to set ClusterChecksRunnerReconcileConditionType to successful
+	condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.ClusterChecksRunnerReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
+
+	// 3. Cleanup extraneous resources.
+	if err = r.cleanupExtraneousResources(ctx, logger, instance, newStatus, resourceManagers); err != nil {
+		logger.Error(err, "Error cleaning up extraneous resources")
+		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
 	}
 
-	// ------------------------------
-	// Cleanup old agents/DCA/CCR components
-	// ------------------------------
-	if err = r.cleanupExtraneousDaemonSets(ctx, logger, instance, newStatus, providerList, profiles); err != nil {
-		errs = append(errs, err)
-		logger.Error(err, "Error cleaning up old DaemonSets")
-	}
-	if err = r.cleanupOldDCADeployments(ctx, logger, instance, resourceManagers, newStatus); err != nil {
-		errs = append(errs, err)
-		logger.Error(err, "Error cleaning up old DCA Deployments")
-	}
-	if err = r.cleanupOldCCRDeployments(ctx, logger, instance, newStatus); err != nil {
-		errs = append(errs, err)
-		logger.Error(err, "Error cleaning up old CCR Deployments")
-	}
-
-	// ------------------------------
-	// Create and update dependencies
-	// ------------------------------
-	errs = append(errs, depsStore.Apply(ctx, r.client)...)
-	if len(errs) > 0 {
-		logger.V(2).Info("Dependencies apply error", "errs", errs)
-		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, errors.NewAggregate(errs), now)
-	}
-
-	// -----------------------------
-	// Cleanup unused dependencies
-	// -----------------------------
-	// Run it after the deployments reconcile
-	if errs = depsStore.Cleanup(ctx, r.client); len(errs) > 0 {
-		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, errors.NewAggregate(errs), now)
+	// 4. Apply and cleanup dependencies.
+	if err = r.applyAndCleanupDependencies(ctx, logger, depsStore); err != nil {
+		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
 	}
 
 	// Always requeue

--- a/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
@@ -1,0 +1,208 @@
+package datadogagent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	"github.com/DataDog/datadog-operator/internal/controller/metrics"
+	"github.com/DataDog/datadog-operator/pkg/condition"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+// STEP 1 of the reconcile loop: validate
+
+// fetchAndValidateDatadogAgent retrieves the DatadogAgent and performs basic validation.
+func (r *Reconciler) fetchAndValidateDatadogAgent(ctx context.Context, req reconcile.Request) (*datadoghqv2alpha1.DatadogAgent, reconcile.Result, error) {
+	instance := &datadoghqv2alpha1.DatadogAgent{}
+	var result reconcile.Result
+	if err := r.client.Get(ctx, req.NamespacedName, instance); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object not found; nothing to do.
+			return nil, result, nil
+		}
+		return nil, result, err
+	}
+	// Ensure required credentials are configured.
+	if instance.Spec.Global == nil || instance.Spec.Global.Credentials == nil {
+		return nil, result, fmt.Errorf("credentials not configured in the DatadogAgent, can't reconcile")
+	}
+	return instance, result, nil
+}
+
+// STEP 2 of the reconcile loop: reconcile 3 components
+
+// setupDependencies initializes the store and resource managers.
+func (r *Reconciler) setupDependencies(instance *datadoghqv2alpha1.DatadogAgent, logger logr.Logger) (*store.Store, feature.ResourceManagers) {
+	storeOptions := &store.StoreOptions{
+		SupportCilium: r.options.SupportCilium,
+		PlatformInfo:  r.platformInfo,
+		Logger:        logger,
+		Scheme:        r.scheme,
+	}
+	depsStore := store.NewStore(instance, storeOptions)
+	resourceManagers := feature.NewResourceManagers(depsStore)
+	return depsStore, resourceManagers
+}
+
+// manageFeatureDependencies iterates over features to set up dependencies.
+func (r *Reconciler) manageFeatureDependencies(logger logr.Logger, features []feature.Feature, requiredComponents feature.RequiredComponents, resourceManagers feature.ResourceManagers) error {
+	var errs []error
+	for _, feat := range features {
+		logger.V(1).Info("Managing dependencies", "featureID", feat.ID())
+		if err := feat.ManageDependencies(resourceManagers, requiredComponents); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// overrideDependencies wraps the dependency override logic.
+func (r *Reconciler) overrideDependencies(logger logr.Logger, resourceManagers feature.ResourceManagers, instance *datadoghqv2alpha1.DatadogAgent) error {
+	errs := override.Dependencies(logger, resourceManagers, instance)
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// reconcileAgentProfiles handles profiles and agent reconciliation.
+func (r *Reconciler) reconcileAgentProfiles(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent, requiredComponents feature.RequiredComponents, features []feature.Feature, resourceManagers feature.ResourceManagers, newStatus *datadoghqv2alpha1.DatadogAgentStatus, now metav1.Time) (reconcile.Result, error) {
+	// Start with a default profile and provider.
+	providerList := map[string]struct{}{kubernetes.LegacyProvider: {}}
+	profiles := []datadoghqv1alpha1.DatadogAgentProfile{{}}
+	metrics.IntrospectionEnabled.Set(metrics.FalseValue)
+	metrics.DAPEnabled.Set(metrics.FalseValue)
+
+	// If profiles or introspection is enabled, get the node list and update providers.
+	if r.options.DatadogAgentProfileEnabled || r.options.IntrospectionEnabled {
+		nodeList, err := r.getNodeList(ctx)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if r.options.IntrospectionEnabled {
+			providerList = kubernetes.GetProviderListFromNodeList(nodeList, logger)
+			metrics.IntrospectionEnabled.Set(metrics.TrueValue)
+		}
+		if r.options.DatadogAgentProfileEnabled {
+			metrics.DAPEnabled.Set(metrics.TrueValue)
+			var profilesByNode map[string]types.NamespacedName
+			profiles, profilesByNode, err = r.profilesToApply(ctx, logger, nodeList, now, instance)
+			// TODO: in main, we error on err instead of e here
+			// https://github.com/DataDog/datadog-operator/blob/8ba3647fbad340015d835b6fc1cb48639502c33d/internal/controller/datadogagent/controller_reconcile_v2.go#L179-L182
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			if err = r.handleProfiles(ctx, profilesByNode, instance.Namespace); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+	}
+
+	// Reconcile the agent for every profile and provider.
+	var errs []error
+	var result reconcile.Result
+	for _, profile := range profiles {
+		for provider := range providerList {
+			res, err := r.reconcileV2Agent(logger, requiredComponents, features, instance, resourceManagers, newStatus, provider, providerList, &profile)
+			if utils.ShouldReturn(res, err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	if utils.ShouldReturn(result, errors.NewAggregate(errs)) {
+		return result, errors.NewAggregate(errs)
+	}
+	condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.AgentReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
+	return reconcile.Result{}, nil
+}
+
+// *************************************
+// STEP 3 of the reconcile loop: cleanup
+// *************************************
+
+// cleanupExtraneousResources groups the cleanup calls for old components.
+func (r *Reconciler) cleanupExtraneousResources(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus, resourceManagers feature.ResourceManagers) error {
+	var errs []error
+	// Cleanup old DaemonSets, DCA and CCR deployments.
+	now := metav1.NewTime(time.Now())
+	providerList := map[string]struct{}{kubernetes.LegacyProvider: {}}
+	profiles := []datadoghqv1alpha1.DatadogAgentProfile{{}}
+
+	// Repeat of the code from reconcileAgentProfiles, but this will be removed in DDAI controller since this logic will be from DDA to DDAI.
+	if r.options.DatadogAgentProfileEnabled || r.options.IntrospectionEnabled {
+		// Get a node list for profiles and introspection
+		nodeList, e := r.getNodeList(ctx)
+		if e != nil {
+			return e
+		}
+
+		if r.options.IntrospectionEnabled {
+			providerList = kubernetes.GetProviderListFromNodeList(nodeList, logger)
+		}
+
+		if r.options.DatadogAgentProfileEnabled {
+			var profilesByNode map[string]types.NamespacedName
+			profiles, profilesByNode, e = r.profilesToApply(ctx, logger, nodeList, now, instance)
+			if e != nil {
+				return e
+			}
+
+			if err := r.handleProfiles(ctx, profilesByNode, instance.Namespace); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := r.cleanupExtraneousDaemonSets(ctx, logger, instance, newStatus, providerList, profiles); err != nil {
+		errs = append(errs, err)
+		logger.Error(err, "Error cleaning up old DaemonSets")
+	}
+	if err := r.cleanupOldDCADeployments(ctx, logger, instance, resourceManagers, newStatus); err != nil {
+		errs = append(errs, err)
+		logger.Error(err, "Error cleaning up old DCA Deployments")
+	}
+	if err := r.cleanupOldCCRDeployments(ctx, logger, instance, newStatus); err != nil {
+		errs = append(errs, err)
+		logger.Error(err, "Error cleaning up old CCR Deployments")
+	}
+	if len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}
+
+// *************************************
+// STEP 4 of the reconcile loop: cleanup dependencies
+// *************************************
+
+// applyAndCleanupDependencies applies pending changes and cleans up unused dependencies.
+func (r *Reconciler) applyAndCleanupDependencies(ctx context.Context, logger logr.Logger, depsStore *store.Store) error {
+	var errs []error
+	errs = append(errs, depsStore.Apply(ctx, r.client)...)
+	if len(errs) > 0 {
+		logger.V(2).Info("Dependencies apply error", "errs", errs)
+		return errors.NewAggregate(errs)
+	}
+	if errs = depsStore.Cleanup(ctx, r.client); len(errs) > 0 {
+		return errors.NewAggregate(errs)
+	}
+	return nil
+}

--- a/internal/controller/datadogagent/controller_reconcile_v2_helpers_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_helpers_test.go
@@ -1,0 +1,170 @@
+package datadogagent
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stretchr/testify/require"
+)
+
+// dummyFeature is a simple implementation of the Feature interface for testing purposes.
+type dummyFeature struct {
+	IDValue                         string
+	ConfigureReturn                 feature.RequiredComponents
+	ManageDependenciesError         error
+	ManageClusterAgentError         error
+	ManageNodeAgentError            error
+	ManageSingleContainerAgentError error
+	ManageClusterChecksRunnerError  error
+}
+
+// ID returns the dummy feature's ID.
+func (df *dummyFeature) ID() feature.IDType {
+	return feature.IDType(df.IDValue)
+}
+
+// Configure returns a predefined RequiredComponents value.
+func (df *dummyFeature) Configure(dda *datadoghqv2alpha1.DatadogAgent) feature.RequiredComponents {
+	return df.ConfigureReturn
+}
+
+// ManageDependencies returns a predefined error (or nil for success).
+func (df *dummyFeature) ManageDependencies(managers feature.ResourceManagers, components feature.RequiredComponents) error {
+	return df.ManageDependenciesError
+}
+
+// ManageClusterAgent returns a predefined error (or nil for success).
+func (df *dummyFeature) ManageClusterAgent(managers feature.PodTemplateManagers) error {
+	return df.ManageClusterAgentError
+}
+
+// ManageNodeAgent returns a predefined error (or nil for success).
+func (df *dummyFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	return df.ManageNodeAgentError
+}
+
+// ManageSingleContainerNodeAgent returns a predefined error (or nil for success).
+func (df *dummyFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	return df.ManageSingleContainerAgentError
+}
+
+// ManageClusterChecksRunner returns a predefined error (or nil for success).
+func (df *dummyFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
+	return df.ManageClusterChecksRunnerError
+}
+
+// Test_fetchAndValidateDatadogAgent tests the retrieval and basic validation of a DatadogAgent.
+func Test_fetchAndValidateDatadogAgent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, datadoghqv2alpha1.AddToScheme(scheme))
+
+	// Create a valid DatadogAgent with credentials configured.
+	validAgent := &datadoghqv2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid",
+			Namespace: "default",
+		},
+		Spec: datadoghqv2alpha1.DatadogAgentSpec{
+			Global: &datadoghqv2alpha1.GlobalConfig{
+				Credentials: &datadoghqv2alpha1.DatadogCredentials{
+					APIKey: apiutils.NewStringPointer("dummy"),
+				},
+			},
+		},
+	}
+	// Create an invalid DatadogAgent (missing credentials).
+	invalidAgent := &datadoghqv2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "invalid",
+			Namespace: "default",
+		},
+		Spec: datadoghqv2alpha1.DatadogAgentSpec{
+			Global: nil,
+		},
+	}
+
+	// --- Valid agent test ---
+	cli := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(validAgent).Build()
+	r := &Reconciler{
+		client: cli,
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "valid", Namespace: "default"}}
+	inst, res, err := r.fetchAndValidateDatadogAgent(context.TODO(), req)
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+	require.Equal(t, reconcile.Result{}, res)
+
+	// --- Not found test ---
+	reqNF := reconcile.Request{NamespacedName: types.NamespacedName{Name: "nonexistent", Namespace: "default"}}
+	inst, res, err = r.fetchAndValidateDatadogAgent(context.TODO(), reqNF)
+	require.NoError(t, err)
+	require.Nil(t, inst)
+
+	// --- Invalid (missing credentials) test ---
+	cli2 := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(invalidAgent).Build()
+	r2 := &Reconciler{
+		client: cli2,
+	}
+	reqInv := reconcile.Request{NamespacedName: types.NamespacedName{Name: "invalid", Namespace: "default"}}
+	inst, res, err = r2.fetchAndValidateDatadogAgent(context.TODO(), reqInv)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "credentials not configured")
+}
+
+// Test_setupDependencies verifies that store and resource managers are initialized.
+func Test_setupDependencies(t *testing.T) {
+	// Create a dummy DatadogAgent instance.
+	dummyAgent := &datadoghqv2alpha1.DatadogAgent{}
+	dummyPlatformInfo := kubernetes.PlatformInfo{}
+	dummyLogger := logr.Discard()
+	dummyOpts := &ReconcilerOptions{
+		SupportCilium: false,
+	}
+	scheme := runtime.NewScheme()
+	r := &Reconciler{
+		options:      *dummyOpts,
+		platformInfo: dummyPlatformInfo,
+		scheme:       scheme,
+	}
+	storeObj, resMgrs := r.setupDependencies(dummyAgent, dummyLogger)
+	require.NotNil(t, storeObj)
+	require.NotNil(t, resMgrs)
+}
+
+// Test_manageFeatureDependencies checks that feature dependency management aggregates errors correctly.
+func Test_manageFeatureDependencies(t *testing.T) {
+	dummyLogger := logr.Discard()
+	dummyResMgrs := feature.NewResourceManagers(nil) // passing nil for simplicity
+	dummyRequiredComponents := feature.RequiredComponents{}
+
+	// One feature succeeds and one fails.
+	f1 := &dummyFeature{
+		IDValue: "f1",
+	}
+	f2 := &dummyFeature{
+		IDValue:                 "f2",
+		ManageDependenciesError: fmt.Errorf("fail dependency"),
+	}
+
+	r := &Reconciler{}
+	// Test when all features succeed.
+	err := r.manageFeatureDependencies(dummyLogger, []feature.Feature{f1}, dummyRequiredComponents, dummyResMgrs)
+	require.NoError(t, err)
+
+	// Test with one failing feature.
+	err = r.manageFeatureDependencies(dummyLogger, []feature.Feature{f1, f2}, dummyRequiredComponents, dummyResMgrs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fail dependency")
+}


### PR DESCRIPTION
### What does this PR do?

* Moves some logic blocks from `controller_reconcile_v2.go` to helpers function to make it more readable and testable
* Some unit tests are added:
    * `reconcileAgentProfiles` is not unit tested due to all its dependencies
    * cleanup helper functions are not unit tested since they only aggregate errors from functions that are themselves unit tested

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
