### PR TITLE
Keep DS same between DDA and DDAI

### DIFF
--- a/api/datadoghq/common/const.go
+++ b/api/datadoghq/common/const.go
@@ -13,4 +13,6 @@ const (
 	AgentDeploymentNameLabelKey = "agent.datadoghq.com/name"
 	// AgentDeploymentComponentLabelKey label key use to know with component is it
 	AgentDeploymentComponentLabelKey = "agent.datadoghq.com/component"
+	// DatadogAgentNameLabelKey is used to know the name of the DatadogAgent
+	DatadogAgentNameLabelKey = "agent.datadoghq.com/datadogagent"
 )

--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -280,9 +280,10 @@ func (r *Reconciler) handleProfiles(ctx context.Context, profilesByNode map[stri
 		return err
 	}
 
-	if err := r.cleanupPodsForProfilesThatNoLongerApply(ctx, profilesByNode, ddaNamespace); err != nil {
-		return err
-	}
+	// TODO: re-evaluate if this is needed
+	// if err := r.cleanupPodsForProfilesThatNoLongerApply(ctx, profilesByNode, ddaNamespace); err != nil {
+	// 	return err
+	// }
 
 	return nil
 }
@@ -358,51 +359,51 @@ func (r *Reconciler) labelNodesWithProfiles(ctx context.Context, profilesByNode 
 // might not always be evicted when there's a change in the profiles to apply.
 // Notice that "RequiredDuringSchedulingRequiredDuringExecution" is not
 // available in Kubernetes yet.
-func (r *Reconciler) cleanupPodsForProfilesThatNoLongerApply(ctx context.Context, profilesByNode map[string]types.NamespacedName, ddaNamespace string) error {
-	agentPods := &corev1.PodList{}
-	err := r.client.List(
-		ctx,
-		agentPods,
-		client.MatchingLabels(map[string]string{
-			apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-		}),
-		client.InNamespace(ddaNamespace),
-	)
-	if err != nil {
-		return err
-	}
+// func (r *Reconciler) cleanupPodsForProfilesThatNoLongerApply(ctx context.Context, profilesByNode map[string]types.NamespacedName, ddaNamespace string) error {
+// 	agentPods := &corev1.PodList{}
+// 	err := r.client.List(
+// 		ctx,
+// 		agentPods,
+// 		client.MatchingLabels(map[string]string{
+// 			apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 		}),
+// 		client.InNamespace(ddaNamespace),
+// 	)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	for _, agentPod := range agentPods.Items {
-		profileNamespacedName, found := profilesByNode[agentPod.Spec.NodeName]
-		if !found {
-			continue
-		}
+// 	for _, agentPod := range agentPods.Items {
+// 		profileNamespacedName, found := profilesByNode[agentPod.Spec.NodeName]
+// 		if !found {
+// 			continue
+// 		}
 
-		isDefaultProfile := agentprofile.IsDefaultProfile(profileNamespacedName.Namespace, profileNamespacedName.Name)
-		expectedProfileLabelValue := profileNamespacedName.Name
+// 		isDefaultProfile := agentprofile.IsDefaultProfile(profileNamespacedName.Namespace, profileNamespacedName.Name)
+// 		expectedProfileLabelValue := profileNamespacedName.Name
 
-		profileLabelValue, profileLabelExists := agentPod.Labels[agentprofile.ProfileLabelKey]
+// 		profileLabelValue, profileLabelExists := agentPod.Labels[agentprofile.ProfileLabelKey]
 
-		deletePod := (isDefaultProfile && profileLabelExists) ||
-			(!isDefaultProfile && !profileLabelExists) ||
-			(!isDefaultProfile && profileLabelValue != expectedProfileLabelValue)
+// 		deletePod := (isDefaultProfile && profileLabelExists) ||
+// 			(!isDefaultProfile && !profileLabelExists) ||
+// 			(!isDefaultProfile && profileLabelValue != expectedProfileLabelValue)
 
-		if deletePod {
-			toDelete := corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: agentPod.Namespace,
-					Name:      agentPod.Name,
-				},
-			}
-			r.log.Info("Deleting pod for profile cleanup", "pod.Namespace", toDelete.Namespace, "pod.Name", toDelete.Name)
-			if err = r.client.Delete(ctx, &toDelete); err != nil && !errors.IsNotFound(err) {
-				return err
-			}
-		}
-	}
+// 		if deletePod {
+// 			toDelete := corev1.Pod{
+// 				ObjectMeta: metav1.ObjectMeta{
+// 					Namespace: agentPod.Namespace,
+// 					Name:      agentPod.Name,
+// 				},
+// 			}
+// 			r.log.Info("Deleting pod for profile cleanup", "pod.Namespace", toDelete.Namespace, "pod.Name", toDelete.Name)
+// 			if err = r.client.Delete(ctx, &toDelete); err != nil && !errors.IsNotFound(err) {
+// 				return err
+// 			}
+// 		}
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 // cleanupExtraneousDaemonSets deletes DSs/EDSs that no longer apply.
 // Use cases include deleting old DSs/EDSs when:

