### PR TITLE
add permission for argorollouts and karpenter

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -120,6 +120,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
@@ -202,13 +209,6 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
-  - '*'
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - datadoghq.com
-  resources:
   - datadogagentinternals
   - datadogagentinternals/finalizers
   - datadogagentprofiles
@@ -276,6 +276,16 @@ rules:
   - watermarkpodautoscalers
   verbs:
   - get
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  - karpenter.azure.com
+  - karpenter.k8s.aws
+  - karpenter.sh
+  resources:
+  - '*'
+  verbs:
   - list
   - watch
 - apiGroups:

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
@@ -107,6 +107,22 @@ func getRBACPolicyRules(logger logr.Logger, crs []string) []rbacv1.PolicyRule {
 			APIGroups: []string{rbac.DatadogAPIGroup},
 			Resources: []string{rbac.Wildcard},
 		},
+		{
+			APIGroups: []string{rbac.ArgoProjAPIGroup},
+			Resources: []string{rbac.Rollout},
+		},
+		{
+			APIGroups: []string{rbac.KarpenterAPIGroup},
+			Resources: []string{rbac.Wildcard},
+		},
+		{
+			APIGroups: []string{rbac.KarpenterAWSAPIGroup},
+			Resources: []string{rbac.Wildcard},
+		},
+		{
+			APIGroups: []string{rbac.KarpenterAzureAPIGroup},
+			Resources: []string{rbac.Wildcard},
+		},
 	}
 
 	groupResources := mapAPIGroupsResources(logger, crs)

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -148,6 +148,10 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=autoscaling.k8s.io,resources=verticalpodautoscalers,verbs=list;watch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=list;watch
 // +kubebuilder:rbac:groups=datadoghq.com,resources="*",verbs=list;watch
+// +kubebuilder:rbac:groups=argoproj.io,resources=rollouts,verbs=list;watch
+// +kubebuilder:rbac:groups=karpenter.sh,resources="*",verbs=list;watch
+// +kubebuilder:rbac:groups=karpenter.k8s.aws,resources="*",verbs=list;watch
+// +kubebuilder:rbac:groups=karpenter.azure.com,resources="*",verbs=list;watch
 
 // Kubernetes_state_core
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -14,6 +14,7 @@ const (
 	AdmissionAPIGroup        = "admissionregistration.k8s.io"
 	APIExtensionsAPIGroup    = "apiextensions.k8s.io"
 	AppsAPIGroup             = "apps"
+	ArgoProjAPIGroup         = "argoproj.io"
 	AuthorizationAPIGroup    = "authorization.k8s.io"
 	AutoscalingAPIGroup      = "autoscaling"
 	AutoscalingK8sIoAPIGroup = "autoscaling.k8s.io"
@@ -32,6 +33,9 @@ const (
 	RegistrationAPIGroup     = "apiregistration.k8s.io"
 	StorageAPIGroup          = "storage.k8s.io"
 	EKSMetricsAPIGroup       = "metrics.eks.amazonaws.com"
+	KarpenterAPIGroup        = "karpenter.sh"
+	KarpenterAWSAPIGroup     = "karpenter.k8s.aws"
+	KarpenterAzureAPIGroup   = "karpenter.azure.com"
 
 	// Resources
 
@@ -79,6 +83,7 @@ const (
 	ResourceQuotasResource              = "resourcequotas"
 	RoleBindingResource                 = "rolebindings"
 	RoleResource                        = "roles"
+	Rollout                             = "rollouts"
 	SecretsResource                     = "secrets"
 	ServiceAccountResource              = "serviceaccounts"
 	ServicesResource                    = "services"


### PR DESCRIPTION
### What does this PR do?

Update orchestrator check permission to include:

- Argo Rollouts (argoproj.io/v1alpha1/rollouts)
- karpenter.sh/*
- karpenter.k8s.aws/*
- karpenter.azure.com/*

required by https://github.com/DataDog/datadog-agent/pull/40430
