### PR TITLE
Add checksd volume to ccr init-config

### DIFF
--- a/internal/controller/datadogagent/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default.go
@@ -56,6 +56,7 @@ func NewDefaultClusterChecksRunnerPodTemplateSpec(dda metav1.Object) *corev1.Pod
 		common.GetVolumeForConfig(),
 		common.GetVolumeForRmCorechecks(),
 		common.GetVolumeForLogs(),
+		common.GetVolumeForChecksd(),
 
 		// /tmp is needed because some versions of the DCA (at least until
 		// 1.19.0) write to it.
@@ -84,6 +85,17 @@ func NewDefaultClusterChecksRunnerPodTemplateSpec(dda metav1.Object) *corev1.Pod
 	}
 
 	return template
+}
+
+func volumeMountsForInitConfig() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		common.GetVolumeMountForInstallInfo(),
+		common.GetVolumeMountForConfig(),
+		common.GetVolumeMountForLogs(),
+		common.GetVolumeMountForTmp(),
+		common.GetVolumeMountForRmCorechecks(),
+		common.GetVolumeMountForChecksd(),
+	}
 }
 
 func GetClusterChecksRunnerPodDisruptionBudgetName(dda metav1.Object) string {
@@ -143,7 +155,7 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				Args: []string{
 					"for script in $(find /etc/cont-init.d/ -type f -name '*.sh' | sort) ; do bash $script ; done",
 				},
-				VolumeMounts: volumeMounts,
+				VolumeMounts: volumeMountsForInitConfig(),
 			},
 		},
 		Containers: []corev1.Container{


### PR DESCRIPTION
### What does this PR do?

Allow custom checks to run on cluster checks runners

### Motivation

https://datadoghq.atlassian.net/browse/CONS-7175

### Additional Notes

We mount this in helm: https://github.com/DataDog/helm-charts/blob/542ee739117f200b79d916b4dcc209ab0ee57220/charts/datadog/templates/agent-clusterchecks-deployment.yaml#L109-L113

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
