### PR TITLE
[GPUM]: added support for gpu core-check and gpu probe split

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -589,10 +589,15 @@ type ServiceDiscoveryNetworkStatsConfig struct {
 
 // GPUFeatureConfig contains the GPU monitoring configuration.
 type GPUFeatureConfig struct {
-	// Enabled enables GPU monitoring.
+	// Enabled enables GPU monitoring core check.
 	// Default: false
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
+
+	// PrivilegedMode enables GPU Probe module in System Probe.
+	// Default: false
+	// +optional
+	PrivilegedMode *bool `json:"privilegedMode,omitempty"`
 
 	// PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature.
 	// If the value is an empty string, the runtime class is not set.

--- a/internal/controller/datadogagent/feature/gpu/envvar.go
+++ b/internal/controller/datadogagent/feature/gpu/envvar.go
@@ -5,7 +5,13 @@
 
 package gpu
 
-const DDEnableGPUMonitoringEnvVar = "DD_GPU_MONITORING_ENABLED"
+// DDEnableGPUProbeEnvVar is the name of the system-probe gpu_monitoring module enablement knob
+const DDEnableGPUProbeEnvVar = "DD_GPU_MONITORING_ENABLED"
+
+// DDEnableGPUMonitoringCheckEnvVar is the name of the gpu core-check config enablement knob
+const DDEnableGPUMonitoringCheckEnvVar = "DD_GPU_ENABLED"
+
+// DDEnableNVMLDetectionEnvVar is deprecated and will be removed in a future release
+// DDEnableNVMLDetectionEnvVar is deprecated and will be removed in a future release.
 const DDEnableNVMLDetectionEnvVar = "DD_ENABLE_NVML_DETECTION"
-const DDCollectGPUTagsEnvVar = "DD_COLLECT_GPU_TAGS"
 const NVIDIAVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -29,8 +29,9 @@ type gpuFeature struct {
 	// podRuntimeClassName is the value to set in the runtimeClassName
 	// configuration of the agent pod. If this is empty, the runtimeClassName
 	// will not be changed.
-	podRuntimeClassName    string
-	podResourcesSocketPath string
+	podRuntimeClassName     string
+	podResourcesSocketPath  string
+	isPrivilegedModeEnabled bool
 }
 
 // ID returns the ID of the Feature
@@ -46,8 +47,10 @@ func (f *gpuFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSp
 
 	reqComp.Agent = feature.RequiredComponent{
 		IsRequired: apiutils.NewBoolPointer(true),
-		Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName},
+		Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
 	}
+
+	f.isPrivilegedModeEnabled = apiutils.BoolValue(ddaSpec.Features.GPU.PrivilegedMode)
 
 	if ddaSpec.Features.GPU.PodRuntimeClassName == nil {
 		// Configuration option not set, so revert to the default
@@ -65,7 +68,7 @@ func (f *gpuFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSp
 
 // ManageDependencies allows a feature to manage its dependencies.
 // Feature's dependencies should be added in the store.
-func (f *gpuFeature) ManageDependencies(managers feature.ResourceManagers) error {
+func (f *gpuFeature) ManageDependencies(_ feature.ResourceManagers) error {
 	return nil
 }
 
@@ -76,11 +79,31 @@ func (f *gpuFeature) ManageClusterAgent(feature.PodTemplateManagers) error {
 }
 
 func configureSystemProbe(managers feature.PodTemplateManagers) {
+	// env var to enable the GPU probe module in system-probe
+	enableSPEnvVar := &corev1.EnvVar{
+		Name:  DDEnableGPUProbeEnvVar,
+		Value: "true",
+	}
+
+	// enable gpu_monitoring module
+	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, enableSPEnvVar)
+
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
 
 	// security context capabilities
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommon.SystemProbeContainerName)
+
+	// Some nvidia-container-runtime setups ignore the NVIDIA_VISIBLE_DEVICES
+	// env variable. This is usually configured with the options
+	//   accept-nvidia-visible-devices-envvar-when-unprivileged = true
+	//   accept-nvidia-visible-devices-as-volume-mounts = true
+	// in the NVIDIA container runtime config. In this case, we need to mount the
+	// /var/run/nvidia-container-devices/all directory into the container, so that
+	// the nvidia-container-runtime can see that we want to use all GPUs.
+	devicesVol, devicesMount := volume.GetVolumes(nvidiaDevicesVolumeName, devNullPath, nvidiaDevicesMountPath, true)
+	managers.Volume().AddVolume(&devicesVol)
+	managers.VolumeMount().AddVolumeMountToContainer(&devicesMount, apicommon.SystemProbeContainerName)
 
 	// socket volume mount (needs write perms for the system probe container but not the others)
 	procdirVol, procdirMount := volume.GetVolumes(common.ProcdirVolumeName, common.ProcdirHostPath, common.ProcdirMountPath, true)
@@ -109,6 +132,15 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 
 	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, socketEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, socketEnvVar)
+
+	// Now we need to add the NVIDIA_VISIBLE_DEVICES env var to both agents again so
+	// that the nvidia runtime can expose the GPU devices in the container
+	nvidiaVisibleDevicesEnvVar := &corev1.EnvVar{
+		Name:  NVIDIAVisibleDevicesEnvVar,
+		Value: "all",
+	}
+
+	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, nvidiaVisibleDevicesEnvVar)
 }
 
 func (f *gpuFeature) configurePodResourcesSocket(managers feature.PodTemplateManagers) {
@@ -131,19 +163,13 @@ func (f *gpuFeature) configurePodResourcesSocket(managers feature.PodTemplateMan
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *gpuFeature) ManageNodeAgent(managers feature.PodTemplateManagers, _ string) error {
-	configureSystemProbe(managers)
-	f.configurePodResourcesSocket(managers)
-
-	// env var to enable the GPU module
-	enableEnvVar := &corev1.EnvVar{
-		Name:  DDEnableGPUMonitoringEnvVar,
+	// env var to enable the GPU core check
+	enableCoreCheckEnvVar := &corev1.EnvVar{
+		Name:  DDEnableGPUMonitoringCheckEnvVar,
 		Value: "true",
 	}
 
-	// Both in the core agent and the system probe
-	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName}, enableEnvVar)
-
-	// env var to enable NVML detection, so that workloadmeta features depending on it
+	// DEPRECATED: env var to enable NVML detection, so that workloadmeta features depending on it
 	// can be enabled
 	nvmlDetectionEnvVar := &corev1.EnvVar{
 		Name:  DDEnableNVMLDetectionEnvVar,
@@ -151,17 +177,19 @@ func (f *gpuFeature) ManageNodeAgent(managers feature.PodTemplateManagers, _ str
 	}
 	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, nvmlDetectionEnvVar)
 
-	// env var to enable collecting gpu host tags ("gpu_host:true" tag)
-	collectGpuTagsEnvVar := &corev1.EnvVar{
-		Name:  DDCollectGPUTagsEnvVar,
-		Value: "true",
+	// in the core agent
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, enableCoreCheckEnvVar)
+
+	f.configurePodResourcesSocket(managers)
+
+	if f.isPrivilegedModeEnabled {
+		configureSystemProbe(managers)
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, collectGpuTagsEnvVar)
 
 	// The agent check does not need to be manually enabled, the init config container will
 	// check if GPU monitoring is enabled and will enable the check automatically (see
 	// Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh in the datadog-agent repo).
-	managers.EnvVar().AddEnvVarToInitContainer(apicommon.InitConfigContainerName, enableEnvVar)
+	managers.EnvVar().AddEnvVarToInitContainer(apicommon.InitConfigContainerName, enableCoreCheckEnvVar)
 
 	// Now we need to add the NVIDIA_VISIBLE_DEVICES env var to both agents again so
 	// that the nvidia runtime can expose the GPU devices in the container
@@ -170,7 +198,7 @@ func (f *gpuFeature) ManageNodeAgent(managers feature.PodTemplateManagers, _ str
 		Value: "all",
 	}
 
-	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName}, nvidiaVisibleDevicesEnvVar)
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, nvidiaVisibleDevicesEnvVar)
 
 	// Some nvidia-container-runtime setups ignore the NVIDIA_VISIBLE_DEVICES
 	// env variable. This is usually configured with the options
