### PR TITLE
[CECO-2270] Modify pkg/constants/utils.go to make it generic, and remove DDAI specific

### DIFF
--- a/internal/controller/datadogagent/component/clusteragent/default.go
+++ b/internal/controller/datadogagent/component/clusteragent/default.go
@@ -188,7 +188,7 @@ func defaultEnvVars(dda *v2alpha1.DatadogAgent) []corev1.EnvVar {
 		},
 		{
 			Name:  DDClusterAgentServiceAccountName,
-			Value: constants.GetClusterAgentServiceAccount(dda),
+			Value: constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec),
 		},
 		{
 			Name:  DDAgentDaemonSet,

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -93,7 +93,7 @@ func shouldEnablesidecarInjection(sidecarInjectionConf *v2alpha1.AgentSidecarInj
 
 func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.RequiredComponents) {
 	f.owner = dda
-	f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+	f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
 	ac := dda.Spec.Features.AdmissionController
 

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -129,7 +129,7 @@ func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqC
 			}
 			// otherwise don't set to fall back to default agent setting `hostip`
 		}
-		f.localServiceName = constants.GetLocalAgentServiceName(dda)
+		f.localServiceName = constants.GetLocalAgentServiceName(dda.Name, &dda.Spec)
 		reqComp = feature.RequiredComponents{
 			ClusterAgent: feature.RequiredComponent{
 				IsRequired: apiutils.NewBoolPointer(true),
@@ -154,7 +154,7 @@ func (f *admissionControllerFeature) Configure(dda *v2alpha1.DatadogAgent) (reqC
 			f.kubernetesAdmissionEvents = &KubernetesAdmissionEventConfig{enabled: true}
 		}
 
-		_, f.networkPolicy = constants.IsNetworkPolicyEnabled(dda)
+		_, f.networkPolicy = constants.IsNetworkPolicyEnabled(&dda.Spec)
 
 		sidecarConfig := dda.Spec.Features.AdmissionController.AgentSidecarInjection
 		if shouldEnablesidecarInjection(sidecarConfig) {

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -126,12 +126,12 @@ func (f *apmFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requ
 	apm := dda.Spec.Features.APM
 	if shouldEnableAPM(apm) {
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
-		f.useHostNetwork = constants.IsHostNetworkEnabled(dda, v2alpha1.NodeAgentComponentName)
+		f.useHostNetwork = constants.IsHostNetworkEnabled(&dda.Spec, v2alpha1.NodeAgentComponentName)
 		// hostPort defaults to 'false' in the defaulting code
 		f.hostPortEnabled = apiutils.BoolValue(apm.HostPortConfig.Enabled)
 		f.hostPortHostPort = *apm.HostPortConfig.Port
 		if f.hostPortEnabled {
-			if enabled, flavor := constants.IsNetworkPolicyEnabled(dda); enabled {
+			if enabled, flavor := constants.IsNetworkPolicyEnabled(&dda.Spec); enabled {
 				if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 					f.createCiliumNetworkPolicy = true
 				} else {
@@ -146,7 +146,7 @@ func (f *apmFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requ
 		if dda.Spec.Global.LocalService != nil {
 			f.forceEnableLocalService = apiutils.BoolValue(dda.Spec.Global.LocalService.ForceEnableLocalService)
 		}
-		f.localServiceName = constants.GetLocalAgentServiceName(dda)
+		f.localServiceName = constants.GetLocalAgentServiceName(dda.Name, &dda.Spec)
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -125,7 +125,7 @@ func (f *apmFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Requ
 	f.owner = dda
 	apm := dda.Spec.Features.APM
 	if shouldEnableAPM(apm) {
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 		f.useHostNetwork = constants.IsHostNetworkEnabled(dda, v2alpha1.NodeAgentComponentName)
 		// hostPort defaults to 'false' in the defaulting code
 		f.hostPortEnabled = apiutils.BoolValue(apm.HostPortConfig.Enabled)

--- a/internal/controller/datadogagent/feature/autoscaling/feature.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature.go
@@ -63,7 +63,7 @@ func (f *autoscalingFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feat
 
 	admission := dda.Spec.Features.AdmissionController
 	f.admissionControllerActivated = apiutils.BoolValue(admission.Enabled)
-	f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+	f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
 	return feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{

--- a/internal/controller/datadogagent/feature/clusterchecks/feature.go
+++ b/internal/controller/datadogagent/feature/clusterchecks/feature.go
@@ -62,7 +62,7 @@ func (f *clusterChecksFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp fe
 		f.updateConfigHash(dda)
 		f.owner = dda
 
-		if enabled, flavor := constants.IsNetworkPolicyEnabled(dda); enabled {
+		if enabled, flavor := constants.IsNetworkPolicyEnabled(&dda.Spec); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 				f.createCiliumNetworkPolicy = true
 			} else {

--- a/internal/controller/datadogagent/feature/cspm/feature.go
+++ b/internal/controller/datadogagent/feature/cspm/feature.go
@@ -73,7 +73,7 @@ func (f *cspmFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Req
 
 	if cspmConfig != nil && apiutils.BoolValue(cspmConfig.Enabled) {
 		f.enable = true
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
 		if cspmConfig.CheckInterval != nil {
 			f.checkInterval = strconv.FormatInt(cspmConfig.CheckInterval.Nanoseconds(), 10)

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -81,7 +81,7 @@ func (f *dogstatsdFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp featur
 	if dogstatsd.TagCardinality != nil {
 		f.tagCardinality = *dogstatsd.TagCardinality
 	}
-	f.useHostNetwork = constants.IsHostNetworkEnabled(dda, v2alpha1.NodeAgentComponentName)
+	f.useHostNetwork = constants.IsHostNetworkEnabled(&dda.Spec, v2alpha1.NodeAgentComponentName)
 	if dogstatsd.MapperProfiles != nil {
 		f.mapperProfiles = dogstatsd.MapperProfiles
 	}
@@ -89,7 +89,7 @@ func (f *dogstatsdFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp featur
 	if dda.Spec.Global.LocalService != nil {
 		f.forceEnableLocalService = apiutils.BoolValue(dda.Spec.Global.LocalService.ForceEnableLocalService)
 	}
-	f.localServiceName = constants.GetLocalAgentServiceName(dda)
+	f.localServiceName = constants.GetLocalAgentServiceName(dda.Name, &dda.Spec)
 
 	f.adpEnabled = featureutils.HasAgentDataPlaneAnnotation(dda)
 

--- a/internal/controller/datadogagent/feature/eventcollection/feature.go
+++ b/internal/controller/datadogagent/feature/eventcollection/feature.go
@@ -70,7 +70,7 @@ func (f *eventCollectionFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 	// v2alpha1 configures event collection using the cluster agent only
 	// leader election is enabled by default
 	if dda.Spec.Features != nil && dda.Spec.Features.EventCollection != nil && apiutils.BoolValue(dda.Spec.Features.EventCollection.CollectKubernetesEvents) {
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 		f.rbacSuffix = common.ClusterAgentSuffix
 
 		if apiutils.BoolValue(dda.Spec.Features.EventCollection.UnbundleEvents) {

--- a/internal/controller/datadogagent/feature/externalmetrics/feature.go
+++ b/internal/controller/datadogagent/feature/externalmetrics/feature.go
@@ -126,7 +126,7 @@ func (f *externalMetricsFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
-		if enabled, flavor := constants.IsNetworkPolicyEnabled(dda); enabled {
+		if enabled, flavor := constants.IsNetworkPolicyEnabled(&dda.Spec); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 				f.createCiliumNetworkPolicy = true
 			} else {

--- a/internal/controller/datadogagent/feature/externalmetrics/feature.go
+++ b/internal/controller/datadogagent/feature/externalmetrics/feature.go
@@ -124,7 +124,7 @@ func (f *externalMetricsFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp 
 			}
 		}
 
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
 		if enabled, flavor := constants.IsNetworkPolicyEnabled(dda); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {

--- a/internal/controller/datadogagent/feature/helmcheck/feature.go
+++ b/internal/controller/datadogagent/feature/helmcheck/feature.go
@@ -78,12 +78,12 @@ func (f *helmCheckFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp featur
 		f.configMapName = fmt.Sprintf("%s-%s", f.owner.GetName(), defaultHelmCheckConf)
 		f.collectEvents = apiutils.BoolValue(helmCheck.CollectEvents)
 		f.valuesAsTags = helmCheck.ValuesAsTags
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
 		if constants.IsClusterChecksEnabled(dda) && constants.IsCCREnabled(dda) {
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
-			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda)
+			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)
 			reqComp.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 			reqComp.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 		}

--- a/internal/controller/datadogagent/feature/helmcheck/feature.go
+++ b/internal/controller/datadogagent/feature/helmcheck/feature.go
@@ -80,7 +80,7 @@ func (f *helmCheckFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp featur
 		f.valuesAsTags = helmCheck.ValuesAsTags
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
-		if constants.IsClusterChecksEnabled(dda) && constants.IsCCREnabled(dda) {
+		if constants.IsClusterChecksEnabled(&dda.Spec) && constants.IsCCREnabled(&dda.Spec) {
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
 			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)

--- a/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
@@ -84,13 +84,13 @@ func (f *ksmFeature) Configure(dda *v2alpha1.DatadogAgent) feature.RequiredCompo
 
 		f.collectAPIServiceMetrics = true
 		f.collectCRDMetrics = true
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
 		// This check will only run in the Cluster Checks Runners or Cluster Agent (not the Node Agent)
 		if dda.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.Enabled) && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners) {
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
-			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda)
+			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)
 			output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 			output.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
@@ -113,7 +113,7 @@ func (f *orchestratorExplorerFeature) Configure(dda *v2alpha1.DatadogAgent) (req
 		if orchestratorExplorer.DDUrl != nil {
 			f.ddURL = *orchestratorExplorer.DDUrl
 		}
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 
 		// Handle automatic addition of OOTB resources
 		// Autoscaling: Add DPA resource if enabled and replace older versions if present
@@ -139,7 +139,7 @@ func (f *orchestratorExplorerFeature) Configure(dda *v2alpha1.DatadogAgent) (req
 			if constants.IsCCREnabled(dda) {
 				f.runInClusterChecksRunner = true
 				f.rbacSuffix = common.ChecksRunnerSuffix
-				f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda)
+				f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)
 				reqComp.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 			}
 		}

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
@@ -135,8 +135,8 @@ func (f *orchestratorExplorerFeature) Configure(dda *v2alpha1.DatadogAgent) (req
 		slices.Sort(f.customResources)
 		f.customResources = slices.Compact(f.customResources)
 
-		if constants.IsClusterChecksEnabled(dda) {
-			if constants.IsCCREnabled(dda) {
+		if constants.IsClusterChecksEnabled(&dda.Spec) {
+			if constants.IsCCREnabled(&dda.Spec) {
 				f.runInClusterChecksRunner = true
 				f.rbacSuffix = common.ChecksRunnerSuffix
 				f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)

--- a/internal/controller/datadogagent/feature/otlp/feature.go
+++ b/internal/controller/datadogagent/feature/otlp/feature.go
@@ -111,7 +111,7 @@ func (f *otlpFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Req
 	if dda.Spec.Global.LocalService != nil {
 		f.forceEnableLocalService = apiutils.BoolValue(dda.Spec.Global.LocalService.ForceEnableLocalService)
 	}
-	f.localServiceName = constants.GetLocalAgentServiceName(dda)
+	f.localServiceName = constants.GetLocalAgentServiceName(dda.Name, &dda.Spec)
 
 	if f.grpcEnabled || f.httpEnabled {
 		reqComp = feature.RequiredComponents{
@@ -128,7 +128,7 @@ func (f *otlpFeature) Configure(dda *v2alpha1.DatadogAgent) (reqComp feature.Req
 		}
 	}
 	if f.grpcEnabled || f.httpEnabled {
-		if enabled, flavor := constants.IsNetworkPolicyEnabled(dda); enabled {
+		if enabled, flavor := constants.IsNetworkPolicyEnabled(&dda.Spec); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 				f.createCiliumNetworkPolicy = true
 			} else {

--- a/internal/controller/datadogagent/global/dependencies.go
+++ b/internal/controller/datadogagent/global/dependencies.go
@@ -207,7 +207,7 @@ func rbacDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager fe
 
 func clusterAgentDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers) error {
 	var errs []error
-	serviceAccountName := constants.GetClusterAgentServiceAccount(dda)
+	serviceAccountName := constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 	rbacResourcesName := clusteragent.GetClusterAgentRbacResourcesName(dda)
 
 	// Service account
@@ -236,7 +236,7 @@ func clusterAgentDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, ma
 
 func nodeAgentDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers) error {
 	var errs []error
-	serviceAccountName := constants.GetAgentServiceAccount(dda)
+	serviceAccountName := constants.GetAgentServiceAccount(dda.Name, &dda.Spec)
 	rbacResourcesName := agent.GetAgentRoleName(dda)
 
 	// Service account
@@ -254,7 +254,7 @@ func nodeAgentDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manag
 
 func clusterChecksRunnerDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers) error {
 	var errs []error
-	serviceAccountName := constants.GetClusterChecksRunnerServiceAccount(dda)
+	serviceAccountName := constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)
 	rbacResourcesName := clusterchecksrunner.GetCCRRbacResourcesName(dda)
 
 	// Service account
@@ -303,11 +303,11 @@ func addSecretBackendDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent
 		var componentSaName string
 		switch component {
 		case v2alpha1.ClusterAgentComponentName:
-			componentSaName = constants.GetClusterAgentServiceAccount(dda)
+			componentSaName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 		case v2alpha1.NodeAgentComponentName:
-			componentSaName = constants.GetAgentServiceAccount(dda)
+			componentSaName = constants.GetAgentServiceAccount(dda.Name, &dda.Spec)
 		case v2alpha1.ClusterChecksRunnerComponentName:
-			componentSaName = constants.GetClusterChecksRunnerServiceAccount(dda)
+			componentSaName = constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)
 		}
 
 		agentName := dda.GetName()
@@ -365,7 +365,7 @@ func resourcesAsTagsDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent,
 		if err := manager.RBACManager().AddClusterPolicyRules(
 			dda.Namespace,
 			clusteragent.GetResourceMetadataAsTagsClusterRoleName(dda),
-			constants.GetClusterAgentServiceAccount(dda),
+			constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec),
 			clusteragent.GetKubernetesResourceMetadataAsTagsPolicyRules(global.KubernetesResourcesLabelsAsTags, global.KubernetesResourcesAnnotationsAsTags),
 		); err != nil {
 			return err

--- a/internal/controller/datadogagent/global/dependencies.go
+++ b/internal/controller/datadogagent/global/dependencies.go
@@ -272,7 +272,7 @@ func clusterChecksRunnerDependencies(logger logr.Logger, dda *v2alpha1.DatadogAg
 
 func addNetworkPolicyDependencies(dda *v2alpha1.DatadogAgent, manager feature.ResourceManagers, componentName v2alpha1.ComponentName) error {
 	config := dda.Spec.Global
-	if enabled, flavor := constants.IsNetworkPolicyEnabled(dda); enabled {
+	if enabled, flavor := constants.IsNetworkPolicyEnabled(&dda.Spec); enabled {
 		switch flavor {
 		case v2alpha1.NetworkPolicyFlavorKubernetes:
 			return manager.NetworkPolicyManager().AddKubernetesNetworkPolicy(objects.BuildKubernetesNetworkPolicy(dda, componentName))
@@ -286,7 +286,7 @@ func addNetworkPolicyDependencies(dda *v2alpha1.DatadogAgent, manager feature.Re
 					dda,
 					*config.Site,
 					getURLEndpoint(dda),
-					constants.IsHostNetworkEnabled(dda, v2alpha1.ClusterAgentComponentName),
+					constants.IsHostNetworkEnabled(&dda.Spec, v2alpha1.ClusterAgentComponentName),
 					dnsSelectorEndpoints,
 					componentName,
 				),

--- a/internal/controller/datadogagent/override/dependencies.go
+++ b/internal/controller/datadogagent/override/dependencies.go
@@ -29,7 +29,7 @@ func Dependencies(logger logr.Logger, manager feature.ResourceManagers, dda *v2a
 	namespace := dda.Namespace
 
 	for component, override := range overrides {
-		err := overrideRBAC(logger, manager, override, component, constants.GetServiceAccountByComponent(dda, component), namespace)
+		err := overrideRBAC(logger, manager, override, component, constants.GetServiceAccountByComponent(dda.Name, &dda.Spec, component), namespace)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/controller/datadogagent/override/dependencies_test.go
+++ b/internal/controller/datadogagent/override/dependencies_test.go
@@ -257,15 +257,15 @@ func TestServiceAccountAnnotationOverride(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res := map[v2alpha1.ComponentName]map[string]interface{}{
 				v2alpha1.NodeAgentComponentName: {
-					"name":        constants.GetAgentServiceAccount(tt.dda),
+					"name":        constants.GetAgentServiceAccount(tt.dda.Name, &tt.dda.Spec),
 					"annotations": getSaAnnotations(tt.dda, v2alpha1.NodeAgentComponentName),
 				},
 				v2alpha1.ClusterChecksRunnerComponentName: {
-					"name":        constants.GetClusterChecksRunnerServiceAccount(tt.dda),
+					"name":        constants.GetClusterChecksRunnerServiceAccount(tt.dda.Name, &tt.dda.Spec),
 					"annotations": getSaAnnotations(tt.dda, v2alpha1.ClusterChecksRunnerComponentName),
 				},
 				v2alpha1.ClusterAgentComponentName: {
-					"name":        constants.GetClusterAgentServiceAccount(tt.dda),
+					"name":        constants.GetClusterAgentServiceAccount(tt.dda.Name, &tt.dda.Spec),
 					"annotations": getSaAnnotations(tt.dda, v2alpha1.ClusterAgentComponentName),
 				},
 			}

--- a/internal/controller/datadogagentinternal/component/clusteragent/default.go
+++ b/internal/controller/datadogagentinternal/component/clusteragent/default.go
@@ -188,7 +188,7 @@ func defaultEnvVars(dda *v1alpha1.DatadogAgentInternal) []corev1.EnvVar {
 		},
 		{
 			Name:  DDClusterAgentServiceAccountName,
-			Value: constants.GetClusterAgentServiceAccountDDAI(dda),
+			Value: constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec),
 		},
 		{
 			Name:  DDAgentDaemonSet,

--- a/internal/controller/datadogagentinternal/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagentinternal/feature/admissioncontroller/feature.go
@@ -94,7 +94,7 @@ func shouldEnablesidecarInjection(sidecarInjectionConf *v2alpha1.AgentSidecarInj
 
 func (f *admissionControllerFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqComp feature.RequiredComponents) {
 	f.owner = ddai
-	f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+	f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
 	ac := ddai.Spec.Features.AdmissionController
 

--- a/internal/controller/datadogagentinternal/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagentinternal/feature/admissioncontroller/feature.go
@@ -130,7 +130,7 @@ func (f *admissionControllerFeature) Configure(ddai *v1alpha1.DatadogAgentIntern
 			}
 			// otherwise don't set to fall back to default agent setting `hostip`
 		}
-		f.localServiceName = constants.GetLocalAgentServiceNameDDAI(ddai)
+		f.localServiceName = constants.GetLocalAgentServiceName(ddai.Name, &ddai.Spec)
 		reqComp = feature.RequiredComponents{
 			ClusterAgent: feature.RequiredComponent{
 				IsRequired: apiutils.NewBoolPointer(true),
@@ -155,7 +155,7 @@ func (f *admissionControllerFeature) Configure(ddai *v1alpha1.DatadogAgentIntern
 			f.kubernetesAdmissionEvents = &KubernetesAdmissionEventConfig{enabled: true}
 		}
 
-		_, f.networkPolicy = constants.IsNetworkPolicyEnabledDDAI(ddai)
+		_, f.networkPolicy = constants.IsNetworkPolicyEnabled(&ddai.Spec)
 
 		sidecarConfig := ddai.Spec.Features.AdmissionController.AgentSidecarInjection
 		if shouldEnablesidecarInjection(sidecarConfig) {

--- a/internal/controller/datadogagentinternal/feature/apm/feature.go
+++ b/internal/controller/datadogagentinternal/feature/apm/feature.go
@@ -126,7 +126,7 @@ func (f *apmFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqComp fea
 	f.owner = ddai
 	apm := ddai.Spec.Features.APM
 	if shouldEnableAPM(apm) {
-		f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 		f.useHostNetwork = constants.IsHostNetworkEnabledDDAI(ddai, v2alpha1.NodeAgentComponentName)
 		// hostPort defaults to 'false' in the defaulting code
 		f.hostPortEnabled = apiutils.BoolValue(apm.HostPortConfig.Enabled)

--- a/internal/controller/datadogagentinternal/feature/apm/feature.go
+++ b/internal/controller/datadogagentinternal/feature/apm/feature.go
@@ -127,12 +127,12 @@ func (f *apmFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqComp fea
 	apm := ddai.Spec.Features.APM
 	if shouldEnableAPM(apm) {
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
-		f.useHostNetwork = constants.IsHostNetworkEnabledDDAI(ddai, v2alpha1.NodeAgentComponentName)
+		f.useHostNetwork = constants.IsHostNetworkEnabled(&ddai.Spec, v2alpha1.NodeAgentComponentName)
 		// hostPort defaults to 'false' in the defaulting code
 		f.hostPortEnabled = apiutils.BoolValue(apm.HostPortConfig.Enabled)
 		f.hostPortHostPort = *apm.HostPortConfig.Port
 		if f.hostPortEnabled {
-			if enabled, flavor := constants.IsNetworkPolicyEnabledDDAI(ddai); enabled {
+			if enabled, flavor := constants.IsNetworkPolicyEnabled(&ddai.Spec); enabled {
 				if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 					f.createCiliumNetworkPolicy = true
 				} else {
@@ -147,7 +147,7 @@ func (f *apmFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqComp fea
 		if ddai.Spec.Global.LocalService != nil {
 			f.forceEnableLocalService = apiutils.BoolValue(ddai.Spec.Global.LocalService.ForceEnableLocalService)
 		}
-		f.localServiceName = constants.GetLocalAgentServiceNameDDAI(ddai)
+		f.localServiceName = constants.GetLocalAgentServiceName(ddai.Name, &ddai.Spec)
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{

--- a/internal/controller/datadogagentinternal/feature/autoscaling/feature.go
+++ b/internal/controller/datadogagentinternal/feature/autoscaling/feature.go
@@ -64,7 +64,7 @@ func (f *autoscalingFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (req
 
 	admission := ddai.Spec.Features.AdmissionController
 	f.admissionControllerActivated = apiutils.BoolValue(admission.Enabled)
-	f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+	f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
 	return feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{

--- a/internal/controller/datadogagentinternal/feature/clusterchecks/feature.go
+++ b/internal/controller/datadogagentinternal/feature/clusterchecks/feature.go
@@ -63,7 +63,7 @@ func (f *clusterChecksFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (r
 		f.updateConfigHash(ddai)
 		f.owner = ddai
 
-		if enabled, flavor := constants.IsNetworkPolicyEnabledDDAI(ddai); enabled {
+		if enabled, flavor := constants.IsNetworkPolicyEnabled(&ddai.Spec); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 				f.createCiliumNetworkPolicy = true
 			} else {

--- a/internal/controller/datadogagentinternal/feature/cspm/feature.go
+++ b/internal/controller/datadogagentinternal/feature/cspm/feature.go
@@ -74,7 +74,7 @@ func (f *cspmFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqComp fe
 
 	if cspmConfig != nil && apiutils.BoolValue(cspmConfig.Enabled) {
 		f.enable = true
-		f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
 		if cspmConfig.CheckInterval != nil {
 			f.checkInterval = strconv.FormatInt(cspmConfig.CheckInterval.Nanoseconds(), 10)

--- a/internal/controller/datadogagentinternal/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagentinternal/feature/dogstatsd/feature.go
@@ -82,7 +82,7 @@ func (f *dogstatsdFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqCo
 	if dogstatsd.TagCardinality != nil {
 		f.tagCardinality = *dogstatsd.TagCardinality
 	}
-	f.useHostNetwork = constants.IsHostNetworkEnabledDDAI(ddai, v2alpha1.NodeAgentComponentName)
+	f.useHostNetwork = constants.IsHostNetworkEnabled(&ddai.Spec, v2alpha1.NodeAgentComponentName)
 	if dogstatsd.MapperProfiles != nil {
 		f.mapperProfiles = dogstatsd.MapperProfiles
 	}
@@ -90,7 +90,7 @@ func (f *dogstatsdFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqCo
 	if ddai.Spec.Global.LocalService != nil {
 		f.forceEnableLocalService = apiutils.BoolValue(ddai.Spec.Global.LocalService.ForceEnableLocalService)
 	}
-	f.localServiceName = constants.GetLocalAgentServiceNameDDAI(ddai)
+	f.localServiceName = constants.GetLocalAgentServiceName(ddai.Name, &ddai.Spec)
 
 	f.adpEnabled = featureutils.HasAgentDataPlaneAnnotation(ddai)
 

--- a/internal/controller/datadogagentinternal/feature/eventcollection/feature.go
+++ b/internal/controller/datadogagentinternal/feature/eventcollection/feature.go
@@ -71,7 +71,7 @@ func (f *eventCollectionFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) 
 	// v2alpha1 configures event collection using the cluster agent only
 	// leader election is enabled by default
 	if ddai.Spec.Features != nil && ddai.Spec.Features.EventCollection != nil && apiutils.BoolValue(ddai.Spec.Features.EventCollection.CollectKubernetesEvents) {
-		f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 		f.rbacSuffix = common.ClusterAgentSuffix
 
 		if apiutils.BoolValue(ddai.Spec.Features.EventCollection.UnbundleEvents) {

--- a/internal/controller/datadogagentinternal/feature/externalmetrics/feature.go
+++ b/internal/controller/datadogagentinternal/feature/externalmetrics/feature.go
@@ -127,7 +127,7 @@ func (f *externalMetricsFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) 
 
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
-		if enabled, flavor := constants.IsNetworkPolicyEnabledDDAI(ddai); enabled {
+		if enabled, flavor := constants.IsNetworkPolicyEnabled(&ddai.Spec); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 				f.createCiliumNetworkPolicy = true
 			} else {

--- a/internal/controller/datadogagentinternal/feature/externalmetrics/feature.go
+++ b/internal/controller/datadogagentinternal/feature/externalmetrics/feature.go
@@ -125,7 +125,7 @@ func (f *externalMetricsFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) 
 			}
 		}
 
-		f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
 		if enabled, flavor := constants.IsNetworkPolicyEnabledDDAI(ddai); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {

--- a/internal/controller/datadogagentinternal/feature/helmcheck/feature.go
+++ b/internal/controller/datadogagentinternal/feature/helmcheck/feature.go
@@ -78,12 +78,12 @@ func (f *helmCheckFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqCo
 		f.configMapName = fmt.Sprintf("%s-%s", f.owner.GetName(), defaultHelmCheckConf)
 		f.collectEvents = apiutils.BoolValue(helmCheck.CollectEvents)
 		f.valuesAsTags = helmCheck.ValuesAsTags
-		f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
 		if constants.IsClusterChecksEnabledDDAI(ddai) && constants.IsCCREnabledDDAI(ddai) {
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
-			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccountDDAI(ddai)
+			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(ddai.Name, &ddai.Spec)
 			reqComp.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 			reqComp.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 		}

--- a/internal/controller/datadogagentinternal/feature/helmcheck/feature.go
+++ b/internal/controller/datadogagentinternal/feature/helmcheck/feature.go
@@ -80,7 +80,7 @@ func (f *helmCheckFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqCo
 		f.valuesAsTags = helmCheck.ValuesAsTags
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
-		if constants.IsClusterChecksEnabledDDAI(ddai) && constants.IsCCREnabledDDAI(ddai) {
+		if constants.IsClusterChecksEnabled(&ddai.Spec) && constants.IsCCREnabled(&ddai.Spec) {
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
 			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(ddai.Name, &ddai.Spec)

--- a/internal/controller/datadogagentinternal/feature/kubernetesstatecore/feature.go
+++ b/internal/controller/datadogagentinternal/feature/kubernetesstatecore/feature.go
@@ -85,13 +85,13 @@ func (f *ksmFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) feature.Requ
 
 		f.collectAPIServiceMetrics = true
 		f.collectCRDMetrics = true
-		f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
 		// This check will only run in the Cluster Checks Runners or Cluster Agent (not the Node Agent)
 		if ddai.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(ddai.Spec.Features.ClusterChecks.Enabled) && apiutils.BoolValue(ddai.Spec.Features.ClusterChecks.UseClusterChecksRunners) {
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
-			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccountDDAI(ddai)
+			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(ddai.Name, &ddai.Spec)
 			output.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 			output.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 

--- a/internal/controller/datadogagentinternal/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagentinternal/feature/orchestratorexplorer/feature.go
@@ -114,7 +114,7 @@ func (f *orchestratorExplorerFeature) Configure(ddai *v1alpha1.DatadogAgentInter
 		if orchestratorExplorer.DDUrl != nil {
 			f.ddURL = *orchestratorExplorer.DDUrl
 		}
-		f.serviceAccountName = constants.GetClusterAgentServiceAccountDDAI(ddai)
+		f.serviceAccountName = constants.GetClusterAgentServiceAccount(ddai.Name, &ddai.Spec)
 
 		// Handle automatic addition of OOTB resources
 		// Autoscaling: Add DPA resource if enabled and replace older versions if present
@@ -140,7 +140,7 @@ func (f *orchestratorExplorerFeature) Configure(ddai *v1alpha1.DatadogAgentInter
 			if constants.IsCCREnabledDDAI(ddai) {
 				f.runInClusterChecksRunner = true
 				f.rbacSuffix = common.ChecksRunnerSuffix
-				f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccountDDAI(ddai)
+				f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(ddai.Name, &ddai.Spec)
 				reqComp.ClusterChecksRunner.IsRequired = apiutils.NewBoolPointer(true)
 			}
 		}

--- a/internal/controller/datadogagentinternal/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagentinternal/feature/orchestratorexplorer/feature.go
@@ -136,8 +136,8 @@ func (f *orchestratorExplorerFeature) Configure(ddai *v1alpha1.DatadogAgentInter
 		slices.Sort(f.customResources)
 		f.customResources = slices.Compact(f.customResources)
 
-		if constants.IsClusterChecksEnabledDDAI(ddai) {
-			if constants.IsCCREnabledDDAI(ddai) {
+		if constants.IsClusterChecksEnabled(&ddai.Spec) {
+			if constants.IsCCREnabled(&ddai.Spec) {
 				f.runInClusterChecksRunner = true
 				f.rbacSuffix = common.ChecksRunnerSuffix
 				f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(ddai.Name, &ddai.Spec)

--- a/internal/controller/datadogagentinternal/feature/otlp/feature.go
+++ b/internal/controller/datadogagentinternal/feature/otlp/feature.go
@@ -112,7 +112,7 @@ func (f *otlpFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqComp fe
 	if ddai.Spec.Global.LocalService != nil {
 		f.forceEnableLocalService = apiutils.BoolValue(ddai.Spec.Global.LocalService.ForceEnableLocalService)
 	}
-	f.localServiceName = constants.GetLocalAgentServiceNameDDAI(ddai)
+	f.localServiceName = constants.GetLocalAgentServiceName(ddai.Name, &ddai.Spec)
 
 	if f.grpcEnabled || f.httpEnabled {
 		reqComp = feature.RequiredComponents{
@@ -129,7 +129,7 @@ func (f *otlpFeature) Configure(ddai *v1alpha1.DatadogAgentInternal) (reqComp fe
 		}
 	}
 	if f.grpcEnabled || f.httpEnabled {
-		if enabled, flavor := constants.IsNetworkPolicyEnabledDDAI(ddai); enabled {
+		if enabled, flavor := constants.IsNetworkPolicyEnabled(&ddai.Spec); enabled {
 			if flavor == v2alpha1.NetworkPolicyFlavorCilium {
 				f.createCiliumNetworkPolicy = true
 			} else {

--- a/internal/controller/datadogagentinternal/global/dependencies.go
+++ b/internal/controller/datadogagentinternal/global/dependencies.go
@@ -224,7 +224,7 @@ func clusterChecksRunnerDependencies(logger logr.Logger, dda *v1alpha1.DatadogAg
 
 func addNetworkPolicyDependencies(dda *v1alpha1.DatadogAgentInternal, manager feature.ResourceManagers, componentName v2alpha1.ComponentName) error {
 	config := dda.Spec.Global
-	if enabled, flavor := constants.IsNetworkPolicyEnabledDDAI(dda); enabled {
+	if enabled, flavor := constants.IsNetworkPolicyEnabled(&dda.Spec); enabled {
 		switch flavor {
 		case v2alpha1.NetworkPolicyFlavorKubernetes:
 			return manager.NetworkPolicyManager().AddKubernetesNetworkPolicy(objects.BuildKubernetesNetworkPolicy(dda, componentName))
@@ -238,7 +238,7 @@ func addNetworkPolicyDependencies(dda *v1alpha1.DatadogAgentInternal, manager fe
 					dda,
 					*config.Site,
 					getURLEndpoint(dda),
-					constants.IsHostNetworkEnabledDDAI(dda, v2alpha1.ClusterAgentComponentName),
+					constants.IsHostNetworkEnabled(&dda.Spec, v2alpha1.ClusterAgentComponentName),
 					dnsSelectorEndpoints,
 					componentName,
 				),

--- a/internal/controller/datadogagentinternal/global/dependencies.go
+++ b/internal/controller/datadogagentinternal/global/dependencies.go
@@ -160,7 +160,7 @@ func rbacDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgentInternal, ma
 
 func clusterAgentDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgentInternal, manager feature.ResourceManagers) error {
 	var errs []error
-	serviceAccountName := constants.GetClusterAgentServiceAccountDDAI(dda)
+	serviceAccountName := constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 	rbacResourcesName := clusteragent.GetClusterAgentRbacResourcesName(dda)
 
 	// Service account
@@ -188,7 +188,7 @@ func clusterAgentDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgentInte
 
 func nodeAgentDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgentInternal, manager feature.ResourceManagers) error {
 	var errs []error
-	serviceAccountName := constants.GetAgentServiceAccountDDAI(dda)
+	serviceAccountName := constants.GetAgentServiceAccount(dda.Name, &dda.Spec)
 	rbacResourcesName := agent.GetAgentRoleName(dda)
 
 	// Service account
@@ -206,7 +206,7 @@ func nodeAgentDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgentInterna
 
 func clusterChecksRunnerDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgentInternal, manager feature.ResourceManagers) error {
 	var errs []error
-	serviceAccountName := constants.GetClusterChecksRunnerServiceAccountDDAI(dda)
+	serviceAccountName := constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)
 	rbacResourcesName := clusterchecksrunner.GetCCRRbacResourcesName(dda)
 
 	// Service account
@@ -255,11 +255,11 @@ func addSecretBackendDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgent
 		var componentSaName string
 		switch component {
 		case v2alpha1.ClusterAgentComponentName:
-			componentSaName = constants.GetClusterAgentServiceAccountDDAI(dda)
+			componentSaName = constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec)
 		case v2alpha1.NodeAgentComponentName:
-			componentSaName = constants.GetAgentServiceAccountDDAI(dda)
+			componentSaName = constants.GetAgentServiceAccount(dda.Name, &dda.Spec)
 		case v2alpha1.ClusterChecksRunnerComponentName:
-			componentSaName = constants.GetClusterChecksRunnerServiceAccountDDAI(dda)
+			componentSaName = constants.GetClusterChecksRunnerServiceAccount(dda.Name, &dda.Spec)
 		}
 
 		agentName := dda.GetName()
@@ -317,7 +317,7 @@ func resourcesAsTagsDependencies(logger logr.Logger, dda *v1alpha1.DatadogAgentI
 		if err := manager.RBACManager().AddClusterPolicyRules(
 			dda.Namespace,
 			clusteragent.GetResourceMetadataAsTagsClusterRoleName(dda),
-			constants.GetClusterAgentServiceAccountDDAI(dda),
+			constants.GetClusterAgentServiceAccount(dda.Name, &dda.Spec),
 			clusteragent.GetKubernetesResourceMetadataAsTagsPolicyRules(global.KubernetesResourcesLabelsAsTags, global.KubernetesResourcesAnnotationsAsTags),
 		); err != nil {
 			return err

--- a/internal/controller/datadogagentinternal/override/dependencies.go
+++ b/internal/controller/datadogagentinternal/override/dependencies.go
@@ -30,7 +30,7 @@ func Dependencies(logger logr.Logger, manager feature.ResourceManagers, ddai *v1
 	namespace := ddai.Namespace
 
 	for component, override := range overrides {
-		err := overrideRBAC(logger, manager, override, component, constants.GetServiceAccountByComponentDDAI(ddai, component), namespace)
+		err := overrideRBAC(logger, manager, override, component, constants.GetServiceAccountByComponent(ddai.Name, &ddai.Spec, component), namespace)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/controller/datadogagentinternal/override/dependencies_test.go
+++ b/internal/controller/datadogagentinternal/override/dependencies_test.go
@@ -258,15 +258,15 @@ func TestServiceAccountAnnotationOverride(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res := map[v2alpha1.ComponentName]map[string]interface{}{
 				v2alpha1.NodeAgentComponentName: {
-					"name":        constants.GetAgentServiceAccountDDAI(tt.ddai),
+					"name":        constants.GetAgentServiceAccount(tt.ddai.Name, &tt.ddai.Spec),
 					"annotations": getSaAnnotations(tt.ddai, v2alpha1.NodeAgentComponentName),
 				},
 				v2alpha1.ClusterChecksRunnerComponentName: {
-					"name":        constants.GetClusterChecksRunnerServiceAccountDDAI(tt.ddai),
+					"name":        constants.GetClusterChecksRunnerServiceAccount(tt.ddai.Name, &tt.ddai.Spec),
 					"annotations": getSaAnnotations(tt.ddai, v2alpha1.ClusterChecksRunnerComponentName),
 				},
 				v2alpha1.ClusterAgentComponentName: {
-					"name":        constants.GetClusterAgentServiceAccountDDAI(tt.ddai),
+					"name":        constants.GetClusterAgentServiceAccount(tt.ddai.Name, &tt.ddai.Spec),
 					"annotations": getSaAnnotations(tt.ddai, v2alpha1.ClusterAgentComponentName),
 				},
 			}

--- a/pkg/constants/utils.go
+++ b/pkg/constants/utils.go
@@ -28,14 +28,14 @@ func GetConfName(owner metav1.Object, conf *v2alpha1.CustomConfig, defaultName s
 }
 
 // GetServiceAccountByComponent returns the service account name for a given component
-func GetServiceAccountByComponent(dda *v2alpha1.DatadogAgent, component v2alpha1.ComponentName) string {
+func GetServiceAccountByComponent(objName string, ddaSpec *v2alpha1.DatadogAgentSpec, component v2alpha1.ComponentName) string {
 	switch component {
 	case v2alpha1.ClusterAgentComponentName:
-		return GetClusterAgentServiceAccount(dda)
+		return GetClusterAgentServiceAccount(objName, ddaSpec)
 	case v2alpha1.NodeAgentComponentName:
-		return GetAgentServiceAccount(dda)
+		return GetAgentServiceAccount(objName, ddaSpec)
 	case v2alpha1.ClusterChecksRunnerComponentName:
-		return GetClusterChecksRunnerServiceAccount(dda)
+		return GetClusterChecksRunnerServiceAccount(objName, ddaSpec)
 	default:
 		return ""
 	}
@@ -56,10 +56,10 @@ func GetServiceAccountByComponentDDAI(ddai *v1alpha1.DatadogAgentInternal, compo
 }
 
 // GetClusterAgentServiceAccount return the cluster-agent serviceAccountName
-func GetClusterAgentServiceAccount(dda *v2alpha1.DatadogAgent) string {
-	saDefault := fmt.Sprintf("%s-%s", dda.Name, DefaultClusterAgentResourceSuffix)
-	if dda.Spec.Override[v2alpha1.ClusterAgentComponentName] != nil && dda.Spec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName != nil {
-		return *dda.Spec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName
+func GetClusterAgentServiceAccount(objName string, ddaSpec *v2alpha1.DatadogAgentSpec) string {
+	saDefault := fmt.Sprintf("%s-%s", objName, DefaultClusterAgentResourceSuffix)
+	if ddaSpec.Override[v2alpha1.ClusterAgentComponentName] != nil && ddaSpec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName != nil {
+		return *ddaSpec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName
 	}
 	return saDefault
 }
@@ -74,10 +74,10 @@ func GetClusterAgentServiceAccountDDAI(ddai *v1alpha1.DatadogAgentInternal) stri
 }
 
 // GetAgentServiceAccount returns the agent service account name
-func GetAgentServiceAccount(dda *v2alpha1.DatadogAgent) string {
-	saDefault := fmt.Sprintf("%s-%s", dda.Name, DefaultAgentResourceSuffix)
-	if dda.Spec.Override[v2alpha1.NodeAgentComponentName] != nil && dda.Spec.Override[v2alpha1.NodeAgentComponentName].ServiceAccountName != nil {
-		return *dda.Spec.Override[v2alpha1.NodeAgentComponentName].ServiceAccountName
+func GetAgentServiceAccount(objName string, ddaSpec *v2alpha1.DatadogAgentSpec) string {
+	saDefault := fmt.Sprintf("%s-%s", objName, DefaultAgentResourceSuffix)
+	if ddaSpec.Override[v2alpha1.NodeAgentComponentName] != nil && ddaSpec.Override[v2alpha1.NodeAgentComponentName].ServiceAccountName != nil {
+		return *ddaSpec.Override[v2alpha1.NodeAgentComponentName].ServiceAccountName
 	}
 	return saDefault
 }
@@ -92,10 +92,10 @@ func GetAgentServiceAccountDDAI(ddai *v1alpha1.DatadogAgentInternal) string {
 }
 
 // GetClusterChecksRunnerServiceAccount return the cluster-checks-runner service account name
-func GetClusterChecksRunnerServiceAccount(dda *v2alpha1.DatadogAgent) string {
-	saDefault := fmt.Sprintf("%s-%s", dda.Name, DefaultClusterChecksRunnerResourceSuffix)
-	if dda.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName] != nil && dda.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName != nil {
-		return *dda.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName
+func GetClusterChecksRunnerServiceAccount(objName string, ddaSpec *v2alpha1.DatadogAgentSpec) string {
+	saDefault := fmt.Sprintf("%s-%s", objName, DefaultClusterChecksRunnerResourceSuffix)
+	if ddaSpec.Override[v2alpha1.ClusterChecksRunnerComponentName] != nil && ddaSpec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName != nil {
+		return *ddaSpec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName
 	}
 	return saDefault
 }

--- a/pkg/constants/utils.go
+++ b/pkg/constants/utils.go
@@ -41,34 +41,11 @@ func GetServiceAccountByComponent(objName string, ddaSpec *v2alpha1.DatadogAgent
 	}
 }
 
-// GetServiceAccountByComponentDDAI returns the service account name for a given component (DDAI)
-func GetServiceAccountByComponentDDAI(ddai *v1alpha1.DatadogAgentInternal, component v2alpha1.ComponentName) string {
-	switch component {
-	case v2alpha1.ClusterAgentComponentName:
-		return GetClusterAgentServiceAccountDDAI(ddai)
-	case v2alpha1.NodeAgentComponentName:
-		return GetAgentServiceAccountDDAI(ddai)
-	case v2alpha1.ClusterChecksRunnerComponentName:
-		return GetClusterChecksRunnerServiceAccountDDAI(ddai)
-	default:
-		return ""
-	}
-}
-
 // GetClusterAgentServiceAccount return the cluster-agent serviceAccountName
 func GetClusterAgentServiceAccount(objName string, ddaSpec *v2alpha1.DatadogAgentSpec) string {
 	saDefault := fmt.Sprintf("%s-%s", objName, DefaultClusterAgentResourceSuffix)
 	if ddaSpec.Override[v2alpha1.ClusterAgentComponentName] != nil && ddaSpec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName != nil {
 		return *ddaSpec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName
-	}
-	return saDefault
-}
-
-// GetClusterAgentServiceAccountDDAI returns the cluster-agent service account name
-func GetClusterAgentServiceAccountDDAI(ddai *v1alpha1.DatadogAgentInternal) string {
-	saDefault := fmt.Sprintf("%s-%s", ddai.Name, DefaultClusterAgentResourceSuffix)
-	if ddai.Spec.Override[v2alpha1.ClusterAgentComponentName] != nil && ddai.Spec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName != nil {
-		return *ddai.Spec.Override[v2alpha1.ClusterAgentComponentName].ServiceAccountName
 	}
 	return saDefault
 }
@@ -82,29 +59,11 @@ func GetAgentServiceAccount(objName string, ddaSpec *v2alpha1.DatadogAgentSpec) 
 	return saDefault
 }
 
-// GetAgentServiceAccountDDAI returns the agent service account name (DDAI)
-func GetAgentServiceAccountDDAI(ddai *v1alpha1.DatadogAgentInternal) string {
-	saDefault := fmt.Sprintf("%s-%s", ddai.Name, DefaultAgentResourceSuffix)
-	if ddai.Spec.Override[v2alpha1.NodeAgentComponentName] != nil && ddai.Spec.Override[v2alpha1.NodeAgentComponentName].ServiceAccountName != nil {
-		return *ddai.Spec.Override[v2alpha1.NodeAgentComponentName].ServiceAccountName
-	}
-	return saDefault
-}
-
 // GetClusterChecksRunnerServiceAccount return the cluster-checks-runner service account name
 func GetClusterChecksRunnerServiceAccount(objName string, ddaSpec *v2alpha1.DatadogAgentSpec) string {
 	saDefault := fmt.Sprintf("%s-%s", objName, DefaultClusterChecksRunnerResourceSuffix)
 	if ddaSpec.Override[v2alpha1.ClusterChecksRunnerComponentName] != nil && ddaSpec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName != nil {
 		return *ddaSpec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName
-	}
-	return saDefault
-}
-
-// GetClusterChecksRunnerServiceAccountDDAI returns the cluster-checks-runner service account name (DDAI)
-func GetClusterChecksRunnerServiceAccountDDAI(ddai *v1alpha1.DatadogAgentInternal) string {
-	saDefault := fmt.Sprintf("%s-%s", ddai.Name, DefaultClusterChecksRunnerResourceSuffix)
-	if ddai.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName] != nil && ddai.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName != nil {
-		return *ddai.Spec.Override[v2alpha1.ClusterChecksRunnerComponentName].ServiceAccountName
 	}
 	return saDefault
 }

--- a/pkg/constants/utils.go
+++ b/pkg/constants/utils.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 )
@@ -78,34 +77,14 @@ func IsHostNetworkEnabled(ddaSpec *v2alpha1.DatadogAgentSpec, component v2alpha1
 	return false
 }
 
-// IsHostNetworkEnabledDDAI returns whether the pod should use the host's network namespace (DDAI)
-func IsHostNetworkEnabledDDAI(ddai *v1alpha1.DatadogAgentInternal, component v2alpha1.ComponentName) bool {
-	if ddai.Spec.Override != nil {
-		if c, ok := ddai.Spec.Override[component]; ok {
-			return apiutils.BoolValue(c.HostNetwork)
-		}
-	}
-	return false
-}
-
 // IsClusterChecksEnabled returns whether the DDA should use cluster checks
 func IsClusterChecksEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 	return ddaSpec.Features.ClusterChecks != nil && apiutils.BoolValue(ddaSpec.Features.ClusterChecks.Enabled)
 }
 
-// IsClusterChecksEnabledDDAI returns whether the DDAI should use cluster checks (DDAI)
-func IsClusterChecksEnabledDDAI(ddai *v1alpha1.DatadogAgentInternal) bool {
-	return ddai.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(ddai.Spec.Features.ClusterChecks.Enabled)
-}
-
 // IsCCREnabled returns whether the DDA should use Cluster Checks Runners
 func IsCCREnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 	return ddaSpec.Features.ClusterChecks != nil && apiutils.BoolValue(ddaSpec.Features.ClusterChecks.UseClusterChecksRunners)
-}
-
-// IsCCREnabledDDAI returns whether the DDAI should use Cluster Checks Runners (DDAI)
-func IsCCREnabledDDAI(ddai *v1alpha1.DatadogAgentInternal) bool {
-	return ddai.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(ddai.Spec.Features.ClusterChecks.UseClusterChecksRunners)
 }
 
 // GetLocalAgentServiceName returns the name used for the local agent service
@@ -116,30 +95,11 @@ func GetLocalAgentServiceName(objName string, ddaSpec *v2alpha1.DatadogAgentSpec
 	return fmt.Sprintf("%s-%s", objName, DefaultAgentResourceSuffix)
 }
 
-// GetLocalAgentServiceNameDDAI returns the name used for the local agent service (DDAI)
-func GetLocalAgentServiceNameDDAI(ddai *v1alpha1.DatadogAgentInternal) string {
-	if ddai.Spec.Global.LocalService != nil && ddai.Spec.Global.LocalService.NameOverride != nil {
-		return *ddai.Spec.Global.LocalService.NameOverride
-	}
-	return fmt.Sprintf("%s-%s", ddai.Name, DefaultAgentResourceSuffix)
-}
-
 // IsNetworkPolicyEnabled returns whether a network policy should be created and which flavor to use
 func IsNetworkPolicyEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) (bool, v2alpha1.NetworkPolicyFlavor) {
 	if ddaSpec.Global != nil && ddaSpec.Global.NetworkPolicy != nil && apiutils.BoolValue(ddaSpec.Global.NetworkPolicy.Create) {
 		if ddaSpec.Global.NetworkPolicy.Flavor != "" {
 			return true, ddaSpec.Global.NetworkPolicy.Flavor
-		}
-		return true, v2alpha1.NetworkPolicyFlavorKubernetes
-	}
-	return false, ""
-}
-
-// IsNetworkPolicyEnabledDDAI returns whether a network policy should be created and which flavor to use (DDAI)
-func IsNetworkPolicyEnabledDDAI(ddai *v1alpha1.DatadogAgentInternal) (bool, v2alpha1.NetworkPolicyFlavor) {
-	if ddai.Spec.Global != nil && ddai.Spec.Global.NetworkPolicy != nil && apiutils.BoolValue(ddai.Spec.Global.NetworkPolicy.Create) {
-		if ddai.Spec.Global.NetworkPolicy.Flavor != "" {
-			return true, ddai.Spec.Global.NetworkPolicy.Flavor
 		}
 		return true, v2alpha1.NetworkPolicyFlavorKubernetes
 	}

--- a/pkg/constants/utils.go
+++ b/pkg/constants/utils.go
@@ -69,9 +69,9 @@ func GetClusterChecksRunnerServiceAccount(objName string, ddaSpec *v2alpha1.Data
 }
 
 // IsHostNetworkEnabled returns whether the pod should use the host's network namespace
-func IsHostNetworkEnabled(dda *v2alpha1.DatadogAgent, component v2alpha1.ComponentName) bool {
-	if dda.Spec.Override != nil {
-		if c, ok := dda.Spec.Override[component]; ok {
+func IsHostNetworkEnabled(ddaSpec *v2alpha1.DatadogAgentSpec, component v2alpha1.ComponentName) bool {
+	if ddaSpec.Override != nil {
+		if c, ok := ddaSpec.Override[component]; ok {
 			return apiutils.BoolValue(c.HostNetwork)
 		}
 	}
@@ -89,8 +89,8 @@ func IsHostNetworkEnabledDDAI(ddai *v1alpha1.DatadogAgentInternal, component v2a
 }
 
 // IsClusterChecksEnabled returns whether the DDA should use cluster checks
-func IsClusterChecksEnabled(dda *v2alpha1.DatadogAgent) bool {
-	return dda.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.Enabled)
+func IsClusterChecksEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
+	return ddaSpec.Features.ClusterChecks != nil && apiutils.BoolValue(ddaSpec.Features.ClusterChecks.Enabled)
 }
 
 // IsClusterChecksEnabledDDAI returns whether the DDAI should use cluster checks (DDAI)
@@ -99,8 +99,8 @@ func IsClusterChecksEnabledDDAI(ddai *v1alpha1.DatadogAgentInternal) bool {
 }
 
 // IsCCREnabled returns whether the DDA should use Cluster Checks Runners
-func IsCCREnabled(dda *v2alpha1.DatadogAgent) bool {
-	return dda.Spec.Features.ClusterChecks != nil && apiutils.BoolValue(dda.Spec.Features.ClusterChecks.UseClusterChecksRunners)
+func IsCCREnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
+	return ddaSpec.Features.ClusterChecks != nil && apiutils.BoolValue(ddaSpec.Features.ClusterChecks.UseClusterChecksRunners)
 }
 
 // IsCCREnabledDDAI returns whether the DDAI should use Cluster Checks Runners (DDAI)
@@ -109,11 +109,11 @@ func IsCCREnabledDDAI(ddai *v1alpha1.DatadogAgentInternal) bool {
 }
 
 // GetLocalAgentServiceName returns the name used for the local agent service
-func GetLocalAgentServiceName(dda *v2alpha1.DatadogAgent) string {
-	if dda.Spec.Global.LocalService != nil && dda.Spec.Global.LocalService.NameOverride != nil {
-		return *dda.Spec.Global.LocalService.NameOverride
+func GetLocalAgentServiceName(objName string, ddaSpec *v2alpha1.DatadogAgentSpec) string {
+	if ddaSpec.Global.LocalService != nil && ddaSpec.Global.LocalService.NameOverride != nil {
+		return *ddaSpec.Global.LocalService.NameOverride
 	}
-	return fmt.Sprintf("%s-%s", dda.Name, DefaultAgentResourceSuffix)
+	return fmt.Sprintf("%s-%s", objName, DefaultAgentResourceSuffix)
 }
 
 // GetLocalAgentServiceNameDDAI returns the name used for the local agent service (DDAI)
@@ -125,10 +125,10 @@ func GetLocalAgentServiceNameDDAI(ddai *v1alpha1.DatadogAgentInternal) string {
 }
 
 // IsNetworkPolicyEnabled returns whether a network policy should be created and which flavor to use
-func IsNetworkPolicyEnabled(dda *v2alpha1.DatadogAgent) (bool, v2alpha1.NetworkPolicyFlavor) {
-	if dda.Spec.Global != nil && dda.Spec.Global.NetworkPolicy != nil && apiutils.BoolValue(dda.Spec.Global.NetworkPolicy.Create) {
-		if dda.Spec.Global.NetworkPolicy.Flavor != "" {
-			return true, dda.Spec.Global.NetworkPolicy.Flavor
+func IsNetworkPolicyEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) (bool, v2alpha1.NetworkPolicyFlavor) {
+	if ddaSpec.Global != nil && ddaSpec.Global.NetworkPolicy != nil && apiutils.BoolValue(ddaSpec.Global.NetworkPolicy.Create) {
+		if ddaSpec.Global.NetworkPolicy.Flavor != "" {
+			return true, ddaSpec.Global.NetworkPolicy.Flavor
 		}
 		return true, v2alpha1.NetworkPolicyFlavorKubernetes
 	}

--- a/pkg/constants/utils_test.go
+++ b/pkg/constants/utils_test.go
@@ -48,9 +48,9 @@ func TestServiceAccountNameOverride(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := map[v2alpha1.ComponentName]string{}
-			res[v2alpha1.NodeAgentComponentName] = GetAgentServiceAccount(tt.dda)
-			res[v2alpha1.ClusterChecksRunnerComponentName] = GetClusterChecksRunnerServiceAccount(tt.dda)
-			res[v2alpha1.ClusterAgentComponentName] = GetClusterAgentServiceAccount(tt.dda)
+			res[v2alpha1.NodeAgentComponentName] = GetAgentServiceAccount(tt.dda.Name, &tt.dda.Spec)
+			res[v2alpha1.ClusterChecksRunnerComponentName] = GetClusterChecksRunnerServiceAccount(tt.dda.Name, &tt.dda.Spec)
+			res[v2alpha1.ClusterAgentComponentName] = GetClusterAgentServiceAccount(tt.dda.Name, &tt.dda.Spec)
 			for name, sa := range tt.want {
 				if res[name] != sa {
 					t.Errorf("Service Account Override error = %v, want %v", res[name], tt.want[name])


### PR DESCRIPTION
### What does this PR do?

* Modifies the signature of a few util functions to use DatadogAgentSpec and name, instead of DatadogAgent
* Removes specific DDAI utils to reference the generic ones instead

### Motivation

* Allows to share functions between DDA and DDAI controllers

### Additional Notes

> [!TIP]
> Review commit by commit:
> 1. 22b20c3340e3d961d81c7b9c7db6c89db56f08c4: (DDA) change the get Service Account DDA functions
> 2. 6888539689a1fec6b9312836f836940c22c2535a: (DDAI) remove the get Service Account DDAI and reference the generic ones
> 3. 0d0f64f1a2b1edb3d38ae8e30327f7059c9f0af6: (DDA) Change the other utils (e.g. ishostnetworkenabled)
> 4. 4a4e240dc8b37607b68996ec08067b2277575187: (DDAI) remove the DDAI other utils and reference the generic ones

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
