### PR TITLE
Add warning for upcoming pod label changes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -224,7 +224,7 @@ func run(opts *options) error {
 	if opts.datadogAgentEnabled {
 		setupLog.Error(nil, "[WARNING] Upcoming Agent DaemonSet selector changes in Operator v1.20. If you rely on Datadog Agent pod labels e.g. in NetworkPolicies, verify if you may be impacted. See README for details.")
 		if opts.datadogAgentProfileEnabled {
-			setupLog.Error(nil, "[WARNING] Upcoming selector change in Agent DaemonSets managed by DAPs in Operator v1.18 and v1.20. If you rely on Datadog Agent pod labels e.g. in NetworkPolicies review if you may be impacted. See README for details.")
+			setupLog.Error(nil, "[WARNING] Upcoming selector changes in Agent DaemonSets managed by DAPs in Operator v1.18 and v1.20. If you rely on Datadog Agent pod labels, e.g. in NetworkPolicies, verify if you may be impacted. See README for details.")
 		}
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,6 +221,13 @@ func run(opts *options) error {
 	}
 	version.PrintVersionLogs(setupLog)
 
+	if opts.datadogAgentEnabled {
+		setupLog.Error(nil, "[WARNING] Upcoming Agent DaemonSet selector changes in Operator v1.20. If you rely on Datadog Agent pod labels e.g. in NetworkPolicies, verify if you may be impacted. See README for details.")
+		if opts.datadogAgentProfileEnabled {
+			setupLog.Error(nil, "[WARNING] Upcoming selector change in Agent DaemonSets managed by DAPs in Operator v1.18 and v1.20. If you rely on Datadog Agent pod labels e.g. in NetworkPolicies review if you may be impacted. See README for details.")
+		}
+	}
+
 	// submits the maximum go routine setting as a metric
 	metrics.MaxGoroutines.Set(float64(opts.maximumGoroutines))
 


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Operator with Agent enabled should log `[WARNING] Upcoming Agent DaemonSet selector changes in Operator v1.20...` at startup.
* Operator with both Agent and DAPs enabled should log additional `[WARNING] Upcoming selector change in Agent DaemonSets managed by DAPs in Operator v1.18 and v1.20..`.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
