### PR TITLE
Allow users to change the requeue period

### DIFF
--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -42,6 +42,7 @@ const (
 	defaultForceSyncPeriod         = 60 * time.Minute
 	maxTriggeredStateGroups        = 10
 	DDMonitorForceSyncPeriodEnvVar = "DD_MONITOR_FORCE_SYNC_PERIOD"
+	DDMonitorRequeuePeriodEnvVar   = "DD_MONITOR_REQUEUE_PERIOD"
 )
 
 var supportedMonitorTypes = map[string]bool{
@@ -93,6 +94,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 	logger.Info("Reconciling DatadogMonitor")
 	now := metav1.NewTime(time.Now())
 	forceSyncPeriod := defaultForceSyncPeriod
+	requeuePeriod := defaultRequeuePeriod
 
 	if userForceSyncPeriod, ok := os.LookupEnv(DDMonitorForceSyncPeriodEnvVar); ok {
 		forceSyncPeriodInt, err := strconv.Atoi(userForceSyncPeriod)
@@ -101,6 +103,16 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 		} else {
 			logger.V(1).Info("Setting monitor force sync period", "minutes", forceSyncPeriodInt)
 			forceSyncPeriod = time.Duration(forceSyncPeriodInt) * time.Minute
+		}
+	}
+
+	if userRequeuePeriod, ok := os.LookupEnv(DDMonitorRequeuePeriodEnvVar); ok {
+		requeuePeriodInt, err := strconv.Atoi(userRequeuePeriod)
+		if err != nil {
+			logger.Error(err, "Invalid value for monitor requeue period. Defaulting to 60 seconds.")
+		} else {
+			logger.V(1).Info("Setting monitor force sync period", "seconds", requeuePeriodInt)
+			requeuePeriod = time.Duration(requeuePeriodInt) * time.Second
 		}
 	}
 
@@ -166,8 +178,8 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 			} else {
 				shouldUpdate = true
 			}
-		} else if instance.Status.MonitorStateLastUpdateTime == nil || (defaultRequeuePeriod-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
-			// If other conditions aren't met, and we have passed the defaultRequeuePeriod, then update monitor state
+		} else if instance.Status.MonitorStateLastUpdateTime == nil || (requeuePeriod-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
+			// If other conditions aren't met, and we have passed the requeuePeriod, then update monitor state
 			// Get monitor to make sure it exists before trying any updates. If it doesn't, set shouldCreate
 			m, err = r.get(instance, newStatus)
 			if err != nil {
@@ -210,9 +222,9 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 		}
 	}
 
-	// If reconcile was successful, requeue with period defaultRequeuePeriod
+	// If reconcile was successful, requeue with period requeuePeriod
 	if !result.Requeue && result.RequeueAfter == 0 {
-		result.RequeueAfter = defaultRequeuePeriod
+		result.RequeueAfter = requeuePeriod
 	}
 
 	// Update the status


### PR DESCRIPTION
### What does this PR do?

Exposes the requeue period used by the internalReconcile function as an environment variable to address https://github.com/DataDog/datadog-operator/issues/1171. 

### Motivation

We want to migrate the management of our monitors from Terraform to the Datadog operator. The problem though is that we will potentially have thousands of monitors that would query the Datadog API every minute. Allowing the user to adjust the requeue period will help reduce the number of requests per minute and avoid rate limit issues.

### Additional Notes

PR currently targets the DatadogMonitor resources only, but the same pattern should be applicable for other resources.

### Minimum Agent Versions

Currently tested with the following versions:

* Agent: v7.50.2
* Cluster Agent: v7.50.2

### Describe your test plan

1. Create a DatadogMonitor resource in the cluster
2. Observe the operator logs to confirm that the reconciliation happens every X seconds as configured through the env var instead of the default of 60 seconds.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
