### PR TITLE
[backport 1.14] Add flag to configure SlowStartAdditiveIncrease

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -114,6 +114,7 @@ type options struct {
 	edsCanaryAutoFailEnabled               bool
 	edsCanaryAutoFailMaxRestarts           int
 	edsCanaryAutoPauseMaxSlowStartDuration time.Duration
+	edsSlowStartAdditiveIncrease           string
 	supportCilium                          bool
 	datadogAgentEnabled                    bool
 	datadogMonitorEnabled                  bool
@@ -164,6 +165,7 @@ func (opts *options) Parse() {
 	// ExtendedDaemonset configuration
 	flag.BoolVar(&opts.supportExtendedDaemonset, "supportExtendedDaemonset", false, "Support usage of Datadog ExtendedDaemonset CRD.")
 	flag.StringVar(&opts.edsMaxPodUnavailable, "edsMaxPodUnavailable", "", "ExtendedDaemonset number of max unavailable pods during the rolling update")
+	flag.StringVar(&opts.edsSlowStartAdditiveIncrease, "edsSlowStartAdditiveIncrease", "", "ExtendedDaemonset slow start additive increase")
 	flag.StringVar(&opts.edsMaxPodSchedulerFailure, "edsMaxPodSchedulerFailure", "", "ExtendedDaemonset number of max pod scheduler failures")
 	flag.DurationVar(&opts.edsCanaryDuration, "edsCanaryDuration", 10*time.Minute, "ExtendedDaemonset canary duration")
 	flag.StringVar(&opts.edsCanaryReplicas, "edsCanaryReplicas", "", "ExtendedDaemonset number of canary pods")
@@ -295,6 +297,7 @@ func run(opts *options) error {
 		SupportExtendedDaemonset: controller.ExtendedDaemonsetOptions{
 			Enabled:                             opts.supportExtendedDaemonset,
 			MaxPodUnavailable:                   opts.edsMaxPodUnavailable,
+			SlowStartAdditiveIncrease:           opts.edsSlowStartAdditiveIncrease,
 			CanaryDuration:                      opts.edsCanaryDuration,
 			CanaryReplicas:                      opts.edsCanaryReplicas,
 			CanaryAutoPauseEnabled:              opts.edsCanaryAutoPauseEnabled,

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -53,9 +53,10 @@ type SetupOptions struct {
 
 // ExtendedDaemonsetOptions defines ExtendedDaemonset options
 type ExtendedDaemonsetOptions struct {
-	Enabled                bool
-	MaxPodUnavailable      string
-	MaxPodSchedulerFailure string
+	Enabled                   bool
+	MaxPodUnavailable         string
+	MaxPodSchedulerFailure    string
+	SlowStartAdditiveIncrease string
 
 	CanaryDuration                      time.Duration
 	CanaryReplicas                      string


### PR DESCRIPTION
### What does this PR do?

Backport https://github.com/DataDog/datadog-operator/pull/1857

### Motivation



### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
