### PR TITLE
(chore) Disable `exportloopref` linter due to depreciation

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -44,6 +44,7 @@
   enable-all = true
   disable = [
     "exhaustruct",
+    "exportloopref",
     "nonamedreturns",
     "revive",
     "lll",


### PR DESCRIPTION
### What does this PR do?

* Adds `exportloopref` to the list of disabled linters

### Motivation

* Avoid warning when running lint commands:
```shell
vscode ➜ /workspaces/datadog-operator $ make lint
go vet ./...
bin/linux-aarch64/golangci-lint run ./... ./api/... ./test/e2e/...
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```
* `copyloopvar` is enabled per `enable-all` replacing it, and we build using Go 1.23:
```shell
vscode ➜ /workspaces/datadog-operator (main) $ bin/linux-aarch64/golangci-lint linters
Enabled by your configuration linters:
asasalint: check for pass []any as any in variadic func(...any) [fast: false, auto-fix: false]
asciicheck: checks that all code identifiers does not have non-ASCII symbols in the name [fast: true, auto-fix: false]
bidichk: Checks for dangerous unicode character sequences [fast: true, auto-fix: false]
canonicalheader: canonicalheader checks whether net/http.Header uses canonical header [fast: false, auto-fix: false]
copyloopvar: copyloopvar is a linter detects places where loop variables are copied [fast: true, auto-fix: false]
decorder: check declaration order and count of types, constants, variables and functions [fast: true, auto-fix: false]
depguard: Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
dogsled: Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
durationcheck: check for two durations multiplied together [fast: false, auto-fix: false]
[...]
```

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Run `make lint`, the warning should not appear anymore

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
