### PR TITLE
(chore) Change test-id to integer string id

### DIFF
--- a/internal/controller/datadoggenericresource/synthetics_test.go
+++ b/internal/controller/datadoggenericresource/synthetics_test.go
@@ -30,7 +30,7 @@ func Test_updateStatusFromSyntheticsTest(t *testing.T) {
 				},
 			},
 			expectedStatus: v1alpha1.DatadogGenericResourceStatus{
-				Id:                "test-id",
+				Id:                "123456789",
 				Creator:           "test-handle",
 				SyncStatus:        v1alpha1.DatadogSyncStatusOK,
 				CurrentHash:       hash,
@@ -46,7 +46,7 @@ func Test_updateStatusFromSyntheticsTest(t *testing.T) {
 				},
 			},
 			expectedStatus: v1alpha1.DatadogGenericResourceStatus{
-				Id:                "test-id",
+				Id:                "123456789",
 				Creator:           "test-handle",
 				SyncStatus:        v1alpha1.DatadogSyncStatusOK,
 				CurrentHash:       hash,
@@ -63,7 +63,7 @@ func Test_updateStatusFromSyntheticsTest(t *testing.T) {
 				},
 			},
 			expectedStatus: v1alpha1.DatadogGenericResourceStatus{
-				Id:                "test-id",
+				Id:                "123456789",
 				Creator:           "test-handle",
 				SyncStatus:        v1alpha1.DatadogSyncStatusOK,
 				CurrentHash:       hash,
@@ -77,7 +77,7 @@ func Test_updateStatusFromSyntheticsTest(t *testing.T) {
 				"created_at": "2024-01-01T00:00:00Z",
 			},
 			expectedStatus: v1alpha1.DatadogGenericResourceStatus{
-				Id:                "test-id",
+				Id:                "123456789",
 				Creator:           "",
 				SyncStatus:        v1alpha1.DatadogSyncStatusOK,
 				CurrentHash:       hash,
@@ -92,7 +92,7 @@ func Test_updateStatusFromSyntheticsTest(t *testing.T) {
 				"created_by": map[string]interface{}{},
 			},
 			expectedStatus: v1alpha1.DatadogGenericResourceStatus{
-				Id:                "test-id",
+				Id:                "123456789",
 				Creator:           "",
 				SyncStatus:        v1alpha1.DatadogSyncStatusOK,
 				CurrentHash:       hash,
@@ -106,7 +106,7 @@ func Test_updateStatusFromSyntheticsTest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			status := &v1alpha1.DatadogGenericResourceStatus{}
 			syntheticTest := &datadogV1.SyntheticsAPITest{}
-			syntheticTest.SetPublicId("test-id")
+			syntheticTest.SetPublicId("123456789")
 			err := updateStatusFromSyntheticsTest(syntheticTest, tt.additionalProperties, status, mockLogger, hash)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus.Id, status.Id)


### PR DESCRIPTION
### What does this PR do?

Changes foo id to integer string id

### Motivation

Avoid erroring sometimes: https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/867820771#L659
```
2025-03-27T14:08:36Z	ERROR	failed to finalize 	{"test:": "a DatadogGenericResource object (with the finalizer) has a deletion timestamp", "custom resource Id": "", "error": "error parsing resource ID: strconv.ParseInt: parsing \"\": invalid syntax"}
```


### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
