### PR TITLE
Reduce status update frequency

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -111,7 +110,7 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 		}
 
 		// Add DDA remote config status to DDAI status
-		if e := r.addRemoteConfigStatusToDDAIStatus(newDDAStatus, ddai); e != nil {
+		if res, e := r.addRemoteConfigStatusToDDAIStatus(ctx, newDDAStatus, ddai.ObjectMeta); utils.ShouldReturn(res, e) {
 			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
 		}
 	}
@@ -239,7 +238,7 @@ func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment 
 
 	r.setMetricsForwarderStatusV2(logger, agentdeployment, newStatus)
 
-	if !apiequality.Semantic.DeepEqual(&agentdeployment.Status, newStatus) {
+	if !IsEqualStatus(&agentdeployment.Status, newStatus) {
 		updateAgentDeployment := agentdeployment.DeepCopy()
 		updateAgentDeployment.Status = *newStatus
 		if err := r.client.Status().Update(context.TODO(), updateAgentDeployment); err != nil {

--- a/internal/controller/datadogagent/ddai.go
+++ b/internal/controller/datadogagent/ddai.go
@@ -7,14 +7,16 @@ package datadogagent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"maps"
+	"time"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -96,20 +98,25 @@ func (r *Reconciler) cleanUpUnusedDDAIs(ctx context.Context, validDDAIs []*v1alp
 	return nil
 }
 
-func (r *Reconciler) addRemoteConfigStatusToDDAIStatus(ddaStatus *v2alpha1.DatadogAgentStatus, ddai *v1alpha1.DatadogAgentInternal) error {
-	if ddaStatus == nil || ddaStatus.RemoteConfigConfiguration == nil {
-		return nil
+func (r *Reconciler) addRemoteConfigStatusToDDAIStatus(ctx context.Context, ddaStatus *v2alpha1.DatadogAgentStatus, ddaiMeta metav1.ObjectMeta) (reconcile.Result, error) {
+	ddai := &v1alpha1.DatadogAgentInternal{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: ddaiMeta.Name, Namespace: ddaiMeta.Namespace}, ddai); err != nil {
+		return reconcile.Result{}, err
 	}
-	// remote config configuration
-	ddai.Status.RemoteConfigConfiguration = ddaStatus.RemoteConfigConfiguration
-
-	status, err := json.Marshal(ddai.Status)
-	if err != nil {
-		return err
+	// check equality
+	if apiequality.Semantic.DeepEqual(ddaStatus.RemoteConfigConfiguration, ddai.Status.RemoteConfigConfiguration) {
+		return reconcile.Result{}, nil
 	}
-	patch := fmt.Sprintf(`{"status":%s}`, string(status))
-	if err := r.client.Status().Patch(context.TODO(), ddai, client.RawPatch(types.MergePatchType, []byte(patch))); err != nil {
-		return err
+	updateDdai := ddai.DeepCopy()
+	updateDdai.Status.RemoteConfigConfiguration = ddaStatus.RemoteConfigConfiguration
+	// update ddai status
+	if err := r.client.Status().Update(ctx, updateDdai); err != nil {
+		if apierrors.IsConflict(err) {
+			r.log.V(1).Info("unable to update DatadogAgentInternal remote config status due to update conflict")
+			return reconcile.Result{RequeueAfter: time.Second}, nil
+		}
+		r.log.Error(err, "unable to update DatadogAgentInternal remote config status")
+		return reconcile.Result{}, err
 	}
-	return nil
+	return reconcile.Result{}, nil
 }

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -129,7 +128,7 @@ func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment 
 
 	r.setMetricsForwarderStatusV2(logger, agentdeployment, newStatus)
 
-	if !apiequality.Semantic.DeepEqual(&agentdeployment.Status, newStatus) {
+	if !IsEqualStatus(&agentdeployment.Status, newStatus) {
 		updateAgentDeployment := agentdeployment.DeepCopy()
 		updateAgentDeployment.Status = *newStatus
 		if err := r.client.Status().Update(context.TODO(), updateAgentDeployment); err != nil {

--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -26,7 +26,6 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/metrics"
-	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 )
@@ -520,29 +519,4 @@ func GetMaxUnavailable(logger logr.Logger, ddaSpec *v2alpha1.DatadogAgentSpec, p
 
 	// k8s default
 	return defaultMaxUnavailable
-}
-
-func IsEqualStatus(current *v1alpha1.DatadogAgentProfileStatus, newStatus *v1alpha1.DatadogAgentProfileStatus) bool {
-	if current.CurrentHash != newStatus.CurrentHash ||
-		current.Valid != newStatus.Valid ||
-		current.Applied != newStatus.Applied {
-		return false
-	}
-	if !isEqualCreateStrategy(current.CreateStrategy, newStatus.CreateStrategy) {
-		return false
-	}
-	return condition.IsEqualConditions(current.Conditions, newStatus.Conditions)
-}
-
-func isEqualCreateStrategy(current *v1alpha1.CreateStrategy, newStrategy *v1alpha1.CreateStrategy) bool {
-	if current == nil && newStrategy == nil {
-		return true
-	}
-	if current == nil || newStrategy == nil {
-		return false
-	}
-	return current.Status == newStrategy.Status &&
-		current.NodesLabeled == newStrategy.NodesLabeled &&
-		current.PodsReady == newStrategy.PodsReady &&
-		current.MaxUnavailable == newStrategy.MaxUnavailable
 }

--- a/pkg/agentprofile/status.go
+++ b/pkg/agentprofile/status.go
@@ -13,7 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/condition"
 )
 
 const (
@@ -94,4 +96,36 @@ func SetDatadogAgentProfileCondition(conditionsList []metav1.Condition, newCondi
 	}
 
 	return conditionsList
+}
+
+func IsEqualStatus(current *v1alpha1.DatadogAgentProfileStatus, newStatus *v1alpha1.DatadogAgentProfileStatus) bool {
+	if current == nil && newStatus == nil {
+		return true
+	}
+	if current == nil || newStatus == nil {
+		return false
+	}
+
+	if current.CurrentHash != newStatus.CurrentHash ||
+		current.Valid != newStatus.Valid ||
+		current.Applied != newStatus.Applied {
+		return false
+	}
+	if !isEqualCreateStrategy(current.CreateStrategy, newStatus.CreateStrategy) {
+		return false
+	}
+	return condition.IsEqualConditions(current.Conditions, newStatus.Conditions)
+}
+
+func isEqualCreateStrategy(current *v1alpha1.CreateStrategy, newStrategy *v1alpha1.CreateStrategy) bool {
+	if current == nil && newStrategy == nil {
+		return true
+	}
+	if current == nil || newStrategy == nil {
+		return false
+	}
+	return current.Status == newStrategy.Status &&
+		current.NodesLabeled == newStrategy.NodesLabeled &&
+		current.PodsReady == newStrategy.PodsReady &&
+		current.MaxUnavailable == newStrategy.MaxUnavailable
 }

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -505,3 +505,48 @@ func IsEqualCondition(current *metav1.Condition, newCond *metav1.Condition) bool
 	}
 	return true
 }
+
+func IsEqualDaemonSetStatus(current *v2alpha1.DaemonSetStatus, newStatus *v2alpha1.DaemonSetStatus) bool {
+	if current == nil && newStatus == nil {
+		return true
+	}
+	if current == nil || newStatus == nil {
+		return false
+	}
+
+	if current.Desired != newStatus.Desired ||
+		current.Current != newStatus.Current ||
+		current.Ready != newStatus.Ready ||
+		current.Available != newStatus.Available ||
+		current.UpToDate != newStatus.UpToDate ||
+		current.CurrentHash != newStatus.CurrentHash ||
+		current.Status != newStatus.Status ||
+		current.State != newStatus.State ||
+		current.DaemonsetName != newStatus.DaemonsetName {
+		return false
+	}
+	return true
+}
+
+func IsEqualDeploymentStatus(current *v2alpha1.DeploymentStatus, newStatus *v2alpha1.DeploymentStatus) bool {
+	if current == nil && newStatus == nil {
+		return true
+	}
+	if current == nil || newStatus == nil {
+		return false
+	}
+
+	if current.Replicas != newStatus.Replicas ||
+		current.UpdatedReplicas != newStatus.UpdatedReplicas ||
+		current.ReadyReplicas != newStatus.ReadyReplicas ||
+		current.AvailableReplicas != newStatus.AvailableReplicas ||
+		current.UnavailableReplicas != newStatus.UnavailableReplicas ||
+		current.CurrentHash != newStatus.CurrentHash ||
+		current.GeneratedToken != newStatus.GeneratedToken ||
+		current.Status != newStatus.Status ||
+		current.State != newStatus.State ||
+		current.DeploymentName != newStatus.DeploymentName {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
### What does this PR do?

Reduce status update frequency for ddai and dda

### Motivation

https://datadoghq.atlassian.net/browse/AGENTONB-1698
https://datadoghq.atlassian.net/browse/AGENTONB-2556
https://datadoghq.atlassian.net/browse/AGENTONB-2557

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Check internal dashboard to confirm requests to k8s have reduced

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
