### PR TITLE
Use object reconciler

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_validation.go
+++ b/api/datadoghq/v2alpha1/datadogagent_validation.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package v2alpha1
+
+import "fmt"
+
+// ValidateDatadogAgent is used to check if a DatadogAgent is valid
+func ValidateDatadogAgent(dda *DatadogAgent) error {
+	// TODO
+	// Ensure required credentials are configured.
+	if dda.Spec.Global == nil || dda.Spec.Global.Credentials == nil {
+		return fmt.Errorf("credentials not configured in the DatadogAgent, can't reconcile")
+	}
+	return nil
+}

--- a/internal/controller/datadogagent/controller.go
+++ b/internal/controller/datadogagent/controller.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	componentagent "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
@@ -94,13 +95,13 @@ func NewReconciler(options ReconcilerOptions, client client.Client, platformInfo
 }
 
 // Reconcile is similar to reconciler.Reconcile interface, but taking a context
-func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, dda *v2alpha1.DatadogAgent) (reconcile.Result, error) {
 	var resp reconcile.Result
 	var err error
 
-	resp, err = r.internalReconcileV2(ctx, request)
+	resp, err = r.internalReconcileV2(ctx, dda)
 
-	r.metricsForwarderProcessError(request, err)
+	r.metricsForwarderProcessError(dda, err)
 	return resp, err
 }
 
@@ -112,8 +113,8 @@ func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logg
 }
 
 // metricsForwarderProcessError convert the reconciler errors into metrics if metrics forwarder is enabled
