### PR TITLE
fix typo in license dir on operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,9 @@ COPY --from=builder /workspace/helpers .
 COPY scripts/readsecret.sh .
 RUN chmod 550 readsecret.sh && chmod 550 helpers
 
-RUN mkdir -p /licences
+RUN mkdir -p /licenses
 COPY ./LICENSE ./LICENSE-3rdparty.csv /licenses/
-RUN chmod -R 755 /licences
+RUN chmod -R 755 /licenses
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,6 @@ COPY --from=builder /workspace/helpers .
 COPY scripts/readsecret.sh .
 RUN chmod 550 readsecret.sh && chmod 550 helpers
 
-RUN mkdir -p /licenses
 COPY ./LICENSE ./LICENSE-3rdparty.csv /licenses/
 RUN chmod -R 755 /licenses
 


### PR DESCRIPTION
### What does this PR do?

Puts licenses in the proper directory, right now we have licences (with them) and empty licenses

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
