### PR TITLE
Percentage of unready Pods to stop autoscaling

### DIFF
--- a/api/datadoghq/common/datadogpodautoscaler_types.go
+++ b/api/datadoghq/common/datadogpodautoscaler_types.go
@@ -199,6 +199,11 @@ type DatadogPodAutoscalerConstraints struct {
 	// MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.
 	MaxReplicas int32 `json:"maxReplicas"`
 
+	// MaxUnreadyPodsPercent is the maximum percentage of unready pods allowed before pausing scaling. Disabled by default.
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=100
+	MaxUnreadyPodsPercent *int32 `json:"maxUnreadyPodsPercent,omitempty"`
+
 	// Containers defines constraints for the containers.
 	Containers []DatadogPodAutoscalerContainerConstraints `json:"containers,omitempty"`
 }

--- a/api/datadoghq/common/zz_generated.deepcopy.go
+++ b/api/datadoghq/common/zz_generated.deepcopy.go
@@ -38,6 +38,11 @@ func (in *DatadogPodAutoscalerConstraints) DeepCopyInto(out *DatadogPodAutoscale
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaxUnreadyPodsPercent != nil {
+		in, out := &in.MaxUnreadyPodsPercent, &out.MaxUnreadyPodsPercent
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Containers != nil {
 		in, out := &in.Containers, &out.Containers
 		*out = make([]DatadogPodAutoscalerContainerConstraints, len(*in))

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -124,6 +124,12 @@ spec:
                       description: MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.
                       format: int32
                       type: integer
+                    maxUnreadyPodsPercent:
+                      description: MaxUnreadyPodsPercent is the maximum percentage of unready pods allowed before pausing scaling. Disabled by default.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
+                      type: integer
                     minReplicas:
                       description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
                       format: int32
@@ -814,6 +820,12 @@ spec:
                     maxReplicas:
                       description: MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.
                       format: int32
+                      type: integer
+                    maxUnreadyPodsPercent:
+                      description: MaxUnreadyPodsPercent is the maximum percentage of unready pods allowed before pausing scaling. Disabled by default.
+                      format: int32
+                      maximum: 100
+                      minimum: 0
                       type: integer
                     minReplicas:
                       description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -113,6 +113,13 @@
               "format": "int32",
               "type": "integer"
             },
+            "maxUnreadyPodsPercent": {
+              "description": "MaxUnreadyPodsPercent is the maximum percentage of unready pods allowed before pausing scaling. Disabled by default.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
             "minReplicas": {
               "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 1. Defaults to 1.",
               "format": "int32",

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -267,6 +267,13 @@
               "format": "int32",
               "type": "integer"
             },
+            "maxUnreadyPodsPercent": {
+              "description": "MaxUnreadyPodsPercent is the maximum percentage of unready pods allowed before pausing scaling. Disabled by default.",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
             "minReplicas": {
               "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 1. Defaults to 1.",
               "format": "int32",


### PR DESCRIPTION
### What does this PR do?

Introduction of a parameter for a new autoscaling safety mechanism that allows users to define a threshold for percentage of unready Pods. If the actual percentage of unready Pods in a workload exceeds this configured threshold, all autoscaling activities (both scale-up and scale-down) will be temporarily paused.

### Motivation

We want to have additional safety check in order to allow autoscaling not to interfere with a turbulent cluster.

### Additional Notes

No

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

???

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
