### PR TITLE
Clean up finalizer

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -147,17 +147,26 @@ rules:
 - apiGroups:
   - authorization.k8s.io
   resources:
-  - subjectaccessreviews
+  - apiservices
   verbs:
-  - create
-  - get
+  - deletecollection
 - apiGroups:
   - authorization.k8s.io
-  - rbac.authorization.k8s.io
-  - roles.rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
   - rolebindings
   - roles
   verbs:
@@ -168,6 +177,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+  - get
 - apiGroups:
   - autoscaling
   resources:
@@ -352,6 +368,22 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - rbac.authorization.k8s.io
+  - roles.rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - security.openshift.io
   resourceNames:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -148,20 +148,16 @@ rules:
 - apiGroups:
   - authorization.k8s.io
   resources:
-  - clusterrolebindings
-  - clusterroles
+  - subjectaccessreviews
   verbs:
   - create
-  - delete
-  - deletecollection
   - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - authorization.k8s.io
+  - roles.rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
+  - clusterroles
   - rolebindings
   - roles
   verbs:
@@ -172,13 +168,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-  - get
 - apiGroups:
   - autoscaling
   resources:
@@ -365,10 +354,21 @@ rules:
   - list
 - apiGroups:
   - rbac.authorization.k8s.io
-  - roles.rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
   - clusterroles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - rolebindings
   - roles
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -94,6 +94,7 @@ rules:
   - apiservices
   verbs:
   - '*'
+  - deletecollection
   - list
   - watch
 - apiGroups:
@@ -144,12 +145,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - apiservices
-  verbs:
-  - deletecollection
 - apiGroups:
   - authorization.k8s.io
   resources:

--- a/internal/controller/datadogagent/finalizer.go
+++ b/internal/controller/datadogagent/finalizer.go
@@ -7,7 +7,6 @@ package datadogagent
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -15,14 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/defaults"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 const (
@@ -67,65 +63,13 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, dda client.Object, f
 }
 
 func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) error {
-	// We need to apply the defaults to be able to delete the resources
-	// associated with those defaults.
-	dda := obj.(*datadoghqv2alpha1.DatadogAgent).DeepCopy()
-	defaults.DefaultDatadogAgent(dda)
-
 	if r.options.OperatorMetricsEnabled {
-		r.forwarders.Unregister(dda)
+		r.forwarders.Unregister(obj)
 	}
 
-	// To delete the resources associated with the DatadogAgent that we need to
-	// delete, we figure out its dependencies, store them in the dependencies
-	// store, and then call the DeleteAll function of the store.
-
-	_, enabledFeatures, requiredComponents := feature.BuildFeatures(
-		dda, reconcilerOptionsToFeatureOptions(&r.options, reqLogger))
-
-	storeOptions := &store.StoreOptions{
-		SupportCilium: r.options.SupportCilium,
-		Logger:        reqLogger,
-		Scheme:        r.scheme,
-		PlatformInfo:  r.platformInfo,
-	}
-	depsStore := store.NewStore(dda, storeOptions)
-	resourceManagers := feature.NewResourceManagers(depsStore)
-
-	var errs []error
-
-	// Global dependencies
-	if err := global.ApplyGlobalDependencies(reqLogger, dda, resourceManagers); len(err) > 0 {
-		errs = append(errs, err...)
-	}
-	if err := global.ApplyGlobalComponentDependencies(reqLogger, dda, resourceManagers, datadoghqv2alpha1.ClusterAgentComponentName, requiredComponents.ClusterAgent); len(err) > 0 {
-		errs = append(errs, err...)
-	}
-	if err := global.ApplyGlobalComponentDependencies(reqLogger, dda, resourceManagers, datadoghqv2alpha1.NodeAgentComponentName, requiredComponents.Agent); len(err) > 0 {
-		errs = append(errs, err...)
-	}
-	if err := global.ApplyGlobalComponentDependencies(reqLogger, dda, resourceManagers, datadoghqv2alpha1.ClusterChecksRunnerComponentName, requiredComponents.ClusterChecksRunner); len(err) > 0 {
-		errs = append(errs, err...)
-	}
-
-	// Set up dependencies required by enabled features
-	for _, feat := range enabledFeatures {
-		if featErr := feat.ManageDependencies(resourceManagers); featErr != nil {
-			errs = append(errs, featErr)
-		}
-	}
-
-	// Examine user configuration to override any external dependencies (e.g. RBACs)
-	errs = append(errs, override.Dependencies(reqLogger, resourceManagers, dda)...)
-
-	if len(errs) > 0 {
-		return fmt.Errorf("errors calculating dependencies while finalizing the DatadogAgent: %v", errs)
-	}
-
-	deleteErrs := depsStore.DeleteAll(context.TODO(), r.client)
-	if len(deleteErrs) > 0 {
-		return fmt.Errorf("error deleting dependencies while finalizing the DatadogAgent: %v", deleteErrs)
-	}
+	// Namespaced resources from the store should be deleted automatically due to owner reference
+	// Delete cluster level resources
+	r.cleanUpClusterLevelResources(reqLogger, obj)
 
 	if err := r.profilesCleanup(); err != nil {
 		return err
@@ -182,5 +126,26 @@ func (r *Reconciler) profilesCleanup() error {
 		}
 	}
 
+	return nil
+}
+
+func (r *Reconciler) cleanUpClusterLevelResources(reqLogger logr.Logger, dda client.Object) error {
+	// Cluster level resources must be deleted manually since they cannot have an owner reference
+	deleteObjectsForResource(r.client, dda, kubernetes.ObjectFromKind(kubernetes.ClusterRolesKind, r.platformInfo))
+	deleteObjectsForResource(r.client, dda, kubernetes.ObjectFromKind(kubernetes.ClusterRoleBindingKind, r.platformInfo))
+	deleteObjectsForResource(r.client, dda, kubernetes.ObjectFromKind(kubernetes.APIServiceKind, r.platformInfo))
+
+	return nil
+}
+
+func deleteObjectsForResource(c client.Client, dda client.Object, kind client.Object) error {
+	matchingLabels := client.MatchingLabels{
+		store.OperatorStoreLabelKey:              "true",
+		kubernetes.AppKubernetesPartOfLabelKey:   object.NewPartOfLabelValue(dda).String(),
+		kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
+	}
+	if err := c.DeleteAllOf(context.TODO(), kind, matchingLabels); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/controller/datadogagent/finalizer_test.go
+++ b/internal/controller/datadogagent/finalizer_test.go
@@ -65,6 +65,8 @@ func Test_handleFinalizer(t *testing.T) {
 				Name: agent.GetAgentRoleName(dda),
 				Labels: map[string]string{
 					"operator.datadoghq.com/managed-by-store": "true",
+					"app.kubernetes.io/part-of":               "foo-bar",
+					"app.kubernetes.io/managed-by":            "datadog-operator",
 				},
 			},
 		},
