### PR TITLE
[e2e] Disable e2e tests on nightly build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,21 +214,21 @@ build_bundle_image:
     KUBERNETES_MEMORY_LIMIT: 16Gi
 
 .on_run_e2e:
-  # Skip e2e tests if only .md files are changed
+  # Skip if only .md files are changed
   - if: $CI_COMMIT_BRANCH
     changes:
       paths:
         - "*.md"
       compare_to: "refs/heads/main"
     when: never
-  # Allow mergequeue branches to merge even if e2e tests fail
+  # Allow mergequeue branches to merge even if testsfail
   - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
     allow_failure: true
-  # Temporarily disable on Conductor-triggered jobs
+  # Disable on Conductor-triggered jobs (ex: nightly)
   - if: '$DDR == "true"'
-    when: manual
+    when: never
+  # Run automatically otherwise
   - when: on_success
-  # Run e2e tests automatically otherwise
 
 trigger_e2e_operator_image:
   stage: e2e

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,7 +221,7 @@ build_bundle_image:
         - "*.md"
       compare_to: "refs/heads/main"
     when: never
-  # Allow mergequeue branches to merge even if testsfail
+  # Allow mergequeue branches to merge even if tests fail
   - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
     allow_failure: true
   # Disable on Conductor-triggered jobs (ex: nightly)


### PR DESCRIPTION
### What does this PR do?

The `e2e` test stage in gitlab was previously set to `manual` on conductor triggered jobs, which blocked the [pipeline](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/60125805) as the `release` and `deploy` stages could not run until `e2e` was manually triggered. 

Fixed by setting the `e2e` stage to never run on conductor triggered jobs. This causes the stage to be skipped. from Github Actions docs:

> A job that is skipped will report its status as "Success". 

This will allow subsequent nightly build pipeline stages to run

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

- verify that if e2e tests complete successfully on nightly build [here](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/60271500) after a manual trigger, pipeline completes successfully
- Verify after merging that nightly build skips the e2e stage and completes successfully

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
