### PR TITLE
(chore) E2E: use m5.xlarge instead of default t3.medium

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ variables:
   PUSH_IMAGES_TO_STAGING:
     description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."
   FIPS_ENABLED: false
+  FF_TIMESTAMPS: true
 
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}

--- a/test/e2e/kind_test.go
+++ b/test/e2e/kind_test.go
@@ -97,7 +97,7 @@ func kindProvisioner(k8sVersion string, extraKustomizeResources []string) provis
 		}
 
 		// Create EC2 VM
-		vm, err := ec2.NewVM(awsEnv, "kind", ec2.WithUserData(UserData))
+		vm, err := ec2.NewVM(awsEnv, "kind", ec2.WithUserData(UserData), ec2.WithInstanceType("m5.xlarge"))
 		if err != nil {
 			return err
 		}

--- a/test/e2e/kind_test.go
+++ b/test/e2e/kind_test.go
@@ -97,7 +97,7 @@ func kindProvisioner(k8sVersion string, extraKustomizeResources []string) provis
 		}
 
 		// Create EC2 VM
-		vm, err := ec2.NewVM(awsEnv, "kind", ec2.WithUserData(UserData), ec2.WithInstanceType("m5.xlarge"))
+		vm, err := ec2.NewVM(awsEnv, "kind", ec2.WithUserData(UserData))
 		if err != nil {
 			return err
 		}

--- a/test/e2e/provisioners/kind.go
+++ b/test/e2e/provisioners/kind.go
@@ -7,13 +7,16 @@ package provisioners
 
 import (
 	"fmt"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"os"
 	"strings"
+
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
 	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
+
+	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/optional"
@@ -34,7 +37,6 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/yaml"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"path/filepath"
 )
 
 const (
@@ -94,7 +96,7 @@ func newAWSK8sProvisionerOpts(params *KubernetesProvisionerParams) []awskubernet
 		awskubernetes.WithExtraConfigParams(extraConfig),
 		awskubernetes.WithWorkloadApp(KustomizeWorkloadAppFunc(params.testName, params.kustomizeResources)),
 		awskubernetes.WithFakeIntakeOptions(params.fakeintakeOptions...),
-		awskubernetes.WithEC2VMOptions([]ec2.VMOption{ec2.WithUserData(UserData)}...),
+		awskubernetes.WithEC2VMOptions([]ec2.VMOption{ec2.WithUserData(UserData), ec2.WithInstanceType("m5.xlarge")}...),
 	}
 
 	for _, yamlWorkload := range params.yamlWorkloads {


### PR DESCRIPTION
### What does this PR do?

* Changes instance type to use m5.xlarge (4 vCPU, 16 GiB) instead of default `t3.medium`
* Enables timestamps in gitlab logs

### Motivation

Speed up E2e tests
Ease up troubleshooting when investigating bottlenecks

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