@@ -77,6 +79,8 @@ func Test_handleFinalizer(t *testing.T) {
 				Name: component.GetClusterAgentName(dda),
 				Labels: map[string]string{
 					"operator.datadoghq.com/managed-by-store": "true",
+					"app.kubernetes.io/part-of":               "foo-bar",
+					"app.kubernetes.io/managed-by":            "datadog-operator",
 				},
 			},
 		},
@@ -94,6 +98,8 @@ func Test_handleFinalizer(t *testing.T) {
 				Name: agent.GetAgentRoleName(dda), // Same name as the cluster role
 				Labels: map[string]string{
 					"operator.datadoghq.com/managed-by-store": "true",
+					"app.kubernetes.io/part-of":               "foo-bar",
+					"app.kubernetes.io/managed-by":            "datadog-operator",
 				},
 			},
 		},
@@ -106,6 +112,8 @@ func Test_handleFinalizer(t *testing.T) {
 				Name: component.GetClusterAgentName(dda),
 				Labels: map[string]string{
 					"operator.datadoghq.com/managed-by-store": "true",
+					"app.kubernetes.io/part-of":               "foo-bar",
+					"app.kubernetes.io/managed-by":            "datadog-operator",
 				},
 			},
 		},

--- a/internal/controller/datadogagent/store/store.go
+++ b/internal/controller/datadogagent/store/store.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	// operatorStoreLabelKey used to identified which resource is managed by the store.
-	operatorStoreLabelKey = "operator.datadoghq.com/managed-by-store"
+	// OperatorStoreLabelKey used to identified which resource is managed by the store.
+	OperatorStoreLabelKey = "operator.datadoghq.com/managed-by-store"
 )
 
 // StoreClient dependencies store client interface
@@ -98,7 +98,7 @@ func (ds *Store) AddOrUpdate(kind kubernetes.ObjectKind, obj client.Object) erro
 	if obj.GetLabels() == nil {
 		obj.SetLabels(map[string]string{})
 	}
