### PR TITLE
Update Go runtime to 1.24.5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"image": "mcr.microsoft.com/devcontainers/go:dev-1.23",
+	"image": "mcr.microsoft.com/devcontainers/go:dev-1.24",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
 	},

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 on:
   push:
 # Permission forced by repo-level setting; only elevate on job-level

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   # packages: read
 env:
-  GO_VERSION: 1.23.10
+  GO_VERSION: 1.24.5
 jobs:
   build-linux-binary:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/images/mirror/library/golang:1.23.10
+image: registry.ddbuild.io/images/mirror/library/golang:1.24.5
 variables:
   PROJECTNAME: "datadog-operator"
   PROJECTNAME_CHECK: "datadog-operator-check"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG FIPS_ENABLED=false
 
 # Build the manager binary
-FROM golang:1.23.10 AS builder
+FROM golang:1.24.5 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,8 @@
 module github.com/DataDog/datadog-operator/api
 
-go 1.23
+go 1.24
 
-toolchain go1.23.10
+toolchain go1.24.5
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.34.0

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.10 AS builder
+FROM golang:1.24.5 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/DataDog/datadog-operator
 
-go 1.23
+go 1.24
 
-toolchain go1.23.10
+toolchain go1.24.5
 
 replace github.com/DataDog/extendeddaemonset v0.10.0-rc.4 => github.com/DataDog/extendeddaemonset/api v0.0.0-20250108205105-6c4d337b78a1
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.10
+go 1.24.5
 
-toolchain go1.23.10
+toolchain go1.24.5
 
 use (
 	.

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,8 +1,8 @@
 module github.com/DataDog/datadog-operator/test/e2e
 
-go 1.23
+go 1.24
 
-toolchain go1.23.10
+toolchain go1.24.5
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types => github.com/DataDog/datadog-agent/comp/core/tagger/types v0.63.0-rc.1


### PR DESCRIPTION
### What does this PR do?

* Updates Go to 1.24

### Motivation

* Anticipate Go 1.23 EOL as 1.25 is due to release in August (ref: https://groups.google.com/a/datadoghq.com/g/announce.dev/c/ExN0-ajL9PQ/m/oEtvvqA7AQAJ?utm_medium=email&utm_source=footer)

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
