### PR TITLE
Wrap maps.Keys() in slices.Collect() for proper serialization

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -75,7 +76,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 
 	if opts.DatadogAgentEnabled {
 		agentNamespaces := getWatchNamespacesFromEnv(logger, agentWatchNamespaceEnvVar)
-		logger.Info("DatadogAgent Enabled", "watching namespaces", maps.Keys(agentNamespaces))
+		logger.Info("DatadogAgent Enabled", "watching namespaces", slices.Collect(maps.Keys(agentNamespaces)))
 		byObject[agentObj] = cache.ByObject{
 			Namespaces: agentNamespaces,
 		}
@@ -83,7 +84,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 
 	if opts.DatadogDashboardEnabled {
 		dashboardNamespaces := getWatchNamespacesFromEnv(logger, dashboardWatchNamespaceEnvVar)
-		logger.Info("DatadogDashboard Enabled", "watching namespaces", maps.Keys(dashboardNamespaces))
+		logger.Info("DatadogDashboard Enabled", "watching namespaces", slices.Collect(maps.Keys(dashboardNamespaces)))
 		byObject[dashboardObj] = cache.ByObject{
 			Namespaces: dashboardNamespaces,
 		}
@@ -91,7 +92,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 
 	if opts.DatadogGenericResourceEnabled {
 		genericResourceNamespaces := getWatchNamespacesFromEnv(logger, genericResourceWatchNamespaceEnvVar)
-		logger.Info("DatadogGenericResource Enabled", "watching namespaces", maps.Keys(genericResourceNamespaces))
+		logger.Info("DatadogGenericResource Enabled", "watching namespaces", slices.Collect(maps.Keys(genericResourceNamespaces)))
 		byObject[genericResourceObj] = cache.ByObject{
 			Namespaces: genericResourceNamespaces,
 		}
@@ -99,7 +100,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 
 	if opts.DatadogMonitorEnabled {
 		monitorNamespaces := getWatchNamespacesFromEnv(logger, monitorWatchNamespaceEnvVar)
-		logger.Info("DatadogMonitor Enabled", "watching namespaces", maps.Keys(monitorNamespaces))
+		logger.Info("DatadogMonitor Enabled", "watching namespaces", slices.Collect(maps.Keys(monitorNamespaces)))
 		byObject[monitorObj] = cache.ByObject{
 			Namespaces: monitorNamespaces,
 		}
@@ -107,7 +108,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 
 	if opts.DatadogSLOEnabled {
 		sloNamespaces := getWatchNamespacesFromEnv(logger, sloWatchNamespaceEnvVar)
-		logger.Info("DatadogSLO Enabled", "watching namespaces", maps.Keys(sloNamespaces))
+		logger.Info("DatadogSLO Enabled", "watching namespaces", slices.Collect(maps.Keys(sloNamespaces)))
 		byObject[sloObj] = cache.ByObject{
 			Namespaces: sloNamespaces,
 		}
@@ -115,7 +116,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 
 	if opts.DatadogAgentProfileEnabled {
 		agentProfileNamespaces := getWatchNamespacesFromEnv(logger, profileWatchNamespaceEnvVar)
-		logger.Info("DatadogAgentProfile Enabled", "watching namespace", maps.Keys(agentProfileNamespaces))
+		logger.Info("DatadogAgentProfile Enabled", "watching namespace", slices.Collect(maps.Keys(agentProfileNamespaces)))
 		byObject[profileObj] = cache.ByObject{
 			Namespaces: agentProfileNamespaces,
 		}
@@ -126,7 +127,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 		// rest of fields to reduce memory usage.
 		// Pods are watched in DatadogAgent namespace(s) since that's where Agent pods are running.
 		agentNamespaces := getWatchNamespacesFromEnv(logger, agentWatchNamespaceEnvVar)
-		logger.Info("DatadogAgentProfile Enabled", "watching Pods in namespaces", maps.Keys(agentNamespaces))
+		logger.Info("DatadogAgentProfile Enabled", "watching Pods in namespaces", slices.Collect(maps.Keys(agentNamespaces)))
 		byObject[podObj] = cache.ByObject{
 			Namespaces: agentNamespaces,
 
@@ -180,7 +181,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 
 	if opts.DatadogAgentInternalEnabled {
 		agentInternalNamespaces := getWatchNamespacesFromEnv(logger, agentWatchNamespaceEnvVar)
-		logger.Info("DatadogAgentInternal Enabled", "watching namespaces", maps.Keys(agentInternalNamespaces))
+		logger.Info("DatadogAgentInternal Enabled", "watching namespaces", slices.Collect(maps.Keys(agentInternalNamespaces)))
 		byObject[agentInternalObj] = cache.ByObject{
 			Namespaces: agentInternalNamespaces,
 		}


### PR DESCRIPTION
### What does this PR do?

* Removes the log `{"level":"INFO","ts":"2025-07-24T07:18:10.931Z","logger":"setup","msg":"DatadogAgent Enabled","watching namespacesError":"json: unsupported type: iter.Seq[string]"}` to once again properly log namespaces that are watched `{"level":"INFO","ts":"2025-07-24T07:36:37.758Z","logger":"setup","msg":"DatadogAgent Enabled","watching namespaces":["kube-system","system"]}`

### Motivation

* `maps.Keys()` in Go 1.24 returns an iter.Seq[string] (iterator)
* The logger tries to serialize this to JSON, but iterators don't support JSON marshaling
* `slices.Collect()` converts the iterator to a slice, which can be properly serialized

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Start the operator with `WATCH_NAMESPACE` env var set to a list, e.g. `""`, or `"kube-system,system"` and ensure the log is expected without an `iter.Seq` error:
```json
{"level":"INFO","ts":"2025-07-24T07:39:05.770Z","logger":"setup","msg":"DatadogAgent Enabled","watching namespaces":[""]}
```

```json
{"level":"INFO","ts":"2025-07-24T07:36:37.758Z","logger":"setup","msg":"DatadogAgent Enabled","watching namespaces":["kube-system","system"]}
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
