### PR TITLE
bug: Disable process config in clc runner

### DIFF
--- a/internal/controller/datadogagent/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default.go
@@ -243,6 +243,10 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 			Value: "false",
 		},
 		{
+			Name:  common.DDProcessConfigRunInCoreAgent,
+			Value: "false",
+		},
+		{
 			Name:  common.DDContainerCollectionEnabled,
 			Value: "true",
 		},


### PR DESCRIPTION
### What does this PR do?

Disables the process configuration from loading on the cluster check runner

### Motivation

CLC runner making periodic requests to the process endpoint 

### Additional Notes

N/A

### Minimum Agent Versions

Fixes issues on CLC runners present in Agent version 7.65+

### Describe your test plan

N/A

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
