### PR TITLE
[profiles] Support GPU feature overrides in DAP

### DIFF
--- a/api/datadoghq/v1alpha1/datadogagentprofile_validation.go
+++ b/api/datadoghq/v1alpha1/datadogagentprofile_validation.go
@@ -13,11 +13,11 @@ import (
 )
 
 // ValidateDatadogAgentProfileSpec is used to check if a DatadogAgentProfileSpec is valid
-func ValidateDatadogAgentProfileSpec(spec *DatadogAgentProfileSpec) error {
+func ValidateDatadogAgentProfileSpec(spec *DatadogAgentProfileSpec, datadogAgentInternalEnabled bool) error {
 	if err := validateProfileAffinity(spec.ProfileAffinity); err != nil {
 		return err
 	}
-	if err := validateConfig(spec.Config); err != nil {
+	if err := validateConfig(spec.Config, datadogAgentInternalEnabled); err != nil {
 		return err
 	}
 
@@ -38,25 +38,126 @@ func validateProfileAffinity(profileAffinity *ProfileAffinity) error {
 	return nil
 }
 
-func validateConfig(spec *v2alpha1.DatadogAgentSpec) error {
+func validateConfig(spec *v2alpha1.DatadogAgentSpec, datadogAgentInternalEnabled bool) error {
 	if spec == nil {
 		return fmt.Errorf("config must be defined")
 	}
-	// features are not supported
-	if spec.Features != nil {
-		return fmt.Errorf("feature overrides are not supported")
+	if err := validateFeatures(spec.Features, datadogAgentInternalEnabled); err != nil {
+		return err
 	}
 	// global is not supported
 	if spec.Global != nil {
 		return fmt.Errorf("global overrides are not supported")
 	}
-	if spec.Override == nil {
+	if !datadogAgentInternalEnabled && spec.Override == nil {
 		return fmt.Errorf("config override must be defined")
 	}
 	for component, override := range spec.Override {
 		if err := validateOverride(component, override); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func validateFeatures(features *v2alpha1.DatadogFeatures, datadogAgentInternalEnabled bool) error {
+	if features == nil {
+		return nil
+	}
+	if !datadogAgentInternalEnabled {
+		return fmt.Errorf("features are not supported when DatadogAgentInternal is disabled")
+	}
+
+	// Valid features:
+	// - GPU
+
+	if features.OtelCollector != nil {
+		return fmt.Errorf("otel collector feature override is not supported")
+	}
+	if features.LogCollection != nil {
+		return fmt.Errorf("log collection feature override is not supported")
+	}
+	if features.LiveProcessCollection != nil {
+		return fmt.Errorf("live process collection feature override is not supported")
+	}
+	if features.LiveContainerCollection != nil {
+		return fmt.Errorf("live container collection feature override is not supported")
+	}
+	if features.ProcessDiscovery != nil {
+		return fmt.Errorf("process discovery feature override is not supported")
+	}
+	if features.OOMKill != nil {
+		return fmt.Errorf("oom kill feature override is not supported")
+	}
+	if features.TCPQueueLength != nil {
+		return fmt.Errorf("tcp queue length feature override is not supported")
+	}
+	if features.EBPFCheck != nil {
+		return fmt.Errorf("ebpf check feature override is not supported")
+	}
+	if features.APM != nil {
+		return fmt.Errorf("apm feature override is not supported")
+	}
+	if features.ASM != nil {
+		return fmt.Errorf("asm feature override is not supported")
+	}
+	if features.CSPM != nil {
+		return fmt.Errorf("cspm feature override is not supported")
+	}
+	if features.CWS != nil {
+		return fmt.Errorf("cws feature override is not supported")
+	}
+	if features.NPM != nil {
+		return fmt.Errorf("npm feature override is not supported")
+	}
+	if features.USM != nil {
+		return fmt.Errorf("usm feature override is not supported")
+	}
+	if features.Dogstatsd != nil {
+		return fmt.Errorf("dogstatsd feature override is not supported")
+	}
+	if features.OTLP != nil {
+		return fmt.Errorf("otlp feature override is not supported")
+	}
+	if features.RemoteConfiguration != nil {
+		return fmt.Errorf("remote configuration feature override is not supported")
+	}
+	if features.SBOM != nil {
+		return fmt.Errorf("sbom feature override is not supported")
+	}
+	if features.ServiceDiscovery != nil {
+		return fmt.Errorf("service discovery feature override is not supported")
+	}
+	if features.EventCollection != nil {
+		return fmt.Errorf("event collection feature override is not supported")
+	}
+	if features.OrchestratorExplorer != nil {
+		return fmt.Errorf("orchestrator explorer feature override is not supported")
+	}
+	if features.KubeStateMetricsCore != nil {
+		return fmt.Errorf("kube state metrics core feature override is not supported")
+	}
+	if features.AdmissionController != nil {
+		return fmt.Errorf("admission controller feature override is not supported")
+	}
+	if features.ExternalMetricsServer != nil {
+		return fmt.Errorf("external metrics server feature override is not supported")
+	}
+	if features.Autoscaling != nil {
+		return fmt.Errorf("autoscaling feature override is not supported")
+	}
+	if features.ClusterChecks != nil {
+		return fmt.Errorf("cluster checks feature override is not supported")
+	}
+	if features.PrometheusScrape != nil {
+		return fmt.Errorf("prometheus scrape feature override is not supported")
+	}
+	if features.HelmCheck != nil {
+		return fmt.Errorf("helm check feature override is not supported")
+	}
+	if features.ControlPlaneMonitoring != nil {
+		return fmt.Errorf("control plane monitoring feature override is not supported")
 	}
 
 	return nil

--- a/api/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
+++ b/api/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
@@ -14,46 +14,40 @@ import (
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/api/utils"
 )
 
 func TestIsValidDatadogAgentProfile(t *testing.T) {
-	// Test cases are missing each of the required parameters
-	valid := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
+	basicProfileAffinity := &ProfileAffinity{
+		ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
+			{
+				Key:      "foo",
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"bar"},
 			},
 		},
-		Config: &v2alpha1.DatadogAgentSpec{
-			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
-				v2alpha1.NodeAgentComponentName: {
-					Containers: map[common.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{
-						common.CoreAgentContainerName: {
-							Resources: &corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
-								},
-							},
+	}
+	basicNodeAgentOverride := map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+		v2alpha1.NodeAgentComponentName: {
+			Containers: map[common.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{
+				common.CoreAgentContainerName: {
+					Resources: &corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
 						},
 					},
 				},
 			},
 		},
 	}
-	validResourceOverrideInOneContainerOnly := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
+	valid := &DatadogAgentProfileSpec{
+		ProfileAffinity: basicProfileAffinity,
+		Config: &v2alpha1.DatadogAgentSpec{
+			Override: basicNodeAgentOverride,
 		},
+	}
+	validResourceOverrideInOneContainerOnly := &DatadogAgentProfileSpec{
+		ProfileAffinity: basicProfileAffinity,
 		Config: &v2alpha1.DatadogAgentSpec{
 			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 				v2alpha1.NodeAgentComponentName: {
@@ -72,15 +66,7 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 		},
 	}
 	invalidComponentOverride := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
-		},
+		ProfileAffinity: basicProfileAffinity,
 		Config: &v2alpha1.DatadogAgentSpec{
 			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 				v2alpha1.NodeAgentComponentName: {
@@ -102,15 +88,7 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 		},
 	}
 	invalidContainerOverride := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
-		},
+		ProfileAffinity: basicProfileAffinity,
 		Config: &v2alpha1.DatadogAgentSpec{
 			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 				v2alpha1.NodeAgentComponentName: {
@@ -130,27 +108,11 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 		},
 	}
 	missingOverride := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
-		},
-		Config: &v2alpha1.DatadogAgentSpec{},
+		ProfileAffinity: basicProfileAffinity,
+		Config:          &v2alpha1.DatadogAgentSpec{},
 	}
 	missingConfig := &DatadogAgentProfileSpec{
-		ProfileAffinity: &ProfileAffinity{
-			ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
-				{
-					Key:      "foo",
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"bar"},
-				},
-			},
-		},
+		ProfileAffinity: basicProfileAffinity,
 	}
 	missingNSR := &DatadogAgentProfileSpec{
 		ProfileAffinity: &ProfileAffinity{
@@ -161,59 +123,116 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 		ProfileAffinity: &ProfileAffinity{},
 	}
 	missingProfileAffinity := &DatadogAgentProfileSpec{}
+	validGPUFeature := &DatadogAgentProfileSpec{
+		ProfileAffinity: basicProfileAffinity,
+		Config: &v2alpha1.DatadogAgentSpec{
+			Features: &v2alpha1.DatadogFeatures{
+				GPU: &v2alpha1.GPUFeatureConfig{
+					Enabled: utils.NewBoolPointer(true),
+				},
+			},
+		},
+	}
+	validFeaturesNoOverride := &DatadogAgentProfileSpec{
+		ProfileAffinity: basicProfileAffinity,
+		Config: &v2alpha1.DatadogAgentSpec{
+			Features: &v2alpha1.DatadogFeatures{
+				GPU: &v2alpha1.GPUFeatureConfig{
+					Enabled:        utils.NewBoolPointer(true),
+					PrivilegedMode: utils.NewBoolPointer(true),
+				},
+			},
+		},
+	}
+	invalidFeaturesNoDDAI := &DatadogAgentProfileSpec{
+		ProfileAffinity: basicProfileAffinity,
+		Config: &v2alpha1.DatadogAgentSpec{
+			Features: &v2alpha1.DatadogFeatures{
+				GPU: &v2alpha1.GPUFeatureConfig{
+					Enabled: utils.NewBoolPointer(true),
+				},
+			},
+		},
+	}
 
 	testCases := []struct {
-		name    string
-		spec    *DatadogAgentProfileSpec
-		wantErr string
+		name                        string
+		spec                        *DatadogAgentProfileSpec
+		datadogAgentInternalEnabled bool
+		wantErr                     string
 	}{
 		{
-			name: "valid dap",
-			spec: valid,
+			name:                        "valid dap",
+			spec:                        valid,
+			datadogAgentInternalEnabled: true,
 		},
 		{
-			name: "valid dap, resources specified in one container only",
-			spec: validResourceOverrideInOneContainerOnly,
+			name:                        "valid dap, resources specified in one container only",
+			spec:                        validResourceOverrideInOneContainerOnly,
+			datadogAgentInternalEnabled: true,
 		},
 		{
-			name:    "invalid component override",
-			spec:    invalidComponentOverride,
-			wantErr: "component node selector override is not supported",
+			name:                        "invalid component override",
+			spec:                        invalidComponentOverride,
+			datadogAgentInternalEnabled: true,
+			wantErr:                     "component node selector override is not supported",
 		},
 		{
-			name:    "invalid container override",
-			spec:    invalidContainerOverride,
-			wantErr: "container command override is not supported",
+			name:                        "invalid container override",
+			spec:                        invalidContainerOverride,
+			datadogAgentInternalEnabled: true,
+			wantErr:                     "container command override is not supported",
 		},
 		{
-			name:    "missing override",
-			spec:    missingOverride,
-			wantErr: "config override must be defined",
+			name:                        "missing override when ddai disabled",
+			spec:                        missingOverride,
+			datadogAgentInternalEnabled: false,
+			wantErr:                     "config override must be defined",
 		},
 		{
-			name:    "missing config",
-			spec:    missingConfig,
-			wantErr: "config must be defined",
+			name:                        "missing config",
+			spec:                        missingConfig,
+			datadogAgentInternalEnabled: true,
+			wantErr:                     "config must be defined",
 		},
 		{
-			name:    "missing node selector requirement",
-			spec:    missingNSR,
-			wantErr: "profileNodeAffinity must have at least 1 requirement",
+			name:                        "missing node selector requirement",
+			spec:                        missingNSR,
+			datadogAgentInternalEnabled: true,
+			wantErr:                     "profileNodeAffinity must have at least 1 requirement",
 		},
 		{
-			name:    "missing profile node affinity",
-			spec:    missingNodeAffinity,
-			wantErr: "profileNodeAffinity must be defined",
+			name:                        "missing profile node affinity",
+			spec:                        missingNodeAffinity,
+			datadogAgentInternalEnabled: true,
+			wantErr:                     "profileNodeAffinity must be defined",
 		},
 		{
-			name:    "missing profile affinity",
-			spec:    missingProfileAffinity,
-			wantErr: "profileAffinity must be defined",
+			name:                        "missing profile affinity",
+			spec:                        missingProfileAffinity,
+			datadogAgentInternalEnabled: true,
+			wantErr:                     "profileAffinity must be defined",
+		},
+		{
+			name:                        "gpu feature override",
+			spec:                        validGPUFeature,
+			datadogAgentInternalEnabled: true,
+		},
+		{
+			name:                        "valid dap with features only when ddai enabled",
+			spec:                        validFeaturesNoOverride,
+			datadogAgentInternalEnabled: true,
+		},
+		{
+			name:                        "features not supported when ddai disabled",
+			spec:                        invalidFeaturesNoDDAI,
+			datadogAgentInternalEnabled: false,
+			wantErr:                     "features are not supported when DatadogAgentInternal is disabled",
 		},
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			result := ValidateDatadogAgentProfileSpec(test.spec)
+			result := ValidateDatadogAgentProfileSpec(test.spec, test.datadogAgentInternalEnabled)
 			if test.wantErr != "" {
 				assert.EqualError(t, result, test.wantErr)
 			} else {

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -321,7 +321,7 @@ func (r *Reconciler) profilesToApply(ctx context.Context, logger logr.Logger, no
 	sortedProfiles := agentprofile.SortProfiles(profilesList.Items)
 	for _, profile := range sortedProfiles {
 		maxUnavailable := agentprofile.GetMaxUnavailable(logger, ddaSpec, &profile, len(nodeList), &r.options.ExtendedDaemonsetOptions)
-		profileAppliedByNode, err = agentprofile.ApplyProfile(logger, &profile, nodeList, profileAppliedByNode, now, maxUnavailable)
+		profileAppliedByNode, err = agentprofile.ApplyProfile(logger, &profile, nodeList, profileAppliedByNode, now, maxUnavailable, r.options.DatadogAgentInternalEnabled)
 		r.updateDAPStatus(logger, &profile)
 		if err != nil {
 			// profile is invalid or conflicts

--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -109,19 +109,27 @@ func setProfileSpec(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.Datad
 		disableComponent(ddai, v2alpha1.ClusterChecksRunnerComponentName)
 		setProfileNodeAgentOverride(ddai, profile)
 	}
+	ensureOverrideExists(ddai, v2alpha1.NodeAgentComponentName)
 	ddai.Spec.Override[v2alpha1.NodeAgentComponentName].Affinity = affinity
 }
 
-func disableComponent(ddai *v1alpha1.DatadogAgentInternal, componentName v2alpha1.ComponentName) {
-	if _, ok := ddai.Spec.Override[componentName]; !ok {
+func ensureOverrideExists(ddai *v1alpha1.DatadogAgentInternal, componentName v2alpha1.ComponentName) {
+	if ddai.Spec.Override == nil {
+		ddai.Spec.Override = make(map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride)
+	}
+	if ddai.Spec.Override[componentName] == nil {
 		ddai.Spec.Override[componentName] = &v2alpha1.DatadogAgentComponentOverride{}
 	}
+}
+
+func disableComponent(ddai *v1alpha1.DatadogAgentInternal, componentName v2alpha1.ComponentName) {
+	ensureOverrideExists(ddai, componentName)
 	ddai.Spec.Override[componentName].Disabled = apiutils.NewBoolPointer(true)
 }
 
 func setProfileDDAIAffinity(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.DatadogAgentProfile) *corev1.Affinity {
 	override, ok := ddai.Spec.Override[v2alpha1.NodeAgentComponentName]
-	if !ok {
+	if !ok || override == nil {
 		override = &v2alpha1.DatadogAgentComponentOverride{}
 	}
 	return common.MergeAffinities(override.Affinity, agentprofile.AffinityOverride(profile))
@@ -156,6 +164,7 @@ func getProfileDDAIName(ddaiName, profileName, profileNamespace string) string {
 
 // The node agent component override is non-nil from the default DDAI creation
 func setProfileNodeAgentOverride(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.DatadogAgentProfile) {
+	ensureOverrideExists(ddai, v2alpha1.NodeAgentComponentName)
 	setProfileDDAILabels(ddai.Spec.Override[v2alpha1.NodeAgentComponentName], profile)
 
 	// Set the DaemonSet name override for profile DDAIs to prevent conflicts

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -542,6 +542,65 @@ func Test_setProfileSpec(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "nil override map and component",
+			ddai: v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: v2alpha1.DatadogAgentSpec{},
+			},
+			profile: v1alpha1.DatadogAgentProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			},
+			want: v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: v2alpha1.DatadogAgentSpec{
+					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+						v2alpha1.NodeAgentComponentName: {
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{
+														Key:      "agent.datadoghq.com/datadogagentprofile",
+														Operator: corev1.NodeSelectorOpDoesNotExist,
+													},
+												},
+											},
+										},
+									},
+								},
+								PodAntiAffinity: &corev1.PodAntiAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+										{
+											LabelSelector: &metav1.LabelSelector{
+												MatchExpressions: []metav1.LabelSelectorRequirement{
+													{
+														Key:      "agent.datadoghq.com/component",
+														Operator: metav1.LabelSelectorOpIn,
+														Values:   []string{"agent"},
+													},
+												},
+											},
+											TopologyKey: "kubernetes.io/hostname",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -44,7 +44,7 @@ const (
 // - existing nodes with the correct label
 // - nodes that need a new or corrected label up to maxUnavailable # of nodes
 func ApplyProfile(logger logr.Logger, profile *v1alpha1.DatadogAgentProfile, nodes []v1.Node, profileAppliedByNode map[string]types.NamespacedName,
-	now metav1.Time, maxUnavailable int) (map[string]types.NamespacedName, error) {
+	now metav1.Time, maxUnavailable int, datadogAgentInternalEnabled bool) (map[string]types.NamespacedName, error) {
 	matchingNodes := map[string]bool{}
 	profileStatus := v1alpha1.DatadogAgentProfileStatus{}
 
@@ -62,7 +62,7 @@ func ApplyProfile(logger logr.Logger, profile *v1alpha1.DatadogAgentProfile, nod
 		return profileAppliedByNode, err
 	}
 
-	if err := v1alpha1.ValidateDatadogAgentProfileSpec(&profile.Spec); err != nil {
+	if err := v1alpha1.ValidateDatadogAgentProfileSpec(&profile.Spec, datadogAgentInternalEnabled); err != nil {
 		logger.Error(err, "profile spec is invalid, skipping", "datadogagentprofile", profile.Name, "datadogagentprofile_namespace", profile.Namespace)
 		metrics.DAPValid.With(prometheus.Labels{"datadogagentprofile": profile.Name}).Set(metrics.FalseValue)
 		profileStatus.Conditions = SetDatadogAgentProfileCondition(profileStatus.Conditions, NewDatadogAgentProfileCondition(ValidConditionType, metav1.ConditionFalse, now, InvalidConditionReason, err.Error()))

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -253,7 +253,7 @@ func TestApplyProfile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			testLogger := zap.New(zap.UseDevMode(true))
 			now := metav1.NewTime(time.Now())
-			profileAppliedByNode, err := ApplyProfile(testLogger, &test.profile, test.nodes, test.profileAppliedByNode, now, 1)
+			profileAppliedByNode, err := ApplyProfile(testLogger, &test.profile, test.nodes, test.profileAppliedByNode, now, 1, true)
 			assert.Equal(t, test.expectedErr, err)
 			assert.Equal(t, test.expectedProfilesAppliedPerNode, profileAppliedByNode)
 		})


### PR DESCRIPTION
### What does this PR do?

Allows GPU feature to be overridden by DAPs (requires DDAIs)

### Motivation

https://datadoghq.atlassian.net/browse/AGENTONB-2322

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy the operator with profiles enabled and DDAI disabled
* With DDAI disabled, try setting GPU feature overrides. It should give a reconciler error (which can be viewed in the DAP status)
* Enable DDAI and ensure a DAP with GPU feature overrides only (no node agent overrides) is valid and that the GPU settings can be overridden

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
