### PR TITLE
add skip-qa label to backport PRs by default

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -30,7 +30,7 @@ jobs:
         id: backport
         with:
           label_pattern: "^backport/(?<base>([^ ]+))$" 
-          labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
+          labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot', 'qa/skip-qa']) %>"
           github_token: ${{ steps.app-token.outputs.token }}
           title_template: "[Backport <%- base %>] <%- title %>"
           body_template: |


### PR DESCRIPTION
### What does this PR do?

Add `qa/skip-qa` label automatically to all PRs created by the backport label, to prevent duplicating QA cards in the release process.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
