### PR TITLE
[autoscaling] Move to v1alpha2 as only supported version for Cluster Agent 7.64+ (#1845)

### DIFF
--- a/api/datadoghq/v1alpha1/datadogpodautoscaler_types.go
+++ b/api/datadoghq/v1alpha1/datadogpodautoscaler_types.go
@@ -142,7 +142,6 @@ type DatadogPodAutoscalerPolicy struct {
 // +kubebuilder:printcolumn:name="Generated",type="date",JSONPath=".status.vertical.target.generatedAt"
 // +kubebuilder:printcolumn:name="Able to Apply",type="string",JSONPath=".status.conditions[?(@.type=='VerticalAbleToApply')].status"
 // +kubebuilder:printcolumn:name="Last Trigger",type="date",JSONPath=".status.vertical.lastAction.time"
-// +kubebuilder:storageversion
 // DatadogPodAutoscaler is the Schema for the datadogpodautoscalers API
 type DatadogPodAutoscaler struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/datadoghq/v1alpha2/datadogpodautoscaler_types.go
+++ b/api/datadoghq/v1alpha2/datadogpodautoscaler_types.go
@@ -134,6 +134,7 @@ type DatadogPodAutoscalerApplyPolicy struct {
 // +kubebuilder:printcolumn:name="Generated",type="date",JSONPath=".status.vertical.target.generatedAt"
 // +kubebuilder:printcolumn:name="Able to Apply",type="string",JSONPath=".status.conditions[?(@.type=='VerticalAbleToApply')].status"
 // +kubebuilder:printcolumn:name="Last Trigger",type="date",JSONPath=".status.vertical.lastAction.time"
+// +kubebuilder:storageversion
 // DatadogPodAutoscaler is the Schema for the datadogpodautoscalers API
 type DatadogPodAutoscaler struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -562,7 +562,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -1110,6 +1110,6 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
@@ -7,6 +7,7 @@ package orchestratorexplorer
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +24,11 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/utils"
+)
+
+const (
+	currentDatadogPodAutoscalerResource = "datadoghq.com/v1alpha2/datadogpodautoscalers"
+	oldDatadogPodAutoscalerResource     = "datadoghq.com/v1alpha1/datadogpodautoscalers"
 )
 
 func init() {
@@ -119,6 +125,26 @@ func (f *orchestratorExplorerFeature) Configure(dda *v2alpha1.DatadogAgent) (req
 			f.ddURL = *orchestratorExplorer.DDUrl
 		}
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+
+		// Handle automatic addition of OOTB resources
+		// Autoscaling: Add DPA resource if enabled and replace older versions if present
+		autoscaling := dda.Spec.Features.Autoscaling
+		if autoscaling != nil && autoscaling.Workload != nil && apiutils.BoolValue(autoscaling.Workload.Enabled) {
+			addRequired := true
+			for i := range f.customResources {
+				if f.customResources[i] == oldDatadogPodAutoscalerResource {
+					f.customResources[i] = currentDatadogPodAutoscalerResource
+					addRequired = false
+				}
+			}
+			if addRequired {
+				f.customResources = append(f.customResources, currentDatadogPodAutoscalerResource)
+			}
+		}
+
+		// Unique the custom resources as the check will output a warning if there are duplicates
+		slices.Sort(f.customResources)
+		f.customResources = slices.Compact(f.customResources)
 
 		if constants.IsClusterChecksEnabled(dda) {
 			if constants.IsCCREnabled(dda) {

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
 	mergerfake "github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger/fake"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,6 +75,36 @@ func Test_orchestratorExplorerFeature_Configure(t *testing.T) {
 			WantConfigure: true,
 			ClusterAgent:  orchestratorExplorerClusterAgentWantFuncV2(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(orchestratorExplorerNodeAgentNoProcessAgentWantFunc),
+		},
+		{
+			Name: "orchestrator explorer enabled with autoscaling and custom CRs",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithOrchestratorExplorerEnabled(true).
+				WithWorkloadAutoscalerEnabled(true).
+				WithOrchestratorExplorerCustomResources([]string{"datadoghq.com/v1alpha1/datadogpodautoscalers", "datadoghq.com/v1alpha1/watermarkpodautoscalers"}).
+				Build(),
+			WantConfigure: true,
+			WantDependenciesFunc: func(t testing.TB, sc store.StoreClient) {
+				cm, found := sc.Get(kubernetes.ConfigMapKind, "", "-orchestrator-explorer-config")
+				assert.True(t, found)
+				assert.NotNil(t, cm)
+
+				cmData := cm.(*corev1.ConfigMap).Data["orchestrator.yaml"]
+				want := `---
+cluster_check: false
+ad_identifiers:
+  - _kube_orchestrator
+init_config:
+
+instances:
+  - skip_leader_election: false
+    crd_collectors:
+      - datadoghq.com/v1alpha1/watermarkpodautoscalers
+      - datadoghq.com/v1alpha2/datadogpodautoscalers
+`
+
+				assert.Equal(t, want, cmData)
+			},
 		},
 		{
 			Name: "orchestrator explorer enabled and runs on cluster checks runner",

--- a/pkg/testutils/builder.go
+++ b/pkg/testutils/builder.go
@@ -179,6 +179,16 @@ func (builder *DatadogAgentBuilder) WithProcessChecksInCoreAgent(enabled bool) *
 	return builder
 }
 
+func (builder *DatadogAgentBuilder) WithWorkloadAutoscalerEnabled(enabled bool) *DatadogAgentBuilder {
+	builder.datadogAgent.Spec.Features.Autoscaling = &v2alpha1.AutoscalingFeatureConfig{
+		Workload: &v2alpha1.WorkloadAutoscalingFeatureConfig{
+			Enabled: apiutils.NewBoolPointer(enabled),
+		},
+	}
+
+	return builder
+}
+
 // Admission Controller
 func (builder *DatadogAgentBuilder) initAdmissionController() {
 	if builder.datadogAgent.Spec.Features.AdmissionController == nil {
@@ -392,8 +402,7 @@ func (builder *DatadogAgentBuilder) WithOTelCollectorEnabled(enabled bool) *Data
 
 func (builder *DatadogAgentBuilder) WithOTelCollectorConfig() *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Features.OtelCollector.Conf = &v2alpha1.CustomConfig{}
-	builder.datadogAgent.Spec.Features.OtelCollector.Conf.ConfigData =
-		apiutils.NewStringPointer(defaultconfig.DefaultOtelCollectorConfig)
+	builder.datadogAgent.Spec.Features.OtelCollector.Conf.ConfigData = apiutils.NewStringPointer(defaultconfig.DefaultOtelCollectorConfig)
 	return builder
 }
 
@@ -579,6 +588,12 @@ func (builder *DatadogAgentBuilder) WithOrchestratorExplorerCustomConfigData(cus
 	builder.datadogAgent.Spec.Features.OrchestratorExplorer.Conf = &v2alpha1.CustomConfig{
 		ConfigData: &customConfigData,
 	}
+	return builder
+}
+
+func (builder *DatadogAgentBuilder) WithOrchestratorExplorerCustomResources(customResources []string) *DatadogAgentBuilder {
+	builder.initOE()
+	builder.datadogAgent.Spec.Features.OrchestratorExplorer.CustomResources = customResources
 	return builder
 }
 


### PR DESCRIPTION
### What does this PR do?

cherry-pick  #1845

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
