### PR TITLE
Admission controller svc and webhook name based on dda

### DIFF
--- a/internal/controller/datadogagent/defaults/datadogagent_default.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default.go
@@ -79,13 +79,11 @@ const (
 
 	defaultCollectKubernetesEvents bool = true
 
-	defaultAdmissionControllerAgentSidecarClusterAgentEnabled bool   = true
-	defaultAdmissionControllerEnabled                         bool   = true
-	defaultAdmissionControllerValidationEnabled               bool   = true
-	defaultAdmissionControllerMutationEnabled                 bool   = true
-	defaultAdmissionControllerMutateUnlabelled                bool   = false
-	defaultAdmissionServiceName                               string = "datadog-admission-controller"
-
+	defaultAdmissionControllerAgentSidecarClusterAgentEnabled  bool = true
+	defaultAdmissionControllerEnabled                          bool = true
+	defaultAdmissionControllerValidationEnabled                bool = true
+	defaultAdmissionControllerMutationEnabled                  bool = true
+	defaultAdmissionControllerMutateUnlabelled                 bool = false
 	defaultAdmissionControllerKubernetesAdmissionEventsEnabled bool = false
 
 	// DefaultAdmissionControllerCWSInstrumentationEnabled default CWS Instrumentation enabled value
@@ -515,7 +513,6 @@ func defaultFeaturesConfig(ddaSpec *v2alpha1.DatadogAgentSpec) {
 	if *ddaSpec.Features.AdmissionController.Enabled {
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.AdmissionController.Enabled, defaultAdmissionControllerEnabled)
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.AdmissionController.MutateUnlabelled, defaultAdmissionControllerMutateUnlabelled)
-		apiutils.DefaultStringIfUnset(&ddaSpec.Features.AdmissionController.ServiceName, defaultAdmissionServiceName)
 	}
 
 	// AdmissionControllerValidation Feature

--- a/internal/controller/datadogagent/defaults/datadogagent_default_test.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default_test.go
@@ -297,7 +297,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -661,7 +660,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -815,7 +813,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -964,7 +961,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -1115,7 +1111,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -1271,7 +1266,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -1423,7 +1417,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -1572,7 +1565,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -1734,7 +1726,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled:       apiutils.NewBoolPointer(valueTrue),
-						ServiceName:            apiutils.NewStringPointer(defaultAdmissionServiceName),
 						AgentCommunicationMode: apiutils.NewStringPointer("socket"),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(valueTrue),
@@ -1886,7 +1877,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -2035,7 +2025,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -2207,7 +2196,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},
@@ -2371,7 +2359,6 @@ func Test_defaultFeatures(t *testing.T) {
 							Enabled: apiutils.NewBoolPointer(defaultAdmissionControllerMutationEnabled),
 						},
 						MutateUnlabelled: apiutils.NewBoolPointer(defaultAdmissionControllerMutateUnlabelled),
-						ServiceName:      apiutils.NewStringPointer(defaultAdmissionServiceName),
 						CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
 							Enabled: apiutils.NewBoolPointer(DefaultAdmissionControllerCWSInstrumentationEnabled),
 						},

--- a/internal/controller/datadogagent/feature/admissioncontroller/const.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/const.go
@@ -8,11 +8,10 @@ package admissioncontroller
 const (
 	admissionControllerPortName                = "admissioncontrollerport"
 	admissionControllerSocketCommunicationMode = "socket"
-
+	admissionControllerServiceNameSuffix       = "admission-controller"
+	admissionControllerWebhookNameSuffix       = "webhook"
 	// DefaultAdmissionControllerServicePort default admission controller service port
 	defaultAdmissionControllerServicePort = 443
 	// DefaultAdmissionControllerTargetPort default admission controller pod port
 	defaultAdmissionControllerTargetPort = 8000
-	// DefaultAdmissionControllerWebhookName default admission controller webhook name
-	defaultAdmissionControllerWebhookName string = "datadog-webhook"
 )

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -94,6 +94,7 @@ func shouldEnablesidecarInjection(sidecarInjectionConf *v2alpha1.AgentSidecarInj
 func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.RequiredComponents) {
 	f.owner = dda
 	f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+	f.serviceName = getACServiceName(dda)
 
 	ac := dda.Spec.Features.AdmissionController
 
@@ -106,6 +107,7 @@ func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqC
 		}
 
 		f.mutateUnlabelled = apiutils.BoolValue(ac.MutateUnlabelled)