-func (r *Reconciler) metricsForwarderProcessError(req reconcile.Request, err error) {
+func (r *Reconciler) metricsForwarderProcessError(dda *v2alpha1.DatadogAgent, err error) {
 	if r.options.OperatorMetricsEnabled {
-		r.forwarders.ProcessError(getMonitoredObj(req), err)
+		r.forwarders.ProcessError(dda, err)
 	}
 }

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -25,22 +25,23 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
+	pkgutils "github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
-func (r *Reconciler) internalReconcileV2(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := r.log.WithValues("datadogagent", request.NamespacedName)
+func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadoghqv2alpha1.DatadogAgent) (reconcile.Result, error) {
+	reqLogger := r.log.WithValues("datadogagent", pkgutils.GetNamespacedName(instance))
 	reqLogger.Info("Reconciling DatadogAgent")
+	var result reconcile.Result
 
-	// 1. Fetch and validate the resource.
-	instance, result, err := r.fetchAndValidateDatadogAgent(ctx, request)
-	if utils.ShouldReturn(result, err) {
+	// 1. Validate the resource.
+	if err := datadoghqv2alpha1.ValidateDatadogAgent(instance); err != nil {
 		return result, err
 	}
 
 	// 2. Handle finalizer logic.
-	if result, err = r.handleFinalizer(reqLogger, instance, r.finalizeDadV2); utils.ShouldReturn(result, err) {
+	if result, err := r.handleFinalizer(reqLogger, instance, r.finalizeDadV2); utils.ShouldReturn(result, err) {
 		return result, err
 	}
 

--- a/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
@@ -2,11 +2,9 @@ package datadogagent
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -23,26 +21,6 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
-
-// STEP 1 of the reconcile loop: validate
-
-// fetchAndValidateDatadogAgent retrieves the DatadogAgent and performs basic validation.
-func (r *Reconciler) fetchAndValidateDatadogAgent(ctx context.Context, req reconcile.Request) (*datadoghqv2alpha1.DatadogAgent, reconcile.Result, error) {
-	instance := &datadoghqv2alpha1.DatadogAgent{}
-	var result reconcile.Result
-	if err := r.client.Get(ctx, req.NamespacedName, instance); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Object not found; nothing to do.
-			return nil, result, nil
-		}
-		return nil, result, err
-	}
-	// Ensure required credentials are configured.
-	if instance.Spec.Global == nil || instance.Spec.Global.Credentials == nil {
-		return nil, result, fmt.Errorf("credentials not configured in the DatadogAgent, can't reconcile")
-	}
-	return instance, result, nil
-}
 
 // STEP 2 of the reconcile loop: reconcile 3 components
 

--- a/internal/controller/datadogagent/controller_test.go
+++ b/internal/controller/datadogagent/controller_test.go
@@ -14,19 +14,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-func newRequest(ns, name string) reconcile.Request {
-	return reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: ns,
-			Name:      name,
-		},
-	}
-}
 
 func containsEnv(slice []corev1.EnvVar, name, value string) bool {
 	for _, element := range slice {

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -45,10 +45,6 @@ type fields struct {
 	platformInfo kubernetes.PlatformInfo
 	recorder     record.EventRecorder
 }
-type args struct {
-	request  reconcile.Request
-	loadFunc func(c client.Client)
-}
 
 func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 	const resourcesName = "foo"
@@ -69,7 +65,7 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 	tests := []struct {
 		name     string
 		fields   fields
-		args     args
+		loadFunc func(c client.Client) *v2alpha1.DatadogAgent
 		want     reconcile.Result
 		wantErr  bool
 		wantFunc func(c client.Client) error
@@ -81,13 +77,11 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -107,14 +101,12 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithSingleContainerStrategy(false).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithSingleContainerStrategy(false).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -134,14 +126,12 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithSingleContainerStrategy(true).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithSingleContainerStrategy(true).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -160,15 +150,13 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithAPMEnabled(true).
-						WithSingleContainerStrategy(false).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithAPMEnabled(true).
+					WithSingleContainerStrategy(false).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -188,15 +176,13 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithAPMEnabled(true).
-						WithSingleContainerStrategy(true).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithAPMEnabled(true).
+					WithSingleContainerStrategy(true).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -215,16 +201,14 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithAPMEnabled(true).
-						WithCWSEnabled(true).
-						WithSingleContainerStrategy(false).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithAPMEnabled(true).
+					WithCWSEnabled(true).
+					WithSingleContainerStrategy(false).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -246,17 +230,15 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithAPMEnabled(true).
-						WithCWSEnabled(true).
-						WithSingleContainerStrategy(true).
-						Build()
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithAPMEnabled(true).
+					WithCWSEnabled(true).
+					WithSingleContainerStrategy(true).
+					Build()
 
-					_ = c.Create(context.TODO(), dda)
-				},
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -278,16 +260,14 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithAPMEnabled(true).
-						WithOOMKillEnabled(true).
-						WithSingleContainerStrategy(false).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithAPMEnabled(true).
+					WithOOMKillEnabled(true).
+					WithSingleContainerStrategy(false).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -308,16 +288,14 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithAPMEnabled(true).
-						WithOOMKillEnabled(true).
-						WithSingleContainerStrategy(true).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithAPMEnabled(true).
+					WithOOMKillEnabled(true).
+					WithSingleContainerStrategy(true).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -338,17 +316,15 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					fipsConfig := v2alpha1.FIPSConfig{
-						Enabled: apiutils.NewBoolPointer(true),
-					}
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithFIPS(fipsConfig).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				fipsConfig := v2alpha1.FIPSConfig{
+					Enabled: apiutils.NewBoolPointer(true),
+				}
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithFIPS(fipsConfig).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -369,20 +345,18 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithComponentOverride(v2alpha1.ClusterAgentComponentName, v2alpha1.DatadogAgentComponentOverride{
-							CreatePodDisruptionBudget: apiutils.NewBoolPointer(true),
-						}).
-						WithClusterChecksUseCLCEnabled(true).
-						WithComponentOverride(v2alpha1.ClusterChecksRunnerComponentName, v2alpha1.DatadogAgentComponentOverride{
-							CreatePodDisruptionBudget: apiutils.NewBoolPointer(true),
-						}).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithComponentOverride(v2alpha1.ClusterAgentComponentName, v2alpha1.DatadogAgentComponentOverride{
+						CreatePodDisruptionBudget: apiutils.NewBoolPointer(true),
+					}).
+					WithClusterChecksUseCLCEnabled(true).
+					WithComponentOverride(v2alpha1.ClusterChecksRunnerComponentName, v2alpha1.DatadogAgentComponentOverride{
+						CreatePodDisruptionBudget: apiutils.NewBoolPointer(true),
+					}).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -397,14 +371,12 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithProcessChecksInCoreAgent(false).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithProcessChecksInCoreAgent(false).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,
@@ -437,10 +409,11 @@ func TestReconcileDatadogAgentV2_Reconcile(t *testing.T) {
 				},
 			}
 
-			if tt.args.loadFunc != nil {
-				tt.args.loadFunc(r.client)
+			var dda *v2alpha1.DatadogAgent
+			if tt.loadFunc != nil {
+				dda = tt.loadFunc(r.client)
 			}
-			got, err := r.Reconcile(context.TODO(), tt.args.request)
+			got, err := r.Reconcile(context.TODO(), dda)
 			if tt.wantErr {
 				assert.Error(t, err, "ReconcileDatadogAgent.Reconcile() expected an error")
 			} else {
@@ -476,7 +449,7 @@ func Test_Introspection(t *testing.T) {
 	tests := []struct {
 		name     string
 		fields   fields
-		args     args
+		loadFunc func(c client.Client) *v2alpha1.DatadogAgent
 		nodes    []client.Object
 		want     reconcile.Result
 		wantErr  bool
@@ -488,29 +461,27 @@ func Test_Introspection(t *testing.T) {
 				scheme:   s,
 				recorder: recorder,
 			},
-			args: args{
-				request: newRequest(resourcesNamespace, resourcesName),
-				loadFunc: func(c client.Client) {
-					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
-						WithComponentOverride(v2alpha1.NodeAgentComponentName, v2alpha1.DatadogAgentComponentOverride{
-							Affinity: &corev1.Affinity{
-								PodAntiAffinity: &corev1.PodAntiAffinity{
-									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-										{
-											LabelSelector: &metav1.LabelSelector{
-												MatchLabels: map[string]string{
-													"foo": "bar",
-												},
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+					WithComponentOverride(v2alpha1.NodeAgentComponentName, v2alpha1.DatadogAgentComponentOverride{
+						Affinity: &corev1.Affinity{
+							PodAntiAffinity: &corev1.PodAntiAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+									{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"foo": "bar",
 											},
-											TopologyKey: "baz",
 										},
+										TopologyKey: "baz",
 									},
 								},
 							},
-						}).
-						Build()
-					_ = c.Create(context.TODO(), dda)
-				},
+						},
+					}).
+					Build()
+				_ = c.Create(context.TODO(), dda)
+				return dda
 			},
 			nodes: []client.Object{
 				&corev1.Node{
@@ -561,10 +532,11 @@ func Test_Introspection(t *testing.T) {
 				},
 			}
 
-			if tt.args.loadFunc != nil {
-				tt.args.loadFunc(r.client)
+			var dda *v2alpha1.DatadogAgent
+			if tt.loadFunc != nil {
+				dda = tt.loadFunc(r.client)
 			}
-			got, err := r.Reconcile(context.TODO(), tt.args.request)
+			got, err := r.Reconcile(context.TODO(), dda)
 			if tt.wantErr {
 				assert.Error(t, err, "ReconcileDatadogAgent.Reconcile() expected an error")
 			} else {

--- a/internal/controller/datadogagent/utils.go
+++ b/internal/controller/datadogagent/utils.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 )
@@ -118,25 +117,6 @@ func referSameObject(a, b metav1.OwnerReference) bool {
 	}
 
 	return aGV == bGV && a.Kind == b.Kind && a.Name == b.Name
-}
-
-// namespacedName implements the datadog.MonitoredObject interface
-// used to convert reconcile.Request into datadog.MonitoredObject
-type namespacedName struct {
-	reconcile.Request
-}
-
-func (nsn namespacedName) GetNamespace() string {
-	return nsn.Namespace
-}
-
-func (nsn namespacedName) GetName() string {
-	return nsn.Name
-}
-
-// getMonitoredObj returns a namespacedName from a reconcile.Request object
-func getMonitoredObj(req reconcile.Request) namespacedName {
-	return namespacedName{req}
 }
 
 // getReplicas returns the desired replicas of a

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
@@ -183,8 +184,8 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list;watch;patch
 
 // Reconcile loop for DatadogAgent.
-func (r *DatadogAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.internal.Reconcile(ctx, req)
+func (r *DatadogAgentReconciler) Reconcile(ctx context.Context, dda *v2alpha1.DatadogAgent) (ctrl.Result, error) {
+	return r.internal.Reconcile(ctx, dda)
 }
 
 // SetupWithManager creates a new DatadogAgent controller.
@@ -255,7 +256,8 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager, metricForwar
 		}))
 	}
 
-	if err := builder.For(&datadoghqv2alpha1.DatadogAgent{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).Complete(r); err != nil {
+	or := reconcile.AsReconciler[*v2alpha1.DatadogAgent](r.Client, r)
+	if err := builder.For(&datadoghqv2alpha1.DatadogAgent{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).Complete(or); err != nil {
 		return err
 	}
 

--- a/pkg/controller/utils/datadog/common.go
+++ b/pkg/controller/utils/datadog/common.go
@@ -25,8 +25,8 @@ func getObjID(obj MonitoredObject) string {
 	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
 }
 
-// getNamespacedName builds a NamespacedName for a given monitored object
-func getNamespacedName(obj MonitoredObject) types.NamespacedName {
+// GetNamespacedName builds a NamespacedName for a given monitored object
+func GetNamespacedName(obj MonitoredObject) types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -140,7 +140,7 @@ func newMetricsForwarder(k8sClient client.Client, decryptor secrets.Decryptor, o
 		monitoredObjectKind: kind.GroupVersionKind().Kind,
 		k8sClient:           k8sClient,
 		platformInfo:        platforminfo,
-		namespacedName:      getNamespacedName(obj),
+		namespacedName:      GetNamespacedName(obj),
 		retryInterval:       defaultMetricsRetryInterval,
 		sendMetricsInterval: defaultSendMetricsInterval,
 		metricsPrefix:       defaultMetricsNamespace,


### PR DESCRIPTION
### What does this PR do?

Use the object reconciler interface and separate out DDA validation

### Motivation

Newer and shinier way to do the same thing. Saves a few lines of code in the reconciler

[CECO-2101](https://datadoghq.atlassian.net/browse/CECO-2101)

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Should be no-op. Apply a DDA manifest. All components should spin up as normal

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label


[CECO-2101]: https://datadoghq.atlassian.net/browse/CECO-2101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