### PR TITLE
[errortracking] add error tracking standalone var to the core agent

### DIFF
--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -471,10 +471,12 @@ func (f *apmFeature) manageNodeAgent(agentContainerName apicommon.AgentContainer
 
 	// Error Tracking standalone
 	if f.errorTrackingStandalone {
-		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+		etStandaloneEnvVar := &corev1.EnvVar{
 			Name:  common.DDAPMErrorTrackingStandaloneEnabled,
 			Value: "true",
-		})
+		}
+		managers.EnvVar().AddEnvVarToContainer(agentContainerName, etStandaloneEnvVar)
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, etStandaloneEnvVar)
 	}
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

Adds the `DD_APM_ERROR_TRACKING_STANDALONE_ENABLED` flag to the `agent`

### Motivation

This env variable should be present in the core agent as well

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
