### PR TITLE
[CWS] clean up unused security agent features

### DIFF
--- a/internal/controller/datadogagent/feature/cws/feature.go
+++ b/internal/controller/datadogagent/feature/cws/feature.go
@@ -240,12 +240,6 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	}
 	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, policiesDirEnvVar)
 
-	hostRootEnvVar := &corev1.EnvVar{
-		Name:  common.DDHostRootEnvVar,
-		Value: common.HostRootMountPath,
-	}
-	managers.EnvVar().AddEnvVarToContainer(apicommon.SecurityAgentContainerName, hostRootEnvVar)
-
 	volMountMgr := managers.VolumeMount()
 	volMgr := managers.Volume()
 
@@ -298,11 +292,6 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	volMountMgr.AddVolumeMountToContainer(&osReleaseVolMount, apicommon.SystemProbeContainerName)
 	volMgr.AddVolume(&osReleaseVol)
 
-	// hostroot volume mount
-	hostrootVol, hostrootVolMount := volume.GetVolumes(common.HostRootVolumeName, common.HostRootHostPath, common.HostRootMountPath, true)
-	volMountMgr.AddVolumeMountToContainer(&hostrootVolMount, apicommon.SecurityAgentContainerName)
-	volMgr.AddVolume(&hostrootVol)
-
 	// Custom policies are copied and merged with default policies via a workaround in the init-volume container.
 	if f.customConfig != nil {
 		var vol corev1.Volume
@@ -344,12 +333,9 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 			}
 		}
 
-		// Add policies directory envvar to Security Agent, and empty volume to System Probe and Security Agent.
-		managers.EnvVar().AddEnvVarToContainer(apicommon.SecurityAgentContainerName, policiesDirEnvVar)
-
 		policiesVol, policiesVolMount := volume.GetVolumesEmptyDir(securityAgentRuntimePoliciesDirVolumeName, securityAgentRuntimePoliciesDirVolumePath, true)
 		volMgr.AddVolume(&policiesVol)
-		volMountMgr.AddVolumeMountToContainers(&policiesVolMount, []apicommon.AgentContainerName{apicommon.SecurityAgentContainerName, apicommon.SystemProbeContainerName})
+		volMountMgr.AddVolumeMountToContainer(&policiesVolMount, apicommon.SystemProbeContainerName)
 
 		// Add runtime-security.d volume mount to init-volume container at different path
 		policiesVolMountInitVol := corev1.VolumeMount{

--- a/internal/controller/datadogagent/feature/cws/feature_test.go
+++ b/internal/controller/datadogagent/feature/cws/feature_test.go
@@ -124,14 +124,6 @@ func cwsAgentNodeWantFunc(withSubFeatures bool) *test.ComponentTest {
 					Name:  DDRuntimeSecurityConfigSyscallMonitorEnabled,
 					Value: "true",
 				},
-				{
-					Name:  common.DDHostRootEnvVar,
-					Value: common.HostRootMountPath,
-				},
-				{
-					Name:  DDRuntimeSecurityConfigPoliciesDir,
-					Value: securityAgentRuntimePoliciesDirVolumePath,
-				},
 			}
 			sysProbeWant := []*corev1.EnvVar{
 				{
@@ -182,16 +174,6 @@ func cwsAgentNodeWantFunc(withSubFeatures bool) *test.ComponentTest {
 				{
 					Name:      common.SystemProbeSocketVolumeName,
 					MountPath: common.SystemProbeSocketVolumePath,
-					ReadOnly:  true,
-				},
-				{
-					Name:      common.HostRootVolumeName,
-					MountPath: common.HostRootMountPath,
-					ReadOnly:  true,
-				},
-				{
-					Name:      securityAgentRuntimePoliciesDirVolumeName,
-					MountPath: securityAgentRuntimePoliciesDirVolumePath,
 					ReadOnly:  true,
 				},
 			}
@@ -309,14 +291,6 @@ func cwsAgentNodeWantFunc(withSubFeatures bool) *test.ComponentTest {
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
 							Path: common.SystemProbeOSReleaseDirVolumePath,
-						},
-					},
-				},
-				{
-					Name: common.HostRootVolumeName,
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: common.HostRootHostPath,
 						},
 					},
 				},


### PR DESCRIPTION
### What does this PR do?

This PR removes a few unused mounts/envvars/volumes etc applied on the security agent when the CWS feature is used that are not used and only valid on the system-probe.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
