### PR TITLE
Add CA certificate bundle to ubi9-micro base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN if [ "$FIPS_ENABLED" = "true" ]; then \
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o helpers cmd/helpers/main.go
 
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS certs
+
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
 LABEL name="datadog/operator"
@@ -54,6 +56,9 @@ LABEL description="Datadog provides a modern monitoring and analytics platform. 
       metrics, logs and traces for full observability of your Kubernetes cluster with \
       Datadog Operator."
 LABEL maintainer="Datadog Inc."
+
+# ubi-micro variant does not have CA certificates installed
+COPY --from=certs /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
### What does this PR do?

Install CA certificate bundle in operator base image

### Motivation

The Go client uses the CA bundle to communicate with the Datadog API for resources (e.g. DatadogMonitor). Without this bundle, we encounter errors:
`error validating monitor (url.Error): Post "https://api.datadoghq.com/api/v1/monitor/validate":
      tls: failed to verify certificate: x509: certificate signed by unknown authority`

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Deploy a DatadogMonitor or something that uses the Go client to communicate with DD API and ensures the object gets created/ no TLS error about unknown authority

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
