### PR TITLE
fix: mutating admission controller setup ordering issue

### DIFF
--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -99,11 +99,11 @@ func (f *admissionControllerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 	ac := ddaSpec.Features.AdmissionController
 
 	if ac != nil && apiutils.BoolValue(ac.Enabled) {
-		if ac.Validation != nil && ac.Validation.Enabled != nil {
-			f.validationWebhookConfig = &ValidationConfig{enabled: apiutils.BoolValue(ac.Validation.Enabled)}
+		f.validationWebhookConfig = &ValidationConfig{
+			enabled: ac.Validation != nil && apiutils.BoolValue(ac.Validation.Enabled),
 		}
-		if ac.Mutation != nil && ac.Mutation.Enabled != nil {
-			f.mutationWebhookConfig = &MutationConfig{enabled: apiutils.BoolValue(ac.Mutation.Enabled)}
+		f.mutationWebhookConfig = &MutationConfig{
+			enabled: ac.Mutation != nil && apiutils.BoolValue(ac.Mutation.Enabled),
 		}
 
 		f.mutateUnlabelled = apiutils.BoolValue(ac.MutateUnlabelled)

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature_test.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature_test.go
@@ -294,21 +294,17 @@ func getACEnvVars(validation, mutation bool, acm, registry string, cws bool) []*
 		},
 	}
 
-	if validation {
-		validationEnv := corev1.EnvVar{
-			Name:  DDAdmissionControllerValidationEnabled,
-			Value: apiutils.BoolToString(&validation),
-		}
-		envVars = append(envVars, &validationEnv)
+	validationEnv := corev1.EnvVar{
+		Name:  DDAdmissionControllerValidationEnabled,
+		Value: apiutils.BoolToString(&validation),
 	}
+	envVars = append(envVars, &validationEnv)
 
-	if mutation {
-		mutationEnv := corev1.EnvVar{
-			Name:  DDAdmissionControllerMutationEnabled,
-			Value: apiutils.BoolToString(&mutation),
-		}
-		envVars = append(envVars, &mutationEnv)
+	mutationEnv := corev1.EnvVar{
+		Name:  DDAdmissionControllerMutationEnabled,
+		Value: apiutils.BoolToString(&mutation),
 	}
+	envVars = append(envVars, &mutationEnv)
 
 	if acm != "" {
 		acmEnv := corev1.EnvVar{


### PR DESCRIPTION
# Fix: Mutating Admission Controller Setup Ordering Issue

## Problem

Setting `features.apm.instrumentation.enabled = true` does not consistently cause the mutating admission controller to begin to SSI-inject pods, unless we explicitly also set the `features.admissionController.mutation.enabled = true` value. This is _despite the fact_ that the mutation feature is enabled by default. 

The upshot of this is that users can configure SSI correctly - as in, their agent yaml exactly reflects our guidance to configure it - and it simply won't turn on. @spottsdd and I have been able to reproduce this in our lab environment consistently. 

## Why?

I think there's some timing issue in the way the reconciliation interacts with the default configuration set when a mutating change is applied. Changing the guard here seems to address the issue, such that we _always_ create the two webhookConfigs and just conditionally set the `enabled` flag. 

https://github.com/DataDog/datadog-operator/blob/da95e2b6c9c0d338b732422ab7f17b43c61ace08/internal/controller/datadogagent/feature/admissioncontroller/feature.go#L101-L107
