### PR TITLE
README: add link to configuration page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -227,6 +227,10 @@ datadog-agent-lkfqt                          0/1     Running    0          15s
 datadog-agent-zvdbw                          1/1     Running    0          8m1s
 ```
 
+## Configuration
+
+For a full list of configuration options, see the [configuration spec][12].
+
 ## Install the kubectl plugin
 
 See the [`kubectl` plugin documentation][11].
@@ -270,3 +274,4 @@ helm delete my-datadog-operator
 [9]: https://github.com/DataDog/datadog-operator/blob/main/docs/custom-operator-image.md
 [10]: https://docs.datadoghq.com/containers/kubernetes/installation
 [11]: https://github.com/DataDog/datadog-operator/blob/main/docs/kubectl-plugin.md
+[12]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md


### PR DESCRIPTION
### What does this PR do?

Just adds a small section on the install page that links more visibly to the config page. Only a docs change.

### Motivation

Customers were having trouble being directed to the configuration spec.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
