### PR TITLE
[tooling][gitlab] separate publishing latest images, tweak community operators job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -548,6 +548,7 @@ check_preflight_redhat_image:
 # Preflight now supports multiarch image checks
 submit_preflight_redhat_image:
   stage: post-release
+  allow_failure: true
   rules:
     - if: $CI_COMMIT_TAG
       when: manual
@@ -569,7 +570,8 @@ publish_community_operators:
       - if: $CI_COMMIT_TAG
         when: manual
       - when: never
-  # Allow the job to be run manually even if submit_preflight_redhat_image fails, so that even if preflight submission is done locally this job can be used to open the PRs
+  # Allow the job to be run manually even if submit_preflight_redhat_image fails, so that
+  # preflight submission can be retried locally followed by this manual job trigger in the pipeline
   # needs:
   #   - "submit_preflight_redhat_image"
   tags: [ "runner:docker", "size:large" ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ stages:
   - image
   - test-image
   - release
+  - release-latest
   - e2e
   - post-release
   - deploy
@@ -297,7 +298,7 @@ publish_redhat_public_tag_fips:
     IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:$CI_COMMIT_TAG-fips
 
 publish_public_latest:
-  stage: release
+  stage: release-latest
   rules:
     - if: $CI_COMMIT_TAG
       when: manual
@@ -319,7 +320,7 @@ publish_public_latest_fips:
     IMG_DESTINATIONS: operator:latest-fips
 
 publish_redhat_public_latest:
-  stage: release
+  stage: release-latest
   rules:
     - if: $CI_COMMIT_TAG
       when: manual
@@ -568,8 +569,9 @@ publish_community_operators:
       - if: $CI_COMMIT_TAG
         when: manual
       - when: never
-  needs:
-    - "submit_preflight_redhat_image"
+  # Allow the job to be run manually even if submit_preflight_redhat_image fails, so that even if preflight submission is done locally this job can be used to open the PRs
+  # needs:
+  #   - "submit_preflight_redhat_image"
   tags: [ "runner:docker", "size:large" ]
   image: $JOB_DOCKER_IMAGE
   before_script:


### PR DESCRIPTION
### What does this PR do?

- Separate `latest` image publish jobs into their own stage to reduce potential error
- Allow community operators job to run without depending on the preflight submission job

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
