### PR TITLE
Merge DDAI affinities instead of replacing when using profiles

### DIFF
--- a/internal/controller/datadogagent/ddai_test.go
+++ b/internal/controller/datadogagent/ddai_test.go
@@ -3,6 +3,7 @@ package datadogagent
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -157,6 +158,22 @@ func Test_generateSpecFromDDA(t *testing.T) {
 								"foo": "bar",
 							},
 							PriorityClassName: apiutils.NewStringPointer("foo-priority-class"),
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "key",
+														Operator: corev1.NodeSelectorOpIn,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 						v2alpha1.ClusterAgentComponentName: {
 							PriorityClassName: apiutils.NewStringPointer("bar-priority-class"),
@@ -185,6 +202,22 @@ func Test_generateSpecFromDDA(t *testing.T) {
 								"foo": "bar",
 							},
 							PriorityClassName: apiutils.NewStringPointer("foo-priority-class"),
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "key",
+														Operator: corev1.NodeSelectorOpIn,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 						v2alpha1.ClusterAgentComponentName: {
 							PriorityClassName: apiutils.NewStringPointer("bar-priority-class"),

--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -108,6 +108,8 @@ func (r *Reconciler) computeProfileMerge(ddai *v1alpha1.DatadogAgentInternal, pr
 }
 
 func setProfileSpec(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.DatadogAgentProfile) {
+	// create affinity from ddai and profile prior to re-set after replacing the ddai spec
+	affinity := setProfileDDAIAffinity(ddai, profile)
 	if !agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
 		ddai.Spec = *profile.Spec.Config
 		// DCA and CCR are auto disabled for user created profiles
@@ -115,7 +117,7 @@ func setProfileSpec(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.Datad
 		disableComponent(ddai, v2alpha1.ClusterChecksRunnerComponentName)
 		setProfileNodeAgentOverride(ddai, profile)
 	}
-	setProfileDDAIAffinity(ddai, profile)
+	ddai.Spec.Override[v2alpha1.NodeAgentComponentName].Affinity = affinity
 }
 
 func disableComponent(ddai *v1alpha1.DatadogAgentInternal, componentName v2alpha1.ComponentName) {
@@ -125,12 +127,12 @@ func disableComponent(ddai *v1alpha1.DatadogAgentInternal, componentName v2alpha
 	ddai.Spec.Override[componentName].Disabled = apiutils.NewBoolPointer(true)
 }
 
-func setProfileDDAIAffinity(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.DatadogAgentProfile) {
+func setProfileDDAIAffinity(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.DatadogAgentProfile) *corev1.Affinity {
 	override, ok := ddai.Spec.Override[v2alpha1.NodeAgentComponentName]
 	if !ok {
 		override = &v2alpha1.DatadogAgentComponentOverride{}
 	}
-	override.Affinity = common.MergeAffinities(override.Affinity, agentprofile.AffinityOverride(profile))
+	return common.MergeAffinities(override.Affinity, agentprofile.AffinityOverride(profile))
 }
 
 func setProfileDDAIMeta(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.DatadogAgentProfile) error {

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -322,6 +322,23 @@ func Test_setProfileSpec(t *testing.T) {
 							Labels: map[string]string{
 								constants.MD5AgentDeploymentProviderLabelKey: "",
 							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "key",
+														Operator: corev1.NodeSelectorOpIn,
+														Values:   []string{"value"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -345,6 +362,11 @@ func Test_setProfileSpec(t *testing.T) {
 										NodeSelectorTerms: []corev1.NodeSelectorTerm{
 											{
 												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "key",
+														Operator: corev1.NodeSelectorOpIn,
+														Values:   []string{"value"},
+													},
 													{
 														Key:      "agent.datadoghq.com/datadogagentprofile",
 														Operator: corev1.NodeSelectorOpDoesNotExist,
@@ -395,6 +417,23 @@ func Test_setProfileSpec(t *testing.T) {
 							Labels: map[string]string{
 								constants.MD5AgentDeploymentProviderLabelKey: "",
 							},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "key",
+														Operator: corev1.NodeSelectorOpIn,
+														Values:   []string{"value"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -442,6 +481,11 @@ func Test_setProfileSpec(t *testing.T) {
 										NodeSelectorTerms: []corev1.NodeSelectorTerm{
 											{
 												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "key",
+														Operator: corev1.NodeSelectorOpIn,
+														Values:   []string{"value"},
+													},
 													{
 														Key:      "test",
 														Operator: corev1.NodeSelectorOpIn,


### PR DESCRIPTION
### What does this PR do?

Merge DDAI and profile affinities keeping the DDAI affinities instead of replacing them

### Motivation

🐛 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
