### PR TITLE
Add feature flag when GPU monitoring is enabled

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/envvar.go
+++ b/internal/controller/datadogagent/feature/gpu/envvar.go
@@ -6,4 +6,5 @@
 package gpu
 
 const DDEnableGPUMonitoringEnvVar = "DD_GPU_MONITORING_ENABLED"
+const DDEnableNVMLDetectionEnvVar = "DD_ENABLE_NVML_DETECTION"
 const NVIDIAVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -138,6 +138,14 @@ func (f *gpuFeature) ManageNodeAgent(managers feature.PodTemplateManagers, _ str
 	// Both in the core agent and the system probe
 	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName}, enableEnvVar)
 
+	// env var to enable NVML detection, so that workloadmeta features depending on it
+	// can be enabled
+	nvmlDetectionEnvVar := &corev1.EnvVar{
+		Name:  DDEnableNVMLDetectionEnvVar,
+		Value: "true",
+	}
+	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName}, nvmlDetectionEnvVar)
+
 	// The agent check does not need to be manually enabled, the init config container will
 	// check if GPU monitoring is enabled and will enable the check automatically (see
 	// Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh in the datadog-agent repo).

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -170,6 +170,10 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				Name:  common.DDKubernetesPodResourcesSocket,
 				Value: path.Join(podResourcesSocketPath, "kubelet.sock"),
 			},
+			{
+				Name:  DDEnableNVMLDetectionEnvVar,
+				Value: "true",
+			},
 		}, wantSystemProbeEnvVars...)
 
 		agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent: N/A

Agents that do not support this feature will just ignore the environment variable.

### Describe your test plan

Unit tests validate that the flag is present.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
