### PR TITLE
[CECO-2013] Use `app.kubernetes.io/part-of` label to cleanup only owned ds/deployments

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	componentagent "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
@@ -399,6 +400,7 @@ func (r *Reconciler) cleanupExtraneousDaemonSets(ctx context.Context, logger log
 	matchLabels := client.MatchingLabels{
 		apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 		kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+		kubernetes.AppKubernetesPartOfLabelKey:     object.NewPartOfLabelValue(dda).String(),
 	}
 
 	dsName := getDaemonSetNameFromDatadogAgent(dda)

--- a/internal/controller/datadogagent/controller_reconcile_agent_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent_test.go
@@ -271,6 +271,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -289,6 +290,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 						},
 					},
@@ -306,6 +308,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -325,6 +328,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 						},
 					},
@@ -343,6 +347,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -371,6 +376,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 								constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 								apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -391,6 +397,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -420,6 +427,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 								constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 								apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -438,6 +446,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						}},
 				},
 				&appsv1.DaemonSet{
@@ -447,6 +456,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -458,6 +468,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -486,6 +497,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 								constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 								apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -505,6 +517,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -515,6 +528,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -526,6 +540,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -537,6 +552,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -548,6 +564,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -576,6 +593,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 								constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 								apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -592,6 +610,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 								constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 								apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -610,6 +629,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						}},
 				},
 				&appsv1.DaemonSet{
@@ -620,6 +640,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						}},
 				},
 				&appsv1.DaemonSet{
@@ -629,6 +650,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -640,6 +662,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -668,6 +691,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 								constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 								apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -687,6 +711,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -697,6 +722,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -708,6 +734,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -719,6 +746,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -730,6 +758,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -761,6 +790,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 								constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 								apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -779,6 +809,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						}},
 				},
 				&appsv1.DaemonSet{
@@ -788,6 +819,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -799,6 +831,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -832,6 +865,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -843,6 +877,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -862,6 +897,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -872,6 +908,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -883,6 +920,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -894,6 +932,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -905,6 +944,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							constants.MD5AgentDeploymentProviderLabelKey: gkeCosProvider,
 							apicommon.AgentDeploymentComponentLabelKey:   constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:     "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:       "ns--1-dda--foo",
 						},
 					},
 				},
@@ -915,6 +955,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -948,6 +989,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},
@@ -963,6 +1005,7 @@ func Test_cleanupExtraneousDaemonSets(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 							ResourceVersion: "999",
 						},

--- a/internal/controller/datadogagent/controller_reconcile_ccr.go
+++ b/internal/controller/datadogagent/controller_reconcile_ccr.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	componentccr "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusterchecksrunner"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -130,6 +131,7 @@ func (r *Reconciler) cleanupOldCCRDeployments(ctx context.Context, logger logr.L
 	matchLabels := client.MatchingLabels{
 		apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterChecksRunnerResourceSuffix,
 		kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+		kubernetes.AppKubernetesPartOfLabelKey:     object.NewPartOfLabelValue(dda).String(),
 	}
 	deploymentName := getDeploymentNameFromCCR(dda)
 	deploymentList := appsv1.DeploymentList{}

--- a/internal/controller/datadogagent/controller_reconcile_ccr_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_ccr_test.go
@@ -100,6 +100,7 @@ func Test_cleanupOldCCRDeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterChecksRunnerResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -113,6 +114,7 @@ func Test_cleanupOldCCRDeployments(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterChecksRunnerResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 						},
 					},
@@ -129,6 +131,7 @@ func Test_cleanupOldCCRDeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterChecksRunnerResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -138,6 +141,7 @@ func Test_cleanupOldCCRDeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterChecksRunnerResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -147,6 +151,7 @@ func Test_cleanupOldCCRDeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterChecksRunnerResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -160,6 +165,7 @@ func Test_cleanupOldCCRDeployments(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterChecksRunnerResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 						},
 					},

--- a/internal/controller/datadogagent/controller_reconcile_dca.go
+++ b/internal/controller/datadogagent/controller_reconcile_dca.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	componentdca "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -143,6 +144,7 @@ func (r *Reconciler) cleanupOldDCADeployments(ctx context.Context, logger logr.L
 	matchLabels := client.MatchingLabels{
 		apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterAgentResourceSuffix,
 		kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+		kubernetes.AppKubernetesPartOfLabelKey:     object.NewPartOfLabelValue(dda).String(),
 	}
 	deploymentName := getDeploymentNameFromDCA(dda)
 	deploymentList := appsv1.DeploymentList{}

--- a/internal/controller/datadogagent/controller_reconcile_dca_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_dca_test.go
@@ -103,6 +103,7 @@ func Test_cleanupOldDCADeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -116,6 +117,7 @@ func Test_cleanupOldDCADeployments(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 						},
 					},
@@ -132,6 +134,7 @@ func Test_cleanupOldDCADeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -141,6 +144,7 @@ func Test_cleanupOldDCADeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -150,6 +154,7 @@ func Test_cleanupOldDCADeployments(t *testing.T) {
 						Labels: map[string]string{
 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterAgentResourceSuffix,
 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 						},
 					},
 				},
@@ -163,6 +168,7 @@ func Test_cleanupOldDCADeployments(t *testing.T) {
 							Labels: map[string]string{
 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultClusterAgentResourceSuffix,
 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
 							},
 						},
 					},


### PR DESCRIPTION
### What does this PR do?

In cleanup functions, we filter ds/deploy with label `app.kubernetes.io/part-of` to only clean up resources associated to the DDA/DDAI owner. This label is based on namespace + DDA name with `-` replaced by `--` and is injected by `GetDefaultLabels`: https://github.com/DataDog/datadog-operator/blob/54ed5494f98ca4ea2cdcf1536597396812abcc22/internal/controller/datadogagent/object/labels.go#L25

### Motivation

Multiple DDA/DDAI can be reconciled without cleanup interferences

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Covered by unit tests and tested on `kind`: same QA steps as https://github.com/DataDog/datadog-operator/pull/1448. Additional step: create 2 DDA (with different names) and ensure you get multiple deploy/DS that are not cleaned up in a loop like currently

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
