### PR TITLE
Bump agent to 7.65.0

### DIFF
--- a/pkg/defaulting/images.go
+++ b/pkg/defaulting/images.go
@@ -16,9 +16,9 @@ type ContainerRegistry string
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.64.3"
+	AgentLatestVersion = "7.65.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.64.3"
+	ClusterAgentLatestVersion = "7.65.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.10"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry


### PR DESCRIPTION
### What does this PR do?

Upgrade default agent and cluster-agent versions to 7.65.0.

### Motivation

[Agent 7.65.0 is out!](https://dd.slack.com/archives/C8T9KBDFY/p1746544198747949)

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

### Describe your test plan

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
