### PR TITLE
[tooling] fix backport workflow pr number fetching

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -60,7 +60,7 @@ jobs:
             
             // Parse the backport PR number from the JSON output
             const backportData = JSON.parse(process.env.BACKPORT_PR);
-            const prNumber = backportData.backport;
+            const prNumber = Object.values(backportData)[0];
             console.log('Parsed PR number:', prNumber);
             console.log(`Copying milestone ${milestoneNumber} to PR ${prNumber}`);
             


### PR DESCRIPTION
### What does this PR do?

Backport PR workflows are failing to add the milestone to the backport PR because of an error in fetching the correct PR number. `backportData` is formatted as: `{<base>:<pr number>}` when the label added to a PR is `backport/<base>`. This fix will get the PR number regardless of the key, since that will change with each release. I missed this because I was testing with the label `backport/backport`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
Tested in a private repo:
code changed
<img width="677" alt="image" src="https://github.com/user-attachments/assets/ece8d684-c834-48e1-8708-cdec433fbd85" />
output from tibdex/backports step
<img width="488" alt="image" src="https://github.com/user-attachments/assets/fb400a94-6867-4e2e-88e7-72f0eee9029b" />
parsed PR number is correct
<img width="374" alt="image" src="https://github.com/user-attachments/assets/8bfd71a3-17b7-404e-9154-c65e001fa4c7" />
milestone is correctly added to test pr
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/a2445e0b-6292-41ef-8e12-ad5722c59648" />


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
