### PR TITLE
New OTEL Image

### DIFF
--- a/internal/controller/datadogagentinternal/component/agent/default.go
+++ b/internal/controller/datadogagentinternal/component/agent/default.go
@@ -334,9 +334,7 @@ func agentImage() string {
 }
 
 func otelAgentImage() string {
-	// todo(mackjmr): Update once OTel agent is GA (7.64.0), as the ot-beta tag will be discontinued.
-	return fmt.Sprintf("%s/%s:%s", images.DefaultImageRegistry, images.DefaultAgentImageName, images.OTelAgentBetaTag)
-
+	return fmt.Sprintf("%s/%s:%s%s", images.DefaultImageRegistry, images.DefaultAgentImageName, images.AgentLatestVersion, images.FullTagSuffix)
 }
 
 func initContainers(dda metav1.Object, requiredContainers []apicommon.AgentContainerName) []corev1.Container {

--- a/internal/controller/datadogagentinternal/component/agent/default.go
+++ b/internal/controller/datadogagentinternal/component/agent/default.go
@@ -333,8 +333,8 @@ func agentImage() string {
 	return images.GetLatestAgentImage()
 }
 
-func otelAgentImage() string {
-	return fmt.Sprintf("%s/%s:%s%s", images.DefaultImageRegistry, images.DefaultAgentImageName, images.AgentLatestVersion, images.FullTagSuffix)
+func fullAgentImage() string {
+	return images.GetLatestAgentImageWithSuffix(false, false, true)
 }
 
 func initContainers(dda metav1.Object, requiredContainers []apicommon.AgentContainerName) []corev1.Container {
@@ -437,7 +437,7 @@ func processAgentContainer(dda metav1.Object) corev1.Container {
 func otelAgentContainer(_ metav1.Object) corev1.Container {
 	return corev1.Container{
 		Name:  string(apicommon.OtelAgent),
-		Image: otelAgentImage(),
+		Image: fullAgentImage(),
 		Command: []string{
 			"otel-agent",
 			"--config=" + otelCustomConfigVolumePath,

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -42,7 +42,6 @@ const (
 	// Default Image names
 	DefaultAgentImageName        string = "agent"
 	DefaultClusterAgentImageName string = "cluster-agent"
-	OTelAgentBetaTag                    = "7.63.0-ot-beta-jmx"
 )
 
 // imageHasTag identifies whether an image string contains a tag suffix


### PR DESCRIPTION
### What does this PR do?

changed the otel image default that is being used, now includes the -full suffix

### Motivation

Otel image was outdated, using beta tag

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

On a local kind cluster, have spec.features.otelCollector.enabled set to true in the DDA manifest. Then describe an agent, and go under Containers.otel-agent and make sure that the image is gcr.io/datadoghq/agent:7.66.1-full (whatever agent version you use, just make sure it has "-full" as the suffix).

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
