### PR TITLE
[Doc] Documents that otel-agent is not enabled by default

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -791,7 +791,7 @@ type KubeStateMetricsCoreFeatureConfig struct {
 // +k8s:openapi-gen=true
 type OtelCollectorFeatureConfig struct {
 	// Enabled enables the OTel Agent.
-	// Default: true
+	// Default: false
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -1433,7 +1433,7 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_OtelCollectorFeatureConfig(r
 				Properties: map[string]spec.Schema{
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enabled enables the OTel Agent. Default: true",
+							Description: "Enabled enables the OTel Agent. Default: false",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1817,7 +1817,7 @@ spec:
                         enabled:
                           description: |-
                             Enabled enables the OTel Agent.
-                            Default: true
+                            Default: false
                           type: boolean
                         ports:
                           description: |-
@@ -9155,7 +9155,7 @@ spec:
                             enabled:
                               description: |-
                                 Enabled enables the OTel Agent.
-                                Default: true
+                                Default: false
                               type: boolean
                             ports:
                               description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1853,7 +1853,7 @@
                   "type": "object"
                 },
                 "enabled": {
-                  "description": "Enabled enables the OTel Agent.\nDefault: true",
+                  "description": "Enabled enables the OTel Agent.\nDefault: false",
                   "type": "boolean"
                 },
                 "ports": {
@@ -9112,7 +9112,7 @@
                       "type": "object"
                     },
                     "enabled": {
-                      "description": "Enabled enables the OTel Agent.\nDefault: true",
+                      "description": "Enabled enables the OTel Agent.\nDefault: false",
                       "type": "boolean"
                     },
                     "ports": {

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -153,7 +153,7 @@ spec:
 | features.otelCollector.coreConfig.enabled | Marks otelcollector as enabled in core agent. |
 | features.otelCollector.coreConfig.extensionTimeout | Extension URL provides the timout of the ddflareextension to the core agent. |
 | features.otelCollector.coreConfig.extensionURL | Extension URL provides the URL of the ddflareextension to the core agent. |
-| features.otelCollector.enabled | Enables the OTel Agent. Default: true |
+| features.otelCollector.enabled | Enables the OTel Agent. Default: false |
 | features.otelCollector.ports | Contains the ports for the otel-agent. Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317 or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http). If not, this will lead to a port conflict. This limitation will be lifted once annotations support is removed. |
 | features.otlp.receiver.protocols.grpc.enabled | Enable the OTLP/gRPC endpoint. Host port is enabled by default and can be disabled. |
 | features.otlp.receiver.protocols.grpc.endpoint | For OTLP/gRPC. gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md The Datadog Operator supports only 'host:port' (usually `0.0.0.0:port`). Default: `0.0.0.0:4317`. |


### PR DESCRIPTION
### What does this PR do?

* Change the doc comment in otel feature to mention it's disabled by default as is done in code:
    * https://github.com/DataDog/datadog-operator/blob/732b24c97a31dcf29e428aa65ed71a07caa2b750/internal/controller/datadogagent/defaults/datadogagent_default.go#L248
        * https://github.com/DataDog/datadog-operator/blob/732b24c97a31dcf29e428aa65ed71a07caa2b750/internal/controller/datadogagent/defaults/datadogagent_default.go#L30

### Motivation

* While QAing, I had to "manually" enable the otel feature for it to start the otel Agent despite it being documented as enabled by default.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
