### PR TITLE
[feature/autoscaling] Enable local fallback by default when autoscaling enabled

### DIFF
--- a/internal/controller/datadogagent/feature/autoscaling/const.go
+++ b/internal/controller/datadogagent/feature/autoscaling/const.go
@@ -1,0 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package autoscaling
+
+const defaultFailoverMetrics = "container.memory.usage container.cpu.usage"

--- a/internal/controller/datadogagent/feature/autoscaling/envvar.go
+++ b/internal/controller/datadogagent/feature/autoscaling/envvar.go
@@ -5,4 +5,8 @@
 
 package autoscaling
 
-const DDAutoscalingWorkloadEnabled = "DD_AUTOSCALING_WORKLOAD_ENABLED"
+const (
+	DDAutoscalingWorkloadEnabled = "DD_AUTOSCALING_WORKLOAD_ENABLED"
+	DDAutoscalingFailoverEnabled = "DD_AUTOSCALING_FAILOVER_ENABLED"
+	DDAutoscalingFailoverMetrics = "DD_AUTOSCALING_FAILOVER_METRICS"
+)

--- a/internal/controller/datadogagent/feature/autoscaling/feature.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature.go
@@ -92,6 +92,16 @@ func (f *autoscalingFeature) ManageClusterAgent(managers feature.PodTemplateMana
 		Value: "true",
 	})
 
+	managers.EnvVar().AddEnvVarToContainer(apicommon.ClusterAgentContainerName, &corev1.EnvVar{
+		Name:  DDAutoscalingFailoverEnabled,
+		Value: "true",
+	})
+
+	managers.EnvVar().AddEnvVarToContainer(apicommon.ClusterAgentContainerName, &corev1.EnvVar{
+		Name:  DDAutoscalingFailoverMetrics,
+		Value: defaultFailoverMetrics,
+	})
+
 	return nil
 }
 

--- a/internal/controller/datadogagent/feature/autoscaling/feature.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature.go
@@ -97,11 +97,6 @@ func (f *autoscalingFeature) ManageClusterAgent(managers feature.PodTemplateMana
 		Value: "true",
 	})
 
-	managers.EnvVar().AddEnvVarToContainer(apicommon.ClusterAgentContainerName, &corev1.EnvVar{
-		Name:  DDAutoscalingFailoverMetrics,
-		Value: defaultFailoverMetrics,
-	})
-
 	return nil
 }
 
@@ -115,6 +110,16 @@ func (f *autoscalingFeature) ManageSingleContainerNodeAgent(managers feature.Pod
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *autoscalingFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		Name:  DDAutoscalingFailoverEnabled,
+		Value: "true",
+	})
+
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		Name:  DDAutoscalingFailoverMetrics,
+		Value: defaultFailoverMetrics,
+	})
+
 	return nil
 }
 

