### PR TITLE
Allow disabling features that are enabled by default

### DIFF
--- a/internal/controller/datadogagent/controller.go
+++ b/internal/controller/datadogagent/controller.go
@@ -107,8 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, dda *v2alpha1.DatadogAgent) 
 
 func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logger) *feature.Options {
 	return &feature.Options{
-		SupportExtendedDaemonset: opts.ExtendedDaemonsetOptions.Enabled,
-		Logger:                   logger,
+		Logger: logger,
 	}
 }
 

--- a/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
@@ -12,7 +12,6 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
-	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
@@ -36,34 +35,6 @@ func (r *Reconciler) setupDependencies(instance *datadoghqv2alpha1.DatadogAgent,
 	depsStore := store.NewStore(instance, storeOptions)
 	resourceManagers := feature.NewResourceManagers(depsStore)
 	return depsStore, resourceManagers
-}
-
-func (r *Reconciler) buildRequirements(dda *datadoghqv2alpha1.DatadogAgent) ([]feature.Feature, []feature.Feature, feature.RequiredComponents) {
-	var disabledComponents feature.RequiredComponents
-	disabledComponent := feature.RequiredComponent{
-		IsRequired: apiutils.NewBoolPointer(false),
-	}
-
-	// check for overrides
-	if isComponentDisabledInOverride(dda, datadoghqv2alpha1.ClusterAgentComponentName) {
-		disabledComponents.ClusterAgent = disabledComponent
-	}
-	if isComponentDisabledInOverride(dda, datadoghqv2alpha1.NodeAgentComponentName) {
-		disabledComponents.Agent = disabledComponent
-	}
-	if isComponentDisabledInOverride(dda, datadoghqv2alpha1.ClusterChecksRunnerComponentName) {
-		disabledComponents.ClusterChecksRunner = disabledComponent
-	}
-
-	// check features
-	return feature.BuildFeatures(dda, reconcilerOptionsToFeatureOptions(&r.options, r.log), disabledComponents)
-}
-
-func isComponentDisabledInOverride(dda *datadoghqv2alpha1.DatadogAgent, componentName datadoghqv2alpha1.ComponentName) bool {
-	if override, ok := dda.Spec.Override[componentName]; ok {
-		return apiutils.BoolValue(override.Disabled)
-	}
-	return false
 }
 
 // manageFeatureDependencies iterates over features to set up dependencies.

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -131,7 +131,10 @@ func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqC
 		}
 		f.localServiceName = constants.GetLocalAgentServiceName(dda)
 		reqComp = feature.RequiredComponents{
-			ClusterAgent: feature.RequiredComponent{IsRequired: apiutils.NewBoolPointer(true)},
+			ClusterAgent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
+			},
 		}
 		if ac.FailurePolicy != nil && *ac.FailurePolicy != "" {
 			f.failurePolicy = *ac.FailurePolicy

--- a/internal/controller/datadogagent/feature/autoscaling/feature.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature.go
@@ -66,7 +66,10 @@ func (f *autoscalingFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feat
 	f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
 
 	return feature.RequiredComponents{
-		ClusterAgent: feature.RequiredComponent{IsRequired: apiutils.NewBoolPointer(true)},
+		ClusterAgent: feature.RequiredComponent{
+			IsRequired: apiutils.NewBoolPointer(true),
+			Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
+		},
 	}
 }
 

--- a/internal/controller/datadogagent/feature/clusterchecks/feature.go
+++ b/internal/controller/datadogagent/feature/clusterchecks/feature.go
@@ -72,9 +72,18 @@ func (f *clusterChecksFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp fe
 
 		f.useClusterCheckRunners = apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners)
 		reqComp = feature.RequiredComponents{
-			Agent:               feature.RequiredComponent{IsRequired: apiutils.NewBoolPointer(true)},
-			ClusterAgent:        feature.RequiredComponent{IsRequired: apiutils.NewBoolPointer(true)},
-			ClusterChecksRunner: feature.RequiredComponent{IsRequired: &f.useClusterCheckRunners},
+			Agent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
+			},
+			ClusterAgent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
+			},
+			ClusterChecksRunner: feature.RequiredComponent{
+				IsRequired: &f.useClusterCheckRunners,
+				Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
+			},
 		}
 	}
 

