### PR TITLE
[AGENTONB-2523] Set `resourceVersion` in PodDisruptionBudget reconciliation

### DIFF
--- a/internal/controller/datadogagent/store/store.go
+++ b/internal/controller/datadogagent/store/store.go
@@ -219,8 +219,8 @@ func (ds *Store) Apply(ctx context.Context, k8sClient client.Client) []error {
 				objStore.(*v1.Service).Spec.ClusterIPs = objAPIServer.(*v1.Service).Spec.ClusterIPs
 				objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
 			}
-			// The APIServiceKind and CiliumNetworkPoliciesKind resource version must be set.
-			if kind == kubernetes.APIServiceKind || kind == kubernetes.CiliumNetworkPoliciesKind {
+			// The APIServiceKind, CiliumNetworkPoliciesKind, and PodDisruptionBudgetsKind resource version must be set.
+			if kind == kubernetes.APIServiceKind || kind == kubernetes.CiliumNetworkPoliciesKind || kind == kubernetes.PodDisruptionBudgetsKind {
 				objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
 			}
 


### PR DESCRIPTION
### What does this PR do?

* Ensures we set `resourceVersion` for PDBs to properly reconciliate them following manual edits

### Motivation

https://github.com/DataDog/datadog-operator/issues/2186 and https://stackoverflow.com/questions/71581444/how-to-fix-metadata-resourceversion-invalid-value-must-be-specified-for-an/73639549#73639549

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Create DDA with PDBs on either DCA or CCR
* Label them with `k label pdb XXX foo=bar`
* Ensure the label is removed at the next reconciliation loop and no error logs:
```json
{"level":"ERROR","ts":"2025-09-18T14:28:00.674Z","logger":"controllers.DatadogAgent","msg":"store.store Update","datadogagent":{"name":"datadog","namespace":"datadog"},"obj.namespace":"datadog","obj.name":"datadog-cluster-agent-pdb","error":"poddisruptionbudgets.policy \"datadog-cluster-agent-pdb\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update"}
```
### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
