### PR TITLE
feat: add error-tracking alert type to dd monitors

### DIFF
--- a/api/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/api/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -38,7 +38,7 @@ type DatadogMonitorSpec struct {
 	Tags []string `json:"tags,omitempty"`
 	// Type is the monitor type
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=metric alert;query alert;service check;event alert;log alert;process alert;rum alert;trace-analytics alert;slo alert;event-v2 alert;audit alert;composite
+	// +kubebuilder:validation:Enum=metric alert;query alert;service check;event alert;log alert;process alert;rum alert;trace-analytics alert;slo alert;event-v2 alert;audit alert;composite;error-tracking alert
 	Type DatadogMonitorType `json:"type,omitempty"`
 	// Options are the optional parameters associated with your monitor
 	Options DatadogMonitorOptions `json:"options,omitempty"`
@@ -75,6 +75,8 @@ const (
 	DatadogMonitorTypeAudit DatadogMonitorType = "audit alert"
 	// DatadogMonitorTypeComposite is the composite alert monitor type
 	DatadogMonitorTypeComposite DatadogMonitorType = "composite"
+	// DatadogMonitorTypeErrorTracking is the error-tracking alert monitor type
+	DatadogMonitorTypeErrorTracking DatadogMonitorType = "error-tracking alert"
 )
 
 // DatadogMonitorOptionsNotificationPreset toggles the display of additional content sent in the monitor notification.

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -284,6 +284,7 @@ spec:
                     - event-v2 alert
                     - audit alert
                     - composite
+                    - error-tracking alert
                   type: string
               required:
                 - message

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors_v1alpha1.json
@@ -276,7 +276,8 @@
             "slo alert",
             "event-v2 alert",
             "audit alert",
-            "composite"
+            "composite",
+            "error-tracking alert"
           ],
           "type": "string"
         }

--- a/examples/datadogmonitor/error-tracking-alert-monitor-test.yaml
+++ b/examples/datadogmonitor/error-tracking-alert-monitor-test.yaml
@@ -1,0 +1,23 @@
+# Note: this monitor type requires Datadog Operator v1.8+
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMonitor
+metadata:
+  name: datadog-error-tracking-alert-test
+  namespace: datadog
+spec:
+  query: "errors(\"service:my-app\").rollup(\"count\", \"@error.fingerprint\").last(\"5m\") > 10"
+  type: "error-tracking alert"
+  name: "Test error tracking alert made from DatadogMonitor"
+  message: "High error rate detected in error tracking for service my-app"
+  tags:
+    - "test:datadog"
+    - "service:my-app"
+  priority: 3
+  options:
+    evaluationDelay: 300
+    includeTags: true
+    locked: false
+    newGroupDelay: 300
+    notifyNoData: true
+    noDataTimeframe: 30
+    renotifyInterval: 1440

--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -56,6 +56,7 @@ var supportedMonitorTypes = map[string]bool{
 	string(datadogV1.MONITORTYPE_SLO_ALERT):             true,
 	string(datadogV1.MONITORTYPE_EVENT_V2_ALERT):        true,
 	string(datadogV1.MONITORTYPE_AUDIT_ALERT):           true,
+	string(datadogV1.MONITORTYPE_ERROR_TRACKING_ALERT):  true,
 }
 
 const requiredTag = "generated:kubernetes"


### PR DESCRIPTION
### What does this PR do?

Add error-tracking type for datadog monitors to support CRD datadog monitor type.

Implementation Details:

The error-tracking monitor type follows the established pattern used by other monitor types like audit alert and trace-analytics alert. It leverages the existing Datadog API client support for
MONITORTYPE_ERROR_TRACKING_ALERT.

Key files modified:
- internal/controller/datadogmonitor/controller.go:59
- api/datadoghq/v1alpha1/datadogmonitor_types.go:41,79
- examples/datadogmonitor/error-tracking-alert-monitor-test.yaml (new)
### Motivation

I want this to work, and it does not. So lets try this!

### Additional Notes

This will need to match up with the CRDs versions to work. Gotta see how that is expected to be done currently. 

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
Updates made and tested via: 
1. Controller Support (internal/controller/datadogmonitor/controller.go:59):
  - Added MONITORTYPE_ERROR_TRACKING_ALERT to supported monitor types map
2. Type Definitions (api/datadoghq/v1alpha1/datadogmonitor_types.go:41,79):
  - Added DatadogMonitorTypeErrorTracking constant
  - Updated validation enum to include "error-tracking alert"
3. Generated CRDs (config/crd/bases/v1/datadogmonitors.yaml):
  - Successfully regenerated with make build
  - ✅ Confirmed: "error-tracking alert" now in enum list
4. Example & Testing:
  - Created examples/datadogmonitor/error-tracking-alert-monitor-test.yaml
  - ✅ Validated with yq: Proper YAML structure
  - ✅ Tests passing: All controller tests pass

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
