### PR TITLE
fix SBOM feature env vars applying to all agents instead of just core

### DIFF
--- a/internal/controller/datadogagent/feature/sbom/feature.go
+++ b/internal/controller/datadogagent/feature/sbom/feature.go
@@ -142,17 +142,17 @@ func (p sbomFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplate
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *sbomFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	managers.EnvVar().AddEnvVar(&corev1.EnvVar{
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 		Name:  DDSBOMEnabled,
 		Value: apiutils.BoolToString(&f.enabled),
 	})
 
-	managers.EnvVar().AddEnvVar(&corev1.EnvVar{
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 		Name:  DDSBOMContainerImageEnabled,
 		Value: apiutils.BoolToString(&f.containerImageEnabled),
 	})
 	if len(f.containerImageAnalyzers) > 0 {
-		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 			Name:  DDSBOMContainerImageAnalyzers,
 			Value: strings.Join(f.containerImageAnalyzers, " "),
 		})
@@ -189,12 +189,12 @@ func (f *sbomFeature) ManageNodeAgent(managers feature.PodTemplateManagers, prov
 		volMgr.AddVolume(&criLibVol)
 	}
 
-	managers.EnvVar().AddEnvVar(&corev1.EnvVar{
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 		Name:  DDSBOMHostEnabled,
 		Value: apiutils.BoolToString(&f.hostEnabled),
 	})
 	if len(f.hostAnalyzers) > 0 {
-		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 			Name:  DDSBOMHostAnalyzers,
 			Value: strings.Join(f.hostAnalyzers, " "),
 		})

--- a/internal/controller/datadogagent/feature/sbom/feature_test.go
+++ b/internal/controller/datadogagent/feature/sbom/feature_test.go
@@ -70,8 +70,8 @@ func Test_sbomFeature_Configure(t *testing.T) {
 			},
 		}
 
-		nodeAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AllContainers]
-		assert.True(t, apiutils.IsEqualStruct(nodeAgentEnvVars, wantEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeAgentEnvVars, wantEnvVars))
+		nodeCoreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+		assert.True(t, apiutils.IsEqualStruct(nodeCoreAgentEnvVars, wantEnvVars), "Core agent envvars \ndiff = %s", cmp.Diff(nodeCoreAgentEnvVars, wantEnvVars))
 	}
 
 	sbomWithContainerImageWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
@@ -92,8 +92,8 @@ func Test_sbomFeature_Configure(t *testing.T) {
 			},
 		}
 
-		nodeAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AllContainers]
-		assert.True(t, apiutils.IsEqualStruct(nodeAgentEnvVars, wantEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeAgentEnvVars, wantEnvVars))
+		nodeCoreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+		assert.True(t, apiutils.IsEqualStruct(nodeCoreAgentEnvVars, wantEnvVars), "Core agent envvars \ndiff = %s", cmp.Diff(nodeCoreAgentEnvVars, wantEnvVars))
 	}
 
 	sbomWithContainerImageOverlayFSWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
@@ -109,26 +109,24 @@ func Test_sbomFeature_Configure(t *testing.T) {
 				Value: "true",
 			},
 			{
+
+				Name:  DDSBOMContainerOverlayFSDirectScan,
+				Value: "true",
+			},
+			{
 				Name:  DDSBOMHostEnabled,
 				Value: "false",
 			},
 		}
 
-		nodeAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AllContainers]
 		nodeCoreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
-		assert.True(t, apiutils.IsEqualStruct(nodeAgentEnvVars, wantEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeAgentEnvVars, wantEnvVars))
-
-		wantEnvVars = []*corev1.EnvVar{{
-			Name:  DDSBOMContainerOverlayFSDirectScan,
-			Value: "true",
-		}}
 		assert.True(t, apiutils.IsEqualStruct(nodeCoreAgentEnvVars, wantEnvVars), "Core agent envvars \ndiff = %s", cmp.Diff(nodeCoreAgentEnvVars, wantEnvVars))
 	}
 
 	sbomWithHostWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
 
-		wantAllAgentsEnvVars := []*corev1.EnvVar{
+		wantCoreAgentsEnvVars := []*corev1.EnvVar{
 			{
 				Name:  DDSBOMEnabled,
 				Value: "true",
@@ -141,19 +139,14 @@ func Test_sbomFeature_Configure(t *testing.T) {
 				Name:  DDSBOMHostEnabled,
 				Value: "true",
 			},
-		}
-
-		wantCoreAgentHostEnvVars := []*corev1.EnvVar{
 			{
 				Name:  common.DDHostRootEnvVar,
 				Value: "/host",
 			},
 		}
 
-		nodeAllAgentsEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AllContainers]
 		nodeCoreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
-		assert.True(t, apiutils.IsEqualStruct(nodeCoreAgentEnvVars, wantCoreAgentHostEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeCoreAgentEnvVars, wantCoreAgentHostEnvVars))
-		assert.True(t, apiutils.IsEqualStruct(nodeAllAgentsEnvVars, wantAllAgentsEnvVars), "Node agent envvars \ndiff = %s", cmp.Diff(nodeAllAgentsEnvVars, wantAllAgentsEnvVars))
+		assert.True(t, apiutils.IsEqualStruct(nodeCoreAgentEnvVars, wantCoreAgentsEnvVars), "Core agent envvars \ndiff = %s", cmp.Diff(nodeCoreAgentEnvVars, wantCoreAgentsEnvVars))
 
 		wantVolumeMounts := []corev1.VolumeMount{
 			{


### PR DESCRIPTION
### What does this PR do?

The `sbom.containers_image.*` and `sbom.host.*` configuration should only target the core agent, and should only be applied to this container, not all containers. This PR fixes this issue by ensuring the env variables are only applied to the core agent and fixes the associated tests.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Given the following spec,
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    credentials:
      apiKey: XXXXXX

  features:
    sbom:
      enabled: true
      containerImage:
        enabled: true
      host:
        enabled: true
```
testing should ensure container and host sboms are still reported to the app.

This can be done by collecting a flare of the agent and checking that a `host-sbom.json` file is present (for the host SBOM) and in the `workload-list.json` file SBOMs are correctly attached to workload meta container image metadata..

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
