### PR TITLE
Update to Go 1.23.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 env:
-  GO_VERSION: 1.23.6
+  GO_VERSION: 1.23.8
 on:
   push:
 # Permission forced by repo-level setting; only elevate on job-level

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.23.6
+  GO_VERSION: 1.23.8
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   # packages: read
 env:
-  GO_VERSION: 1.23.6
+  GO_VERSION: 1.23.8
 jobs:
   build-linux-binary:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/images/mirror/library/golang:1.23.6
+image: registry.ddbuild.io/images/mirror/library/golang:1.23.8
 variables:
   PROJECTNAME: "datadog-operator"
   PROJECTNAME_CHECK: "datadog-operator-check"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG FIPS_ENABLED=false
 
 # Build the manager binary
-FROM golang:1.23.6 AS builder
+FROM golang:1.23.8 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator/api
 
 go 1.23
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.34.0

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.6 AS builder
+FROM golang:1.23.8 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator
 
 go 1.23
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 replace github.com/DataDog/extendeddaemonset v0.10.0-rc.4 => github.com/DataDog/extendeddaemonset/api v0.0.0-20250108205105-6c4d337b78a1
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.6
+go 1.23.8
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 use (
 	.

--- a/hack/update-golang.sh
+++ b/hack/update-golang.sh
@@ -72,7 +72,7 @@ done
 gitlab_file="$ROOT/.gitlab-ci.yml"
 if [[ -f $gitlab_file ]]; then
     echo "Processing $gitlab_file..."
-    sed -i -E "s|(image: registry\.ddbuild\.io/images/mirror/golang:)[^ ]+|\1$GOVERSION|" "$gitlab_file"
+    sed -i -E "s|(image: registry\.ddbuild\.io/images/mirror/library/golang:)[^ ]+|\1$GOVERSION|" "$gitlab_file"
 else
     echo "Warning: $gitlab_file not found, skipping."
 fi

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator/test/e2e
 
 go 1.23
 
-toolchain go1.23.6
+toolchain go1.23.8
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types => github.com/DataDog/datadog-agent/comp/core/tagger/types v0.63.0-rc.1


### PR DESCRIPTION
### What does this PR do?

* Updates to Go `1.23.8` running `make update-golang`
* Updates `update-golang.sh` script to look for `library/golang` for internal Golang mirrors

### Motivation

* Fixes CVE-2025-22871 (medium sev):

```shell
helpers (gobinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬──────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                          Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22871 │ MEDIUM   │ fixed  │ v1.23.6           │ 1.23.8, 1.24.2 │ net/http: Request smuggling due to acceptance of invalid │
│         │                │          │        │                   │                │ chunked data in net/http...                              │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2025-22871               │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴──────────────────────────────────────────────────────────┘

manager (gobinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬──────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                          Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼──────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-22871 │ MEDIUM   │ fixed  │ v1.23.6           │ 1.23.8, 1.24.2 │ net/http: Request smuggling due to acceptance of invalid │
│         │                │          │        │                   │                │ chunked data in net/http...                              │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2025-22871               │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴──────────────────────────────────────────────────────────┘
```

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
