### PR TITLE
Fix /debug/pprof endpoints

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -259,7 +259,7 @@ func run(opts *options) error {
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   opts.metricsAddr,
 		SecureServing: opts.secureMetrics,
-		ExtraHandlers: debug.GetExtraMetricHandlers(),
+		ExtraHandlers: debug.GetExtraMetricHandlers(opts.pprofActive),
 	}
 
 	if opts.secureMetrics {

--- a/pkg/controller/debug/register.go
+++ b/pkg/controller/debug/register.go
@@ -31,10 +31,16 @@ func DefaultOptions() *Options {
 // GetExtraMetricHandlers creates debug endpoints.
 func GetExtraMetricHandlers() map[string]http.Handler {
 	handlers := make(map[string]http.Handler)
-	handlers["debug/pprof"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/cmdline"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/cmdline"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/symobol"] = http.HandlerFunc(pprof.Index)
-	handlers["/debug/pprof/trace"] = http.HandlerFunc(pprof.Index)
+	handlers["/debug/pprof/"] = http.HandlerFunc(pprof.Index)
+	handlers["/debug/pprof/cmdline"] = http.HandlerFunc(pprof.Cmdline)
+	handlers["/debug/pprof/profile"] = http.HandlerFunc(pprof.Profile)
+	handlers["/debug/pprof/symbol"] = http.HandlerFunc(pprof.Symbol)
+	handlers["/debug/pprof/trace"] = http.HandlerFunc(pprof.Trace)
+	handlers["/debug/pprof/heap"] = pprof.Handler("heap")
+	handlers["/debug/pprof/goroutine"] = pprof.Handler("goroutine")
+	handlers["/debug/pprof/threadcreate"] = pprof.Handler("threadcreate")
+	handlers["/debug/pprof/block"] = pprof.Handler("block")
+	handlers["/debug/pprof/mutex"] = pprof.Handler("mutex")
+	handlers["/debug/pprof/allocs"] = pprof.Handler("allocs")
 	return handlers
 }

--- a/pkg/controller/debug/register.go
+++ b/pkg/controller/debug/register.go
@@ -10,27 +10,14 @@ import (
 	"net/http/pprof"
 )
 
-// Options used to provide configuration options
-type Options struct {
-	CmdLine bool
-	Profile bool
-	Symbol  bool
-	Trace   bool
-}
-
-// DefaultOptions returns default options configuration
-func DefaultOptions() *Options {
-	return &Options{
-		CmdLine: true,
-		Profile: true,
-		Symbol:  true,
-		Trace:   true,
-	}
-}
-
-// GetExtraMetricHandlers creates debug endpoints.
-func GetExtraMetricHandlers() map[string]http.Handler {
+// GetExtraMetricHandlers creates debug endpoints if enabled.
+func GetExtraMetricHandlers(enabled bool) map[string]http.Handler {
 	handlers := make(map[string]http.Handler)
+
+	if !enabled {
+		return handlers
+	}
+
 	handlers["/debug/pprof/"] = http.HandlerFunc(pprof.Index)
 	handlers["/debug/pprof/cmdline"] = http.HandlerFunc(pprof.Cmdline)
 	handlers["/debug/pprof/profile"] = http.HandlerFunc(pprof.Profile)
@@ -42,5 +29,6 @@ func GetExtraMetricHandlers() map[string]http.Handler {
 	handlers["/debug/pprof/block"] = pprof.Handler("block")
 	handlers["/debug/pprof/mutex"] = pprof.Handler("mutex")
 	handlers["/debug/pprof/allocs"] = pprof.Handler("allocs")
+
 	return handlers
 }


### PR DESCRIPTION
### What does this PR do?

* Registers correctly /debug/pprof endpoints with typos, wrong argument
* Only serves pprof if enabled (default true as we provide --pprof) but allows to disable it

### Motivation

* Debugging with pprof for quick local iteration

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Expose the endpoint `k port-forward deployments/datadog-operator-manager 8080:8080` locally (provided you do have `--pprof` in the cmdline which is the default
2. Access http://localhost:8080/debug/pprof/
3. Ensure you can access the sublinks
4. Disable `--pprof` and ensure you can't access the link

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