-	obj.GetLabels()[operatorStoreLabelKey] = "true"
+	obj.GetLabels()[OperatorStoreLabelKey] = "true"
 
 	if ds.owner != nil {
 		defaultLabels := object.GetDefaultLabels(ds.owner, ds.owner.GetName(), common.GetAgentVersion(ds.owner))
@@ -257,7 +257,7 @@ func (ds *Store) Cleanup(ctx context.Context, k8sClient client.Client) []error {
 
 	var errs []error
 
-	requirementLabel, _ := labels.NewRequirement(operatorStoreLabelKey, selection.Exists, nil)
+	requirementLabel, _ := labels.NewRequirement(OperatorStoreLabelKey, selection.Exists, nil)
 	listOptions := &client.ListOptions{
 		LabelSelector: labels.NewSelector().Add(*requirementLabel),
 	}
@@ -297,7 +297,7 @@ func (ds *Store) DeleteAll(ctx context.Context, k8sClient client.Client) []error
 	var objsToDelete []client.Object
 
 	for _, kind := range ds.platformInfo.GetAgentResourcesKind(ds.supportCilium) {
-		requirementLabel, _ := labels.NewRequirement(operatorStoreLabelKey, selection.Exists, nil)
+		requirementLabel, _ := labels.NewRequirement(OperatorStoreLabelKey, selection.Exists, nil)
 		listOptions := &client.ListOptions{
 			LabelSelector: labels.NewSelector().Add(*requirementLabel),
 		}

--- a/internal/controller/datadogagent/store/store_test.go
+++ b/internal/controller/datadogagent/store/store_test.go
@@ -401,7 +401,7 @@ func TestStore_Cleanup(t *testing.T) {
 			Namespace: "bar",
 			Name:      "foo",
 			Labels: map[string]string{
-				operatorStoreLabelKey:                  "true",
+				OperatorStoreLabelKey:                  "true",
 				kubernetes.AppKubernetesPartOfLabelKey: "namespace--test-dda--test",
 			},
 		},
@@ -516,7 +516,7 @@ func TestStore_GetOrCreate(t *testing.T) {
 			Namespace: "bar",
 			Name:      "foo",
 			Labels: map[string]string{
-				operatorStoreLabelKey: "true",
+				OperatorStoreLabelKey: "true",
 			},
 		},
 	}
@@ -625,7 +625,7 @@ func TestStore_DeleteAll(t *testing.T) {
 			Namespace: "ns1",
 			Name:      "some_name",
 			Labels: map[string]string{
-				operatorStoreLabelKey: "true",
+				OperatorStoreLabelKey: "true",
 			},
 		},
 	}
@@ -639,7 +639,7 @@ func TestStore_DeleteAll(t *testing.T) {
 			Namespace: "ns2",
 			Name:      "another_name",
 			Labels: map[string]string{
-				operatorStoreLabelKey: "true",
+				OperatorStoreLabelKey: "true",
 			},
 		},
 	}
@@ -661,7 +661,7 @@ func TestStore_DeleteAll(t *testing.T) {
 			Namespace: "ns3",
 			Name:      "some_name",
 			Labels: map[string]string{
-				operatorStoreLabelKey: "true",
+				OperatorStoreLabelKey: "true",
 			},
 		},
 	}

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -68,6 +68,11 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 
+// Finalizer
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=clusterroles,verbs=deletecollection
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=clusterrolebindings,verbs=deletecollection
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=apiservices,verbs=deletecollection
+
 // Configure Admission Controller
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations;mutatingwebhookconfigurations,verbs=*
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -54,8 +54,8 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadogagents/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // RBAC Management
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete;deletecollection
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;deletecollection
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=roles.rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
@@ -69,8 +69,8 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 
 // Finalizer (cluster-scoped resources)
-// Note: we already have verbs=* for apiservices (External Metrics server feature requires it), so this is not needed.
-// However, we keep it here for clarity.
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=deletecollection
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=deletecollection
 // +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=deletecollection
 
 // Configure Admission Controller

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -71,7 +71,7 @@ type DatadogAgentReconciler struct {
 // Finalizer
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=clusterroles,verbs=deletecollection
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=clusterrolebindings,verbs=deletecollection
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=apiservices,verbs=deletecollection
+// +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=deletecollection
 
 // Configure Admission Controller
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations;mutatingwebhookconfigurations,verbs=*

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -54,8 +54,8 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadogagents/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // RBAC Management
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete;deletecollection
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=roles.rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
@@ -68,9 +68,9 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 
-// Finalizer
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=clusterroles,verbs=deletecollection
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=clusterrolebindings,verbs=deletecollection
+// Finalizer (cluster-scoped resources)
+// Note: we already have verbs=* for apiservices (External Metrics server feature requires it), so this is not needed.
+// However, we keep it here for clarity.
 // +kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=deletecollection
 
 // Configure Admission Controller


### PR DESCRIPTION
### What does this PR do?

Clean up existing finalizer. Most dependencies should be deleted through owner refs so we don't need to recreate the dependencies in the store. Cluster scoped dependencies are delete manually based on label

### Motivation

https://datadoghq.atlassian.net/browse/CECO-2210

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Create a DatadogAgent and delete it. Ensure dependencies related to the DDA are deleted, e.g. configmaps, secrets, etc. Be sure to check that cluster scoped resources such as clusterroles and clusterrolebindings are deleted.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
