### PR TITLE
E2E enable allow_failure when manually pushing images to staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -227,6 +227,9 @@ build_bundle_image:
     allow_failure: true
   - if: $CI_COMMIT_TAG
     allow_failure: true
+  # Allow failure if we're explicitly pushing images to staging
+  - if: $PUSH_IMAGES_TO_STAGING == 'true'
+    allow_failure: true
   # Disable on Conductor-triggered jobs (ex: nightly)
   - if: '$DDR == "true"'
     when: never


### PR DESCRIPTION
### What does this PR do?

Allow e2e tests to fail so as not to block pushing and testing custom images on staging

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
