### PR TITLE
[defaulting] clean up unused image methods

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -101,7 +101,7 @@ func getDefaultServiceAccountName(dda metav1.Object) string {
 }
 
 func agentImage() string {
-	return defaulting.GetLatestAgentImageJMX()
+	return defaulting.GetLatestAgentImage()
 }
 
 func otelAgentImage() string {

--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -101,7 +101,7 @@ func getDefaultServiceAccountName(dda metav1.Object) string {
 }
 
 func agentImage() string {
-	return fmt.Sprintf("%s/%s:%s", defaulting.DefaultImageRegistry, defaulting.DefaultAgentImageName, defaulting.AgentLatestVersion)
+	return defaulting.GetLatestAgentImageJMX()
 }
 
 func otelAgentImage() string {

--- a/internal/controller/datadogagent/component/clusteragent/default.go
+++ b/internal/controller/datadogagent/component/clusteragent/default.go
@@ -115,7 +115,7 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 		Containers: []corev1.Container{
 			{
 				Name:  string(apicommon.ClusterAgentContainerName),
-				Image: fmt.Sprintf("%s/%s:%s", defaulting.DefaultImageRegistry, defaulting.DefaultClusterAgentImageName, defaulting.ClusterAgentLatestVersion),
+				Image: defaulting.GetLatestClusterAgentImage(),
 				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 5005,

--- a/internal/controller/datadogagent/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default.go
@@ -141,7 +141,7 @@ func getDefaultServiceAccountName(dda metav1.Object) string {
 }
 
 func clusterChecksRunnerImage() string {
-	return fmt.Sprintf("%s/%s:%s", defaulting.DefaultImageRegistry, defaulting.DefaultAgentImageName, defaulting.AgentLatestVersion)
+	return defaulting.GetLatestAgentImageJMX()
 }
 
 func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar) corev1.PodSpec {

--- a/internal/controller/datadogagent/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default.go
@@ -141,7 +141,7 @@ func getDefaultServiceAccountName(dda metav1.Object) string {
 }
 
 func clusterChecksRunnerImage() string {
-	return defaulting.GetLatestAgentImageJMX()
+	return defaulting.GetLatestAgentImage()
 }
 
 func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, envVars []corev1.EnvVar) corev1.PodSpec {

--- a/pkg/constants/utils_test.go
+++ b/pkg/constants/utils_test.go
@@ -61,16 +61,6 @@ func Test_GetImage(t *testing.T) {
 			want:     "gcr.io/datadoghq/agent:latest",
 		},
 		{
-			name: "add jmx",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name:       "agent",
-				Tag:        defaulting.AgentLatestVersion,
-				JMXEnabled: true,
-			},
-			registry: nil,
-			want:     defaulting.GetLatestAgentImageJMX(),
-		},
-		{
 			name: "cluster-agent",
 			imageSpec: &v2alpha1.AgentImageConfig{
 				Name:       "cluster-agent",

--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -84,18 +84,6 @@ func GetLatestAgentImage(opts ...ImageOptions) string {
 	return image.String()
 }
 
-// GetLatestAgentImageJMX return the latest JMX stable agent release version
-func GetLatestAgentImageJMX(opts ...ImageOptions) string {
-	image := &Image{
-		registry:  DefaultImageRegistry,
-		imageName: DefaultAgentImageName,
-		tag:       AgentLatestVersion,
-	}
-	processOptions(image, opts...)
-	image.tag = fmt.Sprintf("%s%s", image.tag, JMXTagSuffix)
-	return image.String()
-}
-
 // GetLatestClusterAgentImage return the latest stable agent release version
 func GetLatestClusterAgentImage(opts ...ImageOptions) string {
 	image := &Image{
@@ -125,13 +113,6 @@ func WithTag(tag string) ImageOptions {
 func WithImageName(name string) ImageOptions {
 	return func(image *Image) {
 		image.imageName = name
-	}
-}
-
-// WithJMX ImageOptions to specify if the JMX prefix should be added
-func WithJMX(jmx bool) ImageOptions {
-	return func(image *Image) {
-		image.isJMX = jmx
 	}
 }
 

--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -34,7 +34,7 @@ const (
 	DefaultEuropeImageRegistry string = "eu.gcr.io/datadoghq"
 	DefaultAsiaImageRegistry   string = "asia.gcr.io/datadoghq"
 	DefaultGovImageRegistry    string = "public.ecr.aws/datadog"
-	// JMXTagSuffix prefix tag for agent JMX images
+	// JMXTagSuffix suffix tag for agent JMX images
 	JMXTagSuffix = "-jmx"
 	// Default Image names
 	DefaultAgentImageName        string = "agent"

--- a/pkg/defaulting/images_test.go
+++ b/pkg/defaulting/images_test.go
@@ -46,55 +46,11 @@ func TestGetLatestAgentImage(t *testing.T) {
 			},
 			want: "gcr.io/datadoghq/foo:latest",
 		},
-		{
-			name: "with jmx",
-			opts: []ImageOptions{
-				WithImageName("foo"),
-				WithTag("latest"),
-				WithJMX(true),
-			},
-			want: "gcr.io/datadoghq/foo:latest-jmx",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetLatestAgentImage(tt.opts...); got != tt.want {
 				t.Errorf("GetLatestAgentImage() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestGetLatestAgentImageJMX(t *testing.T) {
-	tests := []struct {
-		name string
-		opts []ImageOptions
-		want string
-	}{
-		{
-			name: "default registry",
-			want: fmt.Sprintf("gcr.io/datadoghq/agent:%s-jmx", AgentLatestVersion),
-		},
-
-		{
-			name: "docker.io",
-			opts: []ImageOptions{
-				WithRegistry(DockerHubContainerRegistry),
-			},
-			want: fmt.Sprintf("docker.io/datadog/agent:%s-jmx", AgentLatestVersion),
-		},
-		{
-			name: "with tag",
-			opts: []ImageOptions{
-				WithTag("latest"),
-			},
-			want: "gcr.io/datadoghq/agent:latest-jmx",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetLatestAgentImageJMX(tt.opts...); got != tt.want {
-				t.Errorf("GetLatestAgentImageJMX() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Use convenience methods for default Agent and Cluster Agent images
Clean up unused convenience methods to reduce confusion

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

This change is noop

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
