### PR TITLE
Limit service equality check

### DIFF
--- a/internal/controller/datadogagent/global/dependencies.go
+++ b/internal/controller/datadogagent/global/dependencies.go
@@ -226,7 +226,8 @@ func clusterAgentDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, ma
 	}
 
 	// Service
-	if err := manager.Store().AddOrUpdate(kubernetes.ServicesKind, clusteragent.GetClusterAgentService(dda)); err != nil {
+	service := clusteragent.GetClusterAgentService(dda)
+	if err := manager.ServiceManager().AddService(service.Name, service.Namespace, service.Spec.Selector, service.Spec.Ports, service.Spec.InternalTrafficPolicy); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/internal/controller/datadogagent/merger/service.go
+++ b/internal/controller/datadogagent/merger/service.go
@@ -33,6 +33,7 @@ type serviceManagerImpl struct {
 }
 
 // AddService creates or updates service
+// If configurable fields are added or deleted, update `isEqualServiceSpec` in `pkg/equality/equality.go`
 func (m *serviceManagerImpl) AddService(name, namespace string, selector map[string]string, ports []corev1.ServicePort, internalTrafficPolicy *corev1.ServiceInternalTrafficPolicyType) error {
 	obj, _ := m.store.GetOrCreate(kubernetes.ServicesKind, namespace, name)
 	service, ok := obj.(*corev1.Service)
@@ -47,6 +48,9 @@ func (m *serviceManagerImpl) AddService(name, namespace string, selector map[str
 		service.Spec.Selector = selector
 	}
 	service.Spec.Type = corev1.ServiceTypeClusterIP
+	// k8s default InternalTrafficPolicy is Cluster
+	clusterPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	service.Spec.InternalTrafficPolicy = &clusterPolicy
 	if internalTrafficPolicy != nil {
 		service.Spec.InternalTrafficPolicy = internalTrafficPolicy
 	}

--- a/pkg/equality/equality.go
+++ b/pkg/equality/equality.go
@@ -163,9 +163,17 @@ func IsEqualServices(objA, objB client.Object) bool {
 	a, okA := objA.(*corev1.Service)
 	b, okB := objB.(*corev1.Service)
 	if okA && okB && a != nil && b != nil {
-		return apiequality.Semantic.DeepEqual(a.Spec, b.Spec)
+		return isEqualServiceSpec(&a.Spec, &b.Spec)
 	}
 	return false
+}
+
+// isEqualServiceSpec checks two ServiceSpecs for equality based on the
+// configurable fields in `internal/controller/datadogagent/merger/service.go`
+func isEqualServiceSpec(a, b *corev1.ServiceSpec) bool {
+	return apiequality.Semantic.DeepEqual(a.Selector, b.Selector) &&
+		apiequality.Semantic.DeepEqual(a.Ports, b.Ports) &&
+		apiequality.Semantic.DeepEqual(a.InternalTrafficPolicy, b.InternalTrafficPolicy)
 }
 
 // IsEqualServiceAccounts return true if the two ServiceAccounts are equal


### PR DESCRIPTION
### What does this PR do?

Checks only selector, ports, and internal traffic policy for service equality

### Motivation

https://datadoghq.atlassian.net/browse/CECO-2266
k8s defaults cause the current service equality check to fail, which leads to unnecessary service update requests being sent to k8s

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Check k8s audit logs to see how frequently update requests are sent for services created by the operator. Also visible in the operator rollout dashboard

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
