### PR TITLE
[tooling] use latest preflight version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ bin/$(PLATFORM)/operator-manifest-tools: Makefile
 	hack/install-operator-manifest-tools.sh 0.6.0
 
 bin/$(PLATFORM)/preflight: Makefile
-	hack/install-openshift-preflight.sh 1.11.1
+	hack/install-openshift-preflight.sh latest
 
 bin/$(PLATFORM)/openapi-gen:
 	mkdir -p $(ROOT)/bin/$(PLATFORM)

--- a/hack/install-openshift-preflight.sh
+++ b/hack/install-openshift-preflight.sh
@@ -29,5 +29,13 @@ then
 fi
 
 mkdir -p "$ROOT/bin/$PLATFORM"
-curl -Lo "$ROOT/bin/$PLATFORM/preflight" "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${RELEASE_VERSION}/preflight-${OS}-amd64"
+
+if [ "$RELEASE_VERSION" == "latest" ];
+then
+  echo "Downloading latest preflight version"
+  curl -Lo "$ROOT/bin/$PLATFORM/preflight" "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/latest/download/preflight-${OS}-amd64"
+else
+  curl -Lo "$ROOT/bin/$PLATFORM/preflight" "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/${RELEASE_VERSION}/preflight-${OS}-amd64"
+fi
+
 chmod +x "$ROOT/bin/$PLATFORM/preflight"


### PR DESCRIPTION
### What does this PR do?

Update script to accept "latest" as the version to use
Update Makefile to set parameter "latest"

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

This can be tested in a linux environment by running the script: `hack/install-openshift-preflight.sh latest`
It can also be tested on a release pipeline, confirming that the latest version is being downloaded in the preflight jobs

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
