### PR TITLE
Fix label selector key in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 > [!WARNING]
 > Upcoming changes to Agent DaemonSet labels and selectors may affect your setup.
 >
-> - In **Operator v1.21.0**, all DaemonSets will replace the `matchLabels` selector `agent.datadoghq.com/name: <dda-name>` with `agent.datadoghq.com/instance: <dda-name>-agent`.
+> - In **Operator v1.21.0**, all DaemonSets will replace the `matchLabels` selector `agent.datadoghq.com/name: <dda-name>` with `app.kubernetes.io/instance: <dda-name>-agent`.
 >
 > If using the preview feature [DatadogAgentProfiles][18] (DAPs), the following changes will occur:
 > - In **Operator v1.18.0**, the `app.kubernetes.io/instance` label value was changed from `<dda-name>-agent` to `<dap-name>-agent` on DAP-managed Pods and DaemonSets.
 > - In **Operator v1.21.0**, the following changes will occur:
->   - All DaemonSets will replace the `matchLabels` selector `agent.datadoghq.com/name: <dda-name>` with `agent.datadoghq.com/instance: <dda-name>-agent` (for default DaemonSets) or `<dap-name>-agent` (for DAP-managed DaemonSets).
+>   - All DaemonSets will replace the `matchLabels` selector `agent.datadoghq.com/name: <dda-name>` with `app.kubernetes.io/instance: <dda-name>-agent` (for default DaemonSets) or `<dap-name>-agent` (for DAP-managed DaemonSets).
 >   - DAP-managed DaemonSets will be renamed from `datadog-agent-with-profile-<dda-name>-<dap-name>` to `<dap-name>-agent`.
 > 
 > ⚠️ If you rely on these labels or `matchLabels` (e.g., in NetworkPolicies, admission controllers, or automation), you may need to update those resources.

--- a/docs/agent_metadata_changes.md
+++ b/docs/agent_metadata_changes.md
@@ -18,7 +18,7 @@ These changes may affect other Kubernetes resources that rely on matching these 
 ### Default setup (DAPs disabled):
 | Operator Version | DaemonSet Name Change | Pod Label Change | Selector Change |
 |------------------|-----------------------|------------------|-----------------|
-| **v1.21**        | _No change_           | _No change_      | `agent.datadoghq.com/name: <dda-name>` → `agent.datadoghq.com/instance: <dda-name>-agent` |
+| **v1.21**        | _No change_           | _No change_      | `agent.datadoghq.com/name: <dda-name>` → `app.kubernetes.io/instance: <dda-name>-agent` |
 
 
 ### DAPs enabled:
@@ -26,8 +26,8 @@ These changes may affect other Kubernetes resources that rely on matching these 
 |------------------|----------------|-----------------------|------------------|-----------------|
 | **v1.18**        | Default DS     | _No change_           | _No change_      | _No change_     |
 |                  | DAP DS         | _No change_           | `app.kubernetes.io/instance: <dda-name>-agent` → `<dap-name>-agent` | _No change_ |
-| **v1.21**        | Default DS     | _No change_           | _No change_      | `agent.datadoghq.com/name: <dda-name>` → `agent.datadoghq.com/instance: <dda-name>-agent` |
-|                  | DAP DS         | `datadog-agent-with-profile-<dda-name>-<dap-name>` → `<dap-name>-agent` | _No change_       | `agent.datadoghq.com/name: <dda-name>` → `agent.datadoghq.com/instance: <dap-name>-agent` |
+| **v1.21**        | Default DS     | _No change_           | _No change_      | `agent.datadoghq.com/name: <dda-name>` → `app.kubernetes.io/instance: <dda-name>-agent` |
+|                  | DAP DS         | `datadog-agent-with-profile-<dda-name>-<dap-name>` → `<dap-name>-agent` | _No change_       | `agent.datadoghq.com/name: <dda-name>` → `app.kubernetes.io/instance: <dap-name>-agent` |
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Fix the label key that's going to change in v1.21 in the docs: `agent.datadoghq.com/instance` -> `app.kubernetes.io/instance`
PRs with the actual changes for reference:
* https://github.com/DataDog/datadog-operator/pull/2054
* https://github.com/DataDog/datadog-operator/pull/2110

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
