### PR TITLE
[metrics-forwarder] Use official go client for Validation and sending events

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -96,7 +96,6 @@ core,github.com/richardartoul/molecule/src/codec,Apache-2.0
 core,github.com/richardartoul/molecule/src/protowire,BSD-3-Clause
 core,github.com/secure-systems-lab/go-securesystemslib/cjson,MIT
 core,github.com/shirou/gopsutil/v3,BSD-3-Clause
-core,github.com/shoenig/go-m1cpu,MPL-2.0
 core,github.com/spaolacci/murmur3,BSD-3-Clause
 core,github.com/spf13/afero,Apache-2.0
 core,github.com/spf13/cast,MIT
@@ -107,7 +106,6 @@ core,github.com/stoewer/go-strcase,MIT
 core,github.com/stretchr/objx,MIT
 core,github.com/stretchr/testify,MIT
 core,github.com/tinylib/msgp/msgp,MIT
-core,github.com/tklauser/go-sysconf,BSD-3-Clause
 core,github.com/x448/float16,MIT
 core,go.etcd.io/bbolt,MIT
 core,go.opentelemetry.io/auto/sdk,Apache-2.0

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -96,6 +96,7 @@ core,github.com/richardartoul/molecule/src/codec,Apache-2.0
 core,github.com/richardartoul/molecule/src/protowire,BSD-3-Clause
 core,github.com/secure-systems-lab/go-securesystemslib/cjson,MIT
 core,github.com/shirou/gopsutil/v3,BSD-3-Clause
+core,github.com/shoenig/go-m1cpu,MPL-2.0
 core,github.com/spaolacci/murmur3,BSD-3-Clause
 core,github.com/spf13/afero,Apache-2.0
 core,github.com/spf13/cast,MIT
@@ -106,8 +107,8 @@ core,github.com/stoewer/go-strcase,MIT
 core,github.com/stretchr/objx,MIT
 core,github.com/stretchr/testify,MIT
 core,github.com/tinylib/msgp/msgp,MIT
+core,github.com/tklauser/go-sysconf,BSD-3-Clause
 core,github.com/x448/float16,MIT
-core,github.com/zorkian/go-datadog-api,BSD-3-Clause
 core,go.etcd.io/bbolt,MIT
 core,go.opentelemetry.io/auto/sdk,Apache-2.0
 core,go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp,Apache-2.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
-	github.com/zorkian/go-datadog-api v2.30.0+incompatible
 	go.uber.org/zap v1.27.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.68.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,6 @@ github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -840,7 +840,7 @@ func (mf *metricsForwarder) forwardEvent(event Event) error {
 // delegatedSendEvent is separated from forwardEvent to facilitate mocking the Datadog API
 func (mf *metricsForwarder) delegatedSendEvent(eventTitle string, eventType EventType) error {
 	eventRequest := datadogV1.EventCreateRequest{
-		DateHappened:   datadogapi.PtrInt64(int64(time.Now().Unix())),
+		DateHappened:   datadogapi.PtrInt64(time.Now().Unix()),
 		Title:          eventTitle,
 		Text:           eventTitle,
 		Tags:           append(mf.globalTags, mf.tags...),
@@ -912,10 +912,11 @@ func (mf *metricsForwarder) setEnabledFeatures(features []string) {
 }
 
 func (mf *metricsForwarder) setUpDatadogAPIClient() {
-	// v2 client is used for metrics only
+	// v2 client is used for metrics and events
 	configuration := datadogapi.NewConfiguration()
 	apiClient := datadogapi.NewAPIClient(configuration)
 	mf.datadogMetricsApi = datadogV2.NewMetricsApi(apiClient)
+	mf.datadogEventsApi = datadogV1.NewEventsApi(apiClient) // Initialize events API
 }
 
 func (mf *metricsForwarder) generateDatadogContext() context.Context {

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	assert "github.com/stretchr/testify/require"
-	api "github.com/zorkian/go-datadog-api"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,12 +57,12 @@ func (c *fakeMetricsForwarder) delegatedSendFeatureMetric(ctx context.Context, f
 	return nil
 }
 
-func (c *fakeMetricsForwarder) delegatedValidateCreds(apiKey string) (*api.Client, error) {
+func (c *fakeMetricsForwarder) delegatedValidateCreds(apiKey string) error {
 	c.Called(apiKey)
 	if strings.Contains(apiKey, "invalid") {
-		return nil, errors.New("invalid creds")
+		return errors.New("invalid creds")
 	}
-	return &api.Client{}, nil
+	return nil
 }
 
 func TestMetricsForwarder_updateCredsIfNeeded(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Finishes migration from zorkian to official go client by using go client for validation and sending events. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.
Apply any datadog resource yaml (monitor/agent/slos/dashboard). There should be a "Detect..." event shown in the [event management page](https://app.datadoghq.com/event/explorer?). 
<img width="939" height="112" alt="image" src="https://github.com/user-attachments/assets/7e0b9a36-0623-4b72-b32c-66f1aea3d269" />

As for testing validation, as long as there is no error (which there is none) from `delegatedValidateCreds` it is working.


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