--- a/internal/controller/datadogagent/controller_reconcile_agent_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent_test.go
@@ -1910,225 +1910,225 @@ func Test_labelNodesWithProfiles(t *testing.T) {
 	}
 }
 
-func Test_cleanupPodsForProfilesThatNoLongerApply(t *testing.T) {
-	sch := runtime.NewScheme()
-	_ = scheme.AddToScheme(sch)
-	ctx := context.Background()
+// func Test_cleanupPodsForProfilesThatNoLongerApply(t *testing.T) {
+// 	sch := runtime.NewScheme()
+// 	_ = scheme.AddToScheme(sch)
+// 	ctx := context.Background()
 
-	testCases := []struct {
-		name           string
-		description    string
-		profilesByNode map[string]types.NamespacedName
-		ddaNamespace   string
-		existingPods   []client.Object
-		wantPods       []corev1.Pod
-	}{
-		{
-			name:        "delete agent pod that shouldn't be running",
-			description: "pod-2 should be deleted",
-			profilesByNode: map[string]types.NamespacedName{
-				"node-1": {
-					Namespace: "foo",
-					Name:      "profile-1",
-				},
-				"node-2": {
-					Namespace: "foo",
-					Name:      "profile-2",
-				},
-				"node-default": {
-					Namespace: "",
-					Name:      "default",
-				},
-			},
-			ddaNamespace: "foo",
-			existingPods: []client.Object{
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-1",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-1",
-						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-1",
-					},
-				},
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-2",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-1",
-						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-2",
-					},
-				},
-			},
-			wantPods: []corev1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-1",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-1",
-						},
-						ResourceVersion: "999",
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-1",
-					},
-				},
-			},
-		},
-		{
-			name:        "delete default agent on profile node",
-			description: "pod-2 should be deleted",
-			profilesByNode: map[string]types.NamespacedName{
-				"node-1": {
-					Namespace: "foo",
-					Name:      "profile-1",
-				},
-				"node-2": {
-					Namespace: "foo",
-					Name:      "profile-2",
-				},
-				"node-default": {
-					Namespace: "",
-					Name:      "default",
-				},
-			},
-			ddaNamespace: "foo",
-			existingPods: []client.Object{
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-1",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-1",
-						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-1",
-					},
-				},
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-default",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-2",
-					},
-				},
-			},
-			wantPods: []corev1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-1",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-1",
-						},
-						ResourceVersion: "999",
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-1",
-					},
-				},
-			},
-		},
-		{
-			name:        "delete profile agent on default node",
-			description: "pod-2 should be deleted",
-			profilesByNode: map[string]types.NamespacedName{
-				"node-1": {
-					Namespace: "foo",
-					Name:      "profile-1",
-				},
-				"node-2": {
-					Namespace: "foo",
-					Name:      "profile-2",
-				},
-				"node-default": {
-					Namespace: "",
-					Name:      "default",
-				},
-			},
-			ddaNamespace: "foo",
-			existingPods: []client.Object{
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-1",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-1",
-						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-1",
-					},
-				},
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-2",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-2",
-						},
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-default",
-					},
-				},
-			},
-			wantPods: []corev1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-1",
-						Namespace: "foo",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							agentprofile.ProfileLabelKey:               "profile-1",
-						},
-						ResourceVersion: "999",
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "node-1",
-					},
-				},
-			},
-		},
-	}
+// 	testCases := []struct {
+// 		name           string
+// 		description    string
+// 		profilesByNode map[string]types.NamespacedName
+// 		ddaNamespace   string
+// 		existingPods   []client.Object
+// 		wantPods       []corev1.Pod
+// 	}{
+// 		{
+// 			name:        "delete agent pod that shouldn't be running",
+// 			description: "pod-2 should be deleted",
+// 			profilesByNode: map[string]types.NamespacedName{
+// 				"node-1": {
+// 					Namespace: "foo",
+// 					Name:      "profile-1",
+// 				},
+// 				"node-2": {
+// 					Namespace: "foo",
+// 					Name:      "profile-2",
+// 				},
+// 				"node-default": {
+// 					Namespace: "",
+// 					Name:      "default",
+// 				},
+// 			},
+// 			ddaNamespace: "foo",
+// 			existingPods: []client.Object{
+// 				&corev1.Pod{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-1",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-1",
+// 						},
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-1",
+// 					},
+// 				},
+// 				&corev1.Pod{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-2",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-1",
+// 						},
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-2",
+// 					},
+// 				},
+// 			},
+// 			wantPods: []corev1.Pod{
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-1",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-1",
+// 						},
+// 						ResourceVersion: "999",
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-1",
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name:        "delete default agent on profile node",
+// 			description: "pod-2 should be deleted",
+// 			profilesByNode: map[string]types.NamespacedName{
+// 				"node-1": {
+// 					Namespace: "foo",
+// 					Name:      "profile-1",
+// 				},
+// 				"node-2": {
+// 					Namespace: "foo",
+// 					Name:      "profile-2",
+// 				},
+// 				"node-default": {
+// 					Namespace: "",
+// 					Name:      "default",
+// 				},
+// 			},
+// 			ddaNamespace: "foo",
+// 			existingPods: []client.Object{
+// 				&corev1.Pod{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-1",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-1",
+// 						},
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-1",
+// 					},
+// 				},
+// 				&corev1.Pod{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-default",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 						},
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-2",
+// 					},
+// 				},
+// 			},
+// 			wantPods: []corev1.Pod{
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-1",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-1",
+// 						},
+// 						ResourceVersion: "999",
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-1",
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			name:        "delete profile agent on default node",
+// 			description: "pod-2 should be deleted",
+// 			profilesByNode: map[string]types.NamespacedName{
+// 				"node-1": {
+// 					Namespace: "foo",
+// 					Name:      "profile-1",
+// 				},
+// 				"node-2": {
+// 					Namespace: "foo",
+// 					Name:      "profile-2",
+// 				},
+// 				"node-default": {
+// 					Namespace: "",
+// 					Name:      "default",
+// 				},
+// 			},
+// 			ddaNamespace: "foo",
+// 			existingPods: []client.Object{
+// 				&corev1.Pod{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-1",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-1",
+// 						},
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-1",
+// 					},
+// 				},
+// 				&corev1.Pod{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-2",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-2",
+// 						},
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-default",
+// 					},
+// 				},
+// 			},
+// 			wantPods: []corev1.Pod{
+// 				{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name:      "pod-1",
+// 						Namespace: "foo",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							agentprofile.ProfileLabelKey:               "profile-1",
+// 						},
+// 						ResourceVersion: "999",
+// 					},
+// 					Spec: corev1.PodSpec{
+// 						NodeName: "node-1",
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(tt.existingPods...).Build()
+// 	for _, tt := range testCases {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(tt.existingPods...).Build()
 
