### PR TITLE
Fix DS lookup by profile name

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -628,7 +628,7 @@ func (r *Reconciler) addDDAIStatusToDDAStatus(status *datadoghqv2alpha1.DatadogA
 // The Daemonset may use the old naming format so we retrieve it via labels
 func (r *Reconciler) getCurrentDaemonset(dda, daemonset metav1.Object) (*appsv1.DaemonSet, error) {
 	// Profile daemonset
-	if profileName, ok := dda.GetLabels()[constants.ProfileLabelKey]; ok {
+	if profileName, ok := daemonset.GetLabels()[constants.ProfileLabelKey]; ok {
 		dsList := appsv1.DaemonSetList{}
 		if err := r.client.List(context.TODO(), &dsList, client.MatchingLabels{
 			apicommon.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in Daemonset -> Profile Name -> Daemonset mapping where we want to find daemonsets associate with the specific profile when they get renamed. DDA doesn't carry `ProfileLabelKey`. 


### Motivation

Without this change we don't correctly orphan Agent pods during migration, leading to deletion all pods and recreated under new DS.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Follow instruction of #2110 

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
