### PR TITLE
Update backport PR conditions

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -25,16 +25,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
-        id: app-token
-        with:
-          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           label_pattern: "^backport/(?<base>([^ ]+))$" 
           labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           title_template: "[ Backport <%- base %> ] <%- title %>"
           body_template: |
             Backport <%- mergeCommitSha %> from #<%- number %>.

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -5,7 +5,6 @@ on:
 
 permissions: {}
 
-
 jobs:
   backport:
     name: Backport PR

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -10,11 +10,15 @@ jobs:
     name: Backport PR
     runs-on: ubuntu-latest
     if: >
-      github.event.pull_request.merged
-      && (
-        ( github.event.action == 'closed' && contains(github.event.label.name, 'backport') )
-        || 
-        ( github.event.action == 'labeled' && contains(github.event.label.name, 'backport') )
+      (
+        github.event.pull_request.merged
+        && contains(join(',', github.event.pull_request.labels.*.name), 'backport/')
+      )
+      ||
+      (
+        github.event.action == 'labeled'
+        && contains(github.event.label.name, 'backport/')
+        && github.event.pull_request.merged_at != null
       )
     permissions:
       contents: write

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -1,7 +1,7 @@
 name: Backport PR
 on:
   pull_request:
-    types: [ labeled, closed ]
+    types: [ labeled ]
 
 permissions: {}
 
@@ -11,16 +11,9 @@ jobs:
     name: Backport PR
     runs-on: ubuntu-latest
     if: >
-      (
-        github.event.pull_request.merged
-        && contains(join(',', github.event.pull_request.labels.*.name), 'backport/')
-      )
-      ||
-      (
         github.event.action == 'labeled'
         && contains(github.event.label.name, 'backport/')
         && github.event.pull_request.merged_at != null
-      )
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
         github.event.action == 'labeled'
-        && contains(github.event.label.name, 'backport/')
         && github.event.pull_request.merged_at != null
+        && contains(github.event.label.name, 'backport/')
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -5,6 +5,7 @@ on:
 
 permissions: {}
 
+
 jobs:
   backport:
     name: Backport PR


### PR DESCRIPTION
### What does this PR do?

Only allow backport PR to be created when the `backport/<branch_name>` label is added AFTER it's been merged 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

i fiddled with this a lot, but here's an example: 
- https://github.com/DataDog/datadog-operator/actions/runs/14088627686/job/39459290489. The job is failing because the noop change I tested it on causes a merge conflict
     - example of replicating it manually 
<img width="615" alt="image" src="https://github.com/user-attachments/assets/a500ec02-2efd-49ed-a5bf-58a16c41e96c" />


- will test after this pr is merged by adding the temporary testing label I made, `backport/testing` to this PR 
### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
