### PR TITLE
Revert "Add timer_create syscall to system-probe seccomp profile"

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -268,7 +268,6 @@ func DefaultSeccompConfigDataForSystemProbe() map[string]string {
 					"symlinkat",
 					"sysinfo",
 					"tgkill",
-					"timer_create",
 					"tkill",
 					"umask",
 					"uname",


### PR DESCRIPTION
### What does this PR do?

Reverts DataDog/datadog-operator#2274, as there are more syscalls that we need to add to avoid panics in system-probe.

### Motivation

Avoid panics

### Additional Notes



### Minimum Agent Versions


* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Revert PR, no need for testing.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label