-			r := &Reconciler{
-				client: fakeClient,
-			}
+// 			r := &Reconciler{
+// 				client: fakeClient,
+// 			}
 
-			err := r.cleanupPodsForProfilesThatNoLongerApply(ctx, tt.profilesByNode, tt.ddaNamespace)
-			assert.NoError(t, err)
+// 			err := r.cleanupPodsForProfilesThatNoLongerApply(ctx, tt.profilesByNode, tt.ddaNamespace)
+// 			assert.NoError(t, err)
 
-			podList := &corev1.PodList{}
-			err = fakeClient.List(ctx, podList)
-			assert.NoError(t, err)
-			assert.Len(t, podList.Items, len(tt.wantPods))
-			assert.Equal(t, tt.wantPods, podList.Items)
-		})
-	}
-}
+// 			podList := &corev1.PodList{}
+// 			err = fakeClient.List(ctx, podList)
+// 			assert.NoError(t, err)
+// 			assert.Len(t, podList.Items, len(tt.wantPods))
+// 			assert.Equal(t, tt.wantPods, podList.Items)
+// 		})
+// 	}
+// }

--- a/internal/controller/datadogagent/ddai_test.go
+++ b/internal/controller/datadogagent/ddai_test.go
@@ -31,6 +31,9 @@ func Test_generateObjMetaFromDDA(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					Labels: map[string]string{
+						"agent.datadoghq.com/datadogagent": "foo",
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         "datadoghq.com/v2alpha1",
@@ -63,7 +66,8 @@ func Test_generateObjMetaFromDDA(t *testing.T) {
 					Name:      "foo",
 					Namespace: "bar",
 					Labels: map[string]string{
-						"foo": "bar",
+						"foo":                              "bar",
+						"agent.datadoghq.com/datadogagent": "foo",
 					},
 					Annotations: map[string]string{
 						"foo": "bar",

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent_test.go
@@ -1,75 +1,62 @@
 package datadogagentinternal
 
 import (
-	"context"
 	"testing"
 
-	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal/component"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal/component/agent"
-	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
-	edsdatadoghqv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const defaultProvider = kubernetes.DefaultProvider
 const gkeCosProvider = kubernetes.GKECloudProvider + "-" + kubernetes.GKECosType
 
-func Test_getValidDaemonSetNames(t *testing.T) {
-	testCases := []struct {
-		name       string
-		dsName     string
-		edsEnabled bool
-		wantDS     map[string]struct{}
-		wantEDS    map[string]struct{}
-	}{
-		{
-			name:       "introspection disabled, profiles disabled, eds disabled",
-			dsName:     "foo",
-			edsEnabled: false,
-			wantDS:     map[string]struct{}{"foo": {}},
-			wantEDS:    map[string]struct{}{},
-		},
-		{
-			name:       "introspection disabled, profiles disabled, eds enabled",
-			dsName:     "foo",
-			edsEnabled: true,
-			wantDS:     map[string]struct{}{},
-			wantEDS:    map[string]struct{}{"foo": {}},
-		},
-	}
+// func Test_getValidDaemonSetNames(t *testing.T) {
+// 	testCases := []struct {
+// 		name       string
+// 		dsName     string
+// 		edsEnabled bool
+// 		wantDS     map[string]struct{}
+// 		wantEDS    map[string]struct{}
+// 	}{
+// 		{
+// 			name:       "introspection disabled, profiles disabled, eds disabled",
+// 			dsName:     "foo",
+// 			edsEnabled: false,
+// 			wantDS:     map[string]struct{}{"foo": {}},
+// 			wantEDS:    map[string]struct{}{},
+// 		},
+// 		{
+// 			name:       "introspection disabled, profiles disabled, eds enabled",
+// 			dsName:     "foo",
+// 			edsEnabled: true,
+// 			wantDS:     map[string]struct{}{},
+// 			wantEDS:    map[string]struct{}{"foo": {}},
+// 		},
+// 	}
 
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &Reconciler{
-				options: ReconcilerOptions{
-					ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
-						Enabled: tt.edsEnabled,
-					},
-				},
-			}
+// 	for _, tt := range testCases {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			r := &Reconciler{
+// 				options: ReconcilerOptions{
+// 					ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+// 						Enabled: tt.edsEnabled,
+// 					},
+// 				},
+// 			}
 
-			// Provide empty maps/slices for removed fields
-			validDSNames, validEDSNames := r.getValidDaemonSetNames(tt.dsName)
-			assert.Equal(t, tt.wantDS, validDSNames)
-			assert.Equal(t, tt.wantEDS, validEDSNames)
-		})
-	}
-}
+// 			// Provide empty maps/slices for removed fields
+// 			validDSNames, validEDSNames := r.getValidDaemonSetNames(tt.dsName)
+// 			assert.Equal(t, tt.wantDS, validDSNames)
+// 			assert.Equal(t, tt.wantEDS, validEDSNames)
+// 		})
+// 	}
+// }
 
 func Test_getDaemonSetNameFromDatadogAgent(t *testing.T) {
 	testCases := []struct {
@@ -146,135 +133,135 @@ func Test_getDaemonSetNameFromDatadogAgent(t *testing.T) {
 	}
 }
 
-func Test_cleanupExtraneousDaemonSets(t *testing.T) {
-	sch := runtime.NewScheme()
-	_ = scheme.AddToScheme(sch)
-	_ = edsdatadoghqv1alpha1.AddToScheme(sch)
-	ctx := context.Background()
+// func Test_cleanupExtraneousDaemonSets(t *testing.T) {
+// 	sch := runtime.NewScheme()
+// 	_ = scheme.AddToScheme(sch)
+// 	_ = edsdatadoghqv1alpha1.AddToScheme(sch)
+// 	ctx := context.Background()
 
-	testCases := []struct {
-		name           string
-		description    string
-		existingAgents []client.Object
-		edsEnabled     bool
-		wantDS         *appsv1.DaemonSetList
-		wantEDS        *edsdatadoghqv1alpha1.ExtendedDaemonSetList
-	}{
-		{
-			name:        "no unused ds, introspection disabled, profiles disabled",
-			description: "DS `dda-foo-agent` should not be deleted",
-			existingAgents: []client.Object{
-				&appsv1.DaemonSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dda-foo-agent",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
-							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
-						},
-					},
-				},
-			},
-			edsEnabled: false,
-			wantDS: &appsv1.DaemonSetList{
-				Items: []appsv1.DaemonSet{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:            "dda-foo-agent",
-							ResourceVersion: "999",
-							Labels: map[string]string{
-								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
-								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
-							},
-						},
-					},
-				},
-			},
-			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
-				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{},
-			},
-		},
-		{
-			name:        "no unused eds, introspection disabled, profiles disabled",
-			description: "EDS `dda-foo-agent` should not be deleted",
-			existingAgents: []client.Object{
-				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "dda-foo-agent",
-						Labels: map[string]string{
-							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
-							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
-						},
-					},
-				},
-			},
-			edsEnabled: true,
-			wantDS: &appsv1.DaemonSetList{
-				Items: []appsv1.DaemonSet{},
-			},
-			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
-				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:            "dda-foo-agent",
-							ResourceVersion: "999",
-							Labels: map[string]string{
-								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
-								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+// 	testCases := []struct {
+// 		name           string
+// 		description    string
+// 		existingAgents []client.Object
+// 		edsEnabled     bool
+// 		wantDS         *appsv1.DaemonSetList
+// 		wantEDS        *edsdatadoghqv1alpha1.ExtendedDaemonSetList
+// 	}{
+// 		{
+// 			name:        "no unused ds, introspection disabled, profiles disabled",
+// 			description: "DS `dda-foo-agent` should not be deleted",
+// 			existingAgents: []client.Object{
+// 				&appsv1.DaemonSet{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name: "dda-foo-agent",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+// 							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			edsEnabled: false,
+// 			wantDS: &appsv1.DaemonSetList{
+// 				Items: []appsv1.DaemonSet{
+// 					{
+// 						ObjectMeta: metav1.ObjectMeta{
+// 							Name:            "dda-foo-agent",
+// 							ResourceVersion: "999",
+// 							Labels: map[string]string{
+// 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+// 								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
+// 				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{},
+// 			},
+// 		},
+// 		{
+// 			name:        "no unused eds, introspection disabled, profiles disabled",
+// 			description: "EDS `dda-foo-agent` should not be deleted",
+// 			existingAgents: []client.Object{
+// 				&edsdatadoghqv1alpha1.ExtendedDaemonSet{
+// 					ObjectMeta: metav1.ObjectMeta{
+// 						Name: "dda-foo-agent",
+// 						Labels: map[string]string{
+// 							apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 							kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+// 							kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
+// 						},
+// 					},
+// 				},
+// 			},
+// 			edsEnabled: true,
+// 			wantDS: &appsv1.DaemonSetList{
+// 				Items: []appsv1.DaemonSet{},
+// 			},
+// 			wantEDS: &edsdatadoghqv1alpha1.ExtendedDaemonSetList{
+// 				Items: []edsdatadoghqv1alpha1.ExtendedDaemonSet{
+// 					{
+// 						ObjectMeta: metav1.ObjectMeta{
+// 							Name:            "dda-foo-agent",
+// 							ResourceVersion: "999",
+// 							Labels: map[string]string{
+// 								apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
+// 								kubernetes.AppKubernetesManageByLabelKey:   "datadog-operator",
+// 								kubernetes.AppKubernetesPartOfLabelKey:     "ns--1-dda--foo",
+// 							},
+// 						},
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(tt.existingAgents...).Build()
-			logger := logf.Log.WithName("test_cleanupExtraneousDaemonSets")
-			eventBroadcaster := record.NewBroadcaster()
-			recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "test_cleanupExtraneousDaemonSets"})
+// 	for _, tt := range testCases {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(tt.existingAgents...).Build()
+// 			logger := logf.Log.WithName("test_cleanupExtraneousDaemonSets")
+// 			eventBroadcaster := record.NewBroadcaster()
+// 			recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "test_cleanupExtraneousDaemonSets"})
 
