### PR TITLE
Add missing debugfs mount for GPU monitoring

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -91,6 +91,10 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 	managers.VolumeMount().AddVolumeMountToContainer(&cgroupsMount, apicommon.SystemProbeContainerName)
 	managers.Volume().AddVolume(&cgroupsVol)
 
+	debugfsVol, debugfsMount := volume.GetVolumes(common.DebugfsVolumeName, common.DebugfsPath, common.DebugfsPath, false)
+	managers.VolumeMount().AddVolumeMountToContainer(&debugfsMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&debugfsVol)
+
 	socketVol, socketVolMount := volume.GetVolumesEmptyDir(common.SystemProbeSocketVolumeName, common.SystemProbeSocketVolumePath, false)
 	managers.Volume().AddVolume(&socketVol)
 	managers.VolumeMount().AddVolumeMountToContainer(&socketVolMount, apicommon.SystemProbeContainerName)

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -89,6 +89,11 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				ReadOnly:  true,
 			},
 			{
+				Name:      common.DebugfsVolumeName,
+				MountPath: common.DebugfsPath,
+				ReadOnly:  false,
+			},
+			{
 				Name:      common.SystemProbeSocketVolumeName,
 				MountPath: common.SystemProbeSocketVolumePath,
 				ReadOnly:  false,
@@ -121,6 +126,14 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: common.CgroupsHostPath,
+					},
+				},
+			},
+			{
+				Name:      common.DebugfsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: common.DebugfsPath,
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Exposes the `debugfs` mount in system-probe when GPU monitoring is enabled.

### Motivation

Ensure we can start the process event data stream, which is required for GPUM.

### Additional Notes

Related ticket: https://datadoghq.atlassian.net/browse/EBPF-768

### Minimum Agent Versions



* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Covered by unit tests.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
