### PR TITLE
Add DD_DASHBOARD_FORCE_SYNC_PERIOD environment variable

### DIFF
--- a/internal/controller/datadogdashboard/controller.go
+++ b/internal/controller/datadogdashboard/controller.go
@@ -2,6 +2,8 @@ package datadogdashboard
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,10 +30,11 @@ import (
 )
 
 const (
-	defaultRequeuePeriod    = 60 * time.Second
-	defaultErrRequeuePeriod = 5 * time.Second
-	defaultForceSyncPeriod  = 60 * time.Minute
-	datadogDashboardKind    = "DatadogDashboard"
+	defaultRequeuePeriod                = 60 * time.Second
+	defaultErrRequeuePeriod             = 5 * time.Second
+	defaultForceSyncPeriod              = 60 * time.Minute
+	datadogDashboardKind                = "DatadogDashboard"
+	DDDashboardForceSyncPeriodEnvVar    = "DD_DASHBOARD_FORCE_SYNC_PERIOD"
 )
 
 type Reconciler struct {
@@ -62,6 +65,18 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 	logger := r.log.WithValues("datadogdashboard", req.NamespacedName)
 	logger.Info("Reconciling Datadog Dashboard")
 	now := metav1.NewTime(time.Now())
+
+	forceSyncPeriod := defaultForceSyncPeriod
+
+	if userForceSyncPeriod, ok := os.LookupEnv(DDDashboardForceSyncPeriodEnvVar); ok {
+		forceSyncPeriodInt, err := strconv.Atoi(userForceSyncPeriod)
+		if err != nil {
+			logger.Error(err, "Invalid value for dashboard force sync period. Defaulting to 60 minutes.")
+		} else {
+			logger.V(1).Info("Setting dashboard force sync period", "minutes", forceSyncPeriodInt)
+			forceSyncPeriod = time.Duration(forceSyncPeriodInt) * time.Minute
+		}
+	}
 
 	instance := &v1alpha1.DatadogDashboard{}
 	var result ctrl.Result
@@ -106,7 +121,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 		if instanceSpecHash != statusSpecHash {
 			logger.Info("DatadogDashboard manifest has changed")
 			shouldUpdate = true
-		} else if instance.Status.LastForceSyncTime == nil || ((defaultForceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
+		} else if instance.Status.LastForceSyncTime == nil || ((forceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
 			// Periodically force a sync with the API to ensure parity
 			// Get Dashboard to make sure it exists before trying any updates. If it doesn't, set shouldCreate
 			_, err = r.get(instance)


### PR DESCRIPTION
### What does this PR do?

Adds DD_DASHBOARD_FORCE_SYNC_PERIOD environment variable to configure DatadogDashboard controller sync frequency, following the same pattern as DD_MONITOR_FORCE_SYNC_PERIOD.

### Motivation

Fixes #2179  - DatadogDashboard controller has a hardcoded 60-minute force sync period, unlike DatadogMonitor which supports DD_MONITOR_FORCE_SYNC_PERIOD. This means dashboard drift from manual UI changes can persist for up to 60 minutes.

### Additional Notes

- Implementation follows the exact same pattern as DatadogMonitor controller
- Defaults to 60 minutes if environment variable is not set
- Includes error handling for invalid values
- All existing tests pass

### Minimum Agent Versions

No minimum version requirements - this is an operator-only change.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- Verified existing DatadogDashboard tests still pass
- Tested environment variable parsing logic with valid/invalid values
- Confirmed lint and build checks pass

### Checklist

- [x] PR has at least one valid label: `enhancement`
- [ ] PR has a milestone or the `qa/skip-qa` label