### PR TITLE
[datadogpodautoscaler] Omit empty fallback scaling direction

### DIFF
--- a/api/datadoghq/v1alpha2/datadogpodautoscaler_types.go
+++ b/api/datadoghq/v1alpha2/datadogpodautoscaler_types.go
@@ -166,7 +166,7 @@ type DatadogPodAutoscalerHorizontalFallbackPolicy struct {
 	// Direction determines the direction that recommendations should be applied.
 	// +optional
 	// +kubebuilder:default=ScaleUp
-	Direction DatadogPodAutoscalerFallbackDirection `json:"direction"`
+	Direction DatadogPodAutoscalerFallbackDirection `json:"direction,omitempty"`
 }
 
 // HorizontalFallbackTriggers defines the triggers that will cause local fallback to be enabled.


### PR DESCRIPTION
### What does this PR do?

Add `omitempty` fallback scaling direction tag

### Motivation

Allow us to still process DPAs that were created before this field was introduced

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
