### PR TITLE
[do not merge] sample formatting for public config doc

### DIFF
--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -1,0 +1,102 @@
+This page lists commonly-used configuration parameters for the Datadog Operator. For all configuration parameters, see the [configuration spec][1] in the [`DataDog/datadog-operator`][2] repo.
+
+### Example manifests
+
+* [Manifest with logs, APM, process, and metrics collection enabled][3]
+* [Manifest with logs, APM, and metrics collection enabled][4]
+* [Manifest with APM and metrics collection enabled][5]
+* [Manifest with Cluster Agent][6]
+* [Manifest with tolerations][7]
+
+## Global options
+
+The table in this section lists configurable parameters for the `DatadogAgent` resource. To override parameters for individual components (Node Agent, Cluster Agent, or Cluster Checks Runner) see [override options](#override-options).
+
+For example: the following manifest uses the `global.clusterName` parameter to set a custom cluster name:
+
+{{< highlight yaml "hl_lines=7" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    clusterName: my-test-cluster
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+      appSecret:
+        secretName: datadog-secret
+        keyName: app-key
+{{< /highlight >}}
+
+{{% collapse-content title="Parameters" level="h4" expanded=true id="global-options-list" %}}
+`features.admissionController.enabled`
+: Enables the Admission Controller. Default: `true`
+
+`features.apm.enabled`
+: Enables Application Performace Monitoring. Default: `true`
+
+`features.autoscaling.workload.enabled`
+: Enables the workload autoscaling product. Default: `false`
+
+`features.clusterChecks.enabled`
+: Enables Cluster Checks scheduling in the Cluster Agent. Default: `true`
+
+`global.clusterName`
+: Sets a unique cluster name for the deployment to easily scope monitoring data in the Datadog app.
+{{% /collapse-content %}}
+
+For a complete list of parameters, see the [Operator configuration spec][8].
+
+## Override options
+
+The following table lists parameters that can be used to override default or global settings. Maps and arrays have a type annotation in the table; properties that are configured as map values contain a `[key]` element, to be replaced with an actual map key. `override` itself is a map with the following possible keys: `nodeAgent`, `clusterAgent`, or `clusterChecksRunner`. 
+
+For example: the following manifest overrides the Node Agent's image and tag, in addition to the resource limits of the system probe container:
+
+{{< highlight yaml "hl_lines=6-16" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    nodeAgent:
+      image:
+        name: agent
+        tag: 7.41.0-rc.5
+      containers:
+        system-probe:
+          resources:
+            limits:
+              cpu: "2"
+              memory: 1Gi
+{{< /highlight >}}
+In the table, `spec.override.nodeAgent.image.name` and `spec.override.nodeAgent.containers.system-probe.resources.limits` appear as `[key].image.name` and `[key].containers.[key].resources.limits`, respectively.
+
+{{% collapse-content title="Parameters" level="h4" expanded=true id="override-options-list" %}}
+`[key].annotations`
+: _type_: `map[string]string`
+<br /> Annotations provide annotations that are added to the different component (Datadog Agent, Cluster Agent, Cluster Check Runner) pods.
+
+`[key].containers.[key].healthPort`
+: HealthPort of the container for the internal liveness probe. Must be the same as the Liveness/Readiness probes.
+
+`[key].tolerations`
+: _type_: `[]object`
+<br /> Configure the component tolerations.
+{{% /collapse-content %}}
+
+For a complete list of parameters, see the [Operator configuration spec][9].
+
+[1]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+[2]: https://github.com/DataDog/datadog-operator/
+[3]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-all.yaml
+[4]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-logs-apm.yaml
+[5]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-apm-hostport.yaml
+[6]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-clusteragent.yaml
+[7]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-tolerations.yaml
+[8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#all-configuration-options
+[9]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#override


### PR DESCRIPTION
Just an example of what a public-facing configuration doc could look like. 

This uses some custom formatting features that wouldn't look great in GitHub's markdown rendering. But on the public docs site, it would look like this: https://docs-staging.datadoghq.com/cswatt/example-operator-config/containers/datadog_operator/config/