### PR TITLE
Add DD_DASHBOARD_FORCE_SYNC_PERIOD environment variable

### DIFF
--- a/docs/datadog_dashboard.md
+++ b/docs/datadog_dashboard.md
@@ -10,7 +10,6 @@ The `DatadogDashboard` Custom Resource Definition (CRD) allows users to create [
 - [Helm][2], to deploy the Datadog Operator
 - The [kubectl CLI][3], to install a `DatadogDashboard`
 
-
 ## Adding a DatadogDashboard
 
 To deploy a `DatadogDashboard` with the Datadog Operator, use the [`datadog-operator` Helm chart][4].
@@ -114,8 +113,8 @@ To deploy a `DatadogDashboard` with the Datadog Operator, use the [`datadog-oper
     ```
 
     This automatically creates a new dashboard in Datadog. You can find it on the [Dashboards][8] page of your Datadog account.
-    Datadog Operator occasionally reconciles and keeps dashboards in line with the given configuration. There is also a force 
-    sync every hour, so if a user deletes a dashboard in the Datadog UI, Datadog Operator restores it in under an hour.
+
+By default, the Operator ensures that the API dashboard definition stays in sync with the DatadogDashboard resource every **60** minutes (per dashboard). This interval can be adjusted using the environment variable `DD_DASHBOARD_FORCE_SYNC_PERIOD`, which specifies the number of minutes. For example, setting this variable to `"30"` changes the interval to 30 minutes.
 
 
 ## Cleanup

--- a/internal/controller/datadogdashboard/controller.go
+++ b/internal/controller/datadogdashboard/controller.go
@@ -2,6 +2,8 @@ package datadogdashboard
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -28,10 +30,11 @@ import (
 )
 
 const (
-	defaultRequeuePeriod    = 60 * time.Second
-	defaultErrRequeuePeriod = 5 * time.Second
-	defaultForceSyncPeriod  = 60 * time.Minute
-	datadogDashboardKind    = "DatadogDashboard"
+	defaultRequeuePeriod                = 60 * time.Second
+	defaultErrRequeuePeriod             = 5 * time.Second
+	defaultForceSyncPeriod              = 60 * time.Minute
+	datadogDashboardKind                = "DatadogDashboard"
+	DDDashboardForceSyncPeriodEnvVar    = "DD_DASHBOARD_FORCE_SYNC_PERIOD"
 )
 
 type Reconciler struct {
@@ -62,6 +65,18 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 	logger := r.log.WithValues("datadogdashboard", req.NamespacedName)
 	logger.Info("Reconciling Datadog Dashboard")
 	now := metav1.NewTime(time.Now())
+
+	forceSyncPeriod := defaultForceSyncPeriod
+
+	if userForceSyncPeriod, ok := os.LookupEnv(DDDashboardForceSyncPeriodEnvVar); ok {
+		forceSyncPeriodInt, err := strconv.Atoi(userForceSyncPeriod)
+		if err != nil {
+			logger.Error(err, "Invalid value for dashboard force sync period. Defaulting to 60 minutes.")
+		} else {
+			logger.V(1).Info("Setting dashboard force sync period", "minutes", forceSyncPeriodInt)
+			forceSyncPeriod = time.Duration(forceSyncPeriodInt) * time.Minute
+		}
+	}
 
 	instance := &v1alpha1.DatadogDashboard{}
 	var result ctrl.Result
@@ -106,7 +121,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 		if instanceSpecHash != statusSpecHash {
 			logger.Info("DatadogDashboard manifest has changed")
 			shouldUpdate = true
-		} else if instance.Status.LastForceSyncTime == nil || ((defaultForceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
+		} else if instance.Status.LastForceSyncTime == nil || ((forceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
 			// Periodically force a sync with the API to ensure parity
 			// Get Dashboard to make sure it exists before trying any updates. If it doesn't, set shouldCreate
 			_, err = r.get(instance)


### PR DESCRIPTION
### What does this PR do?

Adds DD_DASHBOARD_FORCE_SYNC_PERIOD environment variable to configure DatadogDashboard controller sync frequency, following the same pattern as DD_MONITOR_FORCE_SYNC_PERIOD.

### Motivation

https://github.com/DataDog/datadog-operator/pull/2184 but using local branch for CI to run

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Enable the dashboard controller and run operator in debug logging level
2. Add the env var set to "2"
3. Apply the example dashboard `examples/datadogdashboard/simple-dashboard.yaml`
4. Get the lastForceSynctime `k get ddd example-dashboard -oyaml | yq .status.lastForceSyncTime`: ensure it's less than 2mns old
5. Review logs to ensure the debug one is picked  up:
    ```json
    {"level":"DEBUG","ts":"2025-10-23T13:08:55.061Z","logger":"controllers.DatadogDashboard","msg":"Setting dashboard force sync period","datadogdashboard":{"name":"example-dashboard","namespace":"system"},"minutes":2}
    ```
6. Do a change in the UI and ensure it's reverted less than 2mns after
7. Remove the env var, restart the operator and wait for 2mns (after lease happened) and ensure lastForceSyncTime is not updated (because it's been less than 60mns default since the last update)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
