### PR TITLE
Ownerref migration for DDA <-> DDAI

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -394,6 +394,7 @@ func (r *Reconciler) cleanupPodsForProfilesThatNoLongerApply(ctx context.Context
 					Name:      agentPod.Name,
 				},
 			}
+			r.log.Info("Deleting pod for profile cleanup", "pod.Namespace", toDelete.Namespace, "pod.Name", toDelete.Name)
 			if err = r.client.Delete(ctx, &toDelete); err != nil && !errors.IsNotFound(err) {
 				return err
 			}

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -39,11 +39,6 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadogh
 	}
 
 	// 2. Handle finalizer logic.
-	if r.options.DatadogAgentInternalEnabled {
-		if result, err := r.handleFinalizer(reqLogger, instance, r.finalizeDDAWithDDAI); utils.ShouldReturn(result, err) {
-			return result, err
-		}
-	}
 	if result, err := r.handleFinalizer(reqLogger, instance, r.finalizeDadV2); utils.ShouldReturn(result, err) {
 		return result, err
 	}

--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -36,6 +36,7 @@ import (
 const (
 	updateSucceeded = "UpdateSucceeded"
 	createSucceeded = "CreateSucceeded"
+	patchSucceeded  = "PatchSucceeded"
 
 	profileWaitForCanaryKey = "agent.datadoghq.com/profile-wait-for-canary"
 )
@@ -82,6 +83,26 @@ func (r *Reconciler) createOrUpdateDeployment(parentLogger logr.Logger, dda *dat
 	}
 
 	if alreadyExists {
+		// check owner reference
+		if shouldUpdateOwnerReference(currentDeployment.OwnerReferences) {
+			logger.Info("Updating Deployment owner reference")
+			now := metav1.NewTime(time.Now())
+			patch, e := createOwnerReferencePatch(currentDeployment.OwnerReferences, dda, dda.GetObjectKind().GroupVersionKind())
+			if e != nil {
+				logger.Error(e, "Unable to patch Deployment owner reference")
+				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch Deployment owner reference")
+				return reconcile.Result{}, e
+			}
+			// use merge patch to replace the entire existing owner reference list
+			err = r.client.Patch(context.TODO(), currentDeployment, client.RawPatch(types.MergePatchType, patch))
+			if err != nil {
+				logger.Error(err, "Unable to patch Deployment owner reference")
+				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch Deployment owner reference")
+				return reconcile.Result{}, err
+			}
+			logger.Info("Deployment owner reference patched")
+		}
+
 		// check if same hash
 		needUpdate := !comparison.IsSameSpecMD5Hash(hash, currentDeployment.GetAnnotations())
 		if !needUpdate {
@@ -162,6 +183,25 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, dda *data
 	}
 
 	if alreadyExists {
+		// check owner reference
+		if shouldUpdateOwnerReference(currentDaemonset.OwnerReferences) {
+			logger.Info("Updating Daemonset owner reference")
+			now := metav1.NewTime(time.Now())
+			patch, e := createOwnerReferencePatch(currentDaemonset.OwnerReferences, dda, dda.GetObjectKind().GroupVersionKind())
+			if e != nil {
+				logger.Error(e, "Unable to patch Daemonset owner reference")
+				updateStatusFunc(currentDaemonset.Name, currentDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to patch Daemonset owner reference")
+				return reconcile.Result{}, e
+			}
+			// use merge patch to replace the entire existing owner reference list
+			err = r.client.Patch(context.TODO(), currentDaemonset, client.RawPatch(types.MergePatchType, patch))
+			if err != nil {
+				logger.Error(err, "Unable to patch Daemonset owner reference")
+				updateStatusFunc(currentDaemonset.Name, currentDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to patch Daemonset owner reference")
+				return reconcile.Result{}, err
+			}
+			logger.Info("Daemonset owner reference patched")
+		}
 		now := metav1.Now()
 		if agentprofile.CreateStrategyEnabled() {
 			if profile.Status.CreateStrategy != nil {
@@ -327,6 +367,25 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(parentLogger logr.Logger, d
 	}
 
 	if alreadyExists {
+		// check owner reference
+		if shouldUpdateOwnerReference(currentEDS.OwnerReferences) {
+			logger.Info("Updating ExtendedDaemonSet owner reference")
+			now := metav1.NewTime(time.Now())
+			patch, e := createOwnerReferencePatch(currentEDS.OwnerReferences, dda, dda.GetObjectKind().GroupVersionKind())
+			if e != nil {
+				logger.Error(e, "Unable to patch ExtendedDaemonSet owner reference")
+				updateStatusFunc(currentEDS, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to patch ExtendedDaemonSet owner reference")
+				return reconcile.Result{}, e
+			}
+			// use merge patch to replace the entire existing owner reference list
+			err = r.client.Patch(context.TODO(), currentEDS, client.RawPatch(types.MergePatchType, patch))
+			if err != nil {
+				logger.Error(err, "Unable to patch ExtendedDaemonSet owner reference")
+				updateStatusFunc(currentEDS, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to patch ExtendedDaemonSet owner reference")
+				return reconcile.Result{}, err
+			}
+			logger.Info("ExtendedDaemonSet owner reference patched")
+		}
 		// check if same hash
 		needUpdate := !comparison.IsSameSpecMD5Hash(hash, currentEDS.GetAnnotations())
 		if !needUpdate {

--- a/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
@@ -202,10 +202,11 @@ func (r *Reconciler) applyAndCleanupDependencies(ctx context.Context, logger log
 	var errs []error
 	errs = append(errs, depsStore.Apply(ctx, r.client)...)
 	if len(errs) > 0 {
-		logger.V(2).Info("Dependencies apply error", "errs", errs)
+		logger.Error(errors.NewAggregate(errs), "Dependencies apply error")
 		return errors.NewAggregate(errs)
 	}
 	if errs = depsStore.Cleanup(ctx, r.client); len(errs) > 0 {
+		logger.Error(errors.NewAggregate(errs), "Dependencies cleanup error")
 		return errors.NewAggregate(errs)
 	}
 	return nil

--- a/internal/controller/datadogagent/ddai.go
+++ b/internal/controller/datadogagent/ddai.go
@@ -6,26 +6,22 @@
 package datadogagent
 
 import (
-	"fmt"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
-)
-
-const (
-	ddaiNameTemplate = "%s-ddai"
 )
 
 func (r *Reconciler) generateDDAIFromDDA(dda *datadoghqv2alpha1.DatadogAgent) (*datadoghqv1alpha1.DatadogAgentInternal, error) {
 	ddai := &datadoghqv1alpha1.DatadogAgentInternal{}
 	// Object meta
-	if err := r.generateObjMetaFromDDA(dda, ddai); err != nil {
+	if err := generateObjMetaFromDDA(dda, ddai, r.scheme); err != nil {
 		return nil, err
 	}
 	// Spec
@@ -41,25 +37,22 @@ func (r *Reconciler) generateDDAIFromDDA(dda *datadoghqv2alpha1.DatadogAgent) (*
 	return ddai, nil
 }
 
-func (r *Reconciler) generateObjMetaFromDDA(dda *datadoghqv2alpha1.DatadogAgent, ddai *datadoghqv1alpha1.DatadogAgentInternal) error {
+func generateObjMetaFromDDA(dda *datadoghqv2alpha1.DatadogAgent, ddai *datadoghqv1alpha1.DatadogAgentInternal, scheme *runtime.Scheme) error {
 	ddai.ObjectMeta = metav1.ObjectMeta{
-		Name:        getDDAINameFromDDA(dda.Name),
+		Name:        dda.Name,
 		Namespace:   dda.Namespace,
 		Labels:      dda.Labels,
 		Annotations: dda.Annotations,
 	}
-	if err := object.SetOwnerReference(dda, ddai, r.scheme); err != nil {
+	if err := object.SetOwnerReference(dda, ddai, scheme); err != nil {
 		return err
 	}
 	return nil
 }
 
-func getDDAINameFromDDA(ddaName string) string {
-	return fmt.Sprintf(ddaiNameTemplate, ddaName)
-}
-
 func generateSpecFromDDA(dda *datadoghqv2alpha1.DatadogAgent, ddai *datadoghqv1alpha1.DatadogAgentInternal) error {
 	ddai.Spec = dda.Spec
 	global.SetGlobalFromDDA(dda, ddai.Spec.Global)
+	override.SetOverrideFromDDA(dda, &ddai.Spec)
 	return nil
 }

--- a/internal/controller/datadogagent/ddai_test.go
+++ b/internal/controller/datadogagent/ddai_test.go
@@ -1,0 +1,200 @@
+package datadogagent
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_generateObjMetaFromDDA(t *testing.T) {
+	tests := []struct {
+		name string
+		dda  *v2alpha1.DatadogAgent
+		want *v1alpha1.DatadogAgentInternal
+	}{
+		{
+			name: "minimal dda",
+			dda: &v2alpha1.DatadogAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			want: &v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "datadoghq.com/v2alpha1",
+							Kind:               "DatadogAgent",
+							Name:               "foo",
+							UID:                "",
+							BlockOwnerDeletion: apiutils.NewBoolPointer(true),
+							Controller:         apiutils.NewBoolPointer(true),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "dda with meta",
+			dda: &v2alpha1.DatadogAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			want: &v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "datadoghq.com/v2alpha1",
+							Kind:               "DatadogAgent",
+							Name:               "foo",
+							UID:                "",
+							BlockOwnerDeletion: apiutils.NewBoolPointer(true),
+							Controller:         apiutils.NewBoolPointer(true),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddai := &v1alpha1.DatadogAgentInternal{}
+			generateObjMetaFromDDA(tt.dda, ddai, agenttestutils.TestScheme())
+			assert.Equal(t, tt.want, ddai)
+		})
+	}
+}
+
+func Test_generateSpecFromDDA(t *testing.T) {
+	tests := []struct {
+		name string
+		dda  *v2alpha1.DatadogAgent
+		want *v1alpha1.DatadogAgentInternal
+	}{
+		{
+			name: "empty dda override",
+			dda: &v2alpha1.DatadogAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						Credentials: &v2alpha1.DatadogCredentials{
+							APIKey: apiutils.NewStringPointer("key"),
+						},
+					},
+				},
+			},
+			want: &v1alpha1.DatadogAgentInternal{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						Credentials: &v2alpha1.DatadogCredentials{
+							APISecret: &v2alpha1.SecretConfig{
+								SecretName: "foo-secret",
+								KeyName:    "api_key",
+							},
+						},
+						ClusterAgentTokenSecret: &v2alpha1.SecretConfig{
+							SecretName: "foo-token",
+							KeyName:    "token",
+						},
+					},
+					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+						v2alpha1.NodeAgentComponentName: {
+							Labels: map[string]string{
+								constants.MD5AgentDeploymentProviderLabelKey: "",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "dda override configured",
+			dda: &v2alpha1.DatadogAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						Credentials: &v2alpha1.DatadogCredentials{
+							APIKey: apiutils.NewStringPointer("key"),
+						},
+					},
+					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+						v2alpha1.NodeAgentComponentName: {
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+							PriorityClassName: apiutils.NewStringPointer("foo-priority-class"),
+						},
+						v2alpha1.ClusterAgentComponentName: {
+							PriorityClassName: apiutils.NewStringPointer("bar-priority-class"),
+						},
+					},
+				},
+			},
+			want: &v1alpha1.DatadogAgentInternal{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						Credentials: &v2alpha1.DatadogCredentials{
+							APISecret: &v2alpha1.SecretConfig{
+								SecretName: "foo-secret",
+								KeyName:    "api_key",
+							},
+						},
+						ClusterAgentTokenSecret: &v2alpha1.SecretConfig{
+							SecretName: "foo-token",
+							KeyName:    "token",
+						},
+					},
+					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+						v2alpha1.NodeAgentComponentName: {
+							Labels: map[string]string{
+								constants.MD5AgentDeploymentProviderLabelKey: "",
+								"foo": "bar",
+							},
+							PriorityClassName: apiutils.NewStringPointer("foo-priority-class"),
+						},
+						v2alpha1.ClusterAgentComponentName: {
+							PriorityClassName: apiutils.NewStringPointer("bar-priority-class"),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddai := &v1alpha1.DatadogAgentInternal{}
+			generateSpecFromDDA(tt.dda, ddai)
+			assert.Equal(t, tt.want, ddai)
+		})
+	}
+}

--- a/internal/controller/datadogagent/dependencies.go
+++ b/internal/controller/datadogagent/dependencies.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
@@ -38,10 +39,12 @@ func (r *Reconciler) manageDDADependenciesWithDDAI(ctx context.Context, logger l
 		return err
 	}
 
-	// Apply and cleanup dependencies
-	if err := r.applyAndCleanupDependencies(ctx, logger, depsStore); err != nil {
-		return err
+	// Apply dependencies
+	if err := depsStore.Apply(ctx, r.client); err != nil {
+		return errors.NewAggregate(err)
 	}
+	// TODO: clean up dependencies
+
 	return nil
 }
 

--- a/internal/controller/datadogagent/finalizer.go
+++ b/internal/controller/datadogagent/finalizer.go
@@ -62,23 +62,16 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, dda client.Object, f
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) finalizeDDAWithDDAI(reqLogger logr.Logger, obj client.Object) error {
-	// Dependencies are deleted automatically through owner reference
-	// Unregister forwarder
-	if r.options.OperatorMetricsEnabled {
-		r.forwarders.Unregister(obj)
-	}
-	return nil
-}
-
 func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) error {
 	if r.options.OperatorMetricsEnabled {
 		r.forwarders.Unregister(obj)
 	}
 
-	// Namespaced resources from the store should be deleted automatically due to owner reference
-	// Delete cluster level resources
-	r.cleanUpClusterLevelResources(reqLogger, obj)
+	if !r.options.DatadogAgentInternalEnabled {
+		// Namespaced resources from the store should be deleted automatically due to owner reference
+		// Delete cluster level resources
+		r.cleanUpClusterLevelResources(reqLogger, obj)
+	}
 
 	if err := r.profilesCleanup(); err != nil {
 		return err
@@ -140,6 +133,7 @@ func (r *Reconciler) profilesCleanup() error {
 
 func (r *Reconciler) cleanUpClusterLevelResources(reqLogger logr.Logger, dda client.Object) error {
 	// Cluster level resources must be deleted manually since they cannot have an owner reference
+	r.log.Info("Cleaning up cluster level resources")
 	deleteObjectsForResource(r.client, dda, kubernetes.ObjectFromKind(kubernetes.ClusterRolesKind, r.platformInfo))
 	deleteObjectsForResource(r.client, dda, kubernetes.ObjectFromKind(kubernetes.ClusterRoleBindingKind, r.platformInfo))
 	deleteObjectsForResource(r.client, dda, kubernetes.ObjectFromKind(kubernetes.APIServiceKind, r.platformInfo))

--- a/internal/controller/datadogagent/override/utils.go
+++ b/internal/controller/datadogagent/override/utils.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
 func getDefaultConfigMapName(ddaName, fileName string) string {
@@ -22,4 +25,21 @@ func hasProbeHandler(probe *corev1.Probe) bool {
 		return true
 	}
 	return false
+}
+
+func SetOverrideFromDDA(dda *v2alpha1.DatadogAgent, ddaiSpec *v2alpha1.DatadogAgentSpec) {
+	if ddaiSpec == nil {
+		ddaiSpec = &v2alpha1.DatadogAgentSpec{}
+	}
+	if ddaiSpec.Override == nil {
+		ddaiSpec.Override = make(map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride)
+	}
+	if _, ok := ddaiSpec.Override[v2alpha1.NodeAgentComponentName]; !ok {
+		ddaiSpec.Override[v2alpha1.NodeAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{}
+	}
+	if ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels == nil {
+		ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels = make(map[string]string)
+	}
+	// Set empty provider label
+	ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels[constants.MD5AgentDeploymentProviderLabelKey] = ""
 }

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
@@ -16,6 +16,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -30,6 +31,7 @@ import (
 const (
 	updateSucceeded = "UpdateSucceeded"
 	createSucceeded = "CreateSucceeded"
+	patchSucceeded  = "PatchSucceeded"
 )
 
 type updateDepStatusComponentFunc func(deployment *appsv1.Deployment, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string)
@@ -42,7 +44,7 @@ func (r *Reconciler) createOrUpdateDeployment(parentLogger logr.Logger, ddai *da
 	var result reconcile.Result
 	var err error
 
-	// Set DatadogAgent instance as the owner and controller
+	// Set DatadogAgentInternal instance as the owner and controller
 	if err = controllerutil.SetControllerReference(ddai, deployment, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -74,12 +76,31 @@ func (r *Reconciler) createOrUpdateDeployment(parentLogger logr.Logger, ddai *da
 	}
 
 	if alreadyExists {
+		// check owner reference
+		if shouldUpdateOwnerReference(currentDeployment.OwnerReferences) {
+			logger.Info("Updating Deployment owner reference")
+			now := metav1.NewTime(time.Now())
+			patch, e := createOwnerReferencePatch(currentDeployment.OwnerReferences, ddai, ddai.GetObjectKind().GroupVersionKind())
+			if e != nil {
+				logger.Error(e, "Unable to patch Deployment owner reference")
+				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch Deployment owner reference")
+				return reconcile.Result{}, e
+			}
+			// use merge patch to replace the entire existing owner reference list
+			err = r.client.Patch(context.TODO(), currentDeployment, client.RawPatch(types.MergePatchType, patch))
+			if err != nil {
+				logger.Error(err, "Unable to patch Deployment owner reference")
+				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch Deployment owner reference")
+				return reconcile.Result{}, err
+			}
+			logger.Info("Deployment owner reference patched")
+		}
 		// check if same hash
 		needUpdate := !comparison.IsSameSpecMD5Hash(hash, currentDeployment.GetAnnotations())
 		if !needUpdate {
 			// no need to update hasn't changed
 			now := metav1.NewTime(time.Now())
-			updateStatusFunc(currentDeployment, newStatus, now, metav1.ConditionTrue, "DeploymentUpToDate", "Deployment up-to-date")
+			updateStatusFunc(deployment, newStatus, now, metav1.ConditionTrue, createSucceeded, "Deployment created")
 			return reconcile.Result{}, nil
 		}
 
@@ -154,6 +175,25 @@ func (r *Reconciler) createOrUpdateDaemonset(parentLogger logr.Logger, ddai *dat
 	}
 
 	if alreadyExists {
+		// check owner reference
+		if shouldUpdateOwnerReference(currentDaemonset.OwnerReferences) {
+			logger.Info("Updating Daemonset owner reference")
+			now := metav1.NewTime(time.Now())
+			patch, e := createOwnerReferencePatch(currentDaemonset.OwnerReferences, ddai, ddai.GetObjectKind().GroupVersionKind())
+			if e != nil {
+				logger.Error(e, "Unable to patch Daemonset owner reference")
+				updateStatusFunc(currentDaemonset.Name, currentDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to patch Daemonset owner reference")
+				return reconcile.Result{}, e
+			}
+			// use merge patch to replace the entire existing owner reference list
+			err = r.client.Patch(context.TODO(), currentDaemonset, client.RawPatch(types.MergePatchType, patch))
+			if err != nil {
+				logger.Error(err, "Unable to patch Daemonset owner reference")
+				updateStatusFunc(currentDaemonset.Name, currentDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to patch Daemonset owner reference")
+				return reconcile.Result{}, err
+			}
+			logger.Info("Daemonset owner reference patched")
+		}
 		now := metav1.Now()
 
 		// When overriding node labels in <1.7.0, the hash could be updated
@@ -289,6 +329,26 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(parentLogger logr.Logger, d
 	}
 
 	if alreadyExists {
+		// check owner reference
+		if shouldUpdateOwnerReference(currentEDS.OwnerReferences) {
+			logger.Info("Updating ExtendedDaemonSet owner reference")
+			now := metav1.NewTime(time.Now())
+			patch, e := createOwnerReferencePatch(currentEDS.OwnerReferences, ddai, ddai.GetObjectKind().GroupVersionKind())
+			if e != nil {
+				logger.Error(e, "Unable to patch ExtendedDaemonSet owner reference")
+				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch ExtendedDaemonSet owner reference")
+				return reconcile.Result{}, e
+			}
+			// use merge patch to replace the entire existing owner reference list
+			err = r.client.Patch(context.TODO(), currentEDS, client.RawPatch(types.MergePatchType, patch))
+			if err != nil {
+				logger.Error(err, "Unable to patch ExtendedDaemonSet owner reference")
+				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch ExtendedDaemonSet owner reference")
+				return reconcile.Result{}, err
+			}
+			logger.Info("ExtendedDaemonSet owner reference patched")
+		}
+
 		// check if same hash
 		needUpdate := !comparison.IsSameSpecMD5Hash(hash, currentEDS.GetAnnotations())
 		if !needUpdate {

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
@@ -117,8 +117,9 @@ func (r *Reconciler) applyAndCleanupDependencies(ctx context.Context, logger log
 		logger.V(2).Info("Dependencies apply error", "errs", errs)
 		return errors.NewAggregate(errs)
 	}
-	if errs = depsStore.Cleanup(ctx, r.client); len(errs) > 0 {
-		return errors.NewAggregate(errs)
-	}
+	// TODO: modify cleanup to prevent DDA dependency deletion
+	// if errs = depsStore.Cleanup(ctx, r.client); len(errs) > 0 {
+	// 	return errors.NewAggregate(errs)
+	// }
 	return nil
 }

--- a/internal/controller/datadogagentinternal/finalizer.go
+++ b/internal/controller/datadogagentinternal/finalizer.go
@@ -69,7 +69,9 @@ func (r *Reconciler) finalizeDDAI(reqLogger logr.Logger, obj client.Object) erro
 
 	// Namespaced resources from the store are deleted thanks to owner references.
 	// Cluster level resources must be deleted manually since they cannot have an owner reference.
-	r.cleanUpClusterLevelResources(reqLogger, obj)
+	if err := r.cleanUpClusterLevelResources(obj); err != nil {
+		return err
+	}
 
 	if err := r.profilesCleanup(); err != nil {
 		return err
@@ -129,11 +131,17 @@ func (r *Reconciler) profilesCleanup() error {
 	return nil
 }
 
-func (r *Reconciler) cleanUpClusterLevelResources(_ logr.Logger, ddai client.Object) error {
+func (r *Reconciler) cleanUpClusterLevelResources(ddai client.Object) error {
 	// Cluster level resources must be deleted manually since they cannot have an owner reference
-	deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRolesKind, r.platformInfo))
-	deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRoleBindingKind, r.platformInfo))
-	deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.APIServiceKind, r.platformInfo))
+	if err := deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRolesKind, r.platformInfo)); err != nil {
+		return err
+	}
+	if err := deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRoleBindingKind, r.platformInfo)); err != nil {
+		return err
+	}
+	if err := deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.APIServiceKind, r.platformInfo)); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/controller/datadogagentinternal/utils.go
+++ b/internal/controller/datadogagentinternal/utils.go
@@ -6,6 +6,7 @@
 package datadogagentinternal
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -111,6 +112,38 @@ func referSameObject(a, b metav1.OwnerReference) bool {
 	}
 
 	return aGV == bGV && a.Kind == b.Kind && a.Name == b.Name
+}
+
+// createOwnerReferencePatch creates a patch from owner references
+// We assume there is only one DDA owner reference
+func createOwnerReferencePatch(ownerRef []metav1.OwnerReference, owner metav1.Object, gvk schema.GroupVersionKind) ([]byte, error) {
+	patchedRefs := make([]metav1.OwnerReference, len(ownerRef))
+	copy(patchedRefs, ownerRef)
+
+	// Replace DDA owner reference with new owner reference
+	for i, ref := range patchedRefs {
+		if ref.Kind == "DatadogAgent" {
+			patchedRefs[i] = *newOwnerRef(owner, gvk)
+		}
+	}
+
+	// Create JSON patch for ownerReferences field
+	refBytes, err := json.Marshal(patchedRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(fmt.Sprintf(`{"metadata":{"ownerReferences":%s}}`, string(refBytes))), nil
+}
+
+// shouldUpdateOwnerReference returns true if the owner reference is a DatadogAgent
+func shouldUpdateOwnerReference(currentOwnerRef []metav1.OwnerReference) bool {
+	for _, ownerRef := range currentOwnerRef {
+		if ownerRef.Kind == "DatadogAgent" {
+			return true
+		}
+	}
+	return false
 }
 
 // getReplicas returns the desired replicas of a

--- a/pkg/testutils/ddai_new.go
+++ b/pkg/testutils/ddai_new.go
@@ -25,9 +25,10 @@ func NewDatadogAgentInternal(ns, name string, globalOverride *v2alpha1.GlobalCon
 			APIVersion: apiDDAIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-			Labels:    map[string]string{},
+			Namespace:  ns,
+			Name:       name,
+			Labels:     map[string]string{},
+			Finalizers: []string{"finalizer.datadoghq.com/datadogagentinternal"},
 		},
 		Spec: v2alpha1.DatadogAgentSpec{
 			Global: &v2alpha1.GlobalConfig{


### PR DESCRIPTION
### What does this PR do?

* Adds a patch request to change the ownerref of components when DDAI is enabled or disabled
* Removes some ddai specific naming so that component names don't change when enabling/disabling DDAI

### Motivation

What inspired you to submit this pull request?

### Additional Notes

This comments out some calls to dependency cleanup methods since the cleanups were removing the secrets created by the DDA controller

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
