### PR TITLE
[component/agent/default] Don't set DD_LEADER_ELECTION

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -364,10 +364,6 @@ func envVarsForCoreAgent(dda metav1.Object) []corev1.EnvVar {
 			Value: strconv.Itoa(int(constants.DefaultAgentHealthPort)),
 		},
 		{
-			Name:  common.DDLeaderElection,
-			Value: "true",
-		},
-		{
 			// we want to default it in 7.49.0
 			// but in 7.50.0 it will be already defaulted in the agent process.
 			Name:  DDContainerImageEnabled,


### PR DESCRIPTION
### What does this PR do?

This PR removes the automatic setting of `DD_LEADER_ELECTION=true` on the node agent.

Leader election is only necessary on the node agent when running core cluster checks (KSM, Helm, Kube API server, Orchestrator) there. However, this is not the recommended setup. By default, the operator runs these checks on the DCA or cluster check runners, depending on the configuration, so setting leader election on the node agent is not needed.

### Describe your test plan

Nothing specific, apart from the ENV not being set in the node agent.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
