### PR TITLE
CAP-3059 consolidate RBAC creation logic for custom resources

### DIFF
--- a/internal/controller/datadogagent/feature/kubernetesstatecore/rbac.go
+++ b/internal/controller/datadogagent/feature/kubernetesstatecore/rbac.go
@@ -6,13 +6,12 @@
 package kubernetesstatecore
 
 import (
-	"maps"
-	"slices"
 	"strings"
 
 	"github.com/gobuffalo/flect"
 	rbacv1 "k8s.io/api/rbac/v1"
 
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
 )
 
@@ -136,33 +135,16 @@ func getRBACPolicyRules(collectorOpts collectorOptions) []rbacv1.PolicyRule {
 
 	// Add permissions for custom resources
 	if len(collectorOpts.customResources) > 0 {
-		// Group custom resources by API group using sets to avoid duplicates
-		groupedResources := make(map[string]map[string]struct{})
+		rbacBuilder := utils.NewRBACBuilder(commonVerbs...)
 		for _, cr := range collectorOpts.customResources {
-			apiGroup := cr.GroupVersionKind.Group
 			// Use the resource plural if specified, otherwise derive it from the Kind
 			resourceName := cr.ResourcePlural
 			if resourceName == "" {
 				resourceName = strings.ToLower(flect.Pluralize(cr.GroupVersionKind.Kind))
 			}
-
-			if _, exists := groupedResources[apiGroup]; !exists {
-				groupedResources[apiGroup] = make(map[string]struct{})
-			}
-			groupedResources[apiGroup][resourceName] = struct{}{}
+			rbacBuilder.AddGroupKind(cr.GroupVersionKind.Group, resourceName)
 		}
-
-		// Create RBAC rules for each API group
-		for apiGroup, resourceSet := range groupedResources {
-			// Convert set to sorted slice for deterministic output
-			resources := slices.Sorted(maps.Keys(resourceSet))
-
-			rbacRules = append(rbacRules, rbacv1.PolicyRule{
-				APIGroups: []string{apiGroup},
-				Resources: resources,
-				Verbs:     commonVerbs,
-			})
-		}
+		rbacRules = append(rbacRules, rbacBuilder.Build()...)
 	}
 
 	return rbacRules

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
@@ -6,42 +6,59 @@
 package orchestratorexplorer
 
 import (
+	"strings"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 )
 
-func TestMapAPIGroupsResources(t *testing.T) {
-
+func TestRBACBuilderFromCustomResourceStrings(t *testing.T) {
 	for _, tt := range []struct {
 		name            string
 		customResources []string
-		expected        map[string][]string
+		expectedRules   []rbacv1.PolicyRule
 	}{
 		{
 			name:            "empty crs",
 			customResources: []string{},
-			expected:        map[string][]string{},
+			expectedRules:   nil,
 		},
 		{
 			name:            "two crs, same group",
 			customResources: []string{"datadoghq.com/v1alpha1/datadogmetrics", "datadoghq.com/v1alpha1/watermarkpodautoscalers"},
-			expected: map[string][]string{
-				"datadoghq.com": {"datadogmetrics", "watermarkpodautoscalers"},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics", "watermarkpodautoscalers"},
+				},
 			},
 		},
 		{
 			name:            "three crs, different groups",
 			customResources: []string{"datadoghq.com/v1alpha1/datadogmetrics", "datadoghq.com/v1alpha1/watermarkpodautoscalers", "cilium.io/v1/ciliumendpoints"},
-			expected: map[string][]string{
-				"datadoghq.com": {"datadogmetrics", "watermarkpodautoscalers"},
-				"cilium.io":     {"ciliumendpoints"},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"cilium.io"},
+					Resources: []string{"ciliumendpoints"},
+				},
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics", "watermarkpodautoscalers"},
+				},
 			},
 		},
 	} {
-		actualGroupsResources := mapAPIGroupsResources(logr.Logger{}, tt.customResources)
-		assert.Equal(t, tt.expected, actualGroupsResources)
+		t.Run(tt.name, func(t *testing.T) {
+			rbacBuilder := utils.NewRBACBuilder()
+			for _, cr := range tt.customResources {
+				crSplit := strings.Split(cr, "/")
+				rbacBuilder.AddGroupKind(crSplit[0], crSplit[2])
+			}
+			actualRules := rbacBuilder.Build()
+			assert.Equal(t, tt.expectedRules, actualRules)
+		})
 	}
