### PR TITLE
[kubectl plugin] Fallback to configmap leader attempt for `clusteragent` if lease failed

### DIFF
--- a/cmd/kubectl-datadog/clusteragent/leader/leader.go
+++ b/cmd/kubectl-datadog/clusteragent/leader/leader.go
@@ -33,8 +33,7 @@ type options struct {
 	common.Options
 	args []string
 
-	DDAName        string
-	forceConfigMap bool
+	DDAName string
 }
 
 type leaderResponse struct {
@@ -71,7 +70,6 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.DDAName, "dda-name", "", "", "The DatadogAgent resource name to get the leader from")
-	cmd.Flags().BoolVarP(&o.forceConfigMap, "force-configmap", "", false, "Force using ConfigMap for leader election lookup instead of Lease")
 	o.ConfigFlags.AddFlags(cmd.Flags())
 
 	return cmd
@@ -105,26 +103,19 @@ func (o *options) run(cmd *cobra.Command) error {
 	var err error
 	var useLease bool
 
-	// Check if lease is supported by default
 	useLease, err = isLeaseSupported(o.DiscoveryClient)
 	if err != nil {
-		return fmt.Errorf("unable to check if lease is supported %w", err)
+		return fmt.Errorf("unable to check if lease is suppoered %w", err)
 	}
-
-	// Override with force-configmap flag if set
-	if o.forceConfigMap {
-		useLease = false
-	}
-
 	if useLease {
 		fmt.Fprintln(o.IOStreams.Out, "Using lease for leader election")
 		leaderName, err = o.getLeaderFromLease(objKey)
 	} else {
-		fmt.Fprintln(o.IOStreams.Out, "Using ConfigMap for leader election")
+		fmt.Fprintln(o.IOStreams.Out, "Using lease for configmap")
 		leaderName, err = o.getLeaderFromConfigMap(objKey)
 	}
 	if err != nil {
-		return fmt.Errorf("unable to get leader: %w", err)
+		return fmt.Errorf("unable to get leader from lease: %w", err)
 	}
 
 	cmd.Println("The Pod name of the Cluster Agent is:", leaderName)


### PR DESCRIPTION
### What does this PR do?

Falls back to try getting leader from configmap for `clusteragent` even if leases are supported, in the case getting leader from lease failed

### Motivation

Allows to get leader from configmap even if leases are supported in the environment, in a situation where configmap is still being used for leader election of DCA

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* As https://github.com/DataDog/datadog-operator/pull/1375, check by default, we try to retrieve leader when `leader_election_default_resource` is set to `lease`
* In an env with DCA leader election in configmap (https://github.com/DataDog/datadog-agent/blob/5e42ef8869290dcdec42772b0b71538485879f8b/pkg/config/setup/config.go#L515) but leases supported in the cluster, ensure you get the DCA leader

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
