### PR TITLE
Update `publish_community_operators` job to use `dd-octo-sts`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -586,6 +586,9 @@ publish_community_operators:
   #   - "submit_preflight_redhat_image"
   tags: [ "runner:docker", "size:large" ]
   image: $JOB_DOCKER_IMAGE
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   before_script:
     - make install-tools
   script:
@@ -611,14 +614,19 @@ publish_community_operators:
       ci.datadog-operator.redhat-registry-token --with-decryption --query "Parameter.Value" --out text > ~/.redhat/auths.json
     - cd $CI_PROJECT_DIR
     - make bundle-redhat
-    # configure git and github-cli
-    - git config --global user.email $GITLAB_USER_EMAIL
-    - git config --global user.name $GITLAB_USER_NAME
-    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.github-robot-token --with-decryption --query "Parameter.Value" --out text > git-token.txt
-    - gh auth login --with-token < git-token.txt
+
+    # Configure github-cli
+    # Use dd-octo-sts to get GitHub token
+    - dd-octo-sts version
+    - dd-octo-sts debug --scope DataDog/datadog-operator --policy datadog-operator.publish-community-bundles
+    - dd-octo-sts token --scope DataDog/datadog-operator --policy datadog-operator.publish-community-bundles > token.txt
+    - gh auth login --with-token < token.txt
     - gh auth setup-git
     # create pull request for each marketplace repo
     - make publish-community-bundles
+  after_script:
+    # Revoke the token after usage
+    - dd-octo-sts revoke -t $(cat token.txt)
   variables:
     SKOPEO_VERSION: release-1.16
 


### PR DESCRIPTION
### What does this PR do?

The [bot](https://github.com/robot-metascanner-containerintegrations) we currently use for publishing community prs in the operator release process is no longer supported. This PR modifies the workflow to use the `dd-octo-sts` token ([reference](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts#%3Agitlab%3A-Via-Gitlab-CI-job)).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Test during next final release for v1.18

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