-
 }

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -6,8 +6,12 @@
 package utils
 
 import (
+	"maps"
+	"slices"
 	"strconv"
+	"strings"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -66,4 +70,99 @@ func HasAgentDataPlaneAnnotation(dda metav1.Object) bool {
 // HasFineGrainedKubeletAuthz returns true if the feature is enabled via the dedicated `agent.datadoghq.com/fine-grained-kubelet-authorization-enabled` annotation
 func HasFineGrainedKubeletAuthz(dda metav1.Object) bool {
 	return hasFeatureEnableAnnotation(dda, EnableFineGrainedKubeletAuthz)
+}
+
+// resourceSet represents a set of resources with their verbs
+type resourceSet map[string][]string
+
+// groupedResources maps API groups to their resource sets
+type groupedResources map[string]resourceSet
+
+// RBACBuilder provides a simple builder for creating RBAC policy rules for custom resources
+type RBACBuilder struct {
+	// groupedResources stores resources grouped by API group
+	groupedResources groupedResources
+	// verbs stores the verbs to apply to all rules
+	verbs []string
+}
+
+// NewRBACBuilder creates a new RBACBuilder instance with the specified verbs
+func NewRBACBuilder(verbs ...string) *RBACBuilder {
+	return &RBACBuilder{
+		groupedResources: make(groupedResources),
+		verbs:            verbs,
+	}
+}
+
+// AddGroupKind adds a custom resource by group and resource name with optional verbs
+// If no verbs are provided, uses the default verbs from NewRBACBuilder
+func (rb *RBACBuilder) AddGroupKind(group, resource string, verbs ...string) *RBACBuilder {
+	if _, exists := rb.groupedResources[group]; !exists {
+		rb.groupedResources[group] = make(resourceSet)
+	}
+
+	// Use provided verbs or fall back to default verbs
+	resourceVerbs := verbs
+	if len(verbs) == 0 {
+		resourceVerbs = rb.verbs
+	}
+
+	existingVerbs := rb.groupedResources[group][resource]
+	allVerbs := append(existingVerbs, resourceVerbs...)
+	verbSet := make(map[string]struct{})
+	var uniqueVerbs []string
+	for _, verb := range allVerbs {
+		if _, exists := verbSet[verb]; !exists {
+			verbSet[verb] = struct{}{}
+			uniqueVerbs = append(uniqueVerbs, verb)
+		}
+	}
+
+	rb.groupedResources[group][resource] = uniqueVerbs
+	return rb
+}
+
+// Build creates the final RBAC policy rules
+func (rb *RBACBuilder) Build() []rbacv1.PolicyRule {
+	if len(rb.groupedResources) == 0 {
+		return nil
+	}
+
+	var rbacRules []rbacv1.PolicyRule
+
+	// Sort API groups for deterministic output
+	apiGroups := slices.Sorted(maps.Keys(rb.groupedResources))
+
+	// Create RBAC rules for each API group
+	for _, apiGroup := range apiGroups {
+		resourceSet := rb.groupedResources[apiGroup]
+
+		// Group resources by their verbs to minimize the number of rules
+		verbToResources := make(map[string][]string)
+		verbsKeyToActualVerbs := make(map[string][]string)
+
+		for resource, verbs := range resourceSet {
+			verbsKey := strings.Join(verbs, ",")
+			verbToResources[verbsKey] = append(verbToResources[verbsKey], resource)
+			verbsKeyToActualVerbs[verbsKey] = verbs
+		}
+
+		// Create one rule per verb combination
+		// Sort verbsKeys for deterministic output
+		verbsKeys := slices.Sorted(maps.Keys(verbToResources))
+		for _, verbsKey := range verbsKeys {
+			resources := verbToResources[verbsKey]
+			slices.Sort(resources)
+
+			rule := rbacv1.PolicyRule{
+				APIGroups: []string{apiGroup},
+				Resources: resources,
+				Verbs:     verbsKeyToActualVerbs[verbsKey],
+			}
+
+			rbacRules = append(rbacRules, rule)
+		}
+	}
+
+	return rbacRules
 }

--- a/internal/controller/datadogagent/feature/utils/utils_test.go
+++ b/internal/controller/datadogagent/feature/utils/utils_test.go
@@ -1,0 +1,301 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestRBACBuilder(t *testing.T) {
+	type resourceWithVerbs struct {
+		group    string
+		resource string
+		verbs    []string
+	}
+
+	tests := []struct {
+		name          string
+		defaultVerbs  []string
+		additions     []resourceWithVerbs
+		expectedRules []rbacv1.PolicyRule
+	}{
+		{
+			name:          "new builder with no verbs",
+			defaultVerbs:  []string{},
+			expectedRules: nil,
+		},
+		{
+			name:          "new builder with multiple verbs",
+			defaultVerbs:  []string{"list", "watch", "get"},
+			additions:     []resourceWithVerbs{},
+			expectedRules: nil,
+		},
+		{
+			name:         "single resource with default verbs",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"datadoghq.com", "datadogmetrics", nil},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:         "single resource with custom verbs",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"datadoghq.com", "datadogmetrics", []string{"get", "create"}},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics"},
+					Verbs:     []string{"get", "create"},
+				},
+			},
+		},
+		{
+			name:         "multiple resources same group same verbs",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"datadoghq.com", "datadogmetrics", nil},
+				{"datadoghq.com", "watermarkpodautoscalers", nil},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics", "watermarkpodautoscalers"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:         "multiple resources same group different verbs",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"datadoghq.com", "datadogmetrics", nil},
+				{"datadoghq.com", "watermarkpodautoscalers", []string{"get", "create"}},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"watermarkpodautoscalers"},
+					Verbs:     []string{"get", "create"},
+				},
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:         "multiple groups",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"datadoghq.com", "datadogmetrics", nil},
+				{"", "secrets", nil},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"secrets"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:         "duplicate resources are deduplicated",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"datadoghq.com", "datadogmetrics", nil},
+				{"datadoghq.com", "datadogmetrics", nil}, // duplicate
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:         "duplicate resources with different verbs appends verbs",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"datadoghq.com", "datadogmetrics", nil},
+				{"datadoghq.com", "datadogmetrics", []string{"get", "create"}}, // appends
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics"},
+					Verbs:     []string{"list", "watch", "get", "create"},
+				},
+			},
+		},
+		{
+			name:         "complex scenario with mixed verbs and groups",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"", "pods", []string{"get", "list", "watch"}},
+				{"", "services", []string{"get", "list", "watch"}},
+				{"", "configmaps", nil},                           // uses default verbs
+				{"apps", "deployments", []string{"get", "list"}},  // different verbs
+				{"apps", "replicasets", []string{"get", "list"}},  // same verbs as deployments
+				{"datadoghq.com", "watermarkpodautoscalers", nil}, // uses default verbs
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods", "services"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"deployments", "replicasets"},
+					Verbs:     []string{"get", "list"},
+				},
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"watermarkpodautoscalers"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:         "builder with no default verbs",
+			defaultVerbs: []string{},
+			additions: []resourceWithVerbs{
+				{"", "pods", []string{"get", "list"}},
+				{"", "services", []string{"watch"}},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get", "list"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services"},
+					Verbs:     []string{"watch"},
+				},
+			},
+		},
+		{
+			name:         "resources with empty verbs get no verbs",
+			defaultVerbs: []string{},
+			additions: []resourceWithVerbs{
+				{"", "pods", nil}, // no default verbs and no custom verbs
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     nil,
+				},
+			},
+		},
+		{
+			name:         "deterministic output - sorted by API groups",
+			defaultVerbs: []string{"list", "watch"},
+			additions: []resourceWithVerbs{
+				{"rbac.authorization.k8s.io", "roles", nil},
+				{"apps", "deployments", nil},
+				{"datadoghq.com", "datadogmetrics", nil},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"deployments"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{"datadoghq.com"},
+					Resources: []string{"datadogmetrics"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{"rbac.authorization.k8s.io"},
+					Resources: []string{"roles"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:         "empty group name",
+			defaultVerbs: []string{"list"},
+			additions: []resourceWithVerbs{
+				{"", "pods", nil},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list"},
+				},
+			},
+		},
+		{
+			name:         "empty resource name",
+			defaultVerbs: []string{"list"},
+			additions: []resourceWithVerbs{
+				{"", "", nil},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{""},
+					Verbs:     []string{"list"},
+				},
+			},
+		},
+		{
+			name:         "empty verbs slice uses default verbs",
+			defaultVerbs: []string{"list"},
+			additions: []resourceWithVerbs{
+				{"", "pods", []string{}},
+			},
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list"}, // should use default verbs
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewRBACBuilder(tt.defaultVerbs...)
+			for _, addition := range tt.additions {
+				builder = builder.AddGroupKind(addition.group, addition.resource, addition.verbs...)
+			}
+			rules := builder.Build()
+			assert.Equal(t, tt.expectedRules, rules)
+
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

In both `kubernetesstatecore` and `orchestratorexplorer`, we create RBAC resources for custom resources. This PR simply consolidates the RBAC creation logic.  there’s no functional impact.

### Motivation

Improves code structure and ensures the generated RBAC is consistent in format.

### Additional Notes

N/A

### Minimum Agent Versions

N/A

### Describe your test plan

Unit test

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
