### PR TITLE
small fix for FIPS configuration

### DIFF
--- a/internal/controller/datadogagent/global/global.go
+++ b/internal/controller/datadogagent/global/global.go
@@ -236,6 +236,7 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 		}
 	}
 
+	// Configure FIPS Agent image or FIPS proxy.
 	if apiutils.BoolValue(config.UseFIPSAgent) {
 		// Add -fips suffix to each container image
 		for i, container := range manager.PodTemplateSpec().Spec.Containers {
@@ -245,10 +246,7 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 		for i, container := range manager.PodTemplateSpec().Spec.InitContainers {
 			manager.PodTemplateSpec().Spec.InitContainers[i].Image = container.Image + defaulting.FIPSTagSuffix
 		}
-	}
-
-	// Apply FIPS config
-	if config.FIPS != nil && apiutils.BoolValue(config.FIPS.Enabled) {
+	} else if config.FIPS != nil && apiutils.BoolValue(config.FIPS.Enabled) {
 		applyFIPSConfig(logger, manager, dda, resourcesManager)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add an `else if` so that the FIPS proxy sidecar will never be configured if `useFIPSAgent` is true.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