-			r := &Reconciler{
-				client:   fakeClient,
-				log:      logger,
-				recorder: recorder,
-				options: ReconcilerOptions{
-					ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
-						Enabled: tt.edsEnabled,
-					},
-				},
-			}
+// 			r := &Reconciler{
+// 				client:   fakeClient,
+// 				log:      logger,
+// 				recorder: recorder,
+// 				options: ReconcilerOptions{
+// 					ExtendedDaemonsetOptions: agent.ExtendedDaemonsetOptions{
+// 						Enabled: tt.edsEnabled,
+// 					},
+// 				},
+// 			}
 
-			dda := datadoghqv1alpha1.DatadogAgentInternal{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "DatadogAgent",
-					APIVersion: "datadoghq.com/v2alpha1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "dda-foo",
-					Namespace: "ns-1",
-				},
-			}
-			ddaStatus := datadoghqv1alpha1.DatadogAgentInternalStatus{}
+// 			dda := datadoghqv1alpha1.DatadogAgentInternal{
+// 				TypeMeta: metav1.TypeMeta{
+// 					Kind:       "DatadogAgent",
+// 					APIVersion: "datadoghq.com/v2alpha1",
+// 				},
+// 				ObjectMeta: metav1.ObjectMeta{
+// 					Name:      "dda-foo",
+// 					Namespace: "ns-1",
+// 				},
+// 			}
+// 			ddaStatus := datadoghqv1alpha1.DatadogAgentInternalStatus{}
 
