### PR TITLE
Remove verbose debug log

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -144,7 +144,6 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 
 	// Apply features changes on the Deployment.Spec.Template
 	for _, feat := range features {
-		logger.Info("Agent feature", "feature", feat.ID())
 		if singleContainerStrategyEnabled {
 			if errFeat := feat.ManageSingleContainerNodeAgent(podManagers, provider); errFeat != nil {
 				return result, errFeat

--- a/internal/controller/datadogagent/controller_reconcile_dca.go
+++ b/internal/controller/datadogagent/controller_reconcile_dca.go
@@ -48,7 +48,6 @@ func (r *Reconciler) reconcileV2ClusterAgent(ctx context.Context, logger logr.Lo
 	// Apply features changes on the Deployment.Spec.Template
 	var featErrors []error
 	for _, feat := range features {
-		logger.Info("DCA feature", "feature", feat.ID())
 		if errFeat := feat.ManageClusterAgent(podManagers, dcaProvider); errFeat != nil {
 			featErrors = append(featErrors, errFeat)
 		}


### PR DESCRIPTION
### What does this PR do?

* Removes a verbose log that was added as part of https://github.com/DataDog/datadog-operator/pull/1984

### Motivation

* This log is very verbose and is in INFO, making the number of operator logs greatly increase
* I believe it was solely used for debugging when developing the feature

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
