### PR TITLE
Build requirements once per profile, not for every node

### DIFF
--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -75,7 +75,7 @@ func ApplyProfile(logger logr.Logger, profile *v1alpha1.DatadogAgentProfile, nod
 	toLabelNodeCount := 0
 
 	// Parse profile requirements once to avoid recreating them for each node
-	profileRequirements, err := ParseProfileRequirements(profile)
+	profileRequirements, err := parseProfileRequirements(profile)
 	if err != nil {
 		logger.Error(err, "profile selector is invalid, skipping", "datadogagentprofile", profile.Name, "datadogagentprofile_namespace", profile.Namespace)
 		metrics.DAPValid.With(prometheus.Labels{"datadogagentprofile": profile.Name}).Set(metrics.FalseValue)
@@ -376,8 +376,8 @@ func compareProfiles(a, b v1alpha1.DatadogAgentProfile) int {
 	)
 }
 
-// ParseProfileRequirements creates requirements from a profile's node affinity
-func ParseProfileRequirements(profile *v1alpha1.DatadogAgentProfile) ([]*labels.Requirement, error) {
+// parseProfileRequirements creates requirements from a profile's node affinity
+func parseProfileRequirements(profile *v1alpha1.DatadogAgentProfile) ([]*labels.Requirement, error) {
 	if profile == nil || profile.Spec.ProfileAffinity == nil {
 		return nil, nil
 	}
@@ -399,7 +399,7 @@ func ParseProfileRequirements(profile *v1alpha1.DatadogAgentProfile) ([]*labels.
 
 // profileMatchesNodeWithRequirements checks if a node matches the given requirements
 func profileMatchesNodeWithRequirements(requirements []*labels.Requirement, nodeLabels map[string]string) bool {
-	if requirements == nil || len(requirements) == 0 {
+	if len(requirements) == 0 {
 		return true
 	}
 

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -1439,7 +1439,7 @@ func TestParseProfileRequirements(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			requirements, err := ParseProfileRequirements(tt.profile)
+			requirements, err := parseProfileRequirements(tt.profile)
 			assert.Equal(t, tt.expectedRequirements, requirements)
 			if tt.expectedError != nil {
 				assert.Error(t, err)


### PR DESCRIPTION
### What does this PR do?

Refactor requirement generation from profile affinity and node matching so that we generate requirements once per profile instead of generating them for each node. Also separates out requirement generation and node matching into separate functions to help with a future refactor

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Performance impact is minimal since the previous behavior didn't use a significant amount of resources

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

There should be no functional change for existing profiles. Can be confirmed in staging by ensuring the number of nodes with profiles on them doesn't change after this change

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
