### PR TITLE
Update network policy metadata

### DIFF
--- a/internal/controller/datadogagent/component/objects/network.go
+++ b/internal/controller/datadogagent/component/objects/network.go
@@ -14,12 +14,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component"
 	componentccr "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusterchecksrunner"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -131,18 +133,22 @@ func BuildKubernetesNetworkPolicy(dda metav1.Object, componentName v2alpha1.Comp
 
 // GetNetworkPolicyMetadata generates a label selector based on component
 func GetNetworkPolicyMetadata(dda metav1.Object, componentName v2alpha1.ComponentName) (policyName string, podSelector metav1.LabelSelector) {
+	var comp string
 	switch componentName {
 	case v2alpha1.NodeAgentComponentName:
 		policyName = component.GetAgentName(dda)
+		comp = constants.DefaultAgentResourceSuffix
 	case v2alpha1.ClusterAgentComponentName:
 		policyName = component.GetClusterAgentName(dda)
+		comp = constants.DefaultClusterAgentResourceSuffix
 	case v2alpha1.ClusterChecksRunnerComponentName:
 		policyName = componentccr.GetClusterChecksRunnerName(dda)
+		comp = constants.DefaultClusterChecksRunnerResourceSuffix
 	}
 	podSelector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			kubernetes.AppKubernetesInstanceLabelKey: policyName,
-			kubernetes.AppKubernetesPartOfLabelKey:   object.NewPartOfLabelValue(dda).String(),
+			apicommon.AgentDeploymentComponentLabelKey: comp,
+			kubernetes.AppKubernetesPartOfLabelKey:     object.NewPartOfLabelValue(dda).String(),
 		},
 	}
 	return policyName, podSelector


### PR DESCRIPTION
### What does this PR do?

Update network policy metadata to match current dependencies. We're changing the instance label value, so switch to using agent component

### Motivation

https://datadoghq.atlassian.net/browse/AGENTONB-2318

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Use a previous operator image w/o this pr and enable [network policies](https://github.com/DataDog/datadog-operator/blob/3b6feaaca09ca5178d9c06e08e3bdb5d0c39eb2b/api/datadoghq/v2alpha1/datadogagent_types.go#L1586). Check the pod selector uses `app.kubernetes.io/instance`
* Update the operator and check that the network policy pod selector changes from `app.kubernetes.io/instance` to `agent.datadoghq.com/component`

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
