### PR TITLE
Handle Daemonset notFound when deleting Agent DS

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -219,6 +219,9 @@ func updateEDSStatusV2WithAgent(eds *edsv1alpha1.ExtendedDaemonSet, newStatus *d
 func (r *Reconciler) deleteV2DaemonSet(logger logr.Logger, dda *datadoghqv2alpha1.DatadogAgent, ds *appsv1.DaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus) error {
 	err := r.client.Delete(context.TODO(), ds)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	logger.Info("Delete DaemonSet", "daemonSet.Namespace", ds.Namespace, "daemonSet.Name", ds.Name)
@@ -232,6 +235,9 @@ func (r *Reconciler) deleteV2DaemonSet(logger logr.Logger, dda *datadoghqv2alpha
 func (r *Reconciler) deleteV2ExtendedDaemonSet(logger logr.Logger, dda *datadoghqv2alpha1.DatadogAgent, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv2alpha1.DatadogAgentStatus) error {
 	err := r.client.Delete(context.TODO(), eds)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	logger.Info("Delete DaemonSet", "extendedDaemonSet.Namespace", eds.Namespace, "extendedDaemonSet.Name", eds.Name)


### PR DESCRIPTION
### What does this PR do?

CECO-2100 / CONS-7125

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Install Operator without this change and apply DatadogAgent with nodeAgent disabled:
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog-agent
spec:
  override:
    nodeAgent:
      disabled: true
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
    clusterName: test-cluster
    kubelet:
      tlsVerify: false
```
Operator will log error below and cluster agent won't be reconciled (e.g. if feature is updated).
```
{"level":"ERROR","ts":"2025-02-27T20:27:13.998Z","msg":"Reconciler error","controller":"datadogagent","controllerGroup":"datadoghq.com","controllerKind":"DatadogAgent","DatadogAgent":{"name":"datadog","namespace":"datadog-operator"},"namespace":"datadog-operator","name":"datadog","reconcileID":"56a03e4a-7cd4-41c9-927b-577e98717449","error":"daemonsets.apps \"datadog-agent\" not found","errorCauses":[{"error":"daemonsets.apps \"datadog-agent\" not found"}]}
```
Deploy Operator with fix; error should go away and DCA should be reconciled correctly.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
