### PR TITLE
Gate profile canary waits behind annotation

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
@@ -818,3 +818,62 @@ func Test_getDDALastUpdatedTime(t *testing.T) {
 		})
 	}
 }
+
+func Test_shouldProfileWaitForCanary(t *testing.T) {
+	logger := logf.Log.WithName("Test_shouldProfileWaitForCanary")
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "Nil annotations",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "Empty annotations",
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name: "No relevant annotations",
+			annotations: map[string]string{
+				"foo": "bar",
+			},
+			expected: false,
+		},
+		{
+			name: "Relevant annotation exists",
+			annotations: map[string]string{
+				"foo":                   "bar",
+				profileWaitForCanaryKey: "true",
+			},
+			expected: true,
+		},
+		{
+			name: "Relevant annotation exists and is false",
+			annotations: map[string]string{
+				"foo":                   "bar",
+				profileWaitForCanaryKey: "false",
+			},
+			expected: false,
+		},
+		{
+			name: "Relevant annotation exists, but value is not bool",
+			annotations: map[string]string{
+				"foo":                   "bar",
+				profileWaitForCanaryKey: "yes",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shouldWait := shouldProfileWaitForCanary(logger, tt.annotations)
+			assert.Equal(t, tt.expected, shouldWait)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Put https://github.com/DataDog/datadog-operator/pull/1667 behind an annotation for more testing and rollout control

### Motivation

Not all profile tasks are synced. Only DS changes are made with #1667, no node label or agent deletion changes. This means we should not change the profile affinity for a profile with this annotation set to true

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Follow the setup steps from https://github.com/DataDog/datadog-operator/pull/1667 to enable EDS and profiles in the operator
* Without the annotation, make a change to a DDA and ensure that profile agent pods are updated immediately while the EDS agent pods wait for the canary to finish before updating
* Add the annotation `agent.datadoghq.com/profile-wait-for-canary: "true"` to the DDA manifest. Make another change to the DDA and ensure that profile agent pods wait for the canary to be finished before updating

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
