### PR TITLE
[AGTMETRICS-233] Add support for OpenTelemetry Agent and Agent Data Plane to DAPs. (v1.15.0 backport)

### DIFF
--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -311,6 +311,8 @@ func containersOverride(nodeAgentOverride *v1alpha1.Override) map[apicommon.Agen
 		apicommon.ProcessAgentContainerName,
 		apicommon.SecurityAgentContainerName,
 		apicommon.SystemProbeContainerName,
+		apicommon.OtelAgent,
+		apicommon.AgentDataPlaneContainerName,
 	}
 
 	res := map[apicommon.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{}


### PR DESCRIPTION
### What does this PR do?

Backport of #1951.

### Motivation

No intention of _merging_ this PR, but wanted to submit it as a PR to have kind of a paper trail that we're building a custom image from it that will be used temporarily on a few clusters while we wait for v1.16.0.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
