### PR TITLE
fix metrics forwarder metric

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -809,6 +809,11 @@ var objectKindToSnake = map[string]string{
 }
 
 func (mf *metricsForwarder) sendResourceCountMetric() error {
+	// At start mf.monitoredObjectKind may be empty; don't send metric in this case
+	if _, ok := objectKindToSnake[mf.monitoredObjectKind]; !ok {
+		return nil
+	}
+
 	ts := float64(time.Now().Unix())
 	metricName := fmt.Sprintf(customResourceFormat, mf.metricsPrefix, objectKindToSnake[mf.monitoredObjectKind])
 	tags := append(mf.tags, mf.globalTags...)


### PR DESCRIPTION
### What does this PR do?

Fix occasional reporting of `datadog.operator..custom_resource.count` metric

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Run Operator with a DatadogAgent resource. Ensure that `datadog.operator.datadog_agent.custom_resource.count` metric reports and `datadog.operator..custom_resource.count` metric does not.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
