### PR TITLE
[datadogpodautoscalers] Add validation to objective value type is set to `Utilization`

### DIFF
--- a/api/datadoghq/common/datadogpodautoscaler_types.go
+++ b/api/datadoghq/common/datadogpodautoscaler_types.go
@@ -180,6 +180,7 @@ const (
 // +kubebuilder:object:generate=true
 type DatadogPodAutoscalerObjectiveValue struct {
 	// Type specifies how the value is expressed (possible values: Utilization).
+	// +kubebuilder:validation:Enum:=Utilization
 	Type DatadogPodAutoscalerObjectiveValueType `json:"type"`
 
 	// Utilization defines a percentage of the target compared to requested workload

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -325,6 +325,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -353,6 +355,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -868,6 +872,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload
@@ -896,6 +902,8 @@ spec:
                             properties:
                               type:
                                 description: 'Type specifies how the value is expressed (possible values: Utilization).'
+                                enum:
+                                  - Utilization
                                 type: string
                               utilization:
                                 description: Utilization defines a percentage of the target compared to requested workload

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -343,6 +343,9 @@
                     "properties": {
                       "type": {
                         "description": "Type specifies how the value is expressed (possible values: Utilization).",
+                        "enum": [
+                          "Utilization"
+                        ],
                         "type": "string"
                       },
                       "utilization": {
@@ -383,6 +386,9 @@
                     "properties": {
                       "type": {
                         "description": "Type specifies how the value is expressed (possible values: Utilization).",
+                        "enum": [
+                          "Utilization"
+                        ],
                         "type": "string"
                       },
                       "utilization": {

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -343,6 +343,9 @@
                     "properties": {
                       "type": {
                         "description": "Type specifies how the value is expressed (possible values: Utilization).",
+                        "enum": [
+                          "Utilization"
+                        ],
                         "type": "string"
                       },
                       "utilization": {
@@ -383,6 +386,9 @@
                     "properties": {
                       "type": {
                         "description": "Type specifies how the value is expressed (possible values: Utilization).",
+                        "enum": [
+                          "Utilization"
+                        ],
                         "type": "string"
                       },
                       "utilization": {


### PR DESCRIPTION
### What does this PR do?

Add validation for pod/container objective value type to ensure it is set to `Utilization`

### Motivation

We only accept the value of `Utilization` at the moment. Adding validation here ensures that DPAs with invalid objectives are not created

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Try to create a DPA with an invalid objective e.g.:
```
...
  objectives:
  - containerResource:
      container: rapid-prr-provider
      name: cpu
      value:
        type: ContainerResource
        utilization: 65
    type: ContainerResource
```
2. Verify that you get a validation error, and are unable to create it until you fix the objective:
```
...
  objectives:
  - containerResource:
      container: rapid-prr-provider
      name: cpu
      value:
        type: Utilization
        utilization: 65
    type: ContainerResource
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
