### PR TITLE
[SINT-3831] use dd-octo-sts for backport workflow

### DIFF
--- a/.github/chainguard/self.backport-pr.create-pr.sts.yaml
+++ b/.github/chainguard/self.backport-pr.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+#WARN: These are inherently never safe against actors with write access, as the permissions become available on all branches
+subject: repo:DataDog/datadog-operator:pull_request
+
+claim_pattern:
+  event_name: "pull_request"
+  job_workflow_ref: DataDog/datadog-operator/\.github/workflows/backport-pr\.yml@.*
+
+permissions:
+  contents: write
+  pull_requests: write
+  issues: write

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -3,35 +3,31 @@ on:
   pull_request:
     types: [ labeled ]
 
-permissions: {}
+permissions:
+  id-token: write # Required for dd-octo-sts action
 
 jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
     if: >
-        (github.event_name == 'workflow_dispatch' || 
+        (github.event_name == 'workflow_dispatch' ||
         (github.event.action == 'labeled'
         && contains(github.event.label.name, 'backport/')))
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-    steps:    
-      - name: Create app token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
-        id: app-token
+    steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
         with:
-          app-id: ${{ secrets.DD_GITHUBOPS_TOKEN_APP_ID }}
-          private-key: ${{ secrets.DD_GITHUBOPS_TOKEN_PRIVATE_KEY }}
+          scope: DataDog/datadog-operator
+          policy: self.release.create-release
 
       - name: Create backport PR
         uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         id: backport
         with:
-          label_pattern: "^backport/(?<base>([^ ]+))$" 
+          label_pattern: "^backport/(?<base>([^ ]+))$"
           labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot', 'qa/skip-qa']) %>"
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.octo-sts.outputs.token }}
           title_template: "[Backport <%- base %>] <%- title %>"
           body_template: |
             Backport <%- mergeCommitSha %> from #<%- number %>.
@@ -45,10 +41,10 @@ jobs:
         env:
           BACKPORT_PR: ${{ steps.backport.outputs.created_pull_requests }}
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             console.log('Raw backport output:', process.env.BACKPORT_PR);
-            
+
             const orig = context.payload.pull_request;
             if (!orig.milestone) {
               console.log('No milestone to copy.');
@@ -57,13 +53,13 @@ jobs:
             // Get the milestone number
             const milestoneNumber = orig.milestone.number;
             console.log('Milestone number:', milestoneNumber);
-            
+
             // Parse the backport PR number from the JSON output
             const backportData = JSON.parse(process.env.BACKPORT_PR);
             const prNumber = Object.values(backportData)[0];
             console.log('Parsed PR number:', prNumber);
             console.log(`Copying milestone ${milestoneNumber} to PR ${prNumber}`);
-            
+
             await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
### What does this PR do?

This is part of an initiative lead by SDLC security to [harden Github security settings](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3913581900/GitHub+Workflow+Token+Permissions+GITHUB_TOKEN). To do so, we need to move away from GITHUB_TOKEN having the permission to approve and merge PRs, which is a behaviour we see in .github/workflows/release.yaml.

Instead, [dd-octo-sts](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/4705912130/DD+Octo+STS) is an alternative to provide ephemeral scoped tokens delivering the same features with improved security.

This PR implements the migration to dd-octo-sts.

Follow-up of https://github.com/DataDog/datadog-operator/pull/2089, hence bearing the same labels

If the app that was used in this logic is not used anymore, let's get rid of it. In particular:
- delete the app integration
- delete the app
- delete the secrets used by the app

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
