### PR TITLE
GPUM: set DD_GPU_MONITORING_ENABLED in the core agent

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -93,6 +93,9 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 	// enable gpu_monitoring module
 	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, enableSPEnvVar)
 
+	// add the env var to the core agent as well, to prevent config mismatches in runtime
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, enableSPEnvVar)
+
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
 

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -201,6 +201,10 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				Value: "true",
 			},
 			{
+				Name:  DDEnableGPUProbeEnvVar,
+				Value: "true",
+			},
+			{
 				Name:  common.DDSystemProbeSocket,
 				Value: common.DefaultSystemProbeSocketPath,
 			},


### PR DESCRIPTION
### What does this PR do?

Sets `DD_GPU_MONITORING_ENABLED` in the core agent, when `privilegedMode` is enabled (SP GPU module should run)

### Motivation

core-agent reads this flag in runtime to determine which collectors should be created, without setting it explicitly, we won't get the real value of this config, since it is passed as an env var to system-probe

### Additional Notes

this is a workaround until we have a better config sync and resolution between agent components

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
