### PR TITLE
usm: Match volume mounts to the CNM

### DIFF
--- a/internal/controller/datadogagent/feature/usm/feature_test.go
+++ b/internal/controller/datadogagent/feature/usm/feature_test.go
@@ -89,6 +89,21 @@ func Test_usmFeature_Configure(t *testing.T) {
 
 		processWantVolumeMounts := []corev1.VolumeMount{
 			{
+				Name:      common.ProcdirVolumeName,
+				MountPath: common.ProcdirMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      common.CgroupsVolumeName,
+				MountPath: common.CgroupsMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      common.DebugfsVolumeName,
+				MountPath: common.DebugfsPath,
+				ReadOnly:  false,
+			},
+			{
 				Name:      common.SystemProbeSocketVolumeName,
 				MountPath: common.SystemProbeSocketVolumePath,
 				ReadOnly:  true,


### PR DESCRIPTION


### What does this PR do?

Match the volume mounts of USM to the process-agent to the ones set by CNM

### Motivation

We didn't mount the correct volumes to the process agent, hence, if CNM wasn't enabled or after runProcessChecksInCoreAgent config turned on by default, the process-agent container didn't have the correct mounts

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
