### PR TITLE
[datadogpodautoscalers] Update default local fallback threshold to 30m

### DIFF
--- a/api/datadoghq/v1alpha2/datadogpodautoscaler_types.go
+++ b/api/datadoghq/v1alpha2/datadogpodautoscaler_types.go
@@ -155,9 +155,9 @@ type DatadogPodAutoscalerHorizontalFallbackPolicy struct {
 type HorizontalFallbackTriggers struct {
 	// StaleRecommendationThresholdSeconds defines the time window the controller will wait after detecting an error before applying recommendations.
 	// +optional
-	// +kubebuilder:default=600
+	// +kubebuilder:default=1800
 	// +kubebuilder:validation:Minimum=100
-	// +kubebuilder:validation:Maximum=1200
+	// +kubebuilder:validation:Maximum=3600
 	StaleRecommendationThresholdSeconds int32 `json:"staleRecommendationThresholdSeconds,omitempty"`
 }
 

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -836,10 +836,10 @@ spec:
                           description: Triggers defines the triggers that will generate recommendations.
                           properties:
                             staleRecommendationThresholdSeconds:
-                              default: 600
+                              default: 1800
                               description: StaleRecommendationThresholdSeconds defines the time window the controller will wait after detecting an error before applying recommendations.
                               format: int32
-                              maximum: 1200
+                              maximum: 3600
                               minimum: 100
                               type: integer
                           type: object

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -300,10 +300,10 @@
                   "description": "Triggers defines the triggers that will generate recommendations.",
                   "properties": {
                     "staleRecommendationThresholdSeconds": {
-                      "default": 600,
+                      "default": 1800,
                       "description": "StaleRecommendationThresholdSeconds defines the time window the controller will wait after detecting an error before applying recommendations.",
                       "format": "int32",
-                      "maximum": 1200,
+                      "maximum": 3600,
                       "minimum": 100,
                       "type": "integer"
                     }


### PR DESCRIPTION
### What does this PR do?

Change the default local fallback threshold duration from 10m -> 30m to match https://github.com/DataDog/datadog-agent/pull/37581

### Motivation

Now by default local fallback will only activate when no recommendations are received for 30m

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.58.0
* Cluster Agent: v7.58.0

### Describe your test plan

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