--- a/internal/controller/datadogagent/feature/autoscaling/feature_test.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature_test.go
@@ -36,18 +36,23 @@ func TestAutoscalingFeature(t *testing.T) {
 		{
 			Name:          "v2alpha1 autoscaling disabled",
 			DDA:           newAgent(false, true),
+			ClusterAgent:  testDCAResources(false),
+			Agent:         testAgentResources(false),
 			WantConfigure: false,
 		},
 		{
-			Name:                 "v2alpha1 autoscaling enabeld",
+			Name:                 "v2alpha1 autoscaling enabled",
 			DDA:                  newAgent(true, true),
 			WantConfigure:        true,
 			ClusterAgent:         testDCAResources(true),
+			Agent:                testAgentResources(true),
 			WantDependenciesFunc: testRBACResources,
 		},
 		{
-			Name:                      "v2alpha1 autoscaling enabeld but admission disabled",
+			Name:                      "v2alpha1 autoscaling enabled but admission disabled",
 			DDA:                       newAgent(true, false),
+			ClusterAgent:              testDCAResources(true),
+			Agent:                     testAgentResources(true),
 			WantConfigure:             true,
 			WantManageDependenciesErr: true,
 		},
@@ -147,14 +152,40 @@ func testDCAResources(enabled bool) *test.ComponentTest {
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
 
-			agentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
-			var expectedAgentEnvs []*corev1.EnvVar
+			clusterAgentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
+
+			var expectedClusterAgentEnvVars []*corev1.EnvVar
 			if enabled {
-				expectedAgentEnvs = append(expectedAgentEnvs,
+				expectedClusterAgentEnvVars = append(expectedClusterAgentEnvVars,
 					&corev1.EnvVar{
 						Name:  DDAutoscalingWorkloadEnabled,
 						Value: "true",
 					},
+					&corev1.EnvVar{
+						Name:  DDAutoscalingFailoverEnabled,
+						Value: "true",
+					},
+				)
+			}
+
+			assert.True(
+				t,
+				apiutils.IsEqualStruct(clusterAgentEnvs, expectedClusterAgentEnvVars),
+				"Cluster Agent ENVs \ndiff = %s", cmp.Diff(clusterAgentEnvs, expectedClusterAgentEnvVars),
+			)
+		},
+	)
+}
+
+func testAgentResources(enabled bool) *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+			coreAgentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+			var expectedCoreAgentEnvVars []*corev1.EnvVar
+			if enabled {
+				expectedCoreAgentEnvVars = append(expectedCoreAgentEnvVars,
 					&corev1.EnvVar{
 						Name:  DDAutoscalingFailoverEnabled,
 						Value: "true",
@@ -165,10 +196,11 @@ func testDCAResources(enabled bool) *test.ComponentTest {
 					},
 				)
 			}
+
 			assert.True(
 				t,
-				apiutils.IsEqualStruct(agentEnvs, expectedAgentEnvs),
-				"Cluster Agent ENVs \ndiff = %s", cmp.Diff(agentEnvs, expectedAgentEnvs),
+				apiutils.IsEqualStruct(coreAgentEnvs, expectedCoreAgentEnvVars),
+				"Core Agent ENVs \ndiff = %s", cmp.Diff(coreAgentEnvs, expectedCoreAgentEnvVars),
 			)
 		},
 	)

--- a/internal/controller/datadogagent/feature/autoscaling/feature_test.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature_test.go
@@ -155,6 +155,14 @@ func testDCAResources(enabled bool) *test.ComponentTest {
 						Name:  DDAutoscalingWorkloadEnabled,
 						Value: "true",
 					},
+					&corev1.EnvVar{
+						Name:  DDAutoscalingFailoverEnabled,
+						Value: "true",
+					},
+					&corev1.EnvVar{
+						Name:  DDAutoscalingFailoverMetrics,
+						Value: defaultFailoverMetrics,
+					},
 				)
 			}
 			assert.True(

--- a/internal/controller/datadogagentinternal/feature/autoscaling/const.go
+++ b/internal/controller/datadogagentinternal/feature/autoscaling/const.go
@@ -1,0 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package autoscaling
+
+const defaultFailoverMetrics = "container.memory.usage container.cpu.usage"

--- a/internal/controller/datadogagentinternal/feature/autoscaling/envvar.go
+++ b/internal/controller/datadogagentinternal/feature/autoscaling/envvar.go
@@ -5,4 +5,8 @@
 
 package autoscaling
 
-const DDAutoscalingWorkloadEnabled = "DD_AUTOSCALING_WORKLOAD_ENABLED"
+const (
+	DDAutoscalingWorkloadEnabled = "DD_AUTOSCALING_WORKLOAD_ENABLED"
+	DDAutoscalingFailoverEnabled = "DD_AUTOSCALING_FAILOVER_ENABLED"
+	DDAutoscalingFailoverMetrics = "DD_AUTOSCALING_FAILOVER_METRICS"
+)

--- a/internal/controller/datadogagentinternal/feature/autoscaling/feature.go
+++ b/internal/controller/datadogagentinternal/feature/autoscaling/feature.go
@@ -93,6 +93,11 @@ func (f *autoscalingFeature) ManageClusterAgent(managers feature.PodTemplateMana
 		Value: "true",
 	})
 
+	managers.EnvVar().AddEnvVarToContainer(apicommon.ClusterAgentContainerName, &corev1.EnvVar{
+		Name:  DDAutoscalingFailoverEnabled,
+		Value: "true",
+	})
+
 	return nil
 }
 
