### PR TITLE
feat(github): Add workflows for stale issues/PR management

### DIFF
--- a/.github/chainguard/self.stale.manage-stale.sts.yml
+++ b/.github/chainguard/self.stale.manage-stale.sts.yml
@@ -1,0 +1,15 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-operator:ref:refs/heads/main
+
+claim_pattern:
+  event_name: (workflow_dispatch|schedule)
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-operator/\.github/workflows/stale\.yml@refs/heads/main
+
+permissions:
+  actions: write
+  issues: write
+  pull_requests: write

--- a/.github/workflows/check-issue-status.yml
+++ b/.github/workflows/check-issue-status.yml
@@ -1,0 +1,62 @@
+---
+name: Check if datadog member commented an issue
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_comment:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null
+    steps:
+      - name: Check if there is a comment from a datadog member
+        id: datadog-comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          result-encoding: string
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            let commented = "false";
+            for (const comment of comments.data) {
+              try {
+                const membership = await github.rest.orgs.checkMembershipForUser({
+                  org: 'datadog',
+                  username: comment.user.login
+                });
+                if (membership.status === 204) {
+                  commented = "true";
+                  break;
+                }
+              } catch (error) {
+                if (error.name === 'HttpError') {
+                  // User is not a datadog member
+                  continue;
+                }
+                throw error;
+              }
+            }
+            return commented;
+      - name: Remove the pending label when issue is commented
+        if: steps.datadog-comment.outputs.result == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            for (const label of labels.data) {
+              if (label.name === 'pending') {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label.name
+                });
+              }
+            }

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,24 @@
+---
+name: "Set Pending Label at Issue Creation"
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  set_pending_label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Set pending label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["pending"]
+            });

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,78 @@
+---
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    # Every day at noon CEST (10:00 UTC in summer, 11:00 UTC in winter)
+    # Using 10:00 UTC as CEST is UTC+2 (summer time)
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
+    steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-operator
+          policy: self.stale.manage-stale
+
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
+        with:
+          repo-token: ${{ steps.octo-sts.outputs.token }}
+
+          # Stale configuration
+          days-before-stale: 15
+          days-before-close: 30
+
+          # Issue configuration
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had activity in the past 15 days.
+
+
+            It will be closed in 30 days if no further activity occurs. If this issue is still relevant, adding a comment will keep it open. Also, you can always reopen the issue if you missed the window.
+
+
+            Thank you for your contributions!
+
+          close-issue-message: |
+            This issue was automatically closed because it has been stale for 30 days with no activity.
+
+
+            If this issue is still relevant, please reopen it or create a new issue with updated information.
+
+
+            Thanks!
+
+          stale-issue-label: 'stale'
+          close-issue-label: 'auto-closed'
+          # Pull request configuration
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had activity in the past 15 days.
+
+
+            It will be closed in 30 days if no further activity occurs. If this pull request is still relevant, adding a comment or pushing new commits will keep it open. Also, you can always reopen the pull request if you missed the window.
+
+
+            Thank you for your contributions!
+
+          close-pr-message: |
+            This pull request was automatically closed because it has been stale for 15 days with no activity.
+
+
+            If this pull request is still relevant, please reopen it or create a new pull request with updated information.
+
+
+            Thanks!
+
+          stale-pr-label: 'stale'
+          close-pr-label: 'auto-closed'
+
+          # Exemptions
+          exempt-issue-labels: 'kind/bug,kind/feature,kind/security,category/bugfix,category/feature,category/security,pending'
+          exempt-pr-labels: 'do-not-merge/WIP,do-not-merge/hold'


### PR DESCRIPTION
### What does this PR do?
Add workflows for the management of stale issues/PR

- Set a pending label at issue creation
- Removes this label whenever a Datatog employee adds a comment to an issue
- Adds a schedule call for setting issues as stale or closing stale issues

### Motivation
[datadoghq.atlassian.net/browse/ACIX-1024](https://datadoghq.atlassian.net/browse/ACIX-1024)
Improvement of our interactions with external contributors

### Additional Notes

This workflow is the same as the one set in the datadog-agent repository. As described in the [repository management document](https://docs.google.com/document/d/1hRCYeiLtJ6TdGmrrB5UJ2sF-Dbd9rbQPW2OqPNxJ5kc/edit?tab=t.0#heading=h.hcw3d3cr97p), in agreement with Open Source community.


