### PR TITLE
[AGENTONB-2598] Update operator metadata resource count tracking

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -517,6 +517,7 @@ func setupAndStartOperatorMetadataForwarder(logger logr.Logger, client client.Re
 		IntrospectionEnabled:          options.introspectionEnabled,
 		ConfigDDURL:                   os.Getenv(constants.DDURL),
 		ConfigDDSite:                  os.Getenv(constants.DDSite),
+		ResourceCounts:                make(map[string]int),
 	}
 
 	omf.Start()

--- a/pkg/controller/utils/metadata/operator_metadata_test.go
+++ b/pkg/controller/utils/metadata/operator_metadata_test.go
@@ -140,8 +140,10 @@ func Test_setup(t *testing.T) {
 
 			// Create OperatorMetadataForwarder with the new structure
 			omf := &OperatorMetadataForwarder{
-				SharedMetadata:      NewSharedMetadata(zap.New(zap.UseDevMode(true)), nil, "v1.28.0", "v1.19.0", config.NewCredentialManager()),
-				resourceCountsCache: make(map[string]int),
+				SharedMetadata: NewSharedMetadata(zap.New(zap.UseDevMode(true)), nil, "v1.28.0", "v1.19.0", config.NewCredentialManager()),
+				OperatorMetadata: OperatorMetadata{
+					ResourceCounts: make(map[string]int),
+				},
 			}
 
 			tt.loadFunc()
@@ -178,9 +180,8 @@ func Test_GetPayload(t *testing.T) {
 		OperatorMetadata: OperatorMetadata{
 			ClusterName:    expectedClusterName,
 			IsLeader:       true,
-			ResourceCounts: "{}",
+			ResourceCounts: make(map[string]int),
 		},
-		resourceCountsCache: make(map[string]int),
 	}
 
 	// Set hostname in SharedMetadata to simulate it being populated
@@ -280,13 +281,15 @@ func Test_GetPayload(t *testing.T) {
 		}
 	}
 
-	// Verify resource_count is a valid JSON string
-	if resourceCount, ok := metadata["resource_count"].(string); ok {
-		var counts map[string]interface{}
-		if err := json.Unmarshal([]byte(resourceCount), &counts); err != nil {
-			t.Errorf("GetPayload() resource_count is not valid JSON: %v", err)
+	// Verify resource_count is a valid map
+	if resourceCount, ok := metadata["resource_count"].(map[string]interface{}); ok {
+		// Valid map - verify it's structured correctly (values are numbers)
+		for _, value := range resourceCount {
+			if _, ok := value.(float64); !ok {
+				t.Errorf("GetPayload() resource_count value is not a number: %v", value)
+			}
 		}
 	} else {
-		t.Error("GetPayload() resource_count is not a string")
+		t.Errorf("GetPayload() resource_count is not a map, got: %T", metadata["resource_count"])
 	}
 }


### PR DESCRIPTION
### What does this PR do?

* Gates list API calls for all custom resources behind the enabled flags which are also used in Operator Metadata. This way we can avoid unnecessary and/or failed API calls. 
* Adds cache to resource counts with a 5 minute TTL so it is not updated as frequently
* If an API call fails to retrieve resource counts, fall back to the previous cached resource count for that custom resource. 

### Motivation

follow up to #2283 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Deploy an operator with `loglevel=debug` to see the resource and payload logs, and with some custom resources enabled (ex: DAP) 
2. Check for the debug logs in screenshot below. The resource counts from the `Updated resource counts` log should match the counts in the `Operator metadata payload` logged.
<img width="1529" height="354" alt="2025-10-31_17-11-01" src="https://github.com/user-attachments/assets/a432e8f4-4d73-4a7e-ba8d-791ed9d2453c" />

3. Apply some more custom resources to update the resource counts. 
<img width="407" height="96" alt="image" src="https://github.com/user-attachments/assets/f3d4df1b-6f7a-4e27-9631-786829223e32" />

4. After 5 minutes from the initial `Update resource counts` log, check again for a new log. Verify that the counts are accurately updated in the latest log and in the payload. Example:
<img width="1454" height="28" alt="image" src="https://github.com/user-attachments/assets/0deff93d-b2bb-4134-b480-3e1e264f180b" />
<img width="1493" height="187" alt="2025-11-05_10-46-10" src="https://github.com/user-attachments/assets/ac0aef00-7649-43fe-aa90-e5a96a1d6860" />

**e2e testing:**
<img width="1296" height="600" alt="image" src="https://github.com/user-attachments/assets/c2233c8d-b1c1-4a9d-8be9-6a9629d74b5e" />

resource count is not being collected in schema
<img width="238" height="502" alt="image" src="https://github.com/user-attachments/assets/b8bb48d0-1dcc-4b88-a377-f4a27f649313" />

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