@@ -106,6 +111,16 @@ func (f *autoscalingFeature) ManageSingleContainerNodeAgent(managers feature.Pod
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *autoscalingFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		Name:  DDAutoscalingFailoverEnabled,
+		Value: "true",
+	})
+
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		Name:  DDAutoscalingFailoverMetrics,
+		Value: defaultFailoverMetrics,
+	})
+
 	return nil
 }
 

--- a/internal/controller/datadogagentinternal/feature/autoscaling/feature_test.go
+++ b/internal/controller/datadogagentinternal/feature/autoscaling/feature_test.go
@@ -37,6 +37,8 @@ func TestAutoscalingFeature(t *testing.T) {
 		{
 			Name:          "v2alpha1 autoscaling disabled",
 			DDAI:          newAgent(false, true),
+			ClusterAgent:  testDCAResources(false),
+			Agent:         testAgentResources(false),
 			WantConfigure: false,
 		},
 		{
@@ -44,11 +46,14 @@ func TestAutoscalingFeature(t *testing.T) {
 			DDAI:                 newAgent(true, true),
 			WantConfigure:        true,
 			ClusterAgent:         testDCAResources(true),
+			Agent:                testAgentResources(true),
 			WantDependenciesFunc: testRBACResources,
 		},
 		{
 			Name:                      "v2alpha1 autoscaling enabeld but admission disabled",
 			DDAI:                      newAgent(true, false),
+			ClusterAgent:              testDCAResources(true),
+			Agent:                     testAgentResources(true),
 			WantConfigure:             true,
 			WantManageDependenciesErr: true,
 		},
@@ -148,20 +153,55 @@ func testDCAResources(enabled bool) *test.ComponentTest {
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
 
-			agentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
-			var expectedAgentEnvs []*corev1.EnvVar
+			clusterAgentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
+			var expectedClusterAgentEnvVars []*corev1.EnvVar
+
 			if enabled {
-				expectedAgentEnvs = append(expectedAgentEnvs,
+				expectedClusterAgentEnvVars = append(expectedClusterAgentEnvVars,
 					&corev1.EnvVar{
 						Name:  DDAutoscalingWorkloadEnabled,
 						Value: "true",
 					},
+					&corev1.EnvVar{
+						Name:  DDAutoscalingFailoverEnabled,
+						Value: "true",
+					},
 				)
 			}
+
 			assert.True(
 				t,
-				apiutils.IsEqualStruct(agentEnvs, expectedAgentEnvs),
-				"Cluster Agent ENVs \ndiff = %s", cmp.Diff(agentEnvs, expectedAgentEnvs),
+				apiutils.IsEqualStruct(clusterAgentEnvs, expectedClusterAgentEnvVars),
+				"Cluster Agent ENVs \ndiff = %s", cmp.Diff(clusterAgentEnvs, expectedClusterAgentEnvVars),
+			)
+		},
+	)
+}
+
+func testAgentResources(enabled bool) *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+			coreAgentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+			var expectedCoreAgentEnvVars []*corev1.EnvVar
+			if enabled {
+				expectedCoreAgentEnvVars = append(expectedCoreAgentEnvVars,
+					&corev1.EnvVar{
+						Name:  DDAutoscalingFailoverEnabled,
+						Value: "true",
+					},
+					&corev1.EnvVar{
+						Name:  DDAutoscalingFailoverMetrics,
+						Value: defaultFailoverMetrics,
+					},
+				)
+			}
+
+			assert.True(
+				t,
+				apiutils.IsEqualStruct(coreAgentEnvs, expectedCoreAgentEnvVars),
+				"Core Agent ENVs \ndiff = %s", cmp.Diff(coreAgentEnvs, expectedCoreAgentEnvVars),
 			)
 		},
 	)


### PR DESCRIPTION
### What does this PR do?

Set environment variables to enable local fallback by default when kubernetes autoscaling feature is enabled

### Motivation

Avoid users having to manually set env var overrides to make use of the local fallback feature

### Additional Notes

Should the corresponding changes be made in `datadogagentinternal/` as well?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.65.0
* Cluster Agent: v7.65.0

### Describe your test plan

