### PR TITLE
[Remote config feature] Agent & DCA are not required components, but need to be configured

### DIFF
--- a/internal/controller/datadogagent/feature/remoteconfig/feature.go
+++ b/internal/controller/datadogagent/feature/remoteconfig/feature.go
@@ -70,8 +70,8 @@ func (f *rcFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requi
 	if dda.Spec.Features != nil && dda.Spec.Features.RemoteConfiguration != nil && dda.Spec.Features.RemoteConfiguration.Enabled != nil {
 		// If a value exists, explicitly enable or disable Remote Config and override the default
 		f.enabled = apiutils.BoolValue(dda.Spec.Features.RemoteConfiguration.Enabled)
-		reqComp.Agent.IsRequired = apiutils.NewBoolPointer(true)
-		reqComp.ClusterAgent.IsRequired = apiutils.NewBoolPointer(true)
+		reqComp.Agent.IsRequired = dda.Spec.Features.RemoteConfiguration.Enabled
+		reqComp.ClusterAgent.IsRequired = dda.Spec.Features.RemoteConfiguration.Enabled
 	}
 
 	reqComp.Agent.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}

--- a/internal/controller/datadogagent/feature/remoteconfig/feature.go
+++ b/internal/controller/datadogagent/feature/remoteconfig/feature.go
@@ -70,8 +70,13 @@ func (f *rcFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requi
 	if dda.Spec.Features != nil && dda.Spec.Features.RemoteConfiguration != nil && dda.Spec.Features.RemoteConfiguration.Enabled != nil {
 		// If a value exists, explicitly enable or disable Remote Config and override the default
 		f.enabled = apiutils.BoolValue(dda.Spec.Features.RemoteConfiguration.Enabled)
-		reqComp.Agent.IsRequired = dda.Spec.Features.RemoteConfiguration.Enabled
-		reqComp.ClusterAgent.IsRequired = dda.Spec.Features.RemoteConfiguration.Enabled
+		// If Remote Config is enabled, we need to enable the Agent and Cluster Agent components.
+		// We need to only set the IsRequired to true if the feature is enabled as setting it to false will take priority over other features.
+		// Ref: https://github.com/DataDog/datadog-operator/blob/c4b6e498048a11fbe99d1ea51d2870c6be578799/internal/controller/datadogagent/feature/types.go#L37
+		if f.enabled {
+			reqComp.Agent.IsRequired = dda.Spec.Features.RemoteConfiguration.Enabled
+			reqComp.ClusterAgent.IsRequired = dda.Spec.Features.RemoteConfiguration.Enabled
+		}
 	}
 
 	reqComp.Agent.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/DataDog/datadog-operator/pull/1792, we can now configure RC feature (to disable it via env var) without having the component required. 

### Motivation

Avoid un-needed objects from being created if DCA component is not needed by any features (since RC was requiring DCA component, we would enter the enabledefault DCA dependencies even if all other features did not need it)

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
