### PR TITLE
Use default provider DS instead of legacy provider on EKS and Openshift clusters

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
@@ -124,9 +124,9 @@ func (r *Reconciler) reconcileAgentProfiles(ctx context.Context, logger logr.Log
 	var errs []error
 	var result reconcile.Result
 	for _, profile := range profiles {
-		if r.options.IntrospectionEnabled && r.useLegacyDaemonSet(providerList) {
+		if r.options.IntrospectionEnabled && r.useDefaultDaemonset(providerList) {
 			// Use legacy provider if EKS or OpenShift providers are present to prevent daemonset overrides
-			res, err := r.reconcileV2Agent(logger, requiredComponents, features, instance, resourceManagers, newStatus, kubernetes.LegacyProvider, providerList, &profile)
+			res, err := r.reconcileV2Agent(logger, requiredComponents, features, instance, resourceManagers, newStatus, kubernetes.DefaultProvider, providerList, &profile)
 			if utils.ShouldReturn(res, err) {
 				errs = append(errs, err)
 			}
@@ -147,8 +147,8 @@ func (r *Reconciler) reconcileAgentProfiles(ctx context.Context, logger logr.Log
 	return reconcile.Result{}, nil
 }
 
-// useLegacyDaemonSet determines if we should use a legacy provider specific Daemonset for EKS and Openshift providers
-func (r *Reconciler) useLegacyDaemonSet(providerList map[string]struct{}) bool {
+// useDefaultDaemonset determines if we should use a legacy provider specific Daemonset for EKS and Openshift providers
+func (r *Reconciler) useDefaultDaemonset(providerList map[string]struct{}) bool {
 	if len(providerList) == 0 {
 		return false
 	}


### PR DESCRIPTION
### What does this PR do?

Use default provider `"default"` instead of legacy provider `""` for agent pods and daemonset when introspection is enabled on an EKS or Openshift cluster. This matches previous functionality before introspection for EKS or Openshift was enabled. 
Fixes small error from #2114 where I passed an empty `providerList` when EDS and Introspection are enabled.

### Motivation

Feedback from https://github.com/datadog/datadog-operator/pull/2114, https://datadoghq.atlassian.net/browse/AGENTONB-2454

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
- This can be tested locally in kind, if you add a node label to mimic an openshift or EKS cluster. For example,
`k label nodes --all eks.amazonaws.com/nodegroup-image=abcdefg`
- Deploy an operator image to cluster from with the flag `--introspectionEnabled=true`
- Check that daemonset created is `datadog-agent-default` and agent pods are `datadog-agent-default-xxxx`
- Check that daemonset and agent pods include the label `agent.datadoghq.com/provider=default`

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