-			err := r.cleanupExtraneousDaemonSets(ctx, logger, &dda, &ddaStatus)
-			assert.NoError(t, err)
+// 			err := r.cleanupExtraneousDaemonSets(ctx, logger, &dda, &ddaStatus)
+// 			assert.NoError(t, err)
 
-			dsList := &appsv1.DaemonSetList{}
-			tedsList := &edsdatadoghqv1alpha1.ExtendedDaemonSetList{}
+// 			dsList := &appsv1.DaemonSetList{}
+// 			tedsList := &edsdatadoghqv1alpha1.ExtendedDaemonSetList{}
 
-			err = fakeClient.List(ctx, dsList)
-			assert.NoError(t, err)
-			err = fakeClient.List(ctx, tedsList)
-			assert.NoError(t, err)
+// 			err = fakeClient.List(ctx, dsList)
+// 			assert.NoError(t, err)
+// 			err = fakeClient.List(ctx, tedsList)
+// 			assert.NoError(t, err)
 
-			assert.Equal(t, tt.wantDS, dsList)
-			assert.Equal(t, tt.wantEDS, tedsList)
-		})
-	}
-}
+// 			assert.Equal(t, tt.wantDS, dsList)
+// 			assert.Equal(t, tt.wantEDS, tedsList)
+// 		})
+// 	}
+// }

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/defaults"
@@ -53,21 +54,26 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	newStatus := instance.Status.DeepCopy()
 	now := metav1.NewTime(time.Now())
 
