### PR TITLE
[tooling] Add milestone to automated backport PR 

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -47,7 +47,7 @@ jobs:
           echo "PR_NUMBER=$PR_NUM" >> $GITHUB_ENV
 
       - name: Copy milestone to backport PR
-        uses: actions/github-script@v6
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         env:
           PR_NUMBER: ${{ env.PR_NUMBER }}
         with:

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -16,13 +16,18 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
+    env:
+      BRANCH_NAME: ${{ replace(github.event.label.name, 'backport/', '') }}
     steps:
-      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
+      - name: Create app token
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         id: app-token
         with:
           app-id: ${{ secrets.DD_GITHUBOPS_TOKEN_APP_ID }}
           private-key: ${{ secrets.DD_GITHUBOPS_TOKEN_PRIVATE_KEY }}
-      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
+      - name: Create backport PR
+        uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           label_pattern: "^backport/(?<base>([^ ]+))$" 
           labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
@@ -34,3 +39,28 @@ jobs:
             ___
 
             <%- body %>
+      
+      - name: Parse backport PR number
+        run: |
+          echo "CREATED=${{ steps.backport.outputs.created_pull_requests }}" >> $GITHUB_ENV
+          PR_NUM=$(echo "$CREATED" | jq -r ".\"${BRANCH_NAME}\"")
+          echo "PR_NUMBER=$PR_NUM" >> $GITHUB_ENV
+
+      - name: Copy milestone to backport PR
+        uses: actions/github-script@v6
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const orig = context.payload.pull_request;
+            if (!orig.milestone) {
+              console.log('No milestone to copy.');
+              return;
+            }
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.PR_NUMBER, 10)
+              milestone: orig.milestone.number
+            });


### PR DESCRIPTION
### What does this PR do?

* copies the milestone from the PR where the backport PR workflow is triggered and applies it to the backport PR

### Motivation

* backport PR fails the milestone check and we have to manually add it. If we add this, no other work is needed to create a backport other than adding a label. 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Test by adding the backport/1.14 label to this PR after it is merged, verify that the resulting cherry-pick PR has the right milestone.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
