### PR TITLE
(lint) fix gpu test spacing

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -130,7 +130,7 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				},
 			},
 			{
-				Name:      common.DebugfsVolumeName,
+				Name: common.DebugfsVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: common.DebugfsPath,


### PR DESCRIPTION
### What does this PR do?

* Corrects spacing to ensure lint is happy

### Motivation

* Broken since https://github.com/DataDog/datadog-operator/pull/2050

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