-	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instance, &instance.Spec, instance.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(&r.options, r.log))
+	// TODO: temporary fix for DDAI object name
+	// Use DDA name instead of DDAI name
+	instanceCopy := instance.DeepCopy()
+	instanceCopy.Name = instanceCopy.Labels[apicommon.DatadogAgentNameLabelKey]
+
+	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instanceCopy, &instanceCopy.Spec, instanceCopy.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(&r.options, r.log))
 	// update list of enabled features for metrics forwarder
-	r.updateMetricsForwardersFeatures(instance, enabledFeatures)
+	r.updateMetricsForwardersFeatures(instanceCopy, enabledFeatures)
 
 	// 1. Manage dependencies.
 	depsStore, resourceManagers := r.setupDependencies(instance, logger)
 
 	var err error
-	if err = r.manageGlobalDependencies(logger, instance, resourceManagers, requiredComponents); err != nil {
+	if err = r.manageGlobalDependencies(logger, instanceCopy, resourceManagers, requiredComponents); err != nil {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
 	}
 	if err = r.manageFeatureDependencies(logger, enabledFeatures, resourceManagers); err != nil {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
 	}
-	if err = r.overrideDependencies(logger, resourceManagers, instance); err != nil {
+	if err = r.overrideDependencies(logger, resourceManagers, instanceCopy); err != nil {
 		return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
 	}
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
@@ -87,10 +87,11 @@ func (r *Reconciler) cleanupExtraneousResources(ctx context.Context, logger logr
 	var errs []error
 	// Cleanup old DaemonSets, DCA and CCR deployments.
 
-	if err := r.cleanupExtraneousDaemonSets(ctx, logger, instance, newStatus); err != nil {
-		errs = append(errs, err)
-		logger.Error(err, "Error cleaning up old DaemonSets")
-	}
+	// TODO: re-enable once labels are updated to use DDAI name
+	// if err := r.cleanupExtraneousDaemonSets(ctx, logger, instance, newStatus); err != nil {
+	// 	errs = append(errs, err)
+	// 	logger.Error(err, "Error cleaning up old DaemonSets")
+	// }
 	if err := r.cleanupOldDCADeployments(ctx, logger, instance, resourceManagers, newStatus); err != nil {
 		errs = append(errs, err)
 		logger.Error(err, "Error cleaning up old DCA Deployments")


### PR DESCRIPTION
### What does this PR do?

Ensure the DS remains the same when switching from DDA to DDAI and back. This should result in no DS or node agent pod restarts (as long as the DCA token is set in a secret).
Lots of this should be uncommented in future PRs and have been marked with `TODO`.

### Motivation

https://datadoghq.atlassian.net/browse/CECO-2014

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
