### PR TITLE
servicediscovery: add support for eBPF runtime-compilation

### DIFF
--- a/internal/controller/datadogagent/feature/servicediscovery/feature_test.go
+++ b/internal/controller/datadogagent/feature/servicediscovery/feature_test.go
@@ -112,11 +112,20 @@ func getWantFunc(withNetStats bool) func(t testing.TB, mgrInterface feature.PodT
 			},
 		}
 		if withNetStats {
-			wantSystemProbeVolMounts = append(wantSystemProbeVolMounts, corev1.VolumeMount{
-				Name:      common.DebugfsVolumeName,
-				MountPath: common.DebugfsPath,
-				ReadOnly:  false,
-			})
+			wantSystemProbeVolMounts = append(wantSystemProbeVolMounts,
+				corev1.VolumeMount{
+					Name:      common.DebugfsVolumeName,
+					MountPath: common.DebugfsPath,
+					ReadOnly:  false,
+				}, corev1.VolumeMount{
+					Name:      common.ModulesVolumeName,
+					MountPath: common.ModulesVolumePath,
+					ReadOnly:  true,
+				}, corev1.VolumeMount{
+					Name:      common.SrcVolumeName,
+					MountPath: common.SrcVolumePath,
+					ReadOnly:  true,
+				})
 		}
 
 		coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommon.CoreAgentContainerName]
@@ -151,14 +160,29 @@ func getWantFunc(withNetStats bool) func(t testing.TB, mgrInterface feature.PodT
 			},
 		}
 		if withNetStats {
-			wantVolumes = append(wantVolumes, corev1.Volume{
-				Name: common.DebugfsVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: common.DebugfsPath,
+			wantVolumes = append(wantVolumes,
+				corev1.Volume{
+					Name: common.DebugfsVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: common.DebugfsPath,
+						},
 					},
-				},
-			})
+				}, corev1.Volume{
+					Name: common.ModulesVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: common.ModulesVolumePath,
+						},
+					},
+				}, corev1.Volume{
+					Name: common.SrcVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: common.SrcVolumePath,
+						},
+					},
+				})
 		}
 
 		volumes := mgr.VolumeMgr.Volumes


### PR DESCRIPTION
### What does this PR do?

This PR adds additional mounts required for Service Discovery to run with eBPF Runtime-Compilation.

### Motivation

Add support for runtime-compilation

### Additional Notes

Runtime-Compilation requires mounting `/usr/src` which is not possible on GKE COS. The PR has a guard against that which requires introspection to be enabled.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.64.0
* Cluster Agent: N/A

### Describe your test plan

The PR was tested on a GKE cluster:

- Install the operator on the cluster:
	- The docker-build & docker-push tasks can be used to make it available to a registry the cluster can reach.
	- An updated datadog-operator and datadog-crds Helm charts were used to install the operator, and allow setting the new config option.
- Install the agent using the operator.
	- The spec.features.serviceDiscovery.networkStats.enabled must be set to `true`
	- Runtime compilation must be forced enabled (and CO-RE disabled)
The following yaml should accomplish the above:

```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    site: datadoghq.com
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
  override:
    nodeAgent:
      containers:
        system-probe:
          env:
            - name: DD_ENABLE_CO_RE
              value: "false"
            - name: DD_ENABLE_RUNTIME_COMPILER
              value: "true"
  features:
    serviceDiscovery:
      enabled: true
      networkStats:
        enabled: true
```
- Verify that the `modules` and `/usr/src` volumes are mounted into the system-probe container.

If testing on GKE, enabling introspection when installing the operator is necessary.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
