### PR TITLE
Fix mergegate exception bot email addresses

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -23,4 +23,5 @@ kind: mergegate
 rules:
   - require: commit-signatures
     excluded_emails:
-      - '41898282+github-actions[bot]@users.noreply.github.com'
+      - 'github-actions[bot]@users.noreply.github.com' # github-actions[bot]
+      - '152526959+datadog-githubops-containers[bot]@users.noreply.github.com' # datadog-githubops-containers[bot]


### PR DESCRIPTION
### What does this PR do?

I added `mergegate` exceptions for the github-actions bot, but the backport PR workflows made after merging my initial changes still failed the `mergegate` CI check. Updated the email address to point to the right bot.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Checked that the email address is correct:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/04c06649-0e79-44ba-be97-425523f7b753" />


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
