### PR TITLE
Set DD_OTELCOLLECTOR_ENABLED in otel-agent container

### DIFF
--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -232,10 +232,10 @@ func (o *otelCollectorFeature) ManageNodeAgent(managers feature.PodTemplateManag
 				Name:  DDOtelCollectorCoreConfigEnabled,
 				Value: apiutils.BoolToString(o.coreAgentConfig.enabled),
 			}
-			managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName}, enableEnvVar)
+			managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.OtelAgent}, enableEnvVar)
 		}
 	} else {
-		managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName}, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.OtelAgent}, &corev1.EnvVar{
 			Name:  DDOtelCollectorCoreConfigEnabled,
 			Value: "true",
 		})


### PR DESCRIPTION
### What does this PR do?

Set DD_OTELCOLLECTOR_ENABLED in otel-agent container

### Motivation

DD_OTELCOLLECTOR_ENABLED needs to be set in otel-agent for otel-agent to properly start

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
