### PR TITLE
[CECO-2029][DatadogAgentInternal] Setup dependencies with real owner while using copy for naming

### DIFF
--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -64,7 +64,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, logger logr.Logger
 	r.updateMetricsForwardersFeatures(instanceCopy, enabledFeatures)
 
 	// 1. Manage dependencies.
-	depsStore, resourceManagers := r.setupDependencies(instanceCopy, logger)
+	depsStore, resourceManagers := r.setupDependencies(instance, instanceCopy, logger)
 
 	var err error
 	if err = r.manageGlobalDependencies(logger, instanceCopy, resourceManagers, requiredComponents); err != nil {

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
@@ -17,14 +17,15 @@ import (
 // STEP 2 of the reconcile loop: reconcile 3 components
 
 // setupDependencies initializes the store and resource managers.
-func (r *Reconciler) setupDependencies(instance *datadoghqv1alpha1.DatadogAgentInternal, logger logr.Logger) (*store.Store, feature.ResourceManagers) {
+func (r *Reconciler) setupDependencies(owner, namingInstance *datadoghqv1alpha1.DatadogAgentInternal, logger logr.Logger) (*store.Store, feature.ResourceManagers) {
 	storeOptions := &store.StoreOptions{
-		SupportCilium: r.options.SupportCilium,
-		PlatformInfo:  r.platformInfo,
-		Logger:        logger,
-		Scheme:        r.scheme,
+		SupportCilium:  r.options.SupportCilium,
+		PlatformInfo:   r.platformInfo,
+		Logger:         logger,
+		Scheme:         r.scheme,
+		NamingInstance: namingInstance,
 	}
-	depsStore := store.NewStore(instance, storeOptions)
+	depsStore := store.NewStore(owner, storeOptions)
 	resourceManagers := feature.NewResourceManagers(depsStore)
 	return depsStore, resourceManagers
 }

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers_test.go
@@ -76,7 +76,7 @@ func Test_setupDependencies(t *testing.T) {
 		platformInfo: dummyPlatformInfo,
 		scheme:       scheme,
 	}
-	storeObj, resMgrs := r.setupDependencies(dummyAgent, dummyLogger)
+	storeObj, resMgrs := r.setupDependencies(dummyAgent, dummyAgent, dummyLogger)
 	require.NotNil(t, storeObj)
 	require.NotNil(t, resMgrs)
 }


### PR DESCRIPTION
### What does this PR do?

* Provides a store option to use a different object than the owner to get labels/annotations, while still setting ownerref to the provided owner
* Uses this option solely in the DDAI controller to use the profile DDAI copy (that's using the DDA name) for labels/annotations while still setting the ownerref to an existing/real object

### Motivation

* Avoid creating dependencies with non-existing object in ownerref causing it to be GCd: this would happen when using profiles and DDAI

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