@@ -181,7 +209,7 @@ func (f *gpuFeature) ManageNodeAgent(managers feature.PodTemplateManagers, _ str
 	// the nvidia-container-runtime can see that we want to use all GPUs.
 	devicesVol, devicesMount := volume.GetVolumes(nvidiaDevicesVolumeName, devNullPath, nvidiaDevicesMountPath, true)
 	managers.Volume().AddVolume(&devicesVol)
-	managers.VolumeMount().AddVolumeMountToContainers(&devicesMount, []apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName})
+	managers.VolumeMount().AddVolumeMountToContainer(&devicesMount, apicommon.CoreAgentContainerName)
 
 	// Configure the runtime class for the pod
 	if f.podRuntimeClassName != "" {

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -101,9 +101,13 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 	// in the NVIDIA container runtime config. In this case, we need to mount the
 	// /var/run/nvidia-container-devices/all directory into the container, so that
 	// the nvidia-container-runtime can see that we want to use all GPUs.
-	devicesVol, devicesMount := volume.GetVolumes(nvidiaDevicesVolumeName, devNullPath, nvidiaDevicesMountPath, true)
-	managers.Volume().AddVolume(&devicesVol)
-	managers.VolumeMount().AddVolumeMountToContainer(&devicesMount, apicommon.SystemProbeContainerName)
+	nvidiaDevicesMount := &corev1.VolumeMount{
+		Name:      nvidiaDevicesVolumeName,
+		MountPath: nvidiaDevicesMountPath,
+		ReadOnly:  true,
+	}
+
+	managers.VolumeMount().AddVolumeMountToContainer(nvidiaDevicesMount, apicommon.SystemProbeContainerName)
 
 	// socket volume mount (needs write perms for the system probe container but not the others)
 	procdirVol, procdirMount := volume.GetVolumes(common.ProcdirVolumeName, common.ProcdirHostPath, common.ProcdirMountPath, true)

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -27,7 +27,8 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 		Spec: v2alpha1.DatadogAgentSpec{
 			Features: &v2alpha1.DatadogFeatures{
 				GPU: &v2alpha1.GPUFeatureConfig{
-					Enabled: apiutils.NewBoolPointer(false),
+					Enabled:        apiutils.NewBoolPointer(false),
+					PrivilegedMode: apiutils.NewBoolPointer(false),
 				},
 			},
 			Global: &v2alpha1.GlobalConfig{
@@ -39,6 +40,7 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 	}
 	ddaGPUMonitoringEnabled := ddaGPUMonitoringDisabled.DeepCopy()
 	ddaGPUMonitoringEnabled.Spec.Features.GPU.Enabled = apiutils.NewBoolPointer(true)
+	ddaGPUMonitoringEnabled.Spec.Features.GPU.PrivilegedMode = apiutils.NewBoolPointer(true)
 
 	ddaGPUMonitoringEnabledAlternativeRuntimeClass := ddaGPUMonitoringEnabled.DeepCopy()
 	ddaGPUMonitoringEnabledAlternativeRuntimeClass.Spec.Features.GPU.PodRuntimeClassName = apiutils.NewStringPointer(alternativeRuntimeClass)
@@ -169,7 +171,7 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				Value: common.DefaultSystemProbeSocketPath,
 			},
 			{
-				Name:  DDEnableGPUMonitoringEnvVar,
+				Name:  DDEnableGPUProbeEnvVar,
 				Value: "true",
 			},
 			{
@@ -188,7 +190,7 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				Value: "true",
 			},
 			{
-				Name:  DDCollectGPUTagsEnvVar,
+				Name:  DDEnableGPUMonitoringCheckEnvVar,
 				Value: "true",
 			},
 		}, wantSystemProbeEnvVars...)

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -187,7 +187,7 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 			},
 		}
 
