### PR TITLE
[CECO-2029][DatadogAgentInternal] Fix CCR when enabling DDAI

### DIFF
--- a/internal/controller/datadogagent/override/ddai_utils.go
+++ b/internal/controller/datadogagent/override/ddai_utils.go
@@ -30,8 +30,8 @@ func SetOverrideFromDDA(dda *v2alpha1.DatadogAgent, ddaiSpec *v2alpha1.DatadogAg
 	// Set empty provider label
 	ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels[constants.MD5AgentDeploymentProviderLabelKey] = ""
 
-	// Add checksum annotation to the node agent and cluster agent pod templates if the cluster agent token is set in DDA spec
-	// This is used to trigger a redeployment of the node agent when the cluster agent token is changed
+	// Add checksum annotation to the components (nodeAgent, clusterAgent, clusterChecksRunner) pod templates if the cluster agent token is set in DDA spec
+	// This is used to trigger a redeployment of the components when the cluster agent token is changed
 	// This is needed as DDAI are always using a DCA token secret, while the DDA can use a token from a secret or a literal value
 	if shouldAddDCATokenChecksumAnnotation(dda) {
 		token := apiutils.StringValue(dda.Spec.Global.ClusterAgentToken)
@@ -48,6 +48,14 @@ func SetOverrideFromDDA(dda *v2alpha1.DatadogAgent, ddaiSpec *v2alpha1.DatadogAg
 			ddaiSpec.Override[v2alpha1.ClusterAgentComponentName].Annotations = make(map[string]string)
 		}
 		ddaiSpec.Override[v2alpha1.ClusterAgentComponentName].Annotations[global.GetDCATokenChecksumAnnotationKey()] = hash
+
+		if _, ok := ddaiSpec.Override[v2alpha1.ClusterChecksRunnerComponentName]; !ok {
+			ddaiSpec.Override[v2alpha1.ClusterChecksRunnerComponentName] = &v2alpha1.DatadogAgentComponentOverride{}
+		}
+		if ddaiSpec.Override[v2alpha1.ClusterChecksRunnerComponentName].Annotations == nil {
+			ddaiSpec.Override[v2alpha1.ClusterChecksRunnerComponentName].Annotations = make(map[string]string)
+		}
+		ddaiSpec.Override[v2alpha1.ClusterChecksRunnerComponentName].Annotations[global.GetDCATokenChecksumAnnotationKey()] = hash
 	}
 }
 

--- a/internal/controller/datadogagent/override/ddai_utils_test.go
+++ b/internal/controller/datadogagent/override/ddai_utils_test.go
@@ -116,6 +116,11 @@ func TestSetOverrideFromDDA(t *testing.T) {
 							dcaTokenChecksumAnnotationKey: tokenHash,
 						},
 					},
+					v2alpha1.ClusterChecksRunnerComponentName: {
+						Annotations: map[string]string{
+							dcaTokenChecksumAnnotationKey: tokenHash,
+						},
+					},
 				},
 			},
 		},
@@ -181,6 +186,11 @@ func TestSetOverrideFromDDA(t *testing.T) {
 					v2alpha1.ClusterAgentComponentName: {
 						Annotations: map[string]string{
 							existingDCAAnnotation:         existingValue,
+							dcaTokenChecksumAnnotationKey: tokenHash,
+						},
+					},
+					v2alpha1.ClusterChecksRunnerComponentName: {
+						Annotations: map[string]string{
 							dcaTokenChecksumAnnotationKey: tokenHash,
 						},
 					},

--- a/internal/controller/datadogagentinternal/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagentinternal/component/clusterchecksrunner/default.go
@@ -243,6 +243,10 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 			Value: "false",
 		},
 		{
+			Name:  common.DDProcessConfigRunInCoreAgent,
+			Value: "false",
+		},
+		{
 			Name:  common.DDContainerCollectionEnabled,
 			Value: "true",
 		},


### PR DESCRIPTION
### What does this PR do?

* "Backports" https://github.com/DataDog/datadog-operator/pull/1979 to DDAI controller while `component` is still duplicated between both controllers, causing drifts
* Follow-up to https://github.com/DataDog/datadog-operator/pull/1976/s: add the DCA token annotation on CCR

### Motivation

* Test in staging, we want to reduce drift as much as possible

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Tested on `kind` by enabling / disabling DDAI with a `DatadogAgent` with CCR and `spec.global.clusterAgentToken` and ensured the deployment was stable (no restart, just patched ownerref)

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
