### PR TITLE
Mount control plane checks to subfolders 

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1341,7 +1341,7 @@ func verifyDCADeployment(t *testing.T, c client.Client, ddaName, resourcesNamesp
 				"Default provider should not create control plane monitoring ConfigMap")
 		}
 		for _, volume := range dcaDeployment.Spec.Template.Spec.Volumes {
-			assert.NotEqual(t, "kube-apiserver-config", volume.Name,
+			assert.NotEqual(t, "kube-apiserver-metrics-config", volume.Name,
 				"Default provider should not have control plane volumes")
 		}
 	} else if provider == kubernetes.OpenshiftProvider || provider == kubernetes.EKSCloudProvider {
@@ -1352,7 +1352,7 @@ func verifyDCADeployment(t *testing.T, c client.Client, ddaName, resourcesNamesp
 		}, &cpCm)
 		assert.NoError(t, err, "Control plane monitoring ConfigMap should exist for provider %s", provider)
 
-		if err := verifyCheckMounts(t, dcaDeployment, provider, "kube-apiserver"); err != nil {
+		if err := verifyCheckMounts(t, dcaDeployment, provider, "kube-apiserver-metrics"); err != nil {
 			return err
 		}
 		if err := verifyCheckMounts(t, dcaDeployment, provider, "kube-controller-manager"); err != nil {
@@ -1372,7 +1372,7 @@ func verifyDCADeployment(t *testing.T, c client.Client, ddaName, resourcesNamesp
 
 func verifyCheckMounts(t *testing.T, dcaDeployment appsv1.Deployment, provider string, checkName string) error {
 	volumeToKeyMap := map[string]string{
-		"kube-apiserver":          "kube_apiserver_metrics",
+		"kube-apiserver-metrics":  "kube_apiserver_metrics",
 		"kube-controller-manager": "kube_controller_manager",
 		"kube-scheduler":          "kube_scheduler",
 		"etcd":                    "etcd",

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1322,55 +1322,85 @@ func Test_Control_Plane_Monitoring(t *testing.T) {
 }
 
 func verifyDCADeployment(t *testing.T, c client.Client, ddaName, resourcesNamespace, expectedName string, provider string) error {
-	daemonSetList := appsv1.DeploymentList{}
-	if err := c.List(context.TODO(), &daemonSetList, client.HasLabels{constants.MD5AgentDeploymentProviderLabelKey}); err != nil {
+	deploymentList := appsv1.DeploymentList{}
+	if err := c.List(context.TODO(), &deploymentList, client.HasLabels{constants.MD5AgentDeploymentProviderLabelKey}); err != nil {
 		return err
 	}
-	assert.Equal(t, 1, len(daemonSetList.Items))
-	assert.Equal(t, expectedName, daemonSetList.Items[0].ObjectMeta.Name)
+	assert.Equal(t, 1, len(deploymentList.Items))
+	assert.Equal(t, expectedName, deploymentList.Items[0].ObjectMeta.Name)
 
 	cms := corev1.ConfigMapList{}
 	if err := c.List(context.TODO(), &cms, client.InNamespace(resourcesNamespace)); err != nil {
 		return err
 	}
-	cpCm := corev1.ConfigMap{}
-	c.Get(context.TODO(), types.NamespacedName{
-		Name:      fmt.Sprintf("datadog-controlplane-monitoring-%s", provider),
-		Namespace: resourcesNamespace,
-	}, &cpCm)
 
-	dcaDeployment := daemonSetList.Items[0]
-	if provider == "default" {
-		assert.NotContains(t, cms.Items, corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("datadog-controlplane-monitoring-%s", provider),
-				Namespace: resourcesNamespace,
-			},
-		})
-	} else {
-		assert.Contains(t, dcaDeployment.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: "controlplane-config",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: fmt.Sprintf("datadog-controlplane-monitoring-%s", provider),
+	dcaDeployment := deploymentList.Items[0]
+	if provider == kubernetes.DefaultProvider {
+		for _, cm := range cms.Items {
+			assert.NotEqual(t, fmt.Sprintf("datadog-controlplane-monitoring-%s", provider), cm.ObjectMeta.Name,
+				"Default provider should not create control plane monitoring ConfigMap")
+		}
+		for _, volume := range dcaDeployment.Spec.Template.Spec.Volumes {
+			assert.NotEqual(t, "kube-apiserver-config", volume.Name,
+				"Default provider should not have control plane volumes")
+		}
+	} else if provider == kubernetes.OpenshiftProvider || provider == kubernetes.EKSCloudProvider {
+		cpCm := corev1.ConfigMap{}
+		err := c.Get(context.TODO(), types.NamespacedName{
+			Name:      fmt.Sprintf("datadog-controlplane-monitoring-%s", provider),
+			Namespace: resourcesNamespace,
+		}, &cpCm)
+		assert.NoError(t, err, "Control plane monitoring ConfigMap should exist for provider %s", provider)
+
+		if err := verifyCheckMounts(t, dcaDeployment, provider, "kube-apiserver"); err != nil {
+			return err
+		}
+		if err := verifyCheckMounts(t, dcaDeployment, provider, "kube-controller-manager"); err != nil {
+			return err
+		}
+		if err := verifyCheckMounts(t, dcaDeployment, provider, "kube-scheduler"); err != nil {
+			return err
+		}
+	}
+	if provider == kubernetes.OpenshiftProvider {
+		if err := verifyCheckMounts(t, dcaDeployment, provider, "etcd"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyCheckMounts(t *testing.T, dcaDeployment appsv1.Deployment, provider string, checkName string) error {
+	volumeToKeyMap := map[string]string{
+		"kube-apiserver":          "kube_apiserver_metrics",
+		"kube-controller-manager": "kube_controller_manager",
+		"kube-scheduler":          "kube_scheduler",
+		"etcd":                    "etcd",
+	}
+	configMapKey := volumeToKeyMap[checkName]
+
+	assert.Contains(t, dcaDeployment.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: fmt.Sprintf("%s-config", checkName),
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: fmt.Sprintf("datadog-controlplane-monitoring-%s", provider),
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key:  fmt.Sprintf("%s.yaml", configMapKey),
+						Path: fmt.Sprintf("%s.yaml", configMapKey),
 					},
 				},
 			},
-		})
-		dcaContainer := dcaDeployment.Spec.Template.Spec.Containers[0]
-		assert.Contains(t, dcaContainer.VolumeMounts, corev1.VolumeMount{
-			Name:      "controlplane-config",
-			MountPath: "/etc/datadog-agent/conf.d",
-			ReadOnly:  true,
-		})
-	}
-
-	assert.Contains(t, dcaDeployment.Spec.Template.Spec.Volumes, corev1.Volume{
-		Name: "agent-conf-d-writable",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
+	})
+
+	dcaContainer := dcaDeployment.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, dcaContainer.VolumeMounts, corev1.VolumeMount{
+		Name:      fmt.Sprintf("%s-config", checkName),
+		MountPath: fmt.Sprintf("/etc/datadog-agent/conf.d/%s.d", configMapKey),
+		ReadOnly:  true,
 	})
 	return nil
 }

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/const.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/const.go
@@ -10,12 +10,12 @@ const (
 	defaultConfigMapName   = "datadog-controlplane-monitoring-default"
 	eksConfigMapName       = "datadog-controlplane-monitoring-eks"
 
-	kubeApiserverVolumeName         = "kube-apiserver-config"
+	kubeApiserverMetricsVolumeName  = "kube-apiserver-metrics-config"
 	kubeControllerManagerVolumeName = "kube-controller-manager-config"
 	kubeSchedulerVolumeName         = "kube-scheduler-config"
 	etcdVolumeName                  = "etcd-config"
 
-	kubeApiserverMountPath         = "/etc/datadog-agent/conf.d/kube_apiserver_metrics.d"
+	kubeApiserverMetricsMountPath  = "/etc/datadog-agent/conf.d/kube_apiserver_metrics.d"
 	kubeControllerManagerMountPath = "/etc/datadog-agent/conf.d/kube_controller_manager.d"
 	kubeSchedulerMountPath         = "/etc/datadog-agent/conf.d/kube_scheduler.d"
 	etcdMountPath                  = "/etc/datadog-agent/conf.d/etcd.d"

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/const.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/const.go
@@ -10,9 +10,15 @@ const (
 	defaultConfigMapName   = "datadog-controlplane-monitoring-default"
 	eksConfigMapName       = "datadog-controlplane-monitoring-eks"
 
-	controlPlaneMonitoringVolumeName      = "controlplane-config"
-	controlPlaneMonitoringVolumeMountPath = "/etc/datadog-agent/conf.d"
-	emptyDirVolumeName                    = "agent-conf-d-writable"
+	kubeApiserverVolumeName         = "kube-apiserver-config"
+	kubeControllerManagerVolumeName = "kube-controller-manager-config"
+	kubeSchedulerVolumeName         = "kube-scheduler-config"
+	etcdVolumeName                  = "etcd-config"
+
+	kubeApiserverMountPath         = "/etc/datadog-agent/conf.d/kube_apiserver_metrics.d"
+	kubeControllerManagerMountPath = "/etc/datadog-agent/conf.d/kube_controller_manager.d"
+	kubeSchedulerMountPath         = "/etc/datadog-agent/conf.d/kube_scheduler.d"
+	etcdMountPath                  = "/etc/datadog-agent/conf.d/etcd.d"
 
 	etcdCertsVolumeName      = "etcd-client-certs"
 	etcdCertsVolumeMountPath = "/etc/etcd-certs"

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -126,7 +126,7 @@ func (f *controlPlaneMonitoringFeature) ManageClusterAgent(managers feature.PodT
 
 	// Mount checks from configmap to subdirectories
 	kubeApiserverVolume := &corev1.Volume{
-		Name: kubeApiserverVolumeName,
+		Name: kubeApiserverMetricsVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -144,8 +144,8 @@ func (f *controlPlaneMonitoringFeature) ManageClusterAgent(managers feature.PodT
 	managers.Volume().AddVolume(kubeApiserverVolume)
 
 	kubeApiserverVolumeMount := corev1.VolumeMount{
-		Name:      kubeApiserverVolumeName,
-		MountPath: kubeApiserverMountPath,
+		Name:      kubeApiserverMetricsVolumeName,
+		MountPath: kubeApiserverMetricsMountPath,
 		ReadOnly:  true,
 	}
 	managers.VolumeMount().AddVolumeMountToContainer(&kubeApiserverVolumeMount, apicommon.ClusterAgentContainerName)

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
@@ -64,17 +64,12 @@ func controlPlaneWantResourcesFunc() *test.ComponentTest {
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
 
-			// Validate volumes
-			expectedVols := []*corev1.Volume{
-				{
-					Name: emptyDirVolumeName,
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-			}
-
+			// For default provider, no volumes should be created
 			dcaVols := mgr.VolumeMgr.Volumes
+			dcaVolMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommon.ClusterAgentContainerName]
+
+			// No volumes should be created for the default provider
+			expectedVols := []*corev1.Volume{}
 
 			assert.True(
 				t,
@@ -82,16 +77,8 @@ func controlPlaneWantResourcesFunc() *test.ComponentTest {
 				"DCA Volumes \ndiff = %s", cmp.Diff(dcaVols, expectedVols),
 			)
 
-			// Validate volumeMounts
-			expectedVolMounts := []*corev1.VolumeMount{
-				{
-					Name:      emptyDirVolumeName,
-					MountPath: controlPlaneMonitoringVolumeMountPath,
-					ReadOnly:  false,
-				},
-			}
-
-			dcaVolMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommon.ClusterAgentContainerName]
+			// No volume mounts should be created for the default provider
+			var expectedVolMounts []*corev1.VolumeMount
 
 			assert.True(
 				t,


### PR DESCRIPTION
### What does this PR do?

- Mount control plane checks to subfolders in `etc/datadog-agent/conf.d` instead of directly to the root. 
- Resolves issue where when control plane monitoring is enabled (by default), other contents of the root folder get wiped. 
- Update controller testing with the updated control plane monitoring configuration in DCA

### Motivation

Feedback from #1984 

### Additional Notes

Tested on Openshift and EKS; the testing instructions below are for Openshift. 

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: v7.69.1

### Describe your test plan
- Deploy custom operator to openshift cluster ([instructions](https://datadoghq.atlassian.net/wiki/x/5AJWOQE)) with the flag `--introspectionEnabled=true` configured in `spec.container.args` in `bundle/manifests/datadog-operator.clusterserviceversion.yaml`
- Apply the following DDA config (note: **control plane monitoring is disabled**)
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    clusterName: sarah-openshift-test
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
    kubelet:
      tlsVerify: false
  features:
    controlPlaneMonitoring:
      enabled: false
    clusterChecks:
      enabled: true
      useClusterChecksRunners: true
```

- Copy this secret to allow mounting TLS certs:
```
oc get secret etcd-metric-client -n openshift-etcd-operator -o yaml | sed 's/name: etcd-metric-client/name: etcd-metric-client/' | sed 's/namespace: openshift-etcd-operator/namespace: default/' | oc create -f -
```
- exec into the cluster agent pod:
     - run `ls /etc/datadog-agent/conf.d` and verify that `kubernetes_apiserver.d` exists in the root folder. This is added by event collection, which is enabled by default. 
     - run `agent status` on the DCA pod; you should see the `kubernetes_apiserver` check running. 
<img width="720" height="280" alt="image" src="https://github.com/user-attachments/assets/fec9055b-c8db-492d-9349-657d0f403f44" />

- **enable control plane monitoring** and update the DDA manifest:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    clusterName: sarah-openshift-test
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
    kubelet:
      tlsVerify: false
  features:
    clusterChecks:
      enabled: true
      useClusterChecksRunners: true
```

- exec into the cluster agent pod:
     - run `ls /etc/datadog-agent/conf.d` and verify that `kubernetes_apiserver.d` exists in the root folder. This is added by event collection, which is enabled by default. You should also see directories corresponding to the 4 endpoint checks configured by the control plane monitoring feature: `kube_apiserver_metrics`, `etcd`, `kube_controller_manager`, and `kube_scheduler`.
     - run `agent status` on the DCA pod; you should see the `kubernetes_apiserver` check running. 
     - run `agent clusterchecks`: you should see the 4 endpoint checks running
     - Verify that you can see metrics for each check on [Datadog](https://dddev.datadoghq.com/metric/explorer?fromUser=false&state=H4sIAAAAAAAAE12R3WrDMAyF30WXw5S669o1rzKKMbGcCvyTWk4hDXn3oaTNYHfS4fPRkTzBAwtTTtDAYX84Gq3NXoOCrtj-xtD8TODQU6K6QBNUqgGhAVBraZie0uvTpthAnRgG9FXEsRegUkTGQsigoOB9QK7rgILc58RofC7R1v_sfVgrQZON4iXSKDGdrdZwHkorcsRaqH2_GaEB--gaHrli3LX9sBsYy_Qxw3xVIMOGYFffV_NnPV_n6ywY94GqcRQxyZ0E39Q2J0_dYhAoUoVG7xVwLlUulYvDAg045BYWL1nLl2WFCbha4fT5S39ezqfD8VufFGBym3Z5aQV9Qb6ZmJ1syYEcpQ4U9HZgdNB4GxhnBZ5CxfKKuEU2D3qa9yfkPhBXmH8B94EUm_kBAAA&start=1756140643475&end=1756141543475&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyJlsmQDWTtp4IgB0dXgARnBOGPIQfgBuOi3y2jj5bHgaLWwYaEwtOHXA7V1OmWhTCDpOkerIGhjaGIwAtMYYPC0YGuv4IggAFACUIHygezkgsVgATInJBCpdJ4LJffKFYrfUo0XIVKo1OD1RrNFqITJQEZjCZwKYzOBzBZLFadbobLY7T4HI4nc6Xa63TL3J6vd4RKJfH4AZgBKTSGWyyghECKiR+5Uq1VqDSarVW3Q0iKgeDQw1G40Qk2ms3mjEWy3l602Gm22l2HOpxzOFyuNzuzRZbwoHw5MRhABZeUD+aDBblhaKSjpYSB4VKkTLUYamQ8xmhVWaPJF4NosRqmLjtQTdfqSWtySbKRbDla6bbGcyXm8ALpUVzuFU3aygeuqRtu4MJNmt9u5H7-btuNuYDtxHmDhsjvsemtUE1YVUyEDyOaIbbKKA4GBGm4aEWJNCibpyRTlHCHqAHo9OehMZQiIdzJ1JfryTBYJwnr6HkRKHjVng+FDN9xAAYSkYQYBQEQVTQHggA) 
<img width="3572" height="744" alt="image" src="https://github.com/user-attachments/assets/0738d1d4-7a24-4c40-a6bb-d79476313a01" />

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
