### PR TITLE
[DatadogAgentInternal][CECO-2029] Add DCA token checksum annotation to DDAI when user provides literal token in DDA

### DIFF
--- a/internal/controller/datadogagent/ddai.go
+++ b/internal/controller/datadogagent/ddai.go
@@ -51,7 +51,7 @@ func generateObjMetaFromDDA(dda *datadoghqv2alpha1.DatadogAgent, ddai *datadoghq
 }
 
 func generateSpecFromDDA(dda *datadoghqv2alpha1.DatadogAgent, ddai *datadoghqv1alpha1.DatadogAgentInternal) error {
-	ddai.Spec = dda.Spec
+	ddai.Spec = *dda.Spec.DeepCopy()
 	global.SetGlobalFromDDA(dda, ddai.Spec.Global)
 	override.SetOverrideFromDDA(dda, &ddai.Spec)
 	return nil

--- a/internal/controller/datadogagent/global/dependencies.go
+++ b/internal/controller/datadogagent/global/dependencies.go
@@ -140,8 +140,8 @@ func AddCredentialDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, m
 	// Prioritize existing secrets
 	// Credentials should be non-nil from validation
 	global := dda.Spec.Global
-	apiKeySecretValid := isValidSecretConfig(global.Credentials.APISecret)
-	appKeySecretValid := isValidSecretConfig(global.Credentials.AppSecret)
+	apiKeySecretValid := IsValidSecretConfig(global.Credentials.APISecret)
+	appKeySecretValid := IsValidSecretConfig(global.Credentials.AppSecret)
 
 	// User defined secret(s) exist for both keys, nothing to do
 	if apiKeySecretValid && appKeySecretValid {
@@ -178,7 +178,7 @@ func AddDCATokenDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, man
 	var token string
 
 	// Prioritize existing secret
-	if isValidSecretConfig(global.ClusterAgentTokenSecret) {
+	if IsValidSecretConfig(global.ClusterAgentTokenSecret) {
 		return nil
 	}
 
@@ -189,7 +189,7 @@ func AddDCATokenDependencies(logger logr.Logger, dda *v2alpha1.DatadogAgent, man
 	if global.ClusterAgentToken != nil && *global.ClusterAgentToken != "" {
 		token = *global.ClusterAgentToken
 		// Generate hash
-		key = getDCATokenChecksumAnnotationKey()
+		key = GetDCATokenChecksumAnnotationKey()
 		hash, err = comparison.GenerateMD5ForSpec(map[string]string{common.DefaultTokenKey: token})
 		if err != nil {
 			logger.Error(err, "couldn't generate hash for Cluster Agent token hash")

--- a/internal/controller/datadogagent/global/global.go
+++ b/internal/controller/datadogagent/global/global.go
@@ -288,11 +288,11 @@ func credentialResource(dda *v2alpha1.DatadogAgent, podTemplateManager feature.P
 	}
 
 	// User specified names
-	if isValidSecretConfig(global.Credentials.APISecret) {
+	if IsValidSecretConfig(global.Credentials.APISecret) {
 		apiKeySecretName = global.Credentials.APISecret.SecretName
 		apiKeySecretKey = global.Credentials.APISecret.KeyName
 	}
-	if isValidSecretConfig(global.Credentials.AppSecret) {
+	if IsValidSecretConfig(global.Credentials.AppSecret) {
 		appKeySecretName = global.Credentials.AppSecret.SecretName
 		appKeySecretKey = global.Credentials.AppSecret.KeyName
 	}
@@ -312,7 +312,7 @@ func dcaTokenResource(dda *v2alpha1.DatadogAgent, resourcesManager feature.Resou
 	secretKey := common.DefaultTokenKey
 
 	global := dda.Spec.Global
-	if isValidSecretConfig(global.ClusterAgentTokenSecret) {
+	if IsValidSecretConfig(global.ClusterAgentTokenSecret) {
 		secretName = global.ClusterAgentTokenSecret.SecretName
 		secretKey = global.ClusterAgentTokenSecret.KeyName
 	}
@@ -322,7 +322,7 @@ func dcaTokenResource(dda *v2alpha1.DatadogAgent, resourcesManager feature.Resou
 
 	// Add annotation to pod template if secret has annotation
 	if obj, exists := resourcesManager.Store().Get(kubernetes.SecretsKind, dda.Namespace, secretName); exists {
-		key := getDCATokenChecksumAnnotationKey()
+		key := GetDCATokenChecksumAnnotationKey()
 		if val, ok := obj.GetAnnotations()[key]; ok {
 			podTemplateManager.Annotation().AddAnnotation(key, val)
 		}

--- a/internal/controller/datadogagent/global/utils.go
+++ b/internal/controller/datadogagent/global/utils.go
@@ -19,11 +19,11 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/version"
 )
 
-func isValidSecretConfig(secretConfig *v2alpha1.SecretConfig) bool {
+func IsValidSecretConfig(secretConfig *v2alpha1.SecretConfig) bool {
 	return secretConfig != nil && secretConfig.SecretName != "" && secretConfig.KeyName != ""
 }
 
-func getDCATokenChecksumAnnotationKey() string {
+func GetDCATokenChecksumAnnotationKey() string {
 	return object.GetChecksumAnnotationKey("dca-token")
 }
 
@@ -71,7 +71,7 @@ func setCredentialsFromDDA(dda metav1.Object, ddaiGlobal *v2alpha1.GlobalConfig)
 		},
 	}
 	// Prioritize existing secret
-	if isValidSecretConfig(ddaiGlobal.Credentials.APISecret) {
+	if IsValidSecretConfig(ddaiGlobal.Credentials.APISecret) {
 		newCredentials.APISecret = ddaiGlobal.Credentials.APISecret
 	}
 
@@ -82,7 +82,7 @@ func setCredentialsFromDDA(dda metav1.Object, ddaiGlobal *v2alpha1.GlobalConfig)
 			KeyName:    v2alpha1.DefaultAPPKeyKey,
 		}
 		// Prioritize existing secret
-		if isValidSecretConfig(ddaiGlobal.Credentials.AppSecret) {
+		if IsValidSecretConfig(ddaiGlobal.Credentials.AppSecret) {
 			newCredentials.AppSecret = ddaiGlobal.Credentials.AppSecret
 		}
 	}
@@ -91,7 +91,7 @@ func setCredentialsFromDDA(dda metav1.Object, ddaiGlobal *v2alpha1.GlobalConfig)
 
 func setDCATokenFromDDA(dda metav1.Object, ddaiGlobal *v2alpha1.GlobalConfig) {
 	// Use existing ClusterAgentTokenSecret if already set
-	if isValidSecretConfig(ddaiGlobal.ClusterAgentTokenSecret) {
+	if IsValidSecretConfig(ddaiGlobal.ClusterAgentTokenSecret) {
 		return
 	}
 

--- a/internal/controller/datadogagent/override/ddai_utils.go
+++ b/internal/controller/datadogagent/override/ddai_utils.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package override
+
+import (
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+)
+
+func SetOverrideFromDDA(dda *v2alpha1.DatadogAgent, ddaiSpec *v2alpha1.DatadogAgentSpec) {
+	if ddaiSpec == nil {
+		ddaiSpec = &v2alpha1.DatadogAgentSpec{}
+	}
+	if ddaiSpec.Override == nil {
+		ddaiSpec.Override = make(map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride)
+	}
+	if _, ok := ddaiSpec.Override[v2alpha1.NodeAgentComponentName]; !ok {
+		ddaiSpec.Override[v2alpha1.NodeAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{}
+	}
+	if ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels == nil {
+		ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels = make(map[string]string)
+	}
+	// Set empty provider label
+	ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels[constants.MD5AgentDeploymentProviderLabelKey] = ""
+
+	// Add checksum annotation to the node agent and cluster agent pod templates if the cluster agent token is set in DDA spec
+	// This is used to trigger a redeployment of the node agent when the cluster agent token is changed
+	// This is needed as DDAI are always using a DCA token secret, while the DDA can use a token from a secret or a literal value
+	if shouldAddDCATokenChecksumAnnotation(dda) {
+		token := apiutils.StringValue(dda.Spec.Global.ClusterAgentToken)
+		hash, _ := comparison.GenerateMD5ForSpec(map[string]string{common.DefaultTokenKey: token})
+		if ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Annotations == nil {
+			ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Annotations = make(map[string]string)
+		}
+		ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Annotations[global.GetDCATokenChecksumAnnotationKey()] = hash
+
+		if _, ok := ddaiSpec.Override[v2alpha1.ClusterAgentComponentName]; !ok {
+			ddaiSpec.Override[v2alpha1.ClusterAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{}
+		}
+		if ddaiSpec.Override[v2alpha1.ClusterAgentComponentName].Annotations == nil {
+			ddaiSpec.Override[v2alpha1.ClusterAgentComponentName].Annotations = make(map[string]string)
+		}
+		ddaiSpec.Override[v2alpha1.ClusterAgentComponentName].Annotations[global.GetDCATokenChecksumAnnotationKey()] = hash
+	}
+}
+
+// shouldAddDCATokenChecksumAnnotation checks if the cluster agent token is set as a literal value without a secret.
+// If the token is set as a secret, we do not add the annotation.
+func shouldAddDCATokenChecksumAnnotation(dda *v2alpha1.DatadogAgent) bool {
+	return !global.IsValidSecretConfig(dda.Spec.Global.ClusterAgentTokenSecret) && apiutils.StringValue(dda.Spec.Global.ClusterAgentToken) != ""
+}

--- a/internal/controller/datadogagent/override/ddai_utils_test.go
+++ b/internal/controller/datadogagent/override/ddai_utils_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package override
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldAddDCATokenChecksumAnnotation(t *testing.T) {
+	tests := []struct {
+		name string
+		dda  *v2alpha1.DatadogAgent
+		want bool
+	}{
+		{
+			name: "should add checksum annotation when token is set as a literal value",
+			dda: &v2alpha1.DatadogAgent{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						ClusterAgentToken: apiutils.NewStringPointer("token"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "should not add checksum annotation when token is set as a secret",
+			dda: &v2alpha1.DatadogAgent{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						ClusterAgentTokenSecret: &v2alpha1.SecretConfig{SecretName: "secret", KeyName: "key"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should not add checksum annotation when both token and secret are set",
+			dda: &v2alpha1.DatadogAgent{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						ClusterAgentToken: apiutils.NewStringPointer("token"),
+						ClusterAgentTokenSecret: &v2alpha1.SecretConfig{
+							SecretName: "secret",
+							KeyName:    "key",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldAddDCATokenChecksumAnnotation(tt.dda); got != tt.want {
+				t.Errorf("shouldAddDCATokenChecksumAnnotation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetOverrideFromDDA(t *testing.T) {
+	const (
+		tokenValue            = "test-token"
+		existingLabel         = "existing-label"
+		existingAnnotation    = "existing-annotation"
+		existingDCAAnnotation = "existing-dca-annotation"
+		existingValue         = "value"
+		tokenSecretName       = "token-secret"
+		tokenSecretKey        = "key"
+	)
+
+	tokenHash, _ := comparison.GenerateMD5ForSpec(map[string]string{common.DefaultTokenKey: tokenValue})
+	dcaTokenChecksumAnnotationKey := global.GetDCATokenChecksumAnnotationKey()
+
+	tests := []struct {
+		name         string
+		dda          *v2alpha1.DatadogAgent
+		wantDDAISpec *v2alpha1.DatadogAgentSpec
+	}{
+		{
+			name: "token set as literal value",
+			dda: &v2alpha1.DatadogAgent{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						ClusterAgentToken: apiutils.NewStringPointer(tokenValue),
+					},
+				},
+			},
+			wantDDAISpec: &v2alpha1.DatadogAgentSpec{
+				Global: &v2alpha1.GlobalConfig{
+					ClusterAgentToken: apiutils.NewStringPointer(tokenValue),
+				},
+				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.NodeAgentComponentName: {
+						Labels: map[string]string{
+							constants.MD5AgentDeploymentProviderLabelKey: "",
+						},
+						Annotations: map[string]string{
+							dcaTokenChecksumAnnotationKey: tokenHash,
+						},
+					},
+					v2alpha1.ClusterAgentComponentName: {
+						Annotations: map[string]string{
+							dcaTokenChecksumAnnotationKey: tokenHash,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "token set via secret",
+			dda: &v2alpha1.DatadogAgent{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						ClusterAgentTokenSecret: &v2alpha1.SecretConfig{
+							SecretName: tokenSecretName,
+						},
+					},
+				},
+			},
+			wantDDAISpec: &v2alpha1.DatadogAgentSpec{
+				Global: &v2alpha1.GlobalConfig{
+					ClusterAgentTokenSecret: &v2alpha1.SecretConfig{
+						SecretName: tokenSecretName,
+					},
+				},
+				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.NodeAgentComponentName: {
+						Labels: map[string]string{
+							constants.MD5AgentDeploymentProviderLabelKey: "",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "token set as literal value, with existing overrides",
+			dda: &v2alpha1.DatadogAgent{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						ClusterAgentToken: apiutils.NewStringPointer(tokenValue),
+					},
+					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+						v2alpha1.NodeAgentComponentName: {
+							Labels:      map[string]string{existingLabel: existingValue},
+							Annotations: map[string]string{existingAnnotation: existingValue},
+						},
+						v2alpha1.ClusterAgentComponentName: {
+							Annotations: map[string]string{existingDCAAnnotation: existingValue},
+						},
+					},
+				},
+			},
+			wantDDAISpec: &v2alpha1.DatadogAgentSpec{
+				Global: &v2alpha1.GlobalConfig{
+					ClusterAgentToken: apiutils.NewStringPointer(tokenValue),
+				},
+				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.NodeAgentComponentName: {
+						Labels: map[string]string{
+							existingLabel: existingValue,
+							constants.MD5AgentDeploymentProviderLabelKey: "",
+						},
+						Annotations: map[string]string{
+							existingAnnotation:            existingValue,
+							dcaTokenChecksumAnnotationKey: tokenHash,
+						},
+					},
+					v2alpha1.ClusterAgentComponentName: {
+						Annotations: map[string]string{
+							existingDCAAnnotation:         existingValue,
+							dcaTokenChecksumAnnotationKey: tokenHash,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "token set as literal value and secret is set, with existing overrides",
+			dda: &v2alpha1.DatadogAgent{
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						ClusterAgentToken: apiutils.NewStringPointer(tokenValue),
+						ClusterAgentTokenSecret: &v2alpha1.SecretConfig{
+							SecretName: tokenSecretName,
+							KeyName:    tokenSecretKey,
+						},
+					},
+					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+						v2alpha1.NodeAgentComponentName: {
+							Labels: map[string]string{existingLabel: existingValue},
+						},
+					},
+				},
+			},
+			wantDDAISpec: &v2alpha1.DatadogAgentSpec{
+				Global: &v2alpha1.GlobalConfig{
+					ClusterAgentToken: apiutils.NewStringPointer(tokenValue),
+					ClusterAgentTokenSecret: &v2alpha1.SecretConfig{
+						SecretName: tokenSecretName,
+						KeyName:    tokenSecretKey,
+					},
+				},
+				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.NodeAgentComponentName: {
+						Labels: map[string]string{
+							existingLabel: existingValue,
+							constants.MD5AgentDeploymentProviderLabelKey: "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSpec := tt.dda.Spec.DeepCopy()
+			SetOverrideFromDDA(tt.dda, gotSpec)
+			assert.Equal(t, tt.wantDDAISpec, gotSpec)
+		})
+	}
+}

--- a/internal/controller/datadogagent/override/utils.go
+++ b/internal/controller/datadogagent/override/utils.go
@@ -10,9 +10,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
 func getDefaultConfigMapName(ddaName, fileName string) string {
@@ -25,21 +22,4 @@ func hasProbeHandler(probe *corev1.Probe) bool {
 		return true
 	}
 	return false
-}
-
-func SetOverrideFromDDA(dda *v2alpha1.DatadogAgent, ddaiSpec *v2alpha1.DatadogAgentSpec) {
-	if ddaiSpec == nil {
-		ddaiSpec = &v2alpha1.DatadogAgentSpec{}
-	}
-	if ddaiSpec.Override == nil {
-		ddaiSpec.Override = make(map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride)
-	}
-	if _, ok := ddaiSpec.Override[v2alpha1.NodeAgentComponentName]; !ok {
-		ddaiSpec.Override[v2alpha1.NodeAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{}
-	}
-	if ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels == nil {
-		ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels = make(map[string]string)
-	}
-	// Set empty provider label
-	ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels[constants.MD5AgentDeploymentProviderLabelKey] = ""
 }


### PR DESCRIPTION
### What does this PR do?

* When generating spec from DDA, uses a deepcopy to avoid sharing references since modifications are done to DDAI spec
* Make `isValidSecretConfig` and `getDCATokenChecksumAnnotationKey` public to use them in different packages
* Move some utils function from override/utils.go to override/ddai_utils.go to highlight their specific usage solely for DDAI
* When generating spec from DDA, adds DCA token checksum annotation as nodeAgent and DCA component overrides to ensure the daemonset and deploy are not changed: this annotation is added by DDA controller to pod template spec when user is providing a string literal, while DDAI will always reference the secret (created by DDA from this literal) so would not be adding the checksum

### Motivation

* Do not modify DS/deploy spec in case `spec.global.clusterAgentToken` is provided

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
