### PR TITLE
[tooling] Create community PRs with REST API

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -619,6 +619,7 @@ publish_community_operators:
     - dd-octo-sts version
     - dd-octo-sts debug --scope DataDog --policy datadog-operator.publish-community-bundles
     - dd-octo-sts token --scope DataDog --policy datadog-operator.publish-community-bundles > token.txt
+    - export GITHUB_TOKEN=$(cat token.txt)
     - gh auth login --with-token < token.txt
     - gh auth setup-git
     # create pull request for each marketplace repo

--- a/hack/publish-community-bundles.sh
+++ b/hack/publish-community-bundles.sh
@@ -44,10 +44,13 @@ create_pr() {
   git add -A
   git commit -s -m "$message"
   git push -f --set-upstream origin "$PR_BRANCH_NAME"
-  gh pr create --title "$message" \
-               --body "$body" \
-               --repo "$ORG"/"$repo" \
-               --base main
+  curl -L \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    -d "{\"title\":\"$message\",\"body\":\"$body\",\"head\":\"$(git rev-parse --abbrev-ref HEAD)\",\"base\":\"main\"}" \
+    "https://api.github.com/repos/$ORG/$repo/pulls"
 }
 
 


### PR DESCRIPTION
### What does this PR do?

> the GraphQL API tends to use different permissions so sometimes you cannot use a GitHub App with the GraphQL API
* Current hypothesis is that the issue with the publish_community_bundles job is bevcause we are using `gh pr create`, and using the REST API to create the PR upstream may resolve the issue

### Motivation

incident-44423

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Will backport this PR in to `v1.19` branch and test the job during `v1.19.1` release.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
