### PR TITLE
[CECO-2265] Reduce clusterroles update

### DIFF
--- a/internal/controller/datadogagent/component/clusteragent/rbac.go
+++ b/internal/controller/datadogagent/component/clusteragent/rbac.go
@@ -6,7 +6,8 @@
 package clusteragent
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -146,13 +147,11 @@ func GetKubernetesResourceMetadataAsTagsPolicyRules(resourcesLabelsAsTags, resou
 	for gr := range groupResourceSet {
 		groupResources = append(groupResources, gr)
 	}
-	// sort groupResources to have a stable order
-	// This is important to avoid unnecessary RBAC updates
-	sort.Slice(groupResources, func(i, j int) bool {
-		if groupResources[i].group != groupResources[j].group {
-			return groupResources[i].group < groupResources[j].group
+	slices.SortStableFunc(groupResources, func(a, b groupResource) int {
+		if n := cmp.Compare(a.group, b.group); n != 0 {
+			return n
 		}
-		return groupResources[i].resource < groupResources[j].resource
+		return cmp.Compare(a.resource, b.resource)
 	})
 
 	policyRules := make([]rbacv1.PolicyRule, 0, len(groupResources))

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
@@ -6,8 +6,9 @@
 package orchestratorexplorer
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -151,11 +152,11 @@ func mapAPIGroupsResources(logger logr.Logger, customResources []string) []group
 	grs := make([]groupResources, 0, len(groupToResources))
 	for group, resources := range groupToResources {
 		// sort resources to have a stable order
-		sort.Strings(resources)
+		slices.Sort(resources)
 		grs = append(grs, groupResources{group: group, resources: resources})
 	}
-	sort.Slice(grs, func(i, j int) bool {
-		return grs[i].group < grs[j].group
+	slices.SortStableFunc(grs, func(a, b groupResources) int {
+		return cmp.Compare(a.group, b.group)
 	})
 
 	return grs

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
@@ -13,35 +13,44 @@ import (
 )
 
 func TestMapAPIGroupsResources(t *testing.T) {
-
 	for _, tt := range []struct {
 		name            string
 		customResources []string
-		expected        map[string][]string
+		expected        []groupResources
 	}{
 		{
 			name:            "empty crs",
 			customResources: []string{},
-			expected:        map[string][]string{},
+			expected:        []groupResources{},
 		},
 		{
 			name:            "two crs, same group",
 			customResources: []string{"datadoghq.com/v1alpha1/datadogmetrics", "datadoghq.com/v1alpha1/watermarkpodautoscalers"},
-			expected: map[string][]string{
-				"datadoghq.com": {"datadogmetrics", "watermarkpodautoscalers"},
+			expected: []groupResources{
+				{
+					group:     "datadoghq.com",
+					resources: []string{"datadogmetrics", "watermarkpodautoscalers"},
+				},
 			},
 		},
 		{
 			name:            "three crs, different groups",
 			customResources: []string{"datadoghq.com/v1alpha1/datadogmetrics", "datadoghq.com/v1alpha1/watermarkpodautoscalers", "cilium.io/v1/ciliumendpoints"},
-			expected: map[string][]string{
-				"datadoghq.com": {"datadogmetrics", "watermarkpodautoscalers"},
-				"cilium.io":     {"ciliumendpoints"},
+			expected: []groupResources{
+				{
+					group:     "cilium.io",
+					resources: []string{"ciliumendpoints"},
+				},
+				{
+					group:     "datadoghq.com",
+					resources: []string{"datadogmetrics", "watermarkpodautoscalers"},
+				},
 			},
 		},
 	} {
-		actualGroupsResources := mapAPIGroupsResources(logr.Logger{}, tt.customResources)
-		assert.Equal(t, tt.expected, actualGroupsResources)
+		t.Run(tt.name, func(t *testing.T) {
+			actualGroupsResources := mapAPIGroupsResources(logr.Logger{}, tt.customResources)
+			assert.Equal(t, tt.expected, actualGroupsResources)
+		})
 	}
-
 }

--- a/internal/controller/datadogagent/store/store.go
+++ b/internal/controller/datadogagent/store/store.go
@@ -225,7 +225,12 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 			}
 
 			if !equality.IsEqualObject(kind, objStore, objAPIServer) {
-				ds.logger.V(2).Info("store.store Add object to update", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
+				if kind == kubernetes.ClusterRolesKind {
+					ds.logger.Info("TIMOTHEE store.store objStore", "objStore", objStore)
+					ds.logger.Info("TIMOTHEE store.store objAPIServer", "objAPIServer", objAPIServer)
+					ds.logger.Info("TIMOTHEE store.store Add object to update", "obj.namespace", objStore.GetNamespace(), "obj.name", objStore.GetName(), "obj.kind", kind)
+				}
+
 				objsToUpdate = append(objsToUpdate, objStore)
 				continue
 			}


### PR DESCRIPTION
### What does this PR do?

* Ensures stable order when generating rules for non-deterministic CCRs (orchestrator explorer and annotationsAndLabelsAsTags)

### Motivation

* Frequent un-necessary updates for 2 CCRs: orchestrator and annotationsAndLabelsAsTags
* Root cause: non-deterministic generation of the `PolicyRule` slice within these `ClusterRoles`. The code iterated over maps to build the list of rules; because map iteration order is not guaranteed in Go, the resulting slice of rules could have a different order between reconciliations. This caused the deep equality check to fail, triggering an update even when the set of permissions was semantically identical.
* Solution: generate rules in a stable, deterministic order:
    * The approach involves a two-level sort in the functions that generate these rules:
        1. Sort resources within each API group: The list of resources (e.g., pods, services) for a given API group is sorted alphabetically.
        2. Sort the API groups themselves: The PolicyRule objects for each API group are then sorted alphabetically by the group name.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Using either feature, check that before (e.g. using public build) and after this PR, the CCRs remain the same for these 2 features
* Internally, verified the frequency of clusterroles updates has disappeared: https://ddstaging.datadoghq.com/logs?query=service%3Akube-apiserver-audit%20%40usr.id%3A%22system%3Aserviceaccount%3Adatadog-agent%3Adatadog-operator%22%20%40objectRef.resource%3Aclusterroles%20k8s_cluster%3Aabra&agg_m=count&agg_m_source=base&agg_q=%40http.method%2C%40objectRef.name%2C%40http.url_details.path&agg_q_source=base%2Cbase%2Cbase&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&sort_m=%2C%2C&sort_m_source=%2C%2C&sort_t=%2C%2C&storage=hot&stream_sort=desc&top_n=10%2C10%2C10&top_o=top%2Ctop%2Ctop&viz=stream&x_missing=true%2Ctrue%2Ctrue&from_ts=1748442574401&to_ts=1748443474401&live=false

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
