### PR TITLE
[SINT-3831] fix dd-octo-sts policy

### DIFF
--- a/.github/chainguard/self.release.create-release.sts.yaml
+++ b/.github/chainguard/self.release.create-release.sts.yaml
@@ -4,7 +4,7 @@ subject_pattern: "repo:DataDog/datadog-operator:ref:refs/tags/v.*"
 
 claim_pattern:
   event_name: "push"
-  job_workflow_ref: DataDog/datadog-operator/\.github/workflows/release\.yml@refs/tags/v.*
+  job_workflow_ref: DataDog/datadog-operator/\.github/workflows/release\.yaml@refs/tags/v.*
 
 permissions:
   contents: write


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

Solves this error: https://github.com/DataDog/datadog-operator/actions/runs/16727988099/job/47348965719

Local tests:
```
DDOCTOSTS_ID_TOKEN=$(cat claim.txt) dd-octo-sts check --scope DataDog/datadog-operator --policy self.release.create-release
```
with the following claim.txt: 
[claim.txt](https://github.com/user-attachments/files/21581123/claim.txt)


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
