### PR TITLE
[dda] update dependency fx names, move GetImage

### DIFF
--- a/internal/controller/datadogagent/common/utils.go
+++ b/internal/controller/datadogagent/common/utils.go
@@ -94,6 +94,21 @@ func GetAgentVersionFromImage(imageConfig v2alpha1.AgentImageConfig) string {
 	return version
 }
 
+// GetImage builds the image string based on ImageConfig and the registry configuration.
+func GetImage(imageSpec *v2alpha1.AgentImageConfig, registry *string) string {
+	if defaulting.IsImageNameContainsTag(imageSpec.Name) {
+		return imageSpec.Name
+	}
+
+	img := defaulting.NewImage(imageSpec.Name, imageSpec.Tag, imageSpec.JMXEnabled)
+
+	if registry != nil && *registry != "" {
+		defaulting.WithRegistry(defaulting.ContainerRegistry(*registry))(img)
+	}
+
+	return img.String()
+}
+
 // BuildEnvVarFromSource return an *corev1.EnvVar from a Env Var name and *corev1.EnvVarSource
 func BuildEnvVarFromSource(name string, source *corev1.EnvVarSource) *corev1.EnvVar {
 	return &corev1.EnvVar{
@@ -153,5 +168,5 @@ func OverrideAgentImage(currentImg string, overrideImg *v2alpha1.AgentImageConfi
 		overrideImgCopy.Tag = strings.TrimSuffix(splitName[1], defaulting.JMXTagSuffix)
 	}
 
-	return constants.GetImage(&overrideImgCopy, &registry)
+	return GetImage(&overrideImgCopy, &registry)
 }

--- a/internal/controller/datadogagent/common/utils_test.go
+++ b/internal/controller/datadogagent/common/utils_test.go
@@ -1,0 +1,97 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	"github.com/DataDog/datadog-operator/pkg/defaulting"
+)
+
+func Test_GetImage(t *testing.T) {
+	emptyRegistry := ""
+	tests := []struct {
+		name      string
+		imageSpec *v2alpha1.AgentImageConfig
+		registry  *string
+		want      string
+	}{
+		{
+			name: "backward compatible",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name: defaulting.GetLatestAgentImage(),
+			},
+			registry: nil,
+			want:     defaulting.GetLatestAgentImage(),
+		},
+		{
+			name: "nominal case",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name: "agent",
+				Tag:  "7",
+			},
+			registry: apiutils.NewStringPointer("public.ecr.aws/datadog"),
+			want:     "public.ecr.aws/datadog/agent:7",
+		},
+		{
+			name: "prioritize the full path",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name: "docker.io/datadog/agent:7.28.1-rc.3",
+				Tag:  "latest",
+			},
+			registry: apiutils.NewStringPointer("gcr.io/datadoghq"),
+			want:     "docker.io/datadog/agent:7.28.1-rc.3",
+		},
+		{
+			name: "default registry",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name: "agent",
+				Tag:  "latest",
+			},
+			registry: &emptyRegistry,
+			want:     "gcr.io/datadoghq/agent:latest",
+		},
+		{
+			name: "cluster-agent",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name:       "cluster-agent",
+				Tag:        defaulting.ClusterAgentLatestVersion,
+				JMXEnabled: false,
+			},
+			registry: nil,
+			want:     defaulting.GetLatestClusterAgentImage(),
+		},
+		{
+			name: "do not duplicate jmx",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name:       "agent",
+				Tag:        "latest-jmx",
+				JMXEnabled: true,
+			},
+			registry: nil,
+			want:     "gcr.io/datadoghq/agent:latest-jmx",
+		},
+		{
+			name: "do not add jmx",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name:       "agent",
+				Tag:        "latest-jmx",
+				JMXEnabled: true,
+			},
+			registry: nil,
+			want:     "gcr.io/datadoghq/agent:latest-jmx",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetImage(tt.imageSpec, tt.registry))
+		})
+	}
+}

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -28,7 +28,7 @@ type gpuFeature struct {
 	// podRuntimeClassName is the value to set in the runtimeClassName
 	// configuration of the agent pod. If this is empty, the runtimeClassName
 	// will not be changed.
-	podRuntimeClassName string
+	podRuntimeClassName    string
 	podResourcesSocketPath string
 }
 

