### PR TITLE
Add etcd cert checks for control plane monitoring tests

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1162,7 +1162,10 @@ func Test_Control_Plane_Monitoring(t *testing.T) {
 				expectedDaemonsets := []string{
 					string("foo-agent"),
 				}
-				return verifyDaemonsetNames(t, c, resourcesNamespace, expectedDaemonsets)
+				if err := verifyDaemonsetNames(t, c, resourcesNamespace, expectedDaemonsets); err != nil {
+					return err
+				}
+				return verifyEtcdMountsOpenshift(t, c, resourcesNamespace, "foo-agent", "openshift")
 			},
 		},
 		{
@@ -1362,6 +1365,13 @@ func verifyDCADeployment(t *testing.T, c client.Client, ddaName, resourcesNamesp
 			ReadOnly:  true,
 		})
 	}
+
+	assert.Contains(t, dcaDeployment.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: "agent-conf-d-writable",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
 	return nil
 }
 
@@ -1397,6 +1407,97 @@ func verifyDaemonsetNames(t *testing.T, c client.Client, resourcesNamespace stri
 	sort.Strings(actualDSNames)
 	sort.Strings(expectedDSNames)
 	assert.Equal(t, expectedDSNames, actualDSNames)
+	return nil
+}
+
+func verifyEtcdMountsOpenshift(t *testing.T, c client.Client, resourcesNamespace, dsName string, provider string) error {
+	expectedMounts := []corev1.VolumeMount{
+		{
+			Name:      "etcd-client-certs",
+			MountPath: "/etc/etcd-certs",
+			ReadOnly:  true,
+		},
+		{
+			Name:      "disable-etcd-autoconf",
+			MountPath: "/etc/datadog-agent/conf.d/etcd.d",
+			ReadOnly:  false,
+		},
+	}
+
+	// Node Agent
+	ds := &appsv1.DaemonSet{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: dsName}, ds); err != nil {
+		return err
+	}
+
+	var coreAgentContainer *corev1.Container
+	for i, container := range ds.Spec.Template.Spec.Containers {
+		if container.Name == string(apicommon.CoreAgentContainerName) {
+			coreAgentContainer = &ds.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+
+	if coreAgentContainer == nil {
+		return fmt.Errorf("core agent container not found in DaemonSet %s", dsName)
+	}
+
+	for _, expectedMount := range expectedMounts {
+		found := false
+		for _, mount := range coreAgentContainer.VolumeMounts {
+			if mount.Name == expectedMount.Name {
+				found = true
+				assert.Equal(t, expectedMount.MountPath, mount.MountPath, "Mount path mismatch for %s in core agent", expectedMount.Name)
+				assert.Equal(t, expectedMount.ReadOnly, mount.ReadOnly, "ReadOnly mismatch for %s in core agent", expectedMount.Name)
+				break
+			}
+		}
+		assert.True(t, found, "Expected volume mount %s not found in core agent container", expectedMount.Name)
+	}
+
+	// Cluster Checks Runner
+	deploymentList := appsv1.DeploymentList{}
+	if err := c.List(context.TODO(), &deploymentList, client.InNamespace(resourcesNamespace)); err != nil {
+		return err
+	}
+
+	var ccrDeployment *appsv1.Deployment
+	for _, deployment := range deploymentList.Items {
+		if deployment.Name == "foo-cluster-checks-runner" {
+			ccrDeployment = &deployment
+			break
+		}
+	}
+
+	if ccrDeployment == nil {
+		return fmt.Errorf("cluster-checks-runner deployment not found")
+	}
+
+	var ccrContainer *corev1.Container
+	for i, container := range ccrDeployment.Spec.Template.Spec.Containers {
+		if container.Name == string(apicommon.ClusterChecksRunnersContainerName) {
+			ccrContainer = &ccrDeployment.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+
+	if ccrContainer == nil {
+		return fmt.Errorf("cluster-checks-runner container not found in deployment")
+	}
+
+	for _, expectedMount := range expectedMounts {
+		found := false
+		for _, mount := range ccrContainer.VolumeMounts {
+			if mount.Name == expectedMount.Name {
+				found = true
+				assert.Equal(t, expectedMount.MountPath, mount.MountPath, "Mount path mismatch for %s in CCR", expectedMount.Name)
+				assert.Equal(t, expectedMount.ReadOnly, mount.ReadOnly, "ReadOnly mismatch for %s in CCR", expectedMount.Name)
+				break
+			}
+		}
+		assert.True(t, found, "Expected volume mount %s not found in cluster-checks-runner container", expectedMount.Name)
+	}
+
 	return nil
 }
 

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1431,9 +1431,9 @@ func verifyEtcdMountsOpenshift(t *testing.T, c client.Client, resourcesNamespace
 	}
 
 	var coreAgentContainer *corev1.Container
-	for i, container := range ds.Spec.Template.Spec.Containers {
+	for _, container := range ds.Spec.Template.Spec.Containers {
 		if container.Name == string(apicommon.CoreAgentContainerName) {
-			coreAgentContainer = &ds.Spec.Template.Spec.Containers[i]
+			coreAgentContainer = &container
 			break
 		}
 	}
@@ -1474,9 +1474,9 @@ func verifyEtcdMountsOpenshift(t *testing.T, c client.Client, resourcesNamespace
 	}
 
 	var ccrContainer *corev1.Container
-	for i, container := range ccrDeployment.Spec.Template.Spec.Containers {
+	for _, container := range ccrDeployment.Spec.Template.Spec.Containers {
 		if container.Name == string(apicommon.ClusterChecksRunnersContainerName) {
-			ccrContainer = &ccrDeployment.Spec.Template.Spec.Containers[i]
+			ccrContainer = &container
 			break
 		}
 	}

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -194,7 +194,7 @@ func (f *controlPlaneMonitoringFeature) ManageNodeAgent(managers feature.PodTemp
 			MountPath: etcdCertsVolumeMountPath,
 			ReadOnly:  true,
 		}
-		managers.VolumeMount().AddVolumeMountToContainer(&etcdCertsVolumeMount, apicommon.ClusterChecksRunnersContainerName)
+		managers.VolumeMount().AddVolumeMountToContainer(&etcdCertsVolumeMount, apicommon.CoreAgentContainerName)
 
 		// Add disable-etcd-autoconf volume (emptyDir)
 		disableEtcdAutoconfVolume := &corev1.Volume{
@@ -211,7 +211,7 @@ func (f *controlPlaneMonitoringFeature) ManageNodeAgent(managers feature.PodTemp
 			MountPath: disableEtcdAutoconfVolumeMountPath,
 			ReadOnly:  false,
 		}
-		managers.VolumeMount().AddVolumeMountToContainer(&disableEtcdAutoconfVolumeMount, apicommon.ClusterChecksRunnersContainerName)
+		managers.VolumeMount().AddVolumeMountToContainer(&disableEtcdAutoconfVolumeMount, apicommon.CoreAgentContainerName)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Add etcd cert checks for node agent and cluster checks runner in controller tests
fixed naming for etcd certs, noop change (`CoreAgentContainerName` and `ClusterChecksRunnersContainerName` are equal)

### Motivation

[What inspired you to submit this pull request?](https://datadoghq.atlassian.net/browse/AGENTONB-2454)

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

noop changes, only testing improvements. 

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