--- a/internal/controller/datadogagent/feature/cspm/feature.go
+++ b/internal/controller/datadogagent/feature/cspm/feature.go
@@ -97,7 +97,10 @@ func (f *cspmFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Req
 		}
 
 		reqComp = feature.RequiredComponents{
-			ClusterAgent: feature.RequiredComponent{IsRequired: apiutils.NewBoolPointer(true)},
+			ClusterAgent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
+			},
 			Agent: feature.RequiredComponent{
 				IsRequired: apiutils.NewBoolPointer(true),
 				Containers: []apicommon.AgentContainerName{

--- a/internal/controller/datadogagent/feature/enabledefault/feature.go
+++ b/internal/controller/datadogagent/feature/enabledefault/feature.go
@@ -116,6 +116,7 @@ func (f *defaultFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredC
 	return feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{
 			IsRequired: &trueValue,
+			Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 		},
 		Agent: feature.RequiredComponent{
 			IsRequired: &trueValue,

--- a/internal/controller/datadogagent/feature/eventcollection/feature.go
+++ b/internal/controller/datadogagent/feature/eventcollection/feature.go
@@ -84,7 +84,10 @@ func (f *eventCollectionFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 		}
 
 		reqComp = feature.RequiredComponents{
-			ClusterAgent: feature.RequiredComponent{IsRequired: apiutils.NewBoolPointer(true)},
+			ClusterAgent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
+			},
 		}
 	}
 

--- a/internal/controller/datadogagent/feature/externalmetrics/feature.go
+++ b/internal/controller/datadogagent/feature/externalmetrics/feature.go
@@ -135,7 +135,10 @@ func (f *externalMetricsFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 		}
 
 		reqComp = feature.RequiredComponents{
-			ClusterAgent: feature.RequiredComponent{IsRequired: apiutils.NewBoolPointer(true)},
+			ClusterAgent: feature.RequiredComponent{
+				IsRequired: apiutils.NewBoolPointer(true),
+				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
+			},
 		}
 	}
 

--- a/internal/controller/datadogagent/feature/factory.go
+++ b/internal/controller/datadogagent/feature/factory.go
@@ -31,11 +31,12 @@ func Register(id IDType, buildFunc BuildFunc) error {
 }
 
 // BuildFeatures use to build a list features depending of the v2alpha1.DatadogAgent instance
-func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options) ([]Feature, RequiredComponents) {
+func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options, disabledComponents RequiredComponents) ([]Feature, []Feature, RequiredComponents) {
 	builderMutex.RLock()
 	defer builderMutex.RUnlock()
 
-	var output []Feature
+	var configuredFeatures []Feature
+	var enabledFeatures []Feature
 	var requiredComponents RequiredComponents
 
 	// to always return in feature in the same order we need to sort the map keys
@@ -49,12 +50,31 @@ func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options) ([]Feature, Req
 
 	for _, id := range sortedkeys {
 		feat := featureBuilders[id](options)
+		featureID := feat.ID()
 		reqComponents := feat.Configure(dda)
-		// only add feature to the output if one of the components is configured (but not necessarily required)
-		if reqComponents.IsConfigured() {
-			output = append(output, feat)
+		// merge disabled components into feature components
+		reqComponents.Merge(&disabledComponents, IgnoreNilRequiredComponentsMergeFunction)
+		if reqComponents.IsEnabled() {
+			// enabled features
+			enabledFeatures = append(enabledFeatures, feat)
+			options.Logger.V(1).Info("Feature enabled", "featureID", featureID)
+		} else if reqComponents.IsConfigured() {
+			// disabled, but still possibly needing configuration features
+			configuredFeatures = append(configuredFeatures, feat)
+			options.Logger.V(1).Info("Feature configured", "featureID", featureID)
 		}
-		requiredComponents.Merge(&reqComponents)
+		// if reqComponents.IsConfigured() {
+		// 	// enabled features + disabled due to a component being disabled, but still possibly needing configuration features
+		// 	configuredFeatures = append(configuredFeatures, feat)
+		// 	if reqComponents.IsEnabled() {
+		// 		// enabled features
+		// 		enabledFeatures = append(enabledFeatures, feat)
+		// 		options.Logger.V(1).Info("Feature enabled", "featureID", featureID)
+		// 	} else {
+		// 		options.Logger.V(1).Info("Feature configured", "featureID", featureID)
+		// 	}
+		// }
+		requiredComponents.Merge(&reqComponents, DefaultRequiredComponentsMergeFunction)
 	}
 
 	if dda.Spec.Global != nil &&
@@ -66,9 +86,9 @@ func BuildFeatures(dda *v2alpha1.DatadogAgent, options *Options) ([]Feature, Req
 		!requiredComponents.Agent.IsPrivileged() {
 
 		requiredComponents.Agent.Containers = []common.AgentContainerName{common.UnprivilegedSingleAgentContainerName}
-		return output, requiredComponents
+		return configuredFeatures, enabledFeatures, requiredComponents
 	}
-	return output, requiredComponents
+	return configuredFeatures, enabledFeatures, requiredComponents
 }
 
 var (

--- a/internal/controller/datadogagent/feature/helmcheck/feature.go
+++ b/internal/controller/datadogagent/feature/helmcheck/feature.go
@@ -71,7 +71,9 @@ func (f *helmCheckFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp featur
 
 	if helmCheck != nil && apiutils.BoolValue(helmCheck.Enabled) {
 		reqComp.ClusterAgent.IsRequired = apiutils.NewBoolPointer(true)
+		reqComp.ClusterAgent.Containers = []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName}
 		reqComp.Agent.IsRequired = apiutils.NewBoolPointer(true)
+		reqComp.Agent.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 
 		f.configMapName = fmt.Sprintf("%s-%s", f.owner.GetName(), defaultHelmCheckConf)
 		f.collectEvents = apiutils.BoolValue(helmCheck.CollectEvents)
@@ -83,6 +85,7 @@ func (f *helmCheckFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp featur
 			f.rbacSuffix = common.ChecksRunnerSuffix
 			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda)
 			reqComp.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
+			reqComp.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 		}
 
 		// Build configMap based on feature flags.

--- a/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
@@ -78,7 +78,9 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 
 	if dda.Spec.Features != nil && dda.Spec.Features.KubeStateMetricsCore != nil && apiutils.BoolValue(dda.Spec.Features.KubeStateMetricsCore.Enabled) {
 		output.ClusterAgent.IsRequired = apiutils.NewBoolPointer(true)
+		output.ClusterAgent.Containers = []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName}
 		output.Agent.IsRequired = apiutils.NewBoolPointer(true)
+		output.Agent.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 
 		f.collectAPIServiceMetrics = true
 		f.collectCRDMetrics = true
@@ -90,6 +92,7 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 			f.rbacSuffix = common.ChecksRunnerSuffix
 			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda)
 			output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
+			output.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 
 			if ccrOverride, ok := dda.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName]; ok {
 				if ccrOverride.Image != nil && !utils.IsAboveMinVersion(common.GetAgentVersionFromImage(*ccrOverride.Image), crdAPIServiceCollectionMinVersion) {

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/envvar.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/envvar.go
@@ -21,12 +21,15 @@ const (
 	DDOrchestratorExplorerContainerScrubbingEnabled = "DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED"
 )
 
+func (f *orchestratorExplorerFeature) getEnabledEnvVar() *corev1.EnvVar {
+	return &corev1.EnvVar{
+		Name:  DDOrchestratorExplorerEnabled,
+		Value: apiutils.BoolToString(&f.enabled),
+	}
+}
+
 func (f *orchestratorExplorerFeature) getEnvVars() []*corev1.EnvVar {
 	envVarsList := []*corev1.EnvVar{
-		{
-			Name:  DDOrchestratorExplorerEnabled,
-			Value: "true",
-		},
 		{
 			Name:  DDOrchestratorExplorerContainerScrubbingEnabled,
 			Value: apiutils.BoolToString(&f.scrubContainers),

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
@@ -185,6 +185,8 @@ func (f *orchestratorExplorerFeature) ManageDependencies(managers feature.Resour
 // ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *orchestratorExplorerFeature) ManageClusterAgent(managers feature.PodTemplateManagers) error {
+	// Add the env var to explicitly disable this feature
+	// Otherwise, this feature is enabled by default in the Agent code
 	managers.EnvVar().AddEnvVar(f.getEnabledEnvVar())
 	if !f.enabled {
 		return nil
@@ -230,6 +232,8 @@ func (f *orchestratorExplorerFeature) ManageClusterAgent(managers feature.PodTem
 // if SingleContainerStrategy is enabled and can be used with the configured feature set.
 // It should do nothing if the feature doesn't need to configure it.
 func (f *orchestratorExplorerFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	// Add the env var to explicitly disable this feature
+	// Otherwise, this feature is enabled by default in the Agent code
 	managers.EnvVar().AddEnvVar(f.getEnabledEnvVar())
 	if !f.enabled {
 		return nil
@@ -250,6 +254,8 @@ func (f *orchestratorExplorerFeature) ManageNodeAgent(managers feature.PodTempla
 		containers = append(containers, apicommon.ProcessAgentContainerName)
 	}
 
+	// Add the env var to explicitly disable this feature
+	// Otherwise, this feature is enabled by default in the Agent code
 	managers.EnvVar().AddEnvVarToContainers(containers, f.getEnabledEnvVar())
 	if !f.enabled {
 		return nil
@@ -266,6 +272,8 @@ func (f *orchestratorExplorerFeature) ManageNodeAgent(managers feature.PodTempla
 // It should do nothing if the feature doesn't need to configure it.
 func (f *orchestratorExplorerFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
 	if f.runInClusterChecksRunner {
+		// Add the env var to explicitly disable this feature
+		// Otherwise, this feature is enabled by default in the Agent code
 		managers.EnvVar().AddEnvVar(f.getEnabledEnvVar())
 		if !f.enabled {
 			return nil

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
@@ -128,7 +128,7 @@ func orchestratorExplorerNodeAgentNoProcessAgentWantFunc(t testing.TB, mgrInterf
 
 func orchestratorExplorerClusterChecksRunnerWantFunc(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 	mgr := mgrInterface.(*fake.PodTemplateManagers)
-	runnerEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterChecksRunnersContainerName]
+	runnerEnvs := append(mgr.EnvVarMgr.EnvVarsByC[apicommon.AllContainers], mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterChecksRunnersContainerName]...)
 	assert.True(t, apiutils.IsEqualStruct(runnerEnvs, expectedOrchestratorEnvsV2), "Cluster Checks Runner envvars \ndiff = %s", cmp.Diff(runnerEnvs, expectedOrchestratorEnvsV2))
 }
 

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
@@ -58,7 +58,7 @@ func Test_orchestratorExplorerFeature_Configure(t *testing.T) {
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithOrchestratorExplorerEnabled(false).
 				Build(),
-			WantConfigure: false,
+			WantConfigure: true,
 		},
 		{
 			Name: "orchestrator explorer enabled",

--- a/internal/controller/datadogagent/feature/remoteconfig/feature.go
+++ b/internal/controller/datadogagent/feature/remoteconfig/feature.go
@@ -70,22 +70,12 @@ func (f *rcFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requi
 	if dda.Spec.Features != nil && dda.Spec.Features.RemoteConfiguration != nil && dda.Spec.Features.RemoteConfiguration.Enabled != nil {
 		// If a value exists, explicitly enable or disable Remote Config and override the default
 		f.enabled = apiutils.BoolValue(dda.Spec.Features.RemoteConfiguration.Enabled)
+		reqComp.Agent.IsRequired = apiutils.NewBoolPointer(true)
+		reqComp.ClusterAgent.IsRequired = apiutils.NewBoolPointer(true)
 	}
 
-	reqComp = feature.RequiredComponents{
-		Agent: feature.RequiredComponent{
-			IsRequired: apiutils.NewBoolPointer(f.enabled),
-			Containers: []apicommon.AgentContainerName{
-				apicommon.CoreAgentContainerName,
-			},
-		},
-		ClusterAgent: feature.RequiredComponent{
-			IsRequired: apiutils.NewBoolPointer(f.enabled),
-			Containers: []apicommon.AgentContainerName{
-				apicommon.ClusterAgentContainerName,
-			},
-		},
-	}
+	reqComp.Agent.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
+	reqComp.ClusterAgent.Containers = []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName}
 
 	return reqComp
 }

--- a/internal/controller/datadogagent/feature/test/factory_test.go
+++ b/internal/controller/datadogagent/feature/test/factory_test.go
@@ -263,8 +263,7 @@ func TestBuilder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var disabledComponents feature.RequiredComponents
-			_, _, requiredComponents := feature.BuildFeatures(tt.dda, &tt.featureOptions, disabledComponents)
+			_, _, requiredComponents := feature.BuildFeatures(tt.dda, &tt.featureOptions)
 
 			assert.True(t, *requiredComponents.Agent.IsRequired)
 

--- a/internal/controller/datadogagent/feature/test/factory_test.go
+++ b/internal/controller/datadogagent/feature/test/factory_test.go
@@ -263,7 +263,8 @@ func TestBuilder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, requiredComponents := feature.BuildFeatures(tt.dda, &tt.featureOptions)
+			var disabledComponents feature.RequiredComponents
+			_, _, requiredComponents := feature.BuildFeatures(tt.dda, &tt.featureOptions, disabledComponents)
 
 			assert.True(t, *requiredComponents.Agent.IsRequired)
 

--- a/internal/controller/datadogagent/feature/test/testsuite.go
+++ b/internal/controller/datadogagent/feature/test/testsuite.go
@@ -107,7 +107,11 @@ func runTest(t *testing.T, tt FeatureTest) {
 	}
 	featureOptions.Logger = logger
 	if tt.DDA != nil {
-		features, gotConfigure = feature.BuildFeatures(tt.DDA, featureOptions)
+		var disabledComponents feature.RequiredComponents
+		var configuredFeatures []feature.Feature
+		var enabledFeatures []feature.Feature
+		configuredFeatures, enabledFeatures, gotConfigure = feature.BuildFeatures(tt.DDA, featureOptions, disabledComponents)
+		features = append(configuredFeatures, enabledFeatures...)
 		dda = tt.DDA
 	} else {
 		t.Fatal("No DatadogAgent CRD provided")
@@ -180,11 +184,11 @@ func verifyFeatures(t *testing.T, tt FeatureTest, features []feature.Feature, go
 			"it should be 1 if when features is enabled, 0 otherwise. Check code")
 	}
 
-	if tt.WantConfigure && len(features) == 0 {
+	if tt.WantConfigure && gotConfigure.IsEnabled() && len(features) == 0 {
 		t.Errorf("feature wanted but feature.BuildFeatures() return empty slice")
 	}
 
-	if gotConfigure.IsEnabled() != tt.WantConfigure {
-		t.Errorf("feature.Configure() = %v, want %v", gotConfigure.IsEnabled(), tt.WantConfigure)
+	if gotConfigure.IsConfigured() != tt.WantConfigure {
+		t.Errorf("feature.Configure() = %v, want %v", gotConfigure.IsConfigured(), tt.WantConfigure)
 	}
 }

--- a/internal/controller/datadogagent/feature/test/testsuite.go
+++ b/internal/controller/datadogagent/feature/test/testsuite.go
@@ -107,10 +107,9 @@ func runTest(t *testing.T, tt FeatureTest) {
 	}
 	featureOptions.Logger = logger
 	if tt.DDA != nil {
-		var disabledComponents feature.RequiredComponents
 		var configuredFeatures []feature.Feature
 		var enabledFeatures []feature.Feature
-		configuredFeatures, enabledFeatures, gotConfigure = feature.BuildFeatures(tt.DDA, featureOptions, disabledComponents)
+		configuredFeatures, enabledFeatures, gotConfigure = feature.BuildFeatures(tt.DDA, featureOptions)
 		features = append(configuredFeatures, enabledFeatures...)
 		dda = tt.DDA
 	} else {

--- a/internal/controller/datadogagent/feature/types.go
+++ b/internal/controller/datadogagent/feature/types.go
@@ -38,23 +38,10 @@ func (rc *RequiredComponents) IsConfigured() bool {
 // Merge use to merge 2 RequiredComponents
 // merge priority: false > true > nil
 // *
-func (rc *RequiredComponents) Merge(in *RequiredComponents, mergeFunction RequiredComponentsMergeFunction) *RequiredComponents {
-	return mergeFunction(rc, in)
-}
-
-type RequiredComponentsMergeFunction func(rc, in *RequiredComponents) *RequiredComponents
-
-func DefaultRequiredComponentsMergeFunction(rc, in *RequiredComponents) *RequiredComponents {
+func (rc *RequiredComponents) Merge(in *RequiredComponents) *RequiredComponents {
 	rc.ClusterAgent.Merge(&in.ClusterAgent)
 	rc.Agent.Merge(&in.Agent)
 	rc.ClusterChecksRunner.Merge(&in.ClusterChecksRunner)
-	return rc
-}
-
-func IgnoreNilRequiredComponentsMergeFunction(rc, in *RequiredComponents) *RequiredComponents {
-	rc.ignoreNilByComponent(&rc.Agent, &in.Agent)
-	rc.ignoreNilByComponent(&rc.ClusterAgent, &in.ClusterAgent)
-	rc.ignoreNilByComponent(&rc.ClusterChecksRunner, &in.ClusterChecksRunner)
 	return rc
 }
 
@@ -101,27 +88,6 @@ func (rc *RequiredComponent) SingleContainerStrategyEnabled() bool {
 func (rc *RequiredComponent) Merge(in *RequiredComponent) *RequiredComponent {
 	rc.IsRequired = merge(rc.IsRequired, in.IsRequired)
 	rc.Containers = mergeSlices(rc.Containers, in.Containers)
-	return rc
-}
-
-// ignoreNilByComponent is used to merge 2 RequiredComponents
-// merge priority: false > true
-// nil values are unchanged
-// containers are not merged
-func (rc *RequiredComponents) ignoreNilByComponent(reqc *RequiredComponent, in *RequiredComponent) *RequiredComponents {
-	if reqc.IsRequired != nil && in.IsRequired != nil {
-		if *reqc.IsRequired != *in.IsRequired {
-			if rc.Agent.IsRequired != nil {
-				*rc.Agent.IsRequired = *in.IsRequired
-			}
-			if rc.ClusterAgent.IsRequired != nil {
-				*rc.ClusterAgent.IsRequired = *in.IsRequired
-			}
-			if rc.ClusterChecksRunner.IsRequired != nil {
-				*rc.ClusterChecksRunner.IsRequired = *in.IsRequired
-			}
-		}
-	}
 	return rc
 }
 

--- a/internal/controller/datadogagent/feature/types_test.go
+++ b/internal/controller/datadogagent/feature/types_test.go
@@ -206,18 +206,34 @@ func TestRequiredComponent_IsConfigured(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "IsConfigured == true, isRequired == true",
+			name: "IsConfigured == false, isRequired == true",
 			fields: fields{
 				IsRequired: &trueValue,
 				Containers: nil,
 			},
-			want: true,
+			want: false,
+		},
+		{
+			name: "IsConfigured == false, isRequired == false",
+			fields: fields{
+				IsRequired: &falseValue,
+				Containers: nil,
+			},
+			want: false,
 		},
 		{
 			name: "IsConfigured == true, isRequired == false",
 			fields: fields{
 				IsRequired: &falseValue,
-				Containers: nil,
+				Containers: []common.AgentContainerName{common.CoreAgentContainerName},
+			},
+			want: true,
+		},
+		{
+			name: "IsConfigured == true, isRequired == true",
+			fields: fields{
+				IsRequired: &trueValue,
+				Containers: []common.AgentContainerName{common.CoreAgentContainerName},
 			},
 			want: true,
 		},

--- a/internal/controller/datadogagent/finalizer.go
+++ b/internal/controller/datadogagent/finalizer.go
@@ -79,7 +79,8 @@ func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) err
 	// delete, we figure out its dependencies, store them in the dependencies
 	// store, and then call the DeleteAll function of the store.
 
-	_, enabledFeatures, requiredComponents := r.buildRequirements(dda)
+	_, enabledFeatures, requiredComponents := feature.BuildFeatures(
+		dda, reconcilerOptionsToFeatureOptions(&r.options, reqLogger))
 
 	storeOptions := &store.StoreOptions{
 		SupportCilium: r.options.SupportCilium,

--- a/internal/controller/datadogagent/finalizer.go
+++ b/internal/controller/datadogagent/finalizer.go
@@ -79,8 +79,7 @@ func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) err
 	// delete, we figure out its dependencies, store them in the dependencies
 	// store, and then call the DeleteAll function of the store.
 
-	features, requiredComponents := feature.BuildFeatures(
-		dda, reconcilerOptionsToFeatureOptions(&r.options, reqLogger))
+	_, enabledFeatures, requiredComponents := r.buildRequirements(dda)
 
 	storeOptions := &store.StoreOptions{
 		SupportCilium: r.options.SupportCilium,
@@ -94,7 +93,7 @@ func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) err
 	var errs []error
 
 	// Set up dependencies required by enabled features
-	for _, feat := range features {
+	for _, feat := range enabledFeatures {
 		if featErr := feat.ManageDependencies(resourceManagers, requiredComponents); featErr != nil {
 			errs = append(errs, featErr)
 		}


### PR DESCRIPTION
### What does this PR do?

* Splits features into configured and enabled features, where configured features are features that are not enabled but may require configuration
* Changes the way we define a `RequiredComponent`'s `IsEnabled` and `IsConfigured`
  * `IsEnabled`: `nil` = feature disabled, `true` = feature enabled, `false` should not be used
  * `IsConfigured`: `true` = at least one container specified in `RequiredComponent.Containers`, `false` = no containers in `RequiredComponent.Containers`
* Adds `RequiredComponent.Containers` to features that previously only set `RequiredComponent.IsEnabled`
* Adds a path to disable the orchestrator explorer feature

### Motivation

https://datadoghq.atlassian.net/browse/CECO-1895

### Additional Notes

Have only checked the orchestrator explorer and remote config features. Other features may be enabled by default in the agent but have not had config added to allow them to be disabled

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Disable the orchestrator explorer and/or remote config feature and ensure the appropriate `xxx_enabled: false` env vars are set

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
