### PR TITLE
[CECO-2328] Copy status and labels fields outside creds gate

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -163,7 +163,6 @@ func Test_setupFromOperator(t *testing.T) {
 		loadFunc    func(*metricsForwarder, *secrets.DummyDecryptor)
 		wantAPIKey  string
 		wantBaseURL string
-		wantErr     bool
 	}{
 		{
 			name: "basic creds with default URL",
@@ -173,7 +172,6 @@ func Test_setupFromOperator(t *testing.T) {
 			},
 			wantBaseURL: defaultbaseURL,
 			wantAPIKey:  "test123",
-			wantErr:     false,
 		},
 		{
 			name: "basic creds with default DD_URL",
@@ -184,7 +182,6 @@ func Test_setupFromOperator(t *testing.T) {
 			},
 			wantBaseURL: "https://api.dd_url.com",
 			wantAPIKey:  "test123",
-			wantErr:     false,
 		},
 		{
 			name: "basic creds with default DD_DD_URL",
@@ -195,7 +192,6 @@ func Test_setupFromOperator(t *testing.T) {
 			},
 			wantBaseURL: "https://api.dd_dd_url.com",
 			wantAPIKey:  "test123",
-			wantErr:     false,
 		},
 		{
 			name: "basic creds with default DD_SITE",
@@ -206,7 +202,6 @@ func Test_setupFromOperator(t *testing.T) {
 			},
 			wantBaseURL: "https://api.dd_site.com",
 			wantAPIKey:  "test123",
-			wantErr:     false,
 		},
 	}
 	for _, tt := range tests {
@@ -221,11 +216,8 @@ func Test_setupFromOperator(t *testing.T) {
 			if tt.loadFunc != nil {
 				tt.loadFunc(mf, d)
 			}
-			_, err := mf.setupFromOperator()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("metricsForwarder.setupFromOperator() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			_ = mf.setupFromOperator()
+
 			if mf.apiKey != tt.wantAPIKey {
 				t.Errorf("metricsForwarder.setupFromOperator() apiKey = %v, want %v", mf.apiKey, tt.wantAPIKey)
 			}


### PR DESCRIPTION
### What does this PR do?

* Move copy of status fields and labels outside `credsSetFromOperator`
* Unit tests

### Motivation

* [Regression in 1.16](https://github.com/DataDog/datadog-operator/pull/1926/files): we do not send status metrics if creds are set from operator, while we did in 1.15-

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy operator with `DD_API_KEY` and apply a DDA, ensure you get `datadog.operator.agent.deployment.success` metric
* Remove `DD_API_KEY` and ensure you still get the metric with the operator fallbacking to creds set in DDA

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
