### PR TITLE
fix: remove autoMultiLineDetection feature from operator docs

### DIFF
--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -133,7 +133,6 @@ spec:
 | features.liveProcessCollection.enabled | Enables Process monitoring. Default: false |
 | features.liveProcessCollection.scrubProcessArguments | ScrubProcessArguments enables scrubbing of sensitive data in process command-lines (passwords, tokens, etc. ). Default: true |
 | features.liveProcessCollection.stripProcessArguments | StripProcessArguments enables stripping of all process arguments. Default: false |
-| features.logCollection.autoMultiLineDetection | AutoMultiLineDetection allows the Agent to detect and aggregate common multi-line logs automatically. See also: https://docs.datadoghq.com/agent/logs/auto_multiline_detection/ |
 | features.logCollection.containerCollectAll | ContainerCollectAll enables Log collection from all containers. Default: false |
 | features.logCollection.containerCollectUsingFiles | ContainerCollectUsingFiles enables log collection from files in `/var/log/pods instead` of using the container runtime API. Collecting logs from files is usually the most efficient way of collecting logs. See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup Default: true |
 | features.logCollection.containerLogsPath | ContainerLogsPath allows log collection from the container log path. Set to a different path if you are not using the Docker runtime. See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest Default: `/var/lib/docker/containers` |


### PR DESCRIPTION

### What does this PR do?
Removes references to the `spec.features.logCollection.autoMultiLineDetection` option from the Datadog Operator documentation.  

<img width="1306" height="641" alt="image" src="https://github.com/user-attachments/assets/2e2587ba-df6c-4444-98cf-67d662d3a4e1" />


In testing with Datadog Agent **7.70**, this field is not recognized by the Operator CRD and causes a strict decoding error.

### Motivation
I’m running Datadog Agent **7.70** in a test cluster. The Operator documentation currently suggests:

```
spec:
  features:
    logCollection:
      autoMultiLineDetection: true
```

However, applying a DatadogAgent resource with that field fails with:

strict decoding error: unknown field "spec.features.logCollection.autoMultiLineDetection"

<img width="1010" height="684" alt="image" src="https://github.com/user-attachments/assets/84f414bb-beed-4c5a-aa64-75c84dada223" />


#### Maybe It still follows the legacy setting

<img width="759" height="543" alt="image" src="https://github.com/user-attachments/assets/c309007e-ecf7-4635-a61d-1c7cda9b3ccc" />

But the legacy docs says it applies to version earlier than v7.65

<img width="737" height="252" alt="image" src="https://github.com/user-attachments/assets/7c5166b9-ae75-4a14-97e7-8fe5ed75aaab" />


### Minimum Agent Versions
Not identified

### Describe your test plan
Describe your test plan

1. Create a DatadogAgent manifest using spec.features.logCollection.autoMultiLineDetection: true.

2. Apply it and observe the Operator/webhook validation error:
`strict decoding error: unknown field "spec.features.logCollection.autoMultiLineDetection"`