-		wantAgentEnvVars := append([]*corev1.EnvVar{
+		wantAgentEnvVars := []*corev1.EnvVar{
 			{
 				Name:  common.DDKubernetesPodResourcesSocket,
 				Value: path.Join(podResourcesSocketPath, "kubelet.sock"),
@@ -200,13 +200,21 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				Name:  DDEnableGPUMonitoringCheckEnvVar,
 				Value: "true",
 			},
-		}, wantSystemProbeEnvVars...)
+			{
+				Name:  common.DDSystemProbeSocket,
+				Value: common.DefaultSystemProbeSocketPath,
+			},
+			{
+				Name:  NVIDIAVisibleDevicesEnvVar,
+				Value: "all",
+			},
+		}
 
 		agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
 		assert.ElementsMatch(t, agentEnvVars, wantAgentEnvVars)
 
 		systemProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
-		assert.True(t, apiutils.IsEqualStruct(systemProbeEnvVars, wantSystemProbeEnvVars), "System Probe envvars \ndiff = %s", cmp.Diff(systemProbeEnvVars, wantSystemProbeEnvVars))
+		assert.ElementsMatch(t, systemProbeEnvVars, wantSystemProbeEnvVars)
 
 		// Check runtime class
 		if expectedRuntimeClass == "" {

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -27,8 +27,7 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 		Spec: v2alpha1.DatadogAgentSpec{
 			Features: &v2alpha1.DatadogFeatures{
 				GPU: &v2alpha1.GPUFeatureConfig{
-					Enabled:        apiutils.NewBoolPointer(false),
-					PrivilegedMode: apiutils.NewBoolPointer(false),
+					Enabled: apiutils.NewBoolPointer(false),
 				},
 			},
 			Global: &v2alpha1.GlobalConfig{
@@ -47,6 +46,14 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 
 	ddaGPUMonitoringEnabledANoRuntimeClass := ddaGPUMonitoringEnabled.DeepCopy()
 	ddaGPUMonitoringEnabledANoRuntimeClass.Spec.Features.GPU.PodRuntimeClassName = apiutils.NewStringPointer("")
+
+	ddaGPUCoreCheckOnly := ddaGPUMonitoringDisabled.DeepCopy()
+	ddaGPUCoreCheckOnly.Spec.Features.GPU.Enabled = apiutils.NewBoolPointer(true)
+	ddaGPUCoreCheckOnly.Spec.Features.GPU.PrivilegedMode = apiutils.NewBoolPointer(false)
+
+	ddaGPUInvalidConfig := ddaGPUMonitoringDisabled.DeepCopy()
+	ddaGPUInvalidConfig.Spec.Features.GPU.Enabled = apiutils.NewBoolPointer(false)
+	ddaGPUInvalidConfig.Spec.Features.GPU.PrivilegedMode = apiutils.NewBoolPointer(true)
 
 	GPUMonitoringAgentNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers, expectedRuntimeClass string) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -209,6 +216,90 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 		}
 	}
 
+	GPUCoreCheckOnlyWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers, expectedRuntimeClass string) {
+		mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+		// check that system probe capabilities are NOT set for core-check only
+		sysProbeCapabilities := mgr.SecurityContextMgr.CapabilitiesByC[apicommon.SystemProbeContainerName]
+		assert.Nil(t, sysProbeCapabilities, "System Probe should not have capabilities when privileged mode is disabled")
+
+		// check volume mounts - core agent should only have nvidia devices and kubelet socket
+		wantCoreAgentVolMounts := []*corev1.VolumeMount{
+			{
+				Name:      nvidiaDevicesVolumeName,
+				MountPath: nvidiaDevicesMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      common.KubeletPodResourcesVolumeName,
+				MountPath: podResourcesSocketPath,
+				ReadOnly:  false,
+			},
+		}
+
+		coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommon.CoreAgentContainerName]
+		assert.ElementsMatch(t, coreAgentVolumeMounts, wantCoreAgentVolMounts)
+
+		// check that system probe has NO volume mounts for core-check only
+		systemProbeVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommon.SystemProbeContainerName]
+		assert.Empty(t, systemProbeVolumeMounts, "System Probe should not have volume mounts when privileged mode is disabled")
+
+		// check volumes - should only have nvidia devices and kubelet socket
+		wantVolumes := []*corev1.Volume{
+			{
+				Name: nvidiaDevicesVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: devNullPath,
+					},
+				},
+			},
+			{
+				Name: common.KubeletPodResourcesVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{Path: podResourcesSocketPath},
+				},
+			},
+		}
+
+		volumes := mgr.VolumeMgr.Volumes
+		assert.ElementsMatch(t, volumes, wantVolumes)
+
+		// check env vars - core agent should have GPU monitoring check enabled
+		wantAgentEnvVars := []*corev1.EnvVar{
+			{
+				Name:  common.DDKubernetesPodResourcesSocket,
+				Value: path.Join(podResourcesSocketPath, "kubelet.sock"),
+			},
+			{
+				Name:  DDEnableNVMLDetectionEnvVar,
+				Value: "true",
+			},
+			{
+				Name:  DDEnableGPUMonitoringCheckEnvVar,
+				Value: "true",
+			},
+			{
+				Name:  NVIDIAVisibleDevicesEnvVar,
+				Value: "all",
+			},
+		}
+
+		agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+		assert.ElementsMatch(t, agentEnvVars, wantAgentEnvVars)
+
+		// check that system probe has NO env vars for core-check only
+		systemProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
+		assert.Empty(t, systemProbeEnvVars, "System Probe should not have env vars when privileged mode is disabled")
+
+		// Check runtime class
+		if expectedRuntimeClass == "" {
+			assert.Nil(t, mgr.PodTemplateSpec().Spec.RuntimeClassName)
+		} else {
+			assert.Equal(t, expectedRuntimeClass, *mgr.PodTemplateSpec().Spec.RuntimeClassName)
+		}
+	}
+
 	tests := test.FeatureTestSuite{
 		{
 			Name:          "gpu monitoring not enabled",
@@ -216,7 +307,15 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 			WantConfigure: false,
 		},
 		{
-			Name:          "gpu monitoring enabled",
+			Name:          "gpu core-check only (no privileged mode)",
+			DDA:           ddaGPUCoreCheckOnly,
+			WantConfigure: true,
+			Agent: test.NewDefaultComponentTest().WithWantFunc(func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+				GPUCoreCheckOnlyWantFunc(t, mgrInterface, defaultGPURuntimeClass)
+			}),
+		},
+		{
+			Name:          "gpu monitoring enabled with privileged mode",
 			DDA:           ddaGPUMonitoringEnabled,
 			WantConfigure: true,
 			Agent: test.NewDefaultComponentTest().WithWantFunc(func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
@@ -239,6 +338,11 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 			Agent: test.NewDefaultComponentTest().WithWantFunc(func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 				GPUMonitoringAgentNodeWantFunc(t, mgrInterface, "")
 			}),
+		},
+		{
+			Name:          "gpu invalid config (privileged mode without core-check)",
+			DDA:           ddaGPUInvalidConfig,
+			WantConfigure: false,
 		},
 	}
 


### PR DESCRIPTION
A brief description of the change being made with this pull request.

### Motivation

agent refactor to split between gpu core-check and gpu monitoring module in system-probe 

### Additional Notes

Agent [PR](https://github.com/DataDog/datadog-agent/pull/38593)
[Jira Ticket](https://datadoghq.atlassian.net/browse/EBPF-765)

for now kept the deprecated `enabled_nvml_detection` env var to support older agent versions, will be removed in future releases

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.70
* Cluster Agent: vX.Y.Z

### Describe your test plan

Update UTs to test new scenarios

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