--- a/internal/controller/datadogagent/global/dependencies.go
+++ b/internal/controller/datadogagent/global/dependencies.go
@@ -23,34 +23,34 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
 
-func dependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers, componentName v2alpha1.ComponentName) []error {
+func createDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers, componentName v2alpha1.ComponentName) []error {
 	var errs []error
 	// Credentials
-	if err := credentialDependencies(logger, dda, manager); err != nil {
+	if err := createCredentialDependencies(logger, dda, manager); err != nil {
 		errs = append(errs, err)
 	}
 
 	// DCA token
 	if componentName == v2alpha1.ClusterAgentComponentName {
-		if err := dcaTokenDependencies(logger, dda, manager); err != nil {
+		if err := createDCATokenDependencies(logger, dda, manager); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
 	// Network policy
-	if err := networkPolicyDependencies(dda, manager, componentName); err != nil {
+	if err := createNetworkPolicyDependencies(dda, manager, componentName); err != nil {
 		errs = append(errs, err)
 	}
 
 	// Secret backend
-	if err := secretBackendDependencies(logger, dda, manager, componentName); err != nil {
+	if err := createSecretBackendDependencies(logger, dda, manager, componentName); err != nil {
 		errs = append(errs, err)
 	}
 
 	return nil
 }
 
-func credentialDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers) error {
+func createCredentialDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers) error {
 	// Prioritize existing secrets
 	// Credentials should be non-nil from validation
 	global := dda.Spec.Global
@@ -87,7 +87,7 @@ func credentialDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, mana
 	return nil
 }
 
-func dcaTokenDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers) error {
+func createDCATokenDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers) error {
 	global := dda.Spec.Global
 	var token string
 
@@ -132,7 +132,7 @@ func dcaTokenDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manage
 	return nil
 }
 
-func networkPolicyDependencies(dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers, componentName v2alpha1.ComponentName) error {
+func createNetworkPolicyDependencies(dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers, componentName v2alpha1.ComponentName) error {
 	config := dda.Spec.Global
 	if enabled, flavor := constants.IsNetworkPolicyEnabled(dda); enabled {
 		switch flavor {
@@ -159,7 +159,7 @@ func networkPolicyDependencies(dda *v2alpha1.DatadogAgent, manager feature.Resou
 	return nil
 }
 
-func secretBackendDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers, component v2alpha1.ComponentName) error {
+func createSecretBackendDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers, component v2alpha1.ComponentName) error {
 	global := dda.Spec.Global
 	if global.SecretBackend != nil {
 		var componentSaName string

--- a/internal/controller/datadogagent/global/fips.go
+++ b/internal/controller/datadogagent/global/fips.go
@@ -15,11 +15,11 @@ import (
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
-	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -55,7 +55,7 @@ func applyFIPSConfig(logger logr.Logger, manager feature.PodTemplateManagers, dd
 	// Configure FIPS container
 	fipsContainer := getFIPSProxyContainer(fipsConfig)
 
-	image := constants.GetImage(fipsConfig.Image, globalConfig.Registry)
+	image := common.GetImage(fipsConfig.Image, globalConfig.Registry)
 	fipsContainer.Image = image
 	if fipsConfig.Image.PullPolicy != nil {
 		fipsContainer.ImagePullPolicy = *fipsConfig.Image.PullPolicy

--- a/internal/controller/datadogagent/global/global.go
+++ b/internal/controller/datadogagent/global/global.go
@@ -23,7 +23,7 @@ import (
 
 // ApplyGlobalDependencies applies the global dependencies for a component.
 func ApplyGlobalDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, resourceManagers feature.ResourceManagers, componentName v2alpha1.ComponentName) []error {
-	return dependencies(logger, dda, resourceManagers, componentName)
+	return createDependencies(logger, dda, resourceManagers, componentName)
 }
 
 // ApplyGlobalSettingsClusterAgent applies the global settings for the ClusterAgent component.

--- a/pkg/constants/utils.go
+++ b/pkg/constants/utils.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
-	"github.com/DataDog/datadog-operator/pkg/defaulting"
 )
 
 // GetConfName get the name of the Configmap for a CustomConfigSpec
@@ -223,19 +222,4 @@ func GetDefaultAgentDataPlaneReadinessProbe() *corev1.Probe {
 		},
 	}
 	return readinessProbe
-}
-
-// GetImage builds the image string based on ImageConfig and the registry configuration.
-func GetImage(imageSpec *v2alpha1.AgentImageConfig, registry *string) string {
-	if defaulting.IsImageNameContainsTag(imageSpec.Name) {
-		return imageSpec.Name
-	}
-
-	img := defaulting.NewImage(imageSpec.Name, imageSpec.Tag, imageSpec.JMXEnabled)
-
-	if registry != nil && *registry != "" {
-		defaulting.WithRegistry(defaulting.ContainerRegistry(*registry))(img)
-	}
-
-	return img.String()
 }

--- a/pkg/constants/utils_test.go
+++ b/pkg/constants/utils_test.go
@@ -8,105 +8,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
-	apiutils "github.com/DataDog/datadog-operator/api/utils"
-	"github.com/DataDog/datadog-operator/pkg/defaulting"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func Test_GetImage(t *testing.T) {
-	emptyRegistry := ""
-	tests := []struct {
-		name      string
-		imageSpec *v2alpha1.AgentImageConfig
-		registry  *string
-		want      string
-	}{
-		{
-			name: "backward compatible",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name: defaulting.GetLatestAgentImage(),
-			},
-			registry: nil,
-			want:     defaulting.GetLatestAgentImage(),
-		},
-		{
-			name: "nominal case",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name: "agent",
-				Tag:  "7",
-			},
-			registry: apiutils.NewStringPointer("public.ecr.aws/datadog"),
-			want:     "public.ecr.aws/datadog/agent:7",
-		},
-		{
-			name: "prioritize the full path",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name: "docker.io/datadog/agent:7.28.1-rc.3",
-				Tag:  "latest",
-			},
-			registry: apiutils.NewStringPointer("gcr.io/datadoghq"),
-			want:     "docker.io/datadog/agent:7.28.1-rc.3",
-		},
-		{
-			name: "default registry",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name: "agent",
-				Tag:  "latest",
-			},
-			registry: &emptyRegistry,
-			want:     "gcr.io/datadoghq/agent:latest",
-		},
-		{
-			name: "add jmx",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name:       "agent",
-				Tag:        defaulting.AgentLatestVersion,
-				JMXEnabled: true,
-			},
-			registry: nil,
-			want:     defaulting.GetLatestAgentImageJMX(),
-		},
-		{
-			name: "cluster-agent",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name:       "cluster-agent",
-				Tag:        defaulting.ClusterAgentLatestVersion,
-				JMXEnabled: false,
-			},
-			registry: nil,
-			want:     defaulting.GetLatestClusterAgentImage(),
-		},
-		{
-			name: "do not duplicate jmx",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name:       "agent",
-				Tag:        "latest-jmx",
-				JMXEnabled: true,
-			},
-			registry: nil,
-			want:     "gcr.io/datadoghq/agent:latest-jmx",
-		},
-		{
-			name: "do not add jmx",
-			imageSpec: &v2alpha1.AgentImageConfig{
-				Name:       "agent",
-				Tag:        "latest-jmx",
-				JMXEnabled: true,
-			},
-			registry: nil,
-			want:     "gcr.io/datadoghq/agent:latest-jmx",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, GetImage(tt.imageSpec, tt.registry))
-		})
-	}
-}
 
 func TestServiceAccountNameOverride(t *testing.T) {
 	customServiceAccount := "fake"


### PR DESCRIPTION
### What does this PR do?

- Add `create` to dependencies function names
- move `GetImage` function from pkg/constant/utils.go to controller../common/utils.go

### Motivation

Increase intuition by adding an action to the dependencies function names, and moving a function out of the constants pkg

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
