### PR TITLE
update default agent images to 7.68.2

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -15,9 +15,9 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.67.0"
+	AgentLatestVersion = "7.68.2"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.67.0"
+	ClusterAgentLatestVersion = "7.68.2"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.13"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry


### PR DESCRIPTION
### What does this PR do?

Update default agent images to 7.68.2

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Deploy a DatadogAgent with cluster check runners enabled and no image overrides. Ensure that 7.68.2 is running for the node agent, cluster checks runner and cluster agent.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
