### PR TITLE
Enable gpu host tags when GPUM is enabled

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/envvar.go
+++ b/internal/controller/datadogagent/feature/gpu/envvar.go
@@ -7,4 +7,5 @@ package gpu
 
 const DDEnableGPUMonitoringEnvVar = "DD_GPU_MONITORING_ENABLED"
 const DDEnableNVMLDetectionEnvVar = "DD_ENABLE_NVML_DETECTION"
+const DDCollectGPUTagsEnvVar = "DD_COLLECT_GPU_TAGS"
 const NVIDIAVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -144,7 +144,14 @@ func (f *gpuFeature) ManageNodeAgent(managers feature.PodTemplateManagers, _ str
 		Name:  DDEnableNVMLDetectionEnvVar,
 		Value: "true",
 	}
-	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName}, nvmlDetectionEnvVar)
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, nvmlDetectionEnvVar)
+
+	// env var to enable collecting gpu host tags ("gpu_host:true" tag)
+	collectGpuTagsEnvVar := &corev1.EnvVar{
+		Name:  DDCollectGPUTagsEnvVar,
+		Value: "true",
+	}
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, collectGpuTagsEnvVar)
 
 	// The agent check does not need to be manually enabled, the init config container will
 	// check if GPU monitoring is enabled and will enable the check automatically (see


### PR DESCRIPTION
### What does this PR do?

[Jira Ticket](https://datadoghq.atlassian.net/browse/EBPF-752)
Enabled collecting gpu host tags by setting the proper config flag

### Motivation

Today gpu host tags collection is behind a dedicated feature flag which is disabled by default. 
We want to collect those tags when GPUM is enabled

### Additional Notes

in the future we will turn this flag on by default to collect the tag for all hosts, regardless of GPUM feature

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.65.0
* Cluster Agent: vX.Y.Z

### Describe your test plan

Manually tested

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