+		// set service name from feature config to override default if provided
 		if ac.ServiceName != nil && *ac.ServiceName != "" {
 			f.serviceName = *ac.ServiceName
 		}
@@ -137,8 +139,8 @@ func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqC
 			f.failurePolicy = *ac.FailurePolicy
 		}
 
-		f.webhookName = defaultAdmissionControllerWebhookName
-		if ac.WebhookName != nil {
+		f.webhookName = getACWebhookName(dda)
+		if ac.WebhookName != nil && *ac.WebhookName != "" {
 			f.webhookName = *ac.WebhookName
 		}
 

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature_test.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature_test.go
@@ -47,7 +47,7 @@ func Test_admissionControllerFeature_Configure(t *testing.T) {
 				admissionControllerWantFunc(datadogACServiceName, datadogACWebhookName, false, false, "", "", false)),
 		},
 		{
-			Name: "Admission Controller enabled with provided service name, no webhook name",
+			Name: "Admission Controller enabled with valid provided service name, no webhook name",
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithName("datadog").
 				WithAdmissionControllerEnabled(true).
@@ -56,6 +56,18 @@ func Test_admissionControllerFeature_Configure(t *testing.T) {
 			WantConfigure: true,
 			ClusterAgent: test.NewDefaultComponentTest().WithWantFunc(
 				admissionControllerWantFunc("foo-ac-service", datadogACWebhookName, false, false, "", "", false)),
+		},
+		{
+			Name: "Admission Controller enabled with invalid (empty) provided service name, no webhook name",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithName("datadog").
+				WithAdmissionControllerEnabled(true).
+				WithAdmissionControllerServiceName("").
+				Build(),
+			WantConfigure: true,
+			ClusterAgent: test.NewDefaultComponentTest().WithWantFunc(
+				// Expect the service name from DDA to be used as the provided service name is invalid
+				admissionControllerWantFunc(datadogACServiceName, datadogACWebhookName, false, false, "", "", false)),
 		},
 		{
 			Name: "Admission Controller enabled with provided service and webhook name",

--- a/internal/controller/datadogagent/feature/admissioncontroller/utils.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/utils.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package admissioncontroller
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// getACServiceName return the default service name for the admission controller based on the DatadogAgent name
+func getACServiceName(dda metav1.Object) string {
+	return fmt.Sprintf("%s-%s", dda.GetName(), admissionControllerServiceNameSuffix)
+}
+
+// getACWebhookName return the default webhook name for the admission controller based on the DatadogAgent name
+func getACWebhookName(dda metav1.Object) string {
+	return fmt.Sprintf("%s-%s", dda.GetName(), admissionControllerWebhookNameSuffix)
+}

--- a/internal/controller/datadogagent/feature/admissioncontroller/utils_test.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/utils_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package admissioncontroller
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_getACServiceName(t *testing.T) {
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}
+	result := getACServiceName(dda)
+	if result != "foo-admission-controller" {
+		t.Errorf("Expected %s, got %s", "test-admission-controller", result)
+	}
+}
+
+func Test_getACWebhookName(t *testing.T) {
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+	}
+	result := getACWebhookName(dda)
+	if result != "foo-webhook" {
+		t.Errorf("Expected %s, got %s", "test-webhook", result)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

* Uses DDA name to set admission controller feature service and webhook name instead of hard-coded `datadog-admission-controller` and `datadog-webhook` when set
* Adds unit tests for service and webhook name overrides 

### Motivation

* Ensure uniqueness of resources per DDA (DDAI): even though there should only be 1 DDA/DDAI that enables the webhook and this svc, associated resources should be properly identified/unique

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Covered by unit tests. For E2E, ensure admission controller still works by using single step instrumentation (e.g. deploy a pod that should be mutated)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
