### PR TITLE
Use ubi10 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,9 @@ RUN if [ "$FIPS_ENABLED" = "true" ]; then \
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o helpers cmd/helpers/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS certs
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 
 LABEL name="datadog/operator"
 LABEL vendor="Datadog Inc."

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -32,7 +32,7 @@ ARG LDFLAGS
 ARG GOARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o check-operator cmd/check-operator/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/check-operator .
 USER 1001


### PR DESCRIPTION
### What does this PR do?

* Uses ubi10 (RHEL 10) instead of ubi9 as base image

### Motivation

* Fixes some CVE found in RHEL 9 but not 10, e.g. https://access.redhat.com/security/cve/CVE-2025-4802

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
