### PR TITLE
[CECO-2321][DatadogAgentInternal] Delete DDAIs if disabled

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -300,6 +300,22 @@ func run(opts *options) error {
 		}()
 	}
 
+	// Cleanup leftover DatadogAgentInternal resources if DDAI controller is disabled
+	if opts.datadogAgentEnabled && !opts.datadogAgentInternalEnabled {
+		go func() {
+			// Block until this controller manager is elected leader and controllers are set up
+			<-mgr.Elected()
+
+			// Wait a bit more to ensure reconciliation has had a chance to patch ownerRefs
+			time.Sleep(60 * time.Second)
+
+			setupLog.Info("Starting cleanup of DatadogAgentInternal resources")
+			if err := controller.CleanupDatadogAgentInternalResources(setupLog, restConfig); err != nil {
+				setupLog.Error(err, "Failed to cleanup DatadogAgentInternal resources")
+			}
+		}()
+	}
+
 	options := controller.SetupOptions{
 		SupportExtendedDaemonset: controller.ExtendedDaemonsetOptions{
 			Enabled:                             opts.supportExtendedDaemonset,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -310,7 +310,7 @@ func run(opts *options) error {
 			time.Sleep(60 * time.Second)
 
 			setupLog.Info("Starting cleanup of DatadogAgentInternal resources")
-			if err := controller.CleanupDatadogAgentInternalResources(setupLog, restConfig); err != nil {
+			if err = controller.CleanupDatadogAgentInternalResources(setupLog, restConfig); err != nil {
 				setupLog.Error(err, "Failed to cleanup DatadogAgentInternal resources")
 			}
 		}()

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -350,7 +350,7 @@ func CleanupDatadogAgentInternalResources(logger logr.Logger, restConfig *rest.C
 			// Create a patch to remove the finalizer
 			patchData := []byte(`{"metadata":{"finalizers":[]}}`)
 
-			_, err := dynamicClient.Resource(ddaiGVR).Namespace(namespace).Patch(
+			_, err = dynamicClient.Resource(ddaiGVR).Namespace(namespace).Patch(
 				context.TODO(),
 				name,
 				types.MergePatchType,

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -46,6 +46,7 @@ const (
 	CustomResourceDefinitionsResource   = "customresourcedefinitions"
 	DaemonsetsResource                  = "daemonsets"
 	DatadogAgentsResource               = "datadogagents"
+	DatadogAgentInternalsResource       = "datadogagentinternals"
 	DatadogMetricsResource              = "datadogmetrics"
 	DatadogMetricsStatusResource        = "datadogmetrics/status"
 	DatadogPodAutoscalersResource       = "datadogpodautoscalers"


### PR DESCRIPTION
### What does this PR do?

* Introduces `CleanupDatadogAgentInternalResources` that tries to list all DDAIs a minute after being elected leader when DDAI controller is disabled, and deletes them after patching to remove the finalizer
    * We need to wait a small delay to have DDA patch ownerref otherwise, DDA has to re-create daemonsets and deploys

### Motivation

* Removing orphaned resources when DDAI controller is disabled, so they are not immediately re-reconciled when DDAI is re-enabled

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
