### PR TITLE
[CECO-2029] Add profile label to non-default profile DDAIs and do not create EDS if non-default profile DDAI

### DIFF
--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -20,7 +20,6 @@ import (
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -143,14 +142,6 @@ func setProfileDDAIMeta(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.D
 	ddai.Name = getProfileDDAIName(ddai.Name, profile.Name, profile.Namespace)
 	// Managed fields
 	ddai.ManagedFields = []metav1.ManagedFieldsEntry{}
-	// Owner reference
-	if !agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
-		ownerRef, err := object.CreateOwnerRef(profile, scheme)
-		if err != nil {
-			return err
-		}
-		ddai.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
-	}
 	return nil
 }
 

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
-	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/stretchr/testify/assert"
@@ -563,6 +562,9 @@ func Test_setProfileDDAIMeta(t *testing.T) {
 					Name:          "foo-profile-foo",
 					Namespace:     "bar",
 					ManagedFields: []metav1.ManagedFieldsEntry{},
+					Labels: map[string]string{
+						agentprofile.ProfileLabelKey: "foo",
+					},
 				},
 			},
 		},
@@ -570,7 +572,7 @@ func Test_setProfileDDAIMeta(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			setProfileDDAIMeta(&tt.ddai, &tt.profile, agenttestutils.TestScheme())
+			setProfileDDAIMeta(&tt.ddai, &tt.profile)
 			assert.Equal(t, tt.want, tt.ddai)
 		})
 	}

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -197,15 +197,6 @@ func Test_computeProfileMerge(t *testing.T) {
 					Annotations: map[string]string{
 						constants.MD5DDAIDeploymentAnnotationKey: "d302e0505ae43dad0fe5d8556ef539e1",
 					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "datadoghq.com/v1alpha1",
-							Kind:               "DatadogAgentProfile",
-							Name:               "foo-profile",
-							Controller:         apiutils.NewBoolPointer(true),
-							BlockOwnerDeletion: apiutils.NewBoolPointer(true),
-						},
-					},
 				},
 				Spec: v2alpha1.DatadogAgentSpec{
 					Features: &v2alpha1.DatadogFeatures{
@@ -306,7 +297,6 @@ func Test_computeProfileMerge(t *testing.T) {
 			ddai, err := r.computeProfileMerge(&tt.ddai, &tt.profile)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want.Name, ddai.Name)
-			assert.Equal(t, tt.want.OwnerReferences, ddai.OwnerReferences)
 			assert.Equal(t, tt.want.Annotations[constants.MD5DDAIDeploymentAnnotationKey], ddai.Annotations[constants.MD5DDAIDeploymentAnnotationKey])
 			assert.Equal(t, tt.want.Spec, ddai.Spec)
 		})
@@ -560,13 +550,6 @@ func Test_setProfileDDAIMeta(t *testing.T) {
 							Manager: "datadog-operator",
 						},
 					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion: "datadoghq.com/v2alpha1",
-							Kind:       "DatadogAgent",
-							Name:       "foo",
-						},
-					},
 				},
 			},
 			profile: v1alpha1.DatadogAgentProfile{
@@ -577,17 +560,8 @@ func Test_setProfileDDAIMeta(t *testing.T) {
 			},
 			want: v1alpha1.DatadogAgentInternal{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-profile-foo",
-					Namespace: "bar",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "datadoghq.com/v1alpha1",
-							Kind:               "DatadogAgentProfile",
-							Name:               "foo",
-							Controller:         apiutils.NewBoolPointer(true),
-							BlockOwnerDeletion: apiutils.NewBoolPointer(true),
-						},
-					},
+					Name:          "foo-profile-foo",
+					Namespace:     "bar",
 					ManagedFields: []metav1.ManagedFieldsEntry{},
 				},
 			},

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -26,6 +26,7 @@ import (
 	componentagent "github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal/global"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal/override"
+	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
@@ -57,7 +58,7 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 	// DaemonSets.
 	// This is to make deployments simpler. With multiple EDS there would be
 	// multiple canaries, etc.
-	if r.options.ExtendedDaemonsetOptions.Enabled {
+	if r.options.ExtendedDaemonsetOptions.Enabled && !isDDAILabeledWithProfile(ddaiCopy) {
 		// Start by creating the Default Agent extendeddaemonset
 		eds = componentagent.NewDefaultAgentExtendedDaemonset(ddaiCopy, &r.options.ExtendedDaemonsetOptions, requiredComponents.Agent)
 		podManagers = feature.NewPodTemplateManagers(&eds.Spec.Template)
@@ -213,6 +214,16 @@ func (r *Reconciler) deleteV2ExtendedDaemonSet(logger logr.Logger, ddai *datadog
 func deleteStatusWithAgent(newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) {
 	newStatus.Agent = nil
 	condition.DeleteDatadogAgentInternalStatusCondition(newStatus, common.AgentReconcileConditionType)
+}
+
+// isDDAILabeledWithProfile returns true if the DDAI is labeled with a non-default profile.
+// This is used to determine whether or not the EDS should be created.
+func isDDAILabeledWithProfile(ddai *datadoghqv1alpha1.DatadogAgentInternal) bool {
+	labels := ddai.GetLabels()
+	if labels == nil {
+		return false
+	}
+	return labels[agentprofile.ProfileLabelKey] != ""
 }
 
 // cleanupExtraneousDaemonSets deletes DSs/EDSs that no longer apply.

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent_test.go
@@ -7,6 +7,7 @@ import (
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal/component"
+	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	"github.com/stretchr/testify/assert"
@@ -129,6 +130,43 @@ func Test_getDaemonSetNameFromDatadogAgent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dsName := component.GetDaemonSetNameFromDatadogAgent(tt.ddai)
 			assert.Equal(t, tt.wantDSName, dsName)
+		})
+	}
+}
+
+func Test_isDDAILabeledWithProfile(t *testing.T) {
+	testCases := []struct {
+		name string
+		ddai *datadoghqv1alpha1.DatadogAgentInternal
+		want bool
+	}{
+		{
+			name: "no profile label",
+			ddai: &datadoghqv1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "profile label",
+			ddai: &datadoghqv1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						agentprofile.ProfileLabelKey: "foo",
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDDAILabeledWithProfile(tt.ddai)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

* When creating profile DDAIs, include the label `agent.datadoghq.com/datadogagentprofile` in DDAI meta
* Removes `scheme` argument from `setProfileDDAIMeta` as it is not used
* When reconciling Agent, check if non-default profile label and if yes, use DS instead of EDS if enabled

### Motivation

* Keeping behaviour with DDA controller: we do not create EDS for profiles

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

- [ ] EDS enabled 
    * Create a profile
    * Ensure label is present on DDAI
    * Ensure DS gets created instead of EDS for profile pods, while EDS is present for non-profile/default pods
- [ ] EDS disabled
    * Create a profile
    * Ensure label is present on DDAI

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
