### PR TITLE
Keep DDA ownerref for profile DDAI

### DIFF
--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -20,7 +20,6 @@ import (
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -143,14 +142,6 @@ func setProfileDDAIMeta(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.D
 	ddai.Name = getProfileDDAIName(ddai.Name, profile.Name, profile.Namespace)
 	// Managed fields
 	ddai.ManagedFields = []metav1.ManagedFieldsEntry{}
-	// Owner reference
-	if !agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
-		ownerRef, err := object.CreateOwnerRef(profile, scheme)
-		if err != nil {
-			return err
-		}
-		ddai.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
-	}
 	return nil
 }
 

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -197,15 +197,6 @@ func Test_computeProfileMerge(t *testing.T) {
 					Annotations: map[string]string{
 						constants.MD5DDAIDeploymentAnnotationKey: "d302e0505ae43dad0fe5d8556ef539e1",
 					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "datadoghq.com/v1alpha1",
-							Kind:               "DatadogAgentProfile",
-							Name:               "foo-profile",
-							Controller:         apiutils.NewBoolPointer(true),
-							BlockOwnerDeletion: apiutils.NewBoolPointer(true),
-						},
-					},
 				},
 				Spec: v2alpha1.DatadogAgentSpec{
 					Features: &v2alpha1.DatadogFeatures{
@@ -306,7 +297,6 @@ func Test_computeProfileMerge(t *testing.T) {
 			ddai, err := r.computeProfileMerge(&tt.ddai, &tt.profile)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want.Name, ddai.Name)
-			assert.Equal(t, tt.want.OwnerReferences, ddai.OwnerReferences)
 			assert.Equal(t, tt.want.Annotations[constants.MD5DDAIDeploymentAnnotationKey], ddai.Annotations[constants.MD5DDAIDeploymentAnnotationKey])
 			assert.Equal(t, tt.want.Spec, ddai.Spec)
 		})
@@ -560,13 +550,6 @@ func Test_setProfileDDAIMeta(t *testing.T) {
 							Manager: "datadog-operator",
 						},
 					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: "datadoghq.com/v2alpha1",
-							Kind:       "DatadogAgent",
-							Name:       "foo",
-						},
-					},
 				},
 			},
 			profile: v1alpha1.DatadogAgentProfile{
@@ -577,17 +560,8 @@ func Test_setProfileDDAIMeta(t *testing.T) {
 			},
 			want: v1alpha1.DatadogAgentInternal{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-profile-foo",
-					Namespace: "bar",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "datadoghq.com/v1alpha1",
-							Kind:               "DatadogAgentProfile",
-							Name:               "foo",
-							Controller:         apiutils.NewBoolPointer(true),
-							BlockOwnerDeletion: apiutils.NewBoolPointer(true),
-						},
-					},
+					Name:          "foo-profile-foo",
+					Namespace:     "bar",
 					ManagedFields: []metav1.ManagedFieldsEntry{},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Use DDA as ownerref instead of DAP as ownerref

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Deleting profile DDAIs manually for deleted DAPs will be handled in a future PR

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
