### PR TITLE
[CECO-2004] Always run e2e tests on release branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -488,8 +488,6 @@ trigger_custom_operator_check_image_staging:
 trigger_e2e_operator_image:
   stage: e2e
   rules: 
-    - if: '$CI_COMMIT_BRANCH == "swang392/enable-e2e-ci"' # TODO remove after testing
-      when: always
     - if: $CI_COMMIT_TAG
       when: always
   trigger:
@@ -507,8 +505,6 @@ e2e:
   needs:
     - "trigger_e2e_operator_image"
   rules:
-    - if: '$CI_COMMIT_BRANCH == "swang392/enable-e2e-ci"' # TODO remove after testing
-      when: always
     - if: $CI_COMMIT_TAG
       when: always
   parallel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -488,9 +488,10 @@ trigger_custom_operator_check_image_staging:
 trigger_e2e_operator_image:
   stage: e2e
   rules: 
-    - when: manual # TOOD remove after testing
-    # - if: $CI_COMMIT_TAG
-    #   when: always
+    - if: '$CI_COMMIT_BRANCH == "swang392/enable-e2e-ci"' # TODO remove after testing
+      when: always
+    - if: $CI_COMMIT_TAG
+      when: always
   trigger:
     project: DataDog/public-images
     branch: main
@@ -506,9 +507,10 @@ e2e:
   needs:
     - "trigger_e2e_operator_image"
   rules:
-    - when: manual # TODO remove after testing
-    # - if: $CI_COMMIT_TAG
-    #   when: always
+    - if: '$CI_COMMIT_BRANCH == "swang392/enable-e2e-ci"' # TODO remove after testing
+      when: always
+    - if: $CI_COMMIT_TAG
+      when: always
   parallel:
     matrix:
       - K8S_VERSION:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,6 @@ stages:
     KUBERNETES_MEMORY_LIMIT: 16Gi
 
 .on_run_e2e:
-  - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "main"'
-    when: always
   - if: $CI_COMMIT_BRANCH
     changes:
       paths:
@@ -488,8 +486,11 @@ trigger_custom_operator_check_image_staging:
     RELEASE_PROD: "false"
 
 trigger_e2e_operator_image:
-  stage: release
-  rules: !reference [.on_run_e2e]
+  stage: e2e
+  rules: 
+    - when: manual # TOOD remove after testing
+    # - if: $CI_COMMIT_TAG
+    #   when: always
   trigger:
     project: DataDog/public-images
     branch: main
@@ -501,11 +502,13 @@ trigger_e2e_operator_image:
 
 e2e:
   extends: .new_e2e_template
-  variables:
-    TARGET_IMAGE: $E2E_DOCKER_REGISTRY:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+  stage: e2e
   needs:
     - "trigger_e2e_operator_image"
-  rules: !reference [.on_run_e2e]
+  rules:
+    - when: manual # TODO remove after testing
+    # - if: $CI_COMMIT_TAG
+    #   when: always
   parallel:
     matrix:
       - K8S_VERSION:
@@ -514,6 +517,8 @@ e2e:
           - "1.24"
           - "1.25"
           - "1.26"
+  variables:
+    TARGET_IMAGE: $E2E_DOCKER_REGISTRY:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   script:
     - IMAGE_PULL_PASSWORD=$(aws ecr get-login-password) IMG=$TARGET_IMAGE make e2e-tests
 


### PR DESCRIPTION
### What does this PR do?

Configure the CI to always run E2E tests on release branches, i.e. if: $CI_COMMIT_TAG, without any manual clicks

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* initially tested by setting both jobs to run automatically on this branch, confirmed that the e2e tests ran correctly in the [pipeline](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/58000006)
```
  rules: 
    - if: '$CI_COMMIT_BRANCH == "swang392/enable-e2e-ci"' # will be removed after testing
      when: always 
    - if: $CI_COMMIT_TAG
      when: always
```
* next step: test on v1.13.0-rc.3, rules will be changed to run always on `$CI_COMMIT_TAG` [here](https://github.com/DataDog/datadog-operator/pull/1764/commits/f9737debf78c2f9a48085a583df90b4f56d55cdb), confirm that the e2e steps run automatically on the tagged pipeline

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