1. Deploy the agent via the operator and enable autoscaling
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    clusterName: "jenn-operator"
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
    logLevel: debug
    kubelet:
      tlsVerify: false
  features:
    orchestratorExplorer:
      enabled: true
      customResources:
      - datadoghq.com/v1alpha2/datadogpodautoscalers
    autoscaling:
      workload:
        enabled: true
    eventCollection:
      unbundleEvents: true
    clusterChecks:
      enabled: true
      useClusterChecksRunners: true
  override:
    clusterAgent:
      replicas: 1
      image:
        tag: 7.66.1
    nodeAgent:
      tolerations:
        - operator: Exists
      image:
        tag: 7.66.1
    clusterChecksRunner:
      image:
        tag: 7.66.1
```
2. Verify that `DD_AUTOSCALING_FAILOVER_ENABLED` and `DD_AUTOSCALING_FAILOVER_METRICS` are set in the core agent (or check value via `agent config`)
```
$ agent config
...
autoscaling:
  failover:
    enabled: true
    metrics: container.memory.usage container.cpu.usage
  workload:
    enabled: false
    limit: 1000
```
3. Verify that `DD_AUTOSCALING_FAILOVER_ENABLED` is set in the cluster agent (or check value via `agent config`)
```
$ agent config
...
autoscaling:
  failover:
    enabled: true
  workload:
    enabled: true
    limit: 1000
```
4. Verify that local fallback recommendations are populated if a `DatadogPodAutoscaler` is installed
<details>
<summary>example</summary>

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: better-cyclic-burner-query
spec:
  selector:
    matchLabels:
      app: better-cyclic-burner-query
  replicas: 1
  template:
    metadata:
      labels:
        app: better-cyclic-burner-query
        component: better-cyclic-burner
      name: better-cyclic-burner-query
    spec:
      containers:
      - image: vboulineau/better-cyclic-burner
        imagePullPolicy: Always
        name: query
        args: ["query"]
        resources:
          requests:
            cpu: "300m"
            memory: "50Mi"
          limits:
            cpu: "300m"
            memory: "50Mi"
        env:
        - name: TARGET_ADDRESS
          value: "http://better-cyclic-burner-server:8080"
        - name: MIN_GLOBAL_CPU
          value: "0.5"
        - name: MAX_GLOBAL_CPU
          value: "4.0"
        - name: LOWER_CUTOFF
          value: "0.1"
        - name: CYCLE_DURATION
          value: "120m"
      nodeSelector:
        kubernetes.io/os: linux
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: better-cyclic-burner-server
spec:
  selector:
    matchLabels:
      app: better-cyclic-burner-server
  template:
    metadata:
      labels:
        app: better-cyclic-burner-server
        component: better-cyclic-burner
      name: better-cyclic-burner-server
    spec:
      containers:
      - image: vboulineau/better-cyclic-burner
        imagePullPolicy: Always
        name: server
        args: ["server"]
        env:
        - name: MAX_CPU
          value: "1"
        resources:
          requests:
            cpu: "1"
          limits:
            cpu: "1.5"
      nodeSelector:
        kubernetes.io/os: linux
---
apiVersion: v1
kind: Service
metadata:
  name: better-cyclic-burner-server
spec:
  selector:
    app: better-cyclic-burner-server
  ports:
    - protocol: TCP
      port: 8080
```

```
apiVersion: datadoghq.com/v1alpha2
kind: DatadogPodAutoscaler
metadata:
  name:  better-cyclic-burner-server
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: better-cyclic-burner-server
  owner: Local
  constraints:
    minReplicas: 1
    maxReplicas: 5
  objectives:
    - type: PodResource
      podResource:
        name: cpu
        value:
          type: Utilization
          utilization: 85
---
apiVersion: datadoghq.com/v1alpha2
kind: DatadogPodAutoscaler
metadata:
  name:  better-cyclic-burner-query
spec:
  targetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: better-cyclic-burner-query
  owner: Local
  applyPolicy:
    mode: Apply
    scaleUp:
      strategy: Disabled
    scaleDown:
      strategy: Disabled
    update:
      strategy: Auto
```

Verify that you see the metric `datadog.cluster_agent.autoscaling.workload.local.horizontal_scaling_recommended_replicas`
</details>

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
