### PR TITLE
SLO deletion, ignore 404 error in finalizer

### DIFF
--- a/internal/controller/datadogslo/slo.go
+++ b/internal/controller/datadogslo/slo.go
@@ -115,15 +115,15 @@ func updateSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi
 	return sloListResponse, nil
 }
 
-func deleteSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi, sloID string) error {
+func deleteSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi, sloID string) (int, error) {
 	force := "false"
 	optionalParams := datadogV1.DeleteSLOOptionalParameters{
 		Force: &force,
 	}
-	if _, _, err := client.DeleteSLO(auth, sloID, optionalParams); err != nil {
-		return translateClientError(err, "error deleting SLO")
+	if _, localVarHTTPResponse, err := client.DeleteSLO(auth, sloID, optionalParams); err != nil {
+		return localVarHTTPResponse.StatusCode, translateClientError(err, "error deleting SLO")
 	}
-	return nil
+	return 200, nil
 }
 
 func translateClientError(err error, msg string) error {

--- a/internal/controller/datadogslo/slo.go
+++ b/internal/controller/datadogslo/slo.go
@@ -120,10 +120,11 @@ func deleteSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi
 	optionalParams := datadogV1.DeleteSLOOptionalParameters{
 		Force: &force,
 	}
-	if _, localVarHTTPResponse, err := client.DeleteSLO(auth, sloID, optionalParams); err != nil {
+	_, localVarHTTPResponse, err := client.DeleteSLO(auth, sloID, optionalParams)
+	if err != nil {
 		return localVarHTTPResponse.StatusCode, translateClientError(err, "error deleting SLO")
 	}
-	return 200, nil
+	return localVarHTTPResponse.StatusCode, nil
 }
 
 func translateClientError(err error, msg string) error {


### PR DESCRIPTION
### What does this PR do?

CECO-2151/CONS-7192

In SLO finalizer we try to reconcile if Datadog API call to delete SLO resource fails, regardless of the failure. Which means - in a simple scenario where users first deletes SLO in UI and then deletes SLO customer resource leads to finalizer failures and customer resource never getting cleaned up. Current workaround is removing finalizer from the resource.

The change handles 404 Not Found http error code and lets controller finalizer resource.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Deploy Operator with configured API, APP key and SLOs enabled.
1. Apply sample SLO custom resource.
1. In the Datadog app delete create SLO.
1. Delete SLO resource in the cluster.
1. Confirm SLO resource getting cleaned up.

In 1.14 and earlier, resource isn't getting cleaned up instead controller tries to reconcile the resource with backoff.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
