### PR TITLE
CAP-2265 Refactor Orchestrator Explorer ConfigMap Generation and Mounting Logic

### DIFF
--- a/internal/controller/datadogagent/controller.go
+++ b/internal/controller/datadogagent/controller.go
@@ -104,10 +104,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return resp, err
 }
 
-func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logger) *feature.Options {
+func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logger, client client.Client) *feature.Options {
 	return &feature.Options{
 		SupportExtendedDaemonset: opts.ExtendedDaemonsetOptions.Enabled,
 		Logger:                   logger,
+		K8sClient:                client,
 	}
 }
 

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -99,7 +99,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	var result reconcile.Result
 	newStatus := instance.Status.DeepCopy()
 	now := metav1.NewTime(time.Now())
-	features, requiredComponents := feature.BuildFeatures(instance, reconcilerOptionsToFeatureOptions(&r.options, logger))
+	features, requiredComponents := feature.BuildFeatures(instance, reconcilerOptionsToFeatureOptions(&r.options, logger, r.client))
 	// update list of enabled features for metrics forwarder
 	r.updateMetricsForwardersFeatures(instance, features)
 

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/configmap.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/configmap.go
@@ -6,25 +6,58 @@
 package orchestratorexplorer
 
 import (
+	"context"
 	"fmt"
+	"sort"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
+// buildOrchestratorExplorerConfigMap constructs the ConfigMap for the orchestrator explorer.
+//
+// When remote config is disabled:
+//   - If a custom ConfigMap is provided, no new ConfigMap is created.
+//   - If custom config data is provided, a new ConfigMap is created using the parsed data.
+//   - If no custom config is provided, a new ConfigMap is created using the default config.
+//
+// When remote config is enabled:
+//   - If a custom ConfigMap is provided, a new ConfigMap is created by merging it with remote resources.
+//     The generated ConfigMap will be used by the Cluster Agent.
+//   - If custom config data is provided, a new ConfigMap is created by merging the data with remote resources.
+//   - If no custom config is provided, a new ConfigMap is created using the default config merged with remote resources.
 func (f *orchestratorExplorerFeature) buildOrchestratorExplorerConfigMap() (*corev1.ConfigMap, error) {
-	if f.customConfig != nil && f.customConfig.ConfigMap != nil {
-		return nil, nil
-	}
-	if f.customConfig != nil && f.customConfig.ConfigData != nil {
-		return configmap.BuildConfigMapConfigData(f.owner.GetNamespace(), f.customConfig.ConfigData, f.configConfigMapName, orchestratorExplorerConfFileName)
-	}
+	switch {
+	case f.customConfig != nil && f.customConfig.ConfigMap != nil:
+		cm, err := f.buildConfigMapWithCustomConfig()
+		if err != nil {
+			f.logger.Error(err, "Unable to build ConfigMap from custom ConfigMap; using default.")
+		}
+		return cm, nil
 
-	configMap := buildDefaultConfigMap(f.owner.GetNamespace(), f.configConfigMapName, orchestratorExplorerCheckConfig(f.runInClusterChecksRunner, f.customResources))
-	return configMap, nil
+	case f.customConfig != nil && f.customConfig.ConfigData != nil:
+		cm, err := f.buildConfigMapWithConfigData()
+		if err != nil && cm == nil {
+			return nil, err // Fatal: failed to parse config data
+		}
+		if err != nil {
+			f.logger.Error(err, "Unable to build ConfigMap from custom config data; using default.")
+		}
+		return cm, nil
+
+	default:
+		return buildDefaultConfigMap(
+			f.owner.GetNamespace(),
+			f.configConfigMapName,
+			orchestratorExplorerCheckConfig(f.runInClusterChecksRunner, f.customResources),
+		), nil
+	}
 }
 
 func buildDefaultConfigMap(namespace, cmName string, content string) *corev1.ConfigMap {
@@ -60,4 +93,190 @@ instances:
 	}
 
 	return config
+}
+
+// getConfigConfigMapName returns the name of the ConfigMap to use for the orchestrator explorer.
+//
+// - By default, if a custom config is provided, its ConfigMap name is used.
+// - If remote config is enabled:
+//   - The default ConfigMap name is used instead.
+//   - If the custom ConfigMap name conflicts with the default name, a "-rc" suffix will be added to avoid naming collisions.
+func (f *orchestratorExplorerFeature) getConfigConfigMapName() string {
+	name := constants.GetConfName(f.owner, f.customConfig, defaultOrchestratorExplorerConf)
+
+	if f.remoteConfigEnabled {
+		name = constants.GetConfName(f.owner, nil, defaultOrchestratorExplorerConf)
+		if f.customConfig != nil && f.customConfig.ConfigMap != nil &&
+			name == f.customConfig.ConfigMap.Name {
+			name = fmt.Sprintf("%s-rc", name)
+		}
+	}
+
+	return name
+}
+
+// buildConfigMapWithConfigData creates a ConfigMap from the provided custom config data.
+// Merges remote resources if remote config is enabled.
+func (f *orchestratorExplorerFeature) buildConfigMapWithConfigData() (*corev1.ConfigMap, error) {
+	ns := f.owner.GetNamespace()
+
+	cm, err := configmap.BuildConfigMapConfigData(ns, f.customConfig.ConfigData, f.configConfigMapName, orchestratorExplorerConfFileName)
+	if err != nil || !f.remoteConfigEnabled {
+		return cm, err
+	}
+
+	merged, err := addCRToConfig(*f.customConfig.ConfigData, f.customResources)
+	if err != nil {
+		return cm, err
+	}
+
+	return configmap.BuildConfigMapConfigData(ns, &merged, f.configConfigMapName, orchestratorExplorerConfFileName)
+}
+
+// buildConfigMapWithCustomConfig creates a new ConfigMap by merging a user-provided custom ConfigMap
+// with custom resources fetched from remote config.
+//
+// - If remote config is disabled, no new ConfigMap is created.
+// - If the provided custom ConfigMap is invalid, a default ConfigMap is used instead.
+// - If the custom ConfigMap is valid, a new ConfigMap is returned with the custom resources injected into the last entry.
+func (f *orchestratorExplorerFeature) buildConfigMapWithCustomConfig() (*corev1.ConfigMap, error) {
+	if !f.remoteConfigEnabled {
+		return nil, nil
+	}
+
+	ns := f.owner.GetNamespace()
+	defaultCM := buildDefaultConfigMap(ns, f.configConfigMapName, orchestratorExplorerCheckConfig(f.runInClusterChecksRunner, f.customResources))
+
+	configs, instances, err := getAndValidateCustomConfig(f.k8sClient, ns, f.customConfig.ConfigMap.Name, f.runInClusterChecksRunner)
+	if err != nil {
+		return defaultCM, fmt.Errorf("unable to validate custom ConfigMap: %w", err)
+	}
+
+	lastFile := getLastKey(configs)
+	merged, err := addCRToConfig(configs[lastFile], getUniqueCustomResources(f.customResources, instances))
+	if err != nil {
+		return defaultCM, err
+	}
+	configs[lastFile] = merged
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f.configConfigMapName,
+			Namespace: ns,
+		},
+		Data: configs,
+	}, nil
+}
+
+type orchestratorInstance struct {
+	LeaderSkip              bool     `json:"skip_leader_election,omitempty"`
+	Collectors              []string `json:"collectors,omitempty"`
+	CRDCollectors           []string `json:"crd_collectors,omitempty"`
+	ExtraSyncTimeoutSeconds int      `json:"extra_sync_timeout_seconds,omitempty"`
+}
+
+// getAndValidateCustomConfig fetches and validates the user-provided ConfigMap.
+// Parses its entries into orchestrator instances.
+func getAndValidateCustomConfig(k8sClient client.Client, namespace, cmName string, clusterCheckRunners bool) (map[string]string, []orchestratorInstance, error) {
+	cm := &corev1.ConfigMap{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: cmName, Namespace: namespace}, cm)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ConfigMap %q not found in namespace %q", cmName, namespace)
+	}
+
+	if len(cm.Data) == 0 {
+		return nil, nil, fmt.Errorf("ConfigMap %q is empty", cmName)
+	}
+	if !clusterCheckRunners && len(cm.Data) != 1 {
+		return nil, nil, fmt.Errorf("ConfigMap %q must contain exactly one entry if cluster checks are disabled", cmName)
+	}
+
+	instances := make([]orchestratorInstance, 0, len(cm.Data))
+	for _, content := range cm.Data {
+		_, inst, err := parseConfig(content)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse config: %w", err)
+		}
+		instances = append(instances, inst)
+	}
+
+	return cm.Data, instances, nil
+}
+
+// getUniqueCustomResources filters out CRDs already present in the provided config instances.
+func getUniqueCustomResources(customResources []string, instances []orchestratorInstance) []string {
+	seen := map[string]struct{}{}
+	for _, inst := range instances {
+		for _, cr := range inst.CRDCollectors {
+			seen[cr] = struct{}{}
+		}
+	}
+
+	var unique []string
+	for _, cr := range customResources {
+		if _, found := seen[cr]; !found {
+			unique = append(unique, cr)
+		}
+	}
+	return unique
+}
+
+// parseConfig unmarshals a single orchestrator instance from the given config content.
+func parseConfig(content string) (map[string]interface{}, orchestratorInstance, error) {
+	var config map[string]interface{}
+	if err := yaml.Unmarshal([]byte(content), &config); err != nil {
+		return nil, orchestratorInstance{}, err
+	}
+
+	rawInstances, ok := config["instances"]
+	if !ok {
+		return nil, orchestratorInstance{}, fmt.Errorf("missing 'instances' section")
+	}
+
+	instList, ok := rawInstances.([]interface{})
+	if !ok || len(instList) != 1 {
+		return nil, orchestratorInstance{}, fmt.Errorf("'instances' must contain exactly one entry")
+	}
+
+	instData, err := yaml.Marshal(instList[0])
+	if err != nil {
+		return nil, orchestratorInstance{}, err
+	}
+
+	var instance orchestratorInstance
+	if err := yaml.Unmarshal(instData, &instance); err != nil {
+		return nil, orchestratorInstance{}, err
+	}
+
+	return config, instance, nil
+}
+
+// addCRToConfig merges custom resources into the orchestrator config.
+func addCRToConfig(content string, crs []string) (string, error) {
+	config, instance, err := parseConfig(content)
+	if err != nil {
+		return content, fmt.Errorf("unable to parse config: %w", err)
+	}
+
+	instance.CRDCollectors = append(instance.CRDCollectors, crs...)
+	config["instances"] = []interface{}{instance}
+
+	output, err := yaml.Marshal(config)
+	if err != nil {
+		return content, fmt.Errorf("unable to marshal config: %w", err)
+	}
+	return string(output), nil
+}
+
+// getLastKey returns the last key from a sorted map.
+func getLastKey(data map[string]string) string {
+	if len(data) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys[len(keys)-1]
 }

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/configmap_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/configmap_test.go
@@ -6,98 +6,211 @@
 package orchestratorexplorer
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
 )
 
-func Test_orchestratorExplorerFeature_buildOrchestratorExplorerConfigMap(t *testing.T) {
-	owner := &metav1.ObjectMeta{
-		Name:      "test",
-		Namespace: "foo",
-	}
-	overrideConf := `cluster_check: true
+func Test_buildOrchestratorExplorerConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	defaultConfig := `---
+cluster_check: false
+ad_identifiers:
+  - _kube_orchestrator
+init_config:
+
+instances:
+  - skip_leader_election: false
+`
+
+	customConfigData := `cluster_check: true
 init_config:
 instances:
   - collectors:
       - nodes
-      - services
-`
-	crs := []string{"datadoghq.com/v1alpha1/datadogmetrics", "datadoghq.com/v1alpha1/watermarkpodautoscalers"}
-	type fields struct {
-		enable                   bool
-		runInClusterChecksRunner bool
-		rbacSuffix               string
-		serviceAccountName       string
-		owner                    metav1.Object
-		customConfig             *v2alpha1.CustomConfig
-		configConfigMapName      string
-		crCollection             []string
-	}
+      - services`
+
 	tests := []struct {
-		name    string
-		fields  fields
-		want    *corev1.ConfigMap
-		wantErr bool
+		name              string
+		feature           *orchestratorExplorerFeature
+		wantErr           bool
+		wantConfigMapName string
+		wantConfigData    string
+		preloadCM         bool
 	}{
 		{
-			name: "default",
-			fields: fields{
-				owner:                    owner,
-				enable:                   true,
-				runInClusterChecksRunner: false,
-				configConfigMapName:      defaultOrchestratorExplorerConf,
+			name: "default case - no custom config",
+			feature: &orchestratorExplorerFeature{
+				owner: &metav1.ObjectMeta{
+					Name:      "test-agent",
+					Namespace: "test-ns",
+				},
+				configConfigMapName: "test-agent-orchestrator-explorer-config",
+				customConfig:        nil,
+				customResources:     nil,
 			},
-			want: buildDefaultConfigMap(owner.GetNamespace(), defaultOrchestratorExplorerConf, orchestratorExplorerCheckConfig(false, []string{})),
+			wantErr:           false,
+			wantConfigMapName: "test-agent-orchestrator-explorer-config",
+			wantConfigData:    defaultConfig,
 		},
 		{
-			name: "override",
-			fields: fields{
-				owner:                    owner,
-				enable:                   true,
-				runInClusterChecksRunner: true,
-				configConfigMapName:      defaultOrchestratorExplorerConf,
+			name: "custom config data provided",
+			feature: &orchestratorExplorerFeature{
+				owner: &metav1.ObjectMeta{
+					Name:      "test-agent",
+					Namespace: "test-ns",
+				},
+				configConfigMapName: "test-agent-orchestrator-explorer-config",
 				customConfig: &v2alpha1.CustomConfig{
-					ConfigData: &overrideConf,
+					ConfigData: &customConfigData,
+				},
+				customResources:     []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+				remoteConfigEnabled: true,
+			},
+			wantErr:           false,
+			wantConfigMapName: "test-agent-orchestrator-explorer-config",
+			wantConfigData: `cluster_check: true
+init_config: null
+instances:
+- collectors:
+  - nodes
+  - services
+  crd_collectors:
+  - datadoghq.com/v1alpha1/datadogmetrics
+`,
+		},
+		{
+			name: "custom ConfigMap provided with remote config disabled",
+			feature: &orchestratorExplorerFeature{
+				owner: &metav1.ObjectMeta{
+					Name:      "test-agent",
+					Namespace: "test-ns",
+				},
+				configConfigMapName: "test-agent-orchestrator-explorer-config",
+				customConfig: &v2alpha1.CustomConfig{
+					ConfigMap: &v2alpha1.ConfigMapConfig{
+						Name: "custom-cm",
+					},
+				},
+				remoteConfigEnabled: false,
+			},
+			wantErr:           false,
+			wantConfigMapName: "",
+			wantConfigData:    "",
+		},
+		{
+			name: "custom ConfigMap provided with remote config enabled",
+			feature: &orchestratorExplorerFeature{
+				owner: &metav1.ObjectMeta{
+					Name:      "test-agent",
+					Namespace: "test-ns",
+				},
+				k8sClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+					&corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "custom-cm",
+							Namespace: "test-ns",
+						},
+						Data: map[string]string{
+							"orchestrator.yaml": customConfigData,
+						},
+					},
+				).Build(),
+				configConfigMapName: "test-agent-orchestrator-explorer-config",
+				customConfig: &v2alpha1.CustomConfig{
+					ConfigMap: &v2alpha1.ConfigMapConfig{
+						Name: "custom-cm",
+					},
+				},
+				customResources:     []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+				remoteConfigEnabled: true,
+			},
+			wantErr:           false,
+			wantConfigMapName: "test-agent-orchestrator-explorer-config",
+			wantConfigData: `cluster_check: true
+init_config: null
+instances:
+- collectors:
+  - nodes
+  - services
+  crd_collectors:
+  - datadoghq.com/v1alpha1/datadogmetrics
+`,
+		},
+		{
+			name: "invalid custom config data",
+			feature: &orchestratorExplorerFeature{
+				owner: &metav1.ObjectMeta{
+					Name:      "test-agent",
+					Namespace: "test-ns",
+				},
+				configConfigMapName: "test-agent-orchestrator-explorer-config",
+				customConfig: &v2alpha1.CustomConfig{
+					ConfigData: apiutils.NewStringPointer("invalid: :\nyaml: content"),
 				},
 			},
-			want: buildDefaultConfigMap(owner.GetNamespace(), defaultOrchestratorExplorerConf, overrideConf),
-		}, {
-			name: "default config with crs",
-			fields: fields{
-				owner:                    owner,
-				enable:                   true,
-				runInClusterChecksRunner: false,
-				configConfigMapName:      defaultOrchestratorExplorerConf,
-				crCollection:             crs,
+			wantErr: true,
+		},
+		{
+			name: "custom ConfigMap not found",
+			feature: &orchestratorExplorerFeature{
+				owner: &metav1.ObjectMeta{
+					Name:      "test-agent",
+					Namespace: "test-ns",
+				},
+				k8sClient:           fake.NewClientBuilder().WithScheme(scheme).Build(),
+				configConfigMapName: "test-agent-orchestrator-explorer-config",
+				customConfig: &v2alpha1.CustomConfig{
+					ConfigMap: &v2alpha1.ConfigMapConfig{
+						Name: "nonexistent-cm",
+					},
+				},
+				remoteConfigEnabled: true,
 			},
-			want: buildDefaultConfigMap(owner.GetNamespace(), defaultOrchestratorExplorerConf, orchestratorExplorerCheckConfig(false, crs)),
+			wantErr:           false,
+			wantConfigMapName: "test-agent-orchestrator-explorer-config",
+			wantConfigData:    defaultConfig,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &orchestratorExplorerFeature{
-				runInClusterChecksRunner: tt.fields.runInClusterChecksRunner,
-				rbacSuffix:               tt.fields.rbacSuffix,
-				serviceAccountName:       tt.fields.serviceAccountName,
-				owner:                    tt.fields.owner,
-				customConfig:             tt.fields.customConfig,
-				configConfigMapName:      tt.fields.configConfigMapName,
-				customResources:          tt.fields.crCollection,
-			}
-			got, err := f.buildOrchestratorExplorerConfigMap()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("orchestratorExplorerFeature.buildOrchestratorExplorerConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+			// Set up logger
+			tt.feature.logger = logr.Discard()
+
+			// Call the function
+			cm, err := tt.feature.buildOrchestratorExplorerConfigMap()
+
+			if tt.wantErr {
+				require.Error(t, err)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("orchestratorExplorerFeature.buildOrchestratorExplorerConfigMap() = %#v,\nwant %#v", got, tt.want)
+
+			require.NoError(t, err)
+
+			if tt.wantConfigMapName == "" {
+				require.Nil(t, cm)
+				return
+			}
+
+			require.NotNil(t, cm)
+			require.Equal(t, tt.wantConfigMapName, cm.Name)
+			require.Equal(t, tt.feature.owner.GetNamespace(), cm.Namespace)
+
+			if tt.wantConfigData != "" {
+				require.Contains(t, cm.Data, orchestratorExplorerConfFileName)
+				require.Equal(t, tt.wantConfigData, cm.Data[orchestratorExplorerConfFileName])
 			}
 		})
 	}
@@ -120,4 +233,647 @@ instances:
       - datadoghq.com/v1alpha1/watermarkpodautoscalers
 `
 	require.Equal(t, want, got)
+}
+
+func Test_buildConfigMapWithConfigData(t *testing.T) {
+	ns := "test-ns"
+	defaultConfig := `cluster_check: true
+init_config:
+instances:
+  - collectors:
+      - nodes
+`
+	invalidConfig := `init_config:`
+
+	crs := []string{"datadoghq.com/v1alpha1/mycr"}
+
+	tests := []struct {
+		name           string
+		customConfig   *string
+		remoteEnabled  bool
+		expectErr      bool
+		expectCRMerged bool
+	}{
+		{
+			name:           "Remote config enabled - CRs should be merged",
+			customConfig:   &defaultConfig,
+			remoteEnabled:  true,
+			expectErr:      false,
+			expectCRMerged: true,
+		},
+		{
+			name:           "Remote config disabled - returns original config",
+			customConfig:   &defaultConfig,
+			remoteEnabled:  false,
+			expectErr:      false,
+			expectCRMerged: false,
+		},
+		{
+			name:          "Invalid config - should return error",
+			customConfig:  &invalidConfig,
+			remoteEnabled: true,
+			expectErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &orchestratorExplorerFeature{
+				owner: &metav1.ObjectMeta{
+					Namespace: ns,
+				},
+				customConfig: &v2alpha1.CustomConfig{
+					ConfigData: tt.customConfig,
+				},
+				configConfigMapName: "orchestrator-config",
+				customResources:     crs,
+				remoteConfigEnabled: tt.remoteEnabled,
+			}
+
+			cm, err := f.buildConfigMapWithConfigData()
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, cm)
+			require.Contains(t, cm.Data, orchestratorExplorerConfFileName)
+
+			content := cm.Data[orchestratorExplorerConfFileName]
+
+			if tt.expectCRMerged {
+				for _, cr := range crs {
+					require.Contains(t, content, cr, "Expected CR %q to be merged into config", cr)
+				}
+			} else {
+				for _, cr := range crs {
+					require.NotContains(t, content, cr, "Did not expect CR %q to be merged", cr)
+				}
+			}
+		})
+	}
+}
+
+func Test_buildConfigMapWithCustomConfig(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	type fields struct {
+		remoteEnabled bool
+		configData    map[string]string
+		customCRs     []string
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		expectNil   bool
+		expectErr   bool
+		preloadCM   bool
+		cmName      string
+		expectedCRs []string
+	}{
+		{
+			name: "Remote config disabled",
+			fields: fields{
+				remoteEnabled: false,
+			},
+			expectNil: true,
+			expectErr: false,
+		},
+		{
+			name: "Missing custom ConfigMap",
+			fields: fields{
+				remoteEnabled: true,
+			},
+			cmName:    "nonexistent",
+			expectErr: true,
+		},
+		{
+			name: "Invalid YAML in custom ConfigMap",
+			fields: fields{
+				remoteEnabled: true,
+				configData: map[string]string{
+					"orchestrator.yaml": "bad_yaml: :",
+				},
+			},
+			preloadCM: true,
+			expectErr: true,
+		},
+		{
+			name: "Valid config, new CRs added",
+			fields: fields{
+				remoteEnabled: true,
+				configData: map[string]string{
+					"orchestrator.yaml": `cluster_check: true
+init_config:
+instances:
+  - collectors:
+      - nodes
+`,
+				},
+				customCRs: []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+			},
+			preloadCM:   true,
+			expectedCRs: []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+		},
+		{
+			name: "CRs already present, no change",
+			fields: fields{
+				remoteEnabled: true,
+				configData: map[string]string{
+					"orchestrator.yaml": `cluster_check: true
+init_config:
+instances:
+  - collectors:
+      - nodes
+    crd_collectors:
+      - datadoghq.com/v1alpha1/datadogmetrics
+`,
+				},
+				customCRs: []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+			},
+			preloadCM:   true,
+			expectedCRs: []string{"datadoghq.com/v1alpha1/datadogmetrics"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := "test-ns"
+			cmName := tt.cmName
+			if cmName == "" {
+				cmName = "user-cm"
+			}
+
+			var objs []client.Object
+			if tt.preloadCM {
+				objs = append(objs, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cmName,
+						Namespace: ns,
+					},
+					Data: tt.fields.configData,
+				})
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+			f := &orchestratorExplorerFeature{
+				k8sClient:                k8sClient,
+				configConfigMapName:      "generated",
+				remoteConfigEnabled:      tt.fields.remoteEnabled,
+				customResources:          tt.fields.customCRs,
+				runInClusterChecksRunner: true,
+				customConfig: &v2alpha1.CustomConfig{
+					ConfigMap: &v2alpha1.ConfigMapConfig{
+						Name: cmName,
+					},
+				},
+				owner: &metav1.ObjectMeta{
+					Namespace: ns,
+				},
+			}
+
+			cm, err := f.buildConfigMapWithCustomConfig()
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.expectNil {
+				require.Nil(t, cm)
+				return
+			}
+
+			require.NotNil(t, cm)
+			merged := cm.Data["orchestrator.yaml"]
+			for _, cr := range tt.expectedCRs {
+				require.Contains(t, merged, cr)
+			}
+		})
+	}
+}
+
+func Test_getAndValidateCustomConfig(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	namespace := "default"
+	cmName := "test-configmap"
+
+	validConfig := `cluster_check: true
+init_config:
+instances:
+  - collectors:
+      - nodes
+`
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cmName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"orchestrator.yaml": validConfig,
+		},
+	}
+
+	tests := []struct {
+		name                string
+		clientObjs          []client.Object
+		clusterCheckEnabled bool
+		expectErr           bool
+		expectedInstCount   int
+	}{
+		{
+			name:                "valid single-entry configmap with cluster checks off",
+			clientObjs:          []client.Object{cm},
+			clusterCheckEnabled: false,
+			expectErr:           false,
+			expectedInstCount:   1,
+		},
+		{
+			name:                "valid single-entry configmap with cluster checks on",
+			clientObjs:          []client.Object{cm},
+			clusterCheckEnabled: true,
+			expectErr:           false,
+			expectedInstCount:   1,
+		},
+		{
+			name:                "configmap missing",
+			clientObjs:          []client.Object{}, // no CM provided
+			clusterCheckEnabled: false,
+			expectErr:           true,
+		},
+		{
+			name: "empty configmap",
+			clientObjs: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+				},
+			},
+			clusterCheckEnabled: false,
+			expectErr:           true,
+		},
+		{
+			name: "multi-entry configmap with cluster checks off (invalid)",
+			clientObjs: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+					Data: map[string]string{
+						"file1.yaml": validConfig,
+						"file2.yaml": validConfig,
+					},
+				},
+			},
+			clusterCheckEnabled: false,
+			expectErr:           true,
+		},
+		{
+			name: "multi-entry configmap with cluster checks on (valid)",
+			clientObjs: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: namespace},
+					Data: map[string]string{
+						"file1.yaml": validConfig,
+						"file2.yaml": validConfig,
+					},
+				},
+			},
+			clusterCheckEnabled: true,
+			expectErr:           false,
+			expectedInstCount:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.clientObjs...).
+				Build()
+
+			data, instances, err := getAndValidateCustomConfig(fakeClient, namespace, cmName, tt.clusterCheckEnabled)
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedInstCount, len(instances))
+				require.Equal(t, tt.expectedInstCount, len(data))
+			}
+		})
+	}
+}
+
+func Test_getUniqueCustomResources(t *testing.T) {
+	tests := []struct {
+		name            string
+		customResources []string
+		instances       []orchestratorInstance
+		expected        []string
+	}{
+		{
+			name:            "no instances, return all customResources",
+			customResources: []string{"a", "b", "c"},
+			instances:       nil,
+			expected:        []string{"a", "b", "c"},
+		},
+		{
+			name:            "all CRDs already present in instances",
+			customResources: []string{"a", "b"},
+			instances: []orchestratorInstance{
+				{CRDCollectors: []string{"a", "b"}},
+			},
+			expected: []string{},
+		},
+		{
+			name:            "some CRDs are new",
+			customResources: []string{"a", "b", "c"},
+			instances: []orchestratorInstance{
+				{CRDCollectors: []string{"a"}},
+			},
+			expected: []string{"b", "c"},
+		},
+		{
+			name:            "no CRDs provided",
+			customResources: []string{},
+			instances: []orchestratorInstance{
+				{CRDCollectors: []string{"a"}},
+			},
+			expected: []string{},
+		},
+		{
+			name:            "multiple instances with overlapping CRDs",
+			customResources: []string{"x", "y", "z"},
+			instances: []orchestratorInstance{
+				{CRDCollectors: []string{"x"}},
+				{CRDCollectors: []string{"y"}},
+			},
+			expected: []string{"z"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getUniqueCustomResources(tt.customResources, tt.instances)
+			require.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_addCRToConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		crs       []string
+		want      string
+		expectErr bool
+	}{
+		{
+			name: "valid config with collectors",
+			input: `cluster_check: true
+init_config:
+instances:
+  - collectors:
+      - nodes
+      - services
+`,
+			crs: []string{
+				"datadoghq.com/v1alpha1/datadogmetrics",
+				"datadoghq.com/v1alpha1/watermarkpodautoscalers",
+			},
+			want: `cluster_check: true
+init_config: null
+instances:
+- collectors:
+  - nodes
+  - services
+  crd_collectors:
+  - datadoghq.com/v1alpha1/datadogmetrics
+  - datadoghq.com/v1alpha1/watermarkpodautoscalers
+`,
+			expectErr: false,
+		},
+		{
+			name: "invalid config with missing instances",
+			input: `cluster_check: true
+init_config:
+`,
+			crs:       []string{"crd"},
+			want:      "",
+			expectErr: true,
+		},
+		{
+			name: "invalid config with non-list instances",
+			input: `cluster_check: true
+init_config:
+instances:
+  collectors:
+  - nodes
+`,
+			crs:       []string{"crd"},
+			want:      "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addCRToConfig(tt.input, tt.crs)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_getConfigConfigMapName(t *testing.T) {
+	tests := []struct {
+		name                string
+		owner               metav1.ObjectMeta
+		customConfig        *v2alpha1.CustomConfig
+		remoteConfigEnabled bool
+		want                string
+	}{
+		{
+			name: "default name - no custom config",
+			owner: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "foo",
+			},
+			customConfig:        nil,
+			remoteConfigEnabled: false,
+			want:                "test-orchestrator-explorer-config",
+		},
+		{
+			name: "custom config map name",
+			owner: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "foo",
+			},
+			customConfig: &v2alpha1.CustomConfig{
+				ConfigMap: &v2alpha1.ConfigMapConfig{
+					Name: "orchestrator-config",
+				},
+			},
+			remoteConfigEnabled: false,
+			want:                "orchestrator-config",
+		},
+		{
+			name: "custom config with remote config enabled - should use default name",
+			owner: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "foo",
+			},
+			customConfig: &v2alpha1.CustomConfig{
+				ConfigMap: &v2alpha1.ConfigMapConfig{
+					Name: "orchestrator-config",
+				},
+			},
+			remoteConfigEnabled: true,
+			want:                "test-orchestrator-explorer-config",
+		},
+		{
+			name: "custom config name matches default with remote config enabled",
+			owner: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "foo",
+			},
+			customConfig: &v2alpha1.CustomConfig{
+				ConfigMap: &v2alpha1.ConfigMapConfig{
+					Name: "test-orchestrator-explorer-config",
+				},
+			},
+			remoteConfigEnabled: true,
+			want:                "test-orchestrator-explorer-config-rc",
+		},
+		{
+			name: "custom config with ConfigData only",
+			owner: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "foo",
+			},
+			customConfig: &v2alpha1.CustomConfig{
+				ConfigData: apiutils.NewStringPointer("some-config"),
+			},
+			remoteConfigEnabled: false,
+			want:                "test-orchestrator-explorer-config",
+		},
+		{
+			name: "empty owner name",
+			owner: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "foo",
+			},
+			customConfig:        nil,
+			remoteConfigEnabled: false,
+			want:                "-orchestrator-explorer-config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &orchestratorExplorerFeature{
+				owner:               &tt.owner,
+				customConfig:        tt.customConfig,
+				remoteConfigEnabled: tt.remoteConfigEnabled,
+			}
+			got := f.getConfigConfigMapName()
+			require.Equal(t, tt.want, got, "getConfigConfigMapName() = %v, want %v", got, tt.want)
+		})
+	}
+}
+
+func Test_getLastKey(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]string
+		want string
+	}{
+		{
+			name: "alphabetically ordered keys",
+			m: map[string]string{
+				"a": "1",
+				"b": "2",
+				"c": "3",
+				"d": "4",
+			},
+			want: "d",
+		},
+		{
+			name: "reverse ordered keys",
+			m: map[string]string{
+				"d": "4",
+				"c": "3",
+				"b": "2",
+				"a": "1",
+			},
+			want: "d",
+		},
+		{
+			name: "single key",
+			m: map[string]string{
+				"only": "value",
+			},
+			want: "only",
+		},
+		{
+			name: "empty map",
+			m:    map[string]string{},
+			want: "",
+		},
+		{
+			name: "numeric keys",
+			m: map[string]string{
+				"1":  "one",
+				"2":  "two",
+				"10": "ten",
+			},
+			want: "2",
+		},
+		{
+			name: "mixed case keys",
+			m: map[string]string{
+				"A": "upper",
+				"a": "lower",
+				"B": "UPPER",
+				"b": "LOWER",
+			},
+			want: "b",
+		},
+		{
+			name: "orchestrator config files",
+			m: map[string]string{
+				"orchestrator.yaml":   "content1",
+				"orchestrator.yaml.1": "content2",
+				"orchestrator.yaml.2": "content3",
+			},
+			want: "orchestrator.yaml.2",
+		},
+		{
+			name: "special characters",
+			m: map[string]string{
+				"key-1": "value1",
+				"key.2": "value2",
+				"key_3": "value3",
+				"key@4": "value4",
+				"key#5": "value5",
+			},
+			want: "key_3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getLastKey(tt.m)
+			require.Equal(t, tt.want, got, "getLastKey() = %v, want %v", got, tt.want)
+		})
+	}
 }

--- a/internal/controller/datadogagent/feature/types.go
+++ b/internal/controller/datadogagent/feature/types.go
@@ -8,6 +8,7 @@ package feature
 import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -150,6 +151,8 @@ type Options struct {
 	SupportExtendedDaemonset bool
 
 	Logger logr.Logger
+
+	K8sClient client.Client
 }
 
 // BuildFunc function type used by each Feature during its factory registration.

--- a/internal/controller/datadogagent/finalizer.go
+++ b/internal/controller/datadogagent/finalizer.go
@@ -80,7 +80,7 @@ func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) err
 	// store, and then call the DeleteAll function of the store.
 
 	features, requiredComponents := feature.BuildFeatures(
-		dda, reconcilerOptionsToFeatureOptions(&r.options, reqLogger))
+		dda, reconcilerOptionsToFeatureOptions(&r.options, reqLogger, r.client))
 
 	storeOptions := &store.StoreOptions{
 		SupportCilium: r.options.SupportCilium,

--- a/internal/controller/datadogagent/object/volume/volumes.go
+++ b/internal/controller/datadogagent/object/volume/volumes.go
@@ -89,7 +89,7 @@ func GetVolumeFromConfigMap(configMap *v2alpha1.ConfigMapConfig, defaultConfigMa
 		},
 	}
 
-	if len(configMap.Items) > 0 {
+	if configMap != nil && len(configMap.Items) > 0 {
 		cmSource.Items = configMap.Items
 	}
 

--- a/pkg/remoteconfig/orchestrator_k8s_crd.go
+++ b/pkg/remoteconfig/orchestrator_k8s_crd.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
 package remoteconfig
 
 import (
@@ -117,7 +122,7 @@ func (r *RemoteConfigUpdater) crdUpdateInstanceStatus(dda v2alpha1.DatadogAgent,
 		if err := r.kubeClient.Status().Update(context.TODO(), ddaUpdate); err != nil {
 			if apierrors.IsConflict(err) {
 				r.logger.Info("unable to update DatadogAgent CRD status due to update conflict")
-				return nil
+				return err // Retry if conflict
 			}
 			r.logger.Error(err, "unable to update DatadogAgent status")
 			return err

--- a/pkg/remoteconfig/orchestrator_k8s_crd_test.go
+++ b/pkg/remoteconfig/orchestrator_k8s_crd_test.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package remoteconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+)
+
+func TestGetAndUpdateDatadogAgentWithRetry_CRD(t *testing.T) {
+	tests := []struct {
+		name         string
+		client       *mockClient
+		expectedRuns int
+	}{
+		{
+			name: "success on first try",
+			client: &mockClient{
+				mockSubResourceWriter: &mockSubResourceWriter{
+					maxRetries: 1,
+				},
+			},
+			expectedRuns: 1,
+		},
+		{
+			name: "success after conflicts",
+			client: &mockClient{
+				mockSubResourceWriter: &mockSubResourceWriter{
+					maxRetries:   3,
+					conflictMode: true,
+				},
+			},
+			expectedRuns: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updater := NewRemoteConfigUpdater(tt.client, logr.Logger{})
+			config := OrchestratorK8sCRDRemoteConfig{
+				CRDs: &CustomResourceDefinitionURLs{
+					Crds: &[]string{"custom-resource-1", "custom-resource-2"},
+				},
+			}
+
+			err := updater.getAndUpdateDatadogAgentWithRetry(context.Background(), config, updater.crdUpdateInstanceStatus)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedRuns, tt.client.mockSubResourceWriter.updateCount)
+		})
+	}
+}
+
+type mockClient struct {
+	client.Client
+	listError             error
+	mockSubResourceWriter *mockSubResourceWriter
+}
+
+func (m *mockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if m.listError == nil {
+		ddaList := list.(*v2alpha1.DatadogAgentList)
+		ddaList.Items = []v2alpha1.DatadogAgent{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "datadog-agent-test",
+				},
+			},
+		}
+	}
+	return m.listError
+}
+
+func (m *mockClient) Status() client.SubResourceWriter {
+	return m.mockSubResourceWriter
+}
+
+type mockSubResourceWriter struct {
+	client.SubResourceWriter
+	updateCount  int
+	maxRetries   int
+	conflictMode bool
+}
+
+func (m *mockSubResourceWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	m.updateCount++
+	if m.conflictMode && m.updateCount < m.maxRetries {
+		return apierrors.NewConflict(schema.GroupResource{}, "test", errors.New("conflict"))
+	}
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Currently, the operator ignores remote config results when a custom ConfigMap is provided. This means that for custom resource collection, if a user supplies a custom Orchestrator check configuration, they are unable to dynamically extend it via remote config.

This PR refactors the logic for building and mounting the ConfigMap used by the Orchestrator Explorer feature, making the behavior consistent based on the presence of custom config and whether remote config is enabled.


**Improved ConfigMap creation logic:**

- `buildConfigMapWithConfigData()` supports merging inline custom config data with remote custom resources when remote config is enabled.
- `buildConfigMapWithCustomConfig()` validates the user-provided ConfigMap and merges it with remote resources to produce a new ConfigMap.

**Enhanced volume mounting behavior:**

- If remote config is enabled, the operator ignores user-provided ConfigMap reference and instead mounts the internally generated ConfigMap (which includes merged remote config data).

-------
### Describe your test plan

Deploy with:

- No custom config
- Custom config via ConfigMap
- Custom config via ConfigData
- Remote config enabled/disabled


Validate that the generated/mounted ConfigMap behaves as expected in each case.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
