### PR TITLE
[CSPM] fix host benchmarks env variable

### DIFF
--- a/internal/controller/datadogagent/feature/cspm/envvar.go
+++ b/internal/controller/datadogagent/feature/cspm/envvar.go
@@ -9,5 +9,5 @@ const (
 	DDComplianceConfigDir             = "DD_COMPLIANCE_CONFIG_DIR"
 	DDComplianceConfigCheckInterval   = "DD_COMPLIANCE_CONFIG_CHECK_INTERVAL"
 	DDComplianceConfigEnabled         = "DD_COMPLIANCE_CONFIG_ENABLED"
-	DDComplianceHostBenchmarksEnabled = "DD_COMPLIANCE_HOST_BENCHMARKS_ENABLED"
+	DDComplianceHostBenchmarksEnabled = "DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED"
 )


### PR DESCRIPTION
### What does this PR do?

The variable to use is `DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED` and not `DD_COMPLIANCE_HOST_BENCHMARKS_ENABLED`. This is not a critical issue because this feature is enabled by default in the agent side, so currently you just get a log that this env var is not recognized and the feature is enabled anyway, but you can't disable it. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
