### PR TITLE
[documentation] Add cluster name steps in installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,12 +68,12 @@ helm upgrade my-datadog-operator datadog/datadog-operator -f values.yaml
 
 Setting a cluster name is optional but recommended. The cluster name can be configured in the following ways:
 
-1. **Helm chart `clusterName` value** (sets `DD_CLUSTER_NAME` environment variable on the Operator):
+- **Helm chart `clusterName` value** (sets `DD_CLUSTER_NAME` environment variable on the Operator):
    ```yaml
    clusterName: my-cluster
    ```
 
-2. **DatadogAgent CRD `spec.global.clusterName`**:
+- **DatadogAgent CRD `spec.global.clusterName`**:
    ```yaml
    apiVersion: datadoghq.com/v2alpha1
    kind: DatadogAgent


### PR DESCRIPTION
### What does this PR do?

Add step to set clusterName in the installation documentation

### Motivation

If cluster name is not set, the metadata forwarder will be sent without a clusterName (data will be sent w/ empty string) 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
