### PR TITLE
More Talos support

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -383,9 +383,5 @@ func (r *Reconciler) profilesToApply(ctx context.Context, logger logr.Logger, no
 func (r *Reconciler) getNodeList(ctx context.Context) ([]corev1.Node, error) {
 	nodeList := corev1.NodeList{}
 	err := r.client.List(ctx, &nodeList)
-	if err != nil {
-		return nodeList.Items, err
-	}
-
-	return nodeList.Items, nil
+	return nodeList.Items, err
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -169,6 +169,9 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 						Name:   node.Name,
 						Labels: node.Labels,
 					},
+					Status: corev1.NodeStatus{
+						NodeInfo: node.Status.NodeInfo,
+					},
 				}
 
 				return newNode, nil

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -63,9 +63,19 @@ func getProviderNodeAffinity(provider string, providerList map[string]struct{}) 
 	if provider == "" || providerList == nil || len(providerList) == 0 {
 		return nil
 	}
-	// if only the default provider exists, there should be no affinity override
-	if provider == DefaultProvider && len(providerList) == 1 {
-		return nil
+
+	if len(providerList) == 1 {
+		_, ok := providerList[provider]
+		if ok {
+			switch provider {
+			case DefaultProvider:
+				// if only the default provider exists, there should be no affinity override
+				return nil
+			case TalosProvider:
+				// if only the Talos provider exists, there should be no affinity override.
+				return nil
+			}
+		}
 	}
 
 	// default provider has NodeAffinity to NOT match provider-specific labels

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -183,6 +183,14 @@ func Test_getProviderNodeAffinity(t *testing.T) {
 			wantAffinity: nil,
 		},
 		{
+			name: "single talos provider",
+			existingProviders: map[string]struct{}{
+				TalosProvider: {},
+			},
+			provider:     TalosProvider,
+			wantAffinity: nil,
+		},
+		{
 			name: "single cos provider",
 			existingProviders: map[string]struct{}{
 				gkeCosProvider: {},


### PR DESCRIPTION
### What does this PR do?

Adds more changes to support Talos linux.

### Motivation

I saw that some work had already been done in https://github.com/DataDog/datadog-operator/pull/1765. I tried it out, but couldn't get it working without these changes.

### Additional Notes

This PR is just to merge changes into the existing PR for this work. 

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Checked out the existing branch, built an image and pushed to GitHub container registry for testing.
```sh
VERSION=v1.14.0 IMG=ghcr.io/jonstacks/datadog-operator:v1.14.0-talos-patch make docker-build
docker image push ghcr.io/jonstacks/datadog-operator:v1.14.0-talos-patch
```
3. Deployed with Argo into my Talos test cluster:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: datadog-operator
  namespace: argocd
  finalizers:
  - resources-finalizer.argocd.argoproj.io
spec:
  destination:
    namespace: datadog-operator
    server: https://kubernetes.default.svc
  source:
    chart: datadog-operator
    repoURL: https://helm.datadoghq.com
    targetRevision: 2.9.2
    helm:
      releaseName: datadog-operator
      valuesObject:
        introspection:
          enabled: true
        image:
          repository: ghcr.io/jonstacks/datadog-operator
          tag: v1.14.0-talos-patch
          pullPolicy: Always
          doNotCheckTag: true  # needed so that the introspection flag gets passed
        imagePullSecrets:
        - name: ghcr-io
        logLevel: "debug"
  project: default
  syncPolicy:
    automated:
      prune: true
      selfHeal: true
    syncOptions:
    - CreateNamespace=true
    - Validate=false
    retry:
      limit: 5
      backoff:
        duration: 5s
        maxDuration: 3m0s
        factor: 2
```
3. Deployed the following DatadogAgent
```yaml
apiVersion: "datadoghq.com/v2alpha1"
kind: "DatadogAgent"
metadata:
  name: "datadog"
  namespace: "datadog-operator"
spec:
  global:
    clusterName: "home-cluster"
    site: "us5.datadoghq.com"

    credentials:
      apiSecret:
        secretName: "datadog-secret"
        keyName: "api-key"

    kubelet:
      tlsVerify: false
    
    tags:
    - "env:dev"

  features:
    clusterChecks:
      enabled: true
      useClusterChecksRunners: true
    kubeStateMetricsCore:
      enabled: true
    logCollection:
      enabled: true
      containerCollectAll: false
    orchestratorExplorer:
      enabled: true
```
### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
