### PR TITLE
fix dd_url handling

### DIFF
--- a/pkg/controller/utils/metadata/metadata_forwarder.go
+++ b/pkg/controller/utils/metadata/metadata_forwarder.go
@@ -382,7 +382,11 @@ func getURL() string {
 	// check url env var
 	// example: https://app.datadoghq.com
 	if urlFromEnvVar := os.Getenv("DD_URL"); urlFromEnvVar != "" {
-		mdfURL.Host = urlFromEnvVar
+		tempURL, err := url.Parse(urlFromEnvVar)
+		if err == nil {
+			mdfURL.Host = tempURL.Host
+			mdfURL.Scheme = tempURL.Scheme
+		}
 	}
 
 	return mdfURL.String()

--- a/pkg/controller/utils/metadata/metadata_forwarder_test.go
+++ b/pkg/controller/utils/metadata/metadata_forwarder_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metadata
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_getURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		loadFunc func()
+		wantURL  string
+	}{
+		{
+			name: "default case",
+			loadFunc: func() {
+			},
+			wantURL: "https://app.datadoghq.com/api/v1/metadata",
+		},
+		{
+			name: "set DD_SITE",
+			loadFunc: func() {
+				os.Clearenv()
+				os.Setenv("DD_SITE", "datad0g.com")
+			},
+			wantURL: "https://app.datad0g.com/api/v1/metadata",
+		},
+		{
+			name: "set DD_URL",
+			loadFunc: func() {
+				os.Clearenv()
+				os.Setenv("DD_URL", "https://app.datad0g.com")
+			},
+			wantURL: "https://app.datad0g.com/api/v1/metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.loadFunc()
+
+			u := getURL()
+
+			if u != tt.wantURL {
+				t.Errorf("getURL() url = %v, want %v", u, tt.wantURL)
+
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Follow up to #1999 to fix URL handling when DD_URL is set

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Run the Datadog Operator. Check the logs to see if the metadata forwarder runs without issue.

Then try adding DD_SITE (datadoghq.com) on the Operator deployment.

Then try adding DD_URL (https://app.datadoghq.com) on the Operator deployment.


### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
