### PR TITLE
[tooling] sort git tag by semver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ SHELL = /usr/bin/env bash -o pipefail
 # Datadog custom variables
 #
 BUILDINFOPKG=github.com/DataDog/datadog-operator/pkg/version
-GIT_TAG?=$(shell git tag -l --contains HEAD | tail -1)
-TAG_HASH=$(shell git tag | tail -1)_$(shell git rev-parse --short HEAD)
+GIT_TAG?=$(shell git tag | tr - \~ | sort -V | tr \~ - | tail -1)
+TAG_HASH=$(shell git tag | tr - \~ | sort -V | tr \~ - | tail -1)_$(shell git rev-parse --short HEAD)
 IMG_VERSION?=$(if $(VERSION),$(VERSION),latest)
 VERSION?=$(if $(GIT_TAG),$(GIT_TAG),$(TAG_HASH))
 GIT_COMMIT?=$(shell git rev-parse HEAD)


### PR DESCRIPTION
### What does this PR do?

Sort `GIT_TAG` and `TAG_HASH` vars by semver rather than default sort. Drawn from https://gist.github.com/loisaidasam/b1e6879f3deb495c22cc?permalink_comment_id=3008151#gistcomment-3008151

### Motivation

Prevent 1.9.X from being the default latest tag when building locally

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Run `make build` locally and make sure the default version used in the build command is the latest tag.

```
go build -ldflags '-w -s -X github.com/DataDog/datadog-operator/pkg/version.Commit=3ffc9e951b9046a90327c4a645bd02a66246f3e4 -X github.com/DataDog/datadog-operator/pkg/version.Version=[CHECK_THIS_VERSION] -X github.com/DataDog/datadog-operator/pkg/version.BuildTime=2025-03-19/14:08:54' -o bin/darwin-arm64/manager cmd/main.go
```

Can also run the binary and check the first log line, which prints the version. 

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
