### PR TITLE
[BARX-910 ] Fix SlowStartAdditiveIncrease not propagated properly

### DIFF
--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -150,6 +150,7 @@ func startDatadogAgent(logger logr.Logger, mgr manager.Manager, pInfo kubernetes
 				Enabled:                             options.SupportExtendedDaemonset.Enabled,
 				MaxPodUnavailable:                   options.SupportExtendedDaemonset.MaxPodUnavailable,
 				MaxPodSchedulerFailure:              options.SupportExtendedDaemonset.MaxPodSchedulerFailure,
+				SlowStartAdditiveIncrease:           options.SupportExtendedDaemonset.SlowStartAdditiveIncrease,
 				CanaryDuration:                      options.SupportExtendedDaemonset.CanaryDuration,
 				CanaryReplicas:                      options.SupportExtendedDaemonset.CanaryReplicas,
 				CanaryAutoPauseEnabled:              options.SupportExtendedDaemonset.CanaryAutoPauseEnabled,


### PR DESCRIPTION
### What does this PR do?

After deploying the operator with the `edsSlowStartAdditiveIncrease` flag set to 5%, I notice it just doesn't work. It is because the value is not propagated properly

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
