### PR TITLE
[datadogpodautoscalers] Increase max stabilization window/scaling period from 30m to 1h

### DIFF
--- a/api/datadoghq/common/datadogpodautoscaler_types.go
+++ b/api/datadoghq/common/datadogpodautoscaler_types.go
@@ -109,9 +109,9 @@ type DatadogPodAutoscalerScalingRule struct {
 	Value int32 `json:"value"`
 
 	// PeriodSeconds specifies the window of time for which the policy should hold true.
-	// PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+	// PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=1800
+	// +kubebuilder:validation:Maximum=3600
 	PeriodSeconds int32 `json:"periodSeconds"`
 }
 

--- a/api/datadoghq/common/datadogpodautoscaler_types.go
+++ b/api/datadoghq/common/datadogpodautoscaler_types.go
@@ -81,7 +81,7 @@ type DatadogPodAutoscalerScalingPolicy struct {
 	// before deciding to apply a new one. Defaults to 0.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=1800
+	// +kubebuilder:validation:Maximum=3600
 	StabilizationWindowSeconds int32 `json:"stabilizationWindowSeconds,omitempty"`
 }
 

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -200,7 +200,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -266,7 +266,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -685,7 +685,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:
@@ -741,7 +741,7 @@ spec:
                             StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
                             before deciding to apply a new one. Defaults to 0.
                           format: int32
-                          maximum: 1800
+                          maximum: 3600
                           minimum: 0
                           type: integer
                         strategy:

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -170,9 +170,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -236,9 +236,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -655,9 +655,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:
@@ -711,9 +711,9 @@ spec:
                               periodSeconds:
                                 description: |-
                                   PeriodSeconds specifies the window of time for which the policy should hold true.
-                                  PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                  PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
                                 format: int32
-                                maximum: 1800
+                                maximum: 3600
                                 minimum: 1
                                 type: integer
                               type:

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -159,9 +159,9 @@
                     "description": "DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.",
                     "properties": {
                       "periodSeconds": {
-                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).",
                         "format": "int32",
-                        "maximum": 1800,
+                        "maximum": 3600,
                         "minimum": 1,
                         "type": "integer"
                       },
@@ -235,9 +235,9 @@
                     "description": "DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.",
                     "properties": {
                       "periodSeconds": {
-                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).",
                         "format": "int32",
-                        "maximum": 1800,
+                        "maximum": 3600,
                         "minimum": 1,
                         "type": "integer"
                       },

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -193,7 +193,7 @@
                 "stabilizationWindowSeconds": {
                   "description": "StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations\nbefore deciding to apply a new one. Defaults to 0.",
                   "format": "int32",
-                  "maximum": 1800,
+                  "maximum": 3600,
                   "minimum": 0,
                   "type": "integer"
                 },
@@ -269,7 +269,7 @@
                 "stabilizationWindowSeconds": {
                   "description": "StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations\nbefore deciding to apply a new one. Defaults to 0.",
                   "format": "int32",
-                  "maximum": 1800,
+                  "maximum": 3600,
                   "minimum": 0,
                   "type": "integer"
                 },

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -76,7 +76,7 @@
                 "stabilizationWindowSeconds": {
                   "description": "StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations\nbefore deciding to apply a new one. Defaults to 0.",
                   "format": "int32",
-                  "maximum": 1800,
+                  "maximum": 3600,
                   "minimum": 0,
                   "type": "integer"
                 },
@@ -137,7 +137,7 @@
                 "stabilizationWindowSeconds": {
                   "description": "StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations\nbefore deciding to apply a new one. Defaults to 0.",
                   "format": "int32",
-                  "maximum": 1800,
+                  "maximum": 3600,
                   "minimum": 0,
                   "type": "integer"
                 },

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -42,9 +42,9 @@
                     "description": "DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.",
                     "properties": {
                       "periodSeconds": {
-                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).",
                         "format": "int32",
-                        "maximum": 1800,
+                        "maximum": 3600,
                         "minimum": 1,
                         "type": "integer"
                       },
@@ -103,9 +103,9 @@
                     "description": "DatadogPodAutoscalerScalingRule defines rules for horizontal scaling that should be true for a certain amount of time.",
                     "properties": {
                       "periodSeconds": {
-                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                        "description": "PeriodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).",
                         "format": "int32",
-                        "maximum": 1800,
+                        "maximum": 3600,
                         "minimum": 1,
                         "type": "integer"
                       },


### PR DESCRIPTION
### What does this PR do?

Increase maximum stabilization window and up/downscale period seconds from 30m to 1h

### Motivation

Allow users to set a longer stabilization window to prevent constant flapping / quick up or downscales 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
