### PR TITLE
Report deployment status for DDAIs

### DIFF
--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
@@ -100,7 +100,7 @@ func (r *Reconciler) createOrUpdateDeployment(parentLogger logr.Logger, ddai *da
 		if !needUpdate {
 			// no need to update hasn't changed
 			now := metav1.NewTime(time.Now())
-			updateStatusFunc(deployment, newStatus, now, metav1.ConditionTrue, createSucceeded, "Deployment created")
+			updateStatusFunc(currentDeployment, newStatus, now, metav1.ConditionTrue, createSucceeded, "Deployment created")
 			return reconcile.Result{}, nil
 		}
 


### PR DESCRIPTION
### What does this PR do?

Reports deployment status:

```
# ddai
NAME                             AGENT             CLUSTER-AGENT     CLUSTER-CHECKS-RUNNER   AGE
datadog-agent                    Running (1/1/1)   Running (1/1/1)   Failed (0/0/0)          6d6h
datadog-agent-profile-dap-test   Running (1/1/1)                                             21h
```

```
# dda
NAME            AGENT             CLUSTER-AGENT     CLUSTER-CHECKS-RUNNER   AGE
datadog-agent   Running (2/2/2)   Running (1/1/1)   Failed (0/0/0)          6d23h
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
