### PR TITLE
[feature/eventcollection] Don't set anything for the node agent

### DIFF
--- a/internal/controller/datadogagent/feature/eventcollection/feature.go
+++ b/internal/controller/datadogagent/feature/eventcollection/feature.go
@@ -187,44 +187,18 @@ func (f *eventCollectionFeature) ManageClusterAgent(managers feature.PodTemplate
 // ManageSingleContainerNodeAgent allows a feature to configure the Agent container for the Node Agent's corev1.PodTemplateSpec
 // if SingleContainerStrategy is enabled and can be used with the configured feature set.
 // It should do nothing if the feature doesn't need to configure it.
-func (f *eventCollectionFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	f.manageNodeAgent(apicommon.UnprivilegedSingleAgentContainerName, managers, provider)
+func (f *eventCollectionFeature) ManageSingleContainerNodeAgent(_ feature.PodTemplateManagers, _ string) error {
 	return nil
 }
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
-func (f *eventCollectionFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	f.manageNodeAgent(apicommon.CoreAgentContainerName, managers, provider)
-	return nil
-}
-
-func (f *eventCollectionFeature) manageNodeAgent(agentContainerName apicommon.AgentContainerName, managers feature.PodTemplateManagers, _ string) error {
-	managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-		Name:  DDCollectKubernetesEvents,
-		Value: "true",
-	})
-
-	managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-		Name:  common.DDLeaderElection,
-		Value: "true",
-	})
-
-	managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-		Name:  DDLeaderLeaseName,
-		Value: utils.GetDatadogLeaderElectionResourceName(f.owner),
-	})
-
-	managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-		Name:  common.DDClusterAgentTokenName,
-		Value: secrets.GetDefaultDCATokenSecretName(f.owner),
-	})
-
+func (f *eventCollectionFeature) ManageNodeAgent(_ feature.PodTemplateManagers, _ string) error {
 	return nil
 }
 
 // ManageClusterChecksRunner allows a feature to configure the ClusterChecksRunner's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
-func (f *eventCollectionFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
+func (f *eventCollectionFeature) ManageClusterChecksRunner(_ feature.PodTemplateManagers) error {
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue in the event collection feature by removing unnecessary environment variables set in the node-agent.

The recommended approach is to run the kubernetes_apiserver check in the cluster-agent instead of the node-agent, which is already how the operator is configured. The operator marks the cluster-agent as a required component in the feature code.

Currently, the kubernetes_apiserver check is configured in the node-agent, but it never actually runs. This is because the agent code includes a condition that prevents it from running unless DD_CLUSTER_AGENT_ENABLED is set to false. However, in the operator, this variable is set to true (as expected, since the cluster-agent is required).

In summary, there’s no need to set anything for the node-agent because the check won’t run there anyway. However, the check is still being configured because DD_LEADER_ELECTION is set to true elsewhere in the code. I’ll address that in a separate PR, as it might require additional changes.


### Describe your test plan

I checked the "Events Explorer" page to see that I get Kubernetes events from my cluster.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
