### PR TITLE
[AGENTONB-2676] Refactor secret refreshes

### DIFF
--- a/internal/controller/datadogdashboard/controller.go
+++ b/internal/controller/datadogdashboard/controller.go
@@ -43,39 +43,21 @@ type Reconciler struct {
 	client        client.Client
 	datadogClient *datadogV1.DashboardsApi
 	datadogAuth   context.Context
+	credManager   *config.CredentialManager
 	scheme        *runtime.Scheme
 	log           logr.Logger
 	recorder      record.EventRecorder
 }
 
-func NewReconciler(client client.Client, creds config.Creds, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
-	ddClient, err := datadogclient.InitDatadogDashboardClient(log, creds)
-	if err != nil {
-		return &Reconciler{}, err
-	}
-
+func NewReconciler(client client.Client, credManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
 	return &Reconciler{
 		client:        client,
-		datadogClient: ddClient.Client,
-		datadogAuth:   ddClient.Auth,
+		datadogClient: datadogclient.InitDashboardClient(),
+		credManager:   credManager,
 		scheme:        scheme,
 		log:           log,
 		recorder:      recorder,
 	}, nil
-}
-
-func (r *Reconciler) UpdateDatadogClient(newCreds config.Creds) error {
-	r.log.Info("Recreating Datadog client due to credential change", "reconciler", "DatadogDashboard")
-	ddClient, err := datadogclient.InitDatadogDashboardClient(r.log, newCreds)
-	if err != nil {
-		return fmt.Errorf("unable to create Datadog API Client in DatadogDashboard: %w", err)
-	}
-	r.datadogClient = ddClient.Client
-	r.datadogAuth = ddClient.Auth
-
-	r.log.Info("Successfully recreated datadog client due to credential change", "reconciler", "DatadogDashboard")
-
-	return nil
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -135,6 +117,16 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 
 	shouldCreate := false
 	shouldUpdate := false
+
+	// Get fresh credentials and create auth context for this reconcile
+	creds, err := r.credManager.GetCredentials()
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get credentials: %w", err)
+	}
+	r.datadogAuth, err = datadogclient.GetAuth(r.log, creds)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to setup auth: %w", err)
+	}
 
 	if instance.Status.ID == "" {
 		shouldCreate = true

--- a/internal/controller/datadogdashboard/controller.go
+++ b/internal/controller/datadogdashboard/controller.go
@@ -43,17 +43,17 @@ type Reconciler struct {
 	client        client.Client
 	datadogClient *datadogV1.DashboardsApi
 	datadogAuth   context.Context
-	credManager   *config.CredentialManager
+	credsManager  *config.CredentialManager
 	scheme        *runtime.Scheme
 	log           logr.Logger
 	recorder      record.EventRecorder
 }
 
-func NewReconciler(client client.Client, credManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
+func NewReconciler(client client.Client, credsManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
 	return &Reconciler{
 		client:        client,
 		datadogClient: datadogclient.InitDashboardClient(),
-		credManager:   credManager,
+		credsManager:  credsManager,
 		scheme:        scheme,
 		log:           log,
 		recorder:      recorder,
@@ -119,7 +119,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 	shouldUpdate := false
 
 	// Get fresh credentials and create auth context for this reconcile
-	creds, err := r.credManager.GetCredentials()
+	creds, err := r.credsManager.GetCredentials()
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get credentials: %w", err)
 	}

--- a/internal/controller/datadogdashboard/controller_test.go
+++ b/internal/controller/datadogdashboard/controller_test.go
@@ -24,6 +24,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/DataDog/datadog-operator/pkg/datadogclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -182,10 +183,15 @@ func TestReconcileDatadogDashboard_Reconcile(t *testing.T) {
 			t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
 			t.Setenv("DD_URL", httpServer.URL)
 
+			// Parse URL once for the test
+			apiURL, parseErr := datadogclient.ParseURL(logf.Log)
+			assert.NoError(t, parseErr)
+
 			// Set up
 			r := &Reconciler{
 				client:        fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogDashboard{}).Build(),
 				datadogClient: client,
+				apiURL:        apiURL,
 				credsManager:  config.NewCredentialManager(),
 				scheme:        s,
 				recorder:      recorder,

--- a/internal/controller/datadogdashboard/controller_test.go
+++ b/internal/controller/datadogdashboard/controller_test.go
@@ -22,6 +22,7 @@ import (
 	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/stretchr/testify/assert"
 )
@@ -177,13 +178,15 @@ func TestReconcileDatadogDashboard_Reconcile(t *testing.T) {
 			apiClient := datadogapi.NewAPIClient(testConfig)
 			client := datadogV1.NewDashboardsApi(apiClient)
 
-			testAuth := setupTestAuth(httpServer.URL)
+			t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+			t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+			t.Setenv("DD_URL", httpServer.URL)
 
 			// Set up
 			r := &Reconciler{
 				client:        fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogDashboard{}).Build(),
 				datadogClient: client,
-				datadogAuth:   testAuth,
+				credsManager:  config.NewCredentialManager(),
 				scheme:        s,
 				recorder:      recorder,
 				log:           logf.Log.WithName(tt.name),

--- a/internal/controller/datadogdashboard/controller_test.go
+++ b/internal/controller/datadogdashboard/controller_test.go
@@ -22,7 +22,6 @@ import (
 	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
-	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/stretchr/testify/assert"
 )
@@ -256,94 +255,5 @@ func genericDatadogDashboard() *datadoghqv1alpha1.DatadogDashboard {
 			Title:      "test dashboard",
 			LayoutType: "ordered",
 		},
-	}
-}
-
-// TestReconciler_UpdateDatadogClient tests the UpdateDatadogClient method of the Reconciler
-func TestReconciler_UpdateDatadogClient(t *testing.T) {
-	testLogger := zap.New(zap.UseDevMode(true))
-	recorder := record.NewFakeRecorder(10)
-	scheme := scheme.Scheme
-	client := fake.NewClientBuilder().Build()
-
-	tests := []struct {
-		name     string
-		newCreds config.Creds
-		wantErr  bool
-	}{
-		{
-			name: "valid credentials update",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "test-app-key",
-			},
-			wantErr: false,
-		},
-		{
-			name: "empty API key",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "test-app-key",
-			},
-			wantErr: true,
-		},
-		{
-			name: "empty App key",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-		{
-			name: "both keys empty",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create reconciler with initial valid credentials
-			initialCreds := config.Creds{
-				APIKey: "initial-api-key",
-				AppKey: "initial-app-key",
-			}
-			r, err := NewReconciler(client, initialCreds, scheme, testLogger, recorder)
-			assert.NoError(t, err)
-
-			// Store original client and auth references
-			originalClient := r.datadogClient
-			originalAuth := r.datadogAuth
-
-			// Call UpdateDatadogClient
-			err = r.UpdateDatadogClient(tt.newCreds)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				// Verify original client and auth are preserved on error
-				if originalClient != r.datadogClient {
-					t.Errorf("Expected clients to be the same, but they are different")
-				}
-				if originalAuth != r.datadogAuth {
-					t.Errorf("Expected client auth to be the same, but they are different")
-				}
-				assert.Equal(t, originalClient, r.datadogClient)
-				assert.Equal(t, originalAuth, r.datadogAuth)
-			} else {
-				assert.NoError(t, err)
-				// Verify client and auth are recreated
-				// r.datadogAuth
-				if originalClient == r.datadogClient {
-					t.Errorf("Expected clients to be different, but they are the same")
-				}
-				if originalAuth == r.datadogAuth {
-					t.Errorf("Expected auths to be different, but they are the same")
-				}
-			}
-		})
 	}
 }

--- a/internal/controller/datadogdashboard/finalizer.go
+++ b/internal/controller/datadogdashboard/finalizer.go
@@ -20,11 +20,11 @@ const (
 	datadogDashboardFinalizer = "finalizer.datadoghq.com/dashboard"
 )
 
-func (r *Reconciler) handleFinalizer(logger logr.Logger, db *datadoghqv1alpha1.DatadogDashboard) (ctrl.Result, error) {
+func (r *Reconciler) handleFinalizer(auth context.Context, logger logr.Logger, db *datadoghqv1alpha1.DatadogDashboard) (ctrl.Result, error) {
 	// Check if the DatadogDashboard instance is marked to be deleted, which is indicated by the deletion timestamp being set.
 	if db.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(db, datadogDashboardFinalizer) {
-			r.finalizeDatadogDashboard(logger, db)
+			r.finalizeDatadogDashboard(auth, logger, db)
 
 			controllerutil.RemoveFinalizer(db, datadogDashboardFinalizer)
 			err := r.client.Update(context.TODO(), db)
@@ -50,8 +50,8 @@ func (r *Reconciler) handleFinalizer(logger logr.Logger, db *datadoghqv1alpha1.D
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) finalizeDatadogDashboard(logger logr.Logger, db *datadoghqv1alpha1.DatadogDashboard) {
-	err := deleteDashboard(r.datadogAuth, r.datadogClient, db.Status.ID)
+func (r *Reconciler) finalizeDatadogDashboard(auth context.Context, logger logr.Logger, db *datadoghqv1alpha1.DatadogDashboard) {
+	err := deleteDashboard(auth, r.datadogClient, db.Status.ID)
 	if err != nil {
 		logger.Error(err, "failed to finalize dashboard", "dashboard ID", fmt.Sprint(db.Status.ID))
 

--- a/internal/controller/datadogdashboard/finalizer_test.go
+++ b/internal/controller/datadogdashboard/finalizer_test.go
@@ -58,7 +58,7 @@ func Test_handleFinalizer(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			reqLogger := testLogger.WithValues("test:", test.name)
 			_ = r.client.Create(context.TODO(), test.db)
-			_, err := r.handleFinalizer(reqLogger, test.db)
+			_, err := r.handleFinalizer(context.TODO(), reqLogger, test.db)
 			assert.NoError(t, err)
 			if test.finalizerShouldExist {
 				assert.True(t, controllerutil.ContainsFinalizer(test.db, datadogDashboardFinalizer))

--- a/internal/controller/datadogdashboard_controller.go
+++ b/internal/controller/datadogdashboard_controller.go
@@ -22,12 +22,12 @@ import (
 
 // DatadogDashboardReconciler reconciles a DatadogDashboard object
 type DatadogDashboardReconciler struct {
-	Client      client.Client
-	CredManager *config.CredentialManager
-	Log         logr.Logger
-	Scheme      *runtime.Scheme
-	Recorder    record.EventRecorder
-	internal    *datadogdashboard.Reconciler
+	Client       client.Client
+	CredsManager *config.CredentialManager
+	Log          logr.Logger
+	Scheme       *runtime.Scheme
+	Recorder     record.EventRecorder
+	internal     *datadogdashboard.Reconciler
 }
 
 //+kubebuilder:rbac:groups=datadoghq.com,resources=datadogdashboards,verbs=get;list;watch;create;update;patch;delete
@@ -41,7 +41,7 @@ func (r *DatadogDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatadogDashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	internal, err := datadogdashboard.NewReconciler(r.Client, r.CredManager, r.Scheme, r.Log, r.Recorder)
+	internal, err := datadogdashboard.NewReconciler(r.Client, r.CredsManager, r.Scheme, r.Log, r.Recorder)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/datadogdashboard_controller.go
+++ b/internal/controller/datadogdashboard_controller.go
@@ -22,12 +22,12 @@ import (
 
 // DatadogDashboardReconciler reconciles a DatadogDashboard object
 type DatadogDashboardReconciler struct {
-	Client   client.Client
-	Creds    config.Creds
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	internal *datadogdashboard.Reconciler
+	Client      client.Client
+	CredManager *config.CredentialManager
+	Log         logr.Logger
+	Scheme      *runtime.Scheme
+	Recorder    record.EventRecorder
+	internal    *datadogdashboard.Reconciler
 }
 
 //+kubebuilder:rbac:groups=datadoghq.com,resources=datadogdashboards,verbs=get;list;watch;create;update;patch;delete
@@ -41,7 +41,7 @@ func (r *DatadogDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatadogDashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	internal, err := datadogdashboard.NewReconciler(r.Client, r.Creds, r.Scheme, r.Log, r.Recorder)
+	internal, err := datadogdashboard.NewReconciler(r.Client, r.CredManager, r.Scheme, r.Log, r.Recorder)
 	if err != nil {
 		return err
 	}
@@ -57,9 +57,4 @@ func (r *DatadogDashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 	return nil
-}
-
-// Callback function for credential change from credential manager
-func (r *DatadogDashboardReconciler) onCredentialChange(newCreds config.Creds) error {
-	return r.internal.UpdateDatadogClient(newCreds)
 }

--- a/internal/controller/datadoggenericresource/controller.go
+++ b/internal/controller/datadoggenericresource/controller.go
@@ -42,13 +42,13 @@ type Reconciler struct {
 	datadogNotebooksClient  *datadogV1.NotebooksApi
 	datadogMonitorsClient   *datadogV1.MonitorsApi
 	datadogAuth             context.Context
-	credManager             *config.CredentialManager
+	credsManager            *config.CredentialManager
 	scheme                  *runtime.Scheme
 	log                     logr.Logger
 	recorder                record.EventRecorder
 }
 
-func NewReconciler(client client.Client, credManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
+func NewReconciler(client client.Client, credsManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
 	ddClients := datadogclient.InitGenericClients()
 
 	return &Reconciler{
@@ -56,7 +56,7 @@ func NewReconciler(client client.Client, credManager *config.CredentialManager, 
 		datadogSyntheticsClient: ddClients.SyntheticsClient,
 		datadogNotebooksClient:  ddClients.NotebooksClient,
 		datadogMonitorsClient:   ddClients.MonitorsClient,
-		credManager:             credManager,
+		credsManager:            credsManager,
 		scheme:                  scheme,
 		log:                     log,
 		recorder:                recorder,
@@ -109,7 +109,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 	shouldUpdate := false
 
 	// Get fresh credentials and create auth context for this reconcile
-	creds, err := r.credManager.GetCredentials()
+	creds, err := r.credsManager.GetCredentials()
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get credentials: %w", err)
 	}

--- a/internal/controller/datadoggenericresource/controller_test.go
+++ b/internal/controller/datadoggenericresource/controller_test.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
-	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 )
 
@@ -262,107 +261,4 @@ func setupTestAuth(apiURL string) context.Context {
 	})
 
 	return testAuth
-}
-
-// TestReconciler_UpdateDatadogClient tests the UpdateDatadogClient method of the Reconciler
-func TestReconciler_UpdateDatadogClient(t *testing.T) {
-	testLogger := zap.New(zap.UseDevMode(true))
-	recorder := record.NewFakeRecorder(10)
-	scheme := scheme.Scheme
-	client := fake.NewClientBuilder().Build()
-
-	initialCreds := config.Creds{
-		APIKey: "initial-api-key",
-		AppKey: "initial-app-key",
-	}
-
-	// Helper struct + function
-	type clientState struct {
-		syntheticsClient *datadogV1.SyntheticsApi
-		notebooksClient  *datadogV1.NotebooksApi
-		monitorsClient   *datadogV1.MonitorsApi
-		auth             context.Context
-	}
-
-	captureState := func(r *Reconciler) clientState {
-		return clientState{
-			syntheticsClient: r.datadogSyntheticsClient,
-			notebooksClient:  r.datadogNotebooksClient,
-			monitorsClient:   r.datadogMonitorsClient,
-			auth:             r.datadogAuth,
-		}
-	}
-
-	clientsEqual := func(a, b clientState) bool {
-		return a.syntheticsClient == b.syntheticsClient &&
-			a.notebooksClient == b.notebooksClient &&
-			a.monitorsClient == b.monitorsClient &&
-			a.auth == b.auth
-	}
-
-	tests := []struct {
-		name     string
-		newCreds config.Creds
-		wantErr  bool
-	}{
-		{
-			name: "valid credentials update",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "test-app-key",
-			},
-			wantErr: false,
-		},
-		{
-			name: "empty API key",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "test-app-key",
-			},
-			wantErr: true,
-		},
-		{
-			name: "empty App key",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-		{
-			name: "both keys empty",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create reconciler with initial valid credentials
-			r, err := NewReconciler(client, initialCreds, scheme, testLogger, recorder)
-			assert.NoError(t, err)
-
-			// Capture original state
-			originalState := captureState(r)
-
-			// Call UpdateDatadogClient
-			err = r.UpdateDatadogClient(tt.newCreds)
-
-			// Capture new state
-			newState := captureState(r)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				// On error, all clients should remain unchanged
-				assert.True(t, clientsEqual(originalState, newState), "Expected all clients to remain the same on error")
-			} else {
-				assert.NoError(t, err)
-				// On success, all clients should be recreated (different instances)
-				assert.False(t, clientsEqual(originalState, newState), "Expected all clients to be recreated on success")
-			}
-		})
-	}
 }

--- a/internal/controller/datadoggenericresource/controller_test.go
+++ b/internal/controller/datadoggenericresource/controller_test.go
@@ -25,6 +25,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/DataDog/datadog-operator/pkg/datadogclient"
 )
 
 const (
@@ -162,11 +163,16 @@ func TestReconcileGenericResource_Reconcile(t *testing.T) {
 			t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
 			t.Setenv("DD_URL", httpServer.URL)
 
+			// Parse URL once for the test
+			apiURL, parseErr := datadogclient.ParseURL(logf.Log)
+			assert.NoError(t, parseErr)
+
 			// Set up
 			r := &Reconciler{
 				client:                  fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build(),
 				datadogSyntheticsClient: synthClient,
 				datadogNotebooksClient:  nbClient,
+				apiURL:                  apiURL,
 				credsManager:            config.NewCredentialManager(),
 				scheme:                  s,
 				recorder:                recorder,

--- a/internal/controller/datadoggenericresource/finalizer.go
+++ b/internal/controller/datadoggenericresource/finalizer.go
@@ -21,11 +21,11 @@ const (
 	datadogGenericResourceFinalizer = "finalizer.datadoghq.com/genericresource"
 )
 
-func (r *Reconciler) handleFinalizer(logger logr.Logger, instance *datadoghqv1alpha1.DatadogGenericResource) (ctrl.Result, error) {
+func (r *Reconciler) handleFinalizer(auth context.Context, logger logr.Logger, instance *datadoghqv1alpha1.DatadogGenericResource) (ctrl.Result, error) {
 	// Check if the DatadogGenericResource instance is marked to be deleted, which is indicated by the deletion timestamp being set.
 	if instance.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(instance, datadogGenericResourceFinalizer) {
-			r.finalizeDatadogCustomResource(logger, instance)
+			r.finalizeDatadogCustomResource(auth, logger, instance)
 
 			controllerutil.RemoveFinalizer(instance, datadogGenericResourceFinalizer)
 			err := r.client.Update(context.TODO(), instance)
@@ -51,8 +51,8 @@ func (r *Reconciler) handleFinalizer(logger logr.Logger, instance *datadoghqv1al
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) finalizeDatadogCustomResource(logger logr.Logger, instance *datadoghqv1alpha1.DatadogGenericResource) {
-	err := apiDelete(r, instance)
+func (r *Reconciler) finalizeDatadogCustomResource(auth context.Context, logger logr.Logger, instance *datadoghqv1alpha1.DatadogGenericResource) {
+	err := apiDelete(auth, r, instance)
 	if err != nil {
 		logger.Error(err, "failed to finalize ", "custom resource Id", fmt.Sprint(instance.Status.Id))
 

--- a/internal/controller/datadoggenericresource/finalizer_test.go
+++ b/internal/controller/datadoggenericresource/finalizer_test.go
@@ -100,7 +100,7 @@ func Test_handleFinalizer(t *testing.T) {
 			testGcr := &datadoghqv1alpha1.DatadogGenericResource{}
 			err := r.client.Get(context.TODO(), client.ObjectKey{Name: test.resourceName, Namespace: testNamespace}, testGcr)
 
-			_, err = r.handleFinalizer(reqLogger, testGcr)
+			_, err = r.handleFinalizer(context.TODO(), reqLogger, testGcr)
 
 			assert.NoError(t, err)
 			if test.finalizerShouldExist {

--- a/internal/controller/datadoggenericresource/monitors.go
+++ b/internal/controller/datadoggenericresource/monitors.go
@@ -13,8 +13,8 @@ import (
 
 type MonitorHandler struct{}
 
-func (h *MonitorHandler) createResourcefunc(r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
-	createdMonitor, err := createMonitor(r.datadogAuth, r.datadogMonitorsClient, instance)
+func (h *MonitorHandler) createResourcefunc(auth context.Context, r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
+	createdMonitor, err := createMonitor(auth, r.datadogMonitorsClient, instance)
 	if err != nil {
 		logger.Error(err, "error creating monitor")
 		updateErrStatus(status, now, v1alpha1.DatadogSyncStatusCreateError, "CreatingCustomResource", err)
@@ -31,16 +31,16 @@ func (h *MonitorHandler) createResourcefunc(r *Reconciler, logger logr.Logger, i
 	return nil
 }
 
-func (h *MonitorHandler) getResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := getMonitor(r.datadogAuth, r.datadogMonitorsClient, instance.Status.Id)
+func (h *MonitorHandler) getResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := getMonitor(auth, r.datadogMonitorsClient, instance.Status.Id)
 	return err
 }
-func (h *MonitorHandler) updateResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := updateMonitor(r.datadogAuth, r.datadogMonitorsClient, instance)
+func (h *MonitorHandler) updateResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := updateMonitor(auth, r.datadogMonitorsClient, instance)
 	return err
 }
-func (h *MonitorHandler) deleteResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	return deleteMonitor(r.datadogAuth, r.datadogMonitorsClient, instance.Status.Id)
+func (h *MonitorHandler) deleteResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	return deleteMonitor(auth, r.datadogMonitorsClient, instance.Status.Id)
 }
 
 func getMonitor(auth context.Context, client *datadogV1.MonitorsApi, monitorStringID string) (datadogV1.Monitor, error) {

--- a/internal/controller/datadoggenericresource/notebooks.go
+++ b/internal/controller/datadoggenericresource/notebooks.go
@@ -13,8 +13,8 @@ import (
 
 type NotebookHandler struct{}
 
-func (h *NotebookHandler) createResourcefunc(r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
-	createdNotebook, err := createNotebook(r.datadogAuth, r.datadogNotebooksClient, instance)
+func (h *NotebookHandler) createResourcefunc(auth context.Context, r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
+	createdNotebook, err := createNotebook(auth, r.datadogNotebooksClient, instance)
 	if err != nil {
 		logger.Error(err, "error creating notebook")
 		updateErrStatus(status, now, v1alpha1.DatadogSyncStatusCreateError, "CreatingCustomResource", err)
@@ -31,16 +31,16 @@ func (h *NotebookHandler) createResourcefunc(r *Reconciler, logger logr.Logger, 
 	return nil
 }
 
-func (h *NotebookHandler) getResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := getNotebook(r.datadogAuth, r.datadogNotebooksClient, instance.Status.Id)
+func (h *NotebookHandler) getResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := getNotebook(auth, r.datadogNotebooksClient, instance.Status.Id)
 	return err
 }
-func (h *NotebookHandler) updateResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := updateNotebook(r.datadogAuth, r.datadogNotebooksClient, instance)
+func (h *NotebookHandler) updateResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := updateNotebook(auth, r.datadogNotebooksClient, instance)
 	return err
 }
-func (h *NotebookHandler) deleteResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	return deleteNotebook(r.datadogAuth, r.datadogNotebooksClient, instance.Status.Id)
+func (h *NotebookHandler) deleteResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	return deleteNotebook(auth, r.datadogNotebooksClient, instance.Status.Id)
 }
 
 func getNotebook(auth context.Context, client *datadogV1.NotebooksApi, notebookStringID string) (datadogV1.NotebookResponse, error) {

--- a/internal/controller/datadoggenericresource/resource_handler.go
+++ b/internal/controller/datadoggenericresource/resource_handler.go
@@ -1,6 +1,8 @@
 package datadoggenericresource
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -8,8 +10,8 @@ import (
 )
 
 type ResourceHandler interface {
-	createResourcefunc(r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error
-	getResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error
-	updateResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error
-	deleteResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error
+	createResourcefunc(auth context.Context, r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error
+	getResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error
+	updateResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error
+	deleteResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error
 }

--- a/internal/controller/datadoggenericresource/synthetics.go
+++ b/internal/controller/datadoggenericresource/synthetics.go
@@ -14,8 +14,8 @@ import (
 
 type SyntheticsAPITestHandler struct{}
 
-func (h *SyntheticsAPITestHandler) createResourcefunc(r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
-	createdTest, err := createSyntheticsAPITest(r.datadogAuth, r.datadogSyntheticsClient, instance)
+func (h *SyntheticsAPITestHandler) createResourcefunc(auth context.Context, r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
+	createdTest, err := createSyntheticsAPITest(auth, r.datadogSyntheticsClient, instance)
 	if err != nil {
 		logger.Error(err, "error creating API test")
 		updateErrStatus(status, now, v1alpha1.DatadogSyncStatusCreateError, "CreatingCustomResource", err)
@@ -25,22 +25,22 @@ func (h *SyntheticsAPITestHandler) createResourcefunc(r *Reconciler, logger logr
 	return updateStatusFromSyntheticsTest(&createdTest, additionalProperties, status, logger, hash)
 }
 
-func (h *SyntheticsAPITestHandler) getResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := getSyntheticsTest(r.datadogAuth, r.datadogSyntheticsClient, instance.Status.Id)
+func (h *SyntheticsAPITestHandler) getResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := getSyntheticsTest(auth, r.datadogSyntheticsClient, instance.Status.Id)
 	return err
 }
-func (h *SyntheticsAPITestHandler) updateResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := updateSyntheticsAPITest(r.datadogAuth, r.datadogSyntheticsClient, instance)
+func (h *SyntheticsAPITestHandler) updateResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := updateSyntheticsAPITest(auth, r.datadogSyntheticsClient, instance)
 	return err
 }
-func (h *SyntheticsAPITestHandler) deleteResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	return deleteSyntheticTest(r.datadogAuth, r.datadogSyntheticsClient, instance.Status.Id)
+func (h *SyntheticsAPITestHandler) deleteResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	return deleteSyntheticTest(auth, r.datadogSyntheticsClient, instance.Status.Id)
 }
 
 type SyntheticsBrowserTestHandler struct{}
 
-func (h *SyntheticsBrowserTestHandler) createResourcefunc(r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
-	createdTest, err := createSyntheticBrowserTest(r.datadogAuth, r.datadogSyntheticsClient, instance)
+func (h *SyntheticsBrowserTestHandler) createResourcefunc(auth context.Context, r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
+	createdTest, err := createSyntheticBrowserTest(auth, r.datadogSyntheticsClient, instance)
 	if err != nil {
 		logger.Error(err, "error creating browser test")
 		updateErrStatus(status, now, v1alpha1.DatadogSyncStatusCreateError, "CreatingCustomResource", err)
@@ -50,16 +50,16 @@ func (h *SyntheticsBrowserTestHandler) createResourcefunc(r *Reconciler, logger 
 	return updateStatusFromSyntheticsTest(&createdTest, additionalProperties, status, logger, hash)
 }
 
-func (h *SyntheticsBrowserTestHandler) getResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := getSyntheticsTest(r.datadogAuth, r.datadogSyntheticsClient, instance.Status.Id)
+func (h *SyntheticsBrowserTestHandler) getResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := getSyntheticsTest(auth, r.datadogSyntheticsClient, instance.Status.Id)
 	return err
 }
-func (h *SyntheticsBrowserTestHandler) updateResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := updateSyntheticsBrowserTest(r.datadogAuth, r.datadogSyntheticsClient, instance)
+func (h *SyntheticsBrowserTestHandler) updateResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := updateSyntheticsBrowserTest(auth, r.datadogSyntheticsClient, instance)
 	return err
 }
-func (h *SyntheticsBrowserTestHandler) deleteResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	return deleteSyntheticTest(r.datadogAuth, r.datadogSyntheticsClient, instance.Status.Id)
+func (h *SyntheticsBrowserTestHandler) deleteResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	return deleteSyntheticTest(auth, r.datadogSyntheticsClient, instance.Status.Id)
 }
 
 // Synthetic tests (encompass browser and API tests): get

--- a/internal/controller/datadoggenericresource/utils.go
+++ b/internal/controller/datadoggenericresource/utils.go
@@ -1,6 +1,7 @@
 package datadoggenericresource
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -18,7 +19,7 @@ const mockSubresource = "mock_resource"
 
 type MockHandler struct{}
 
-func (h *MockHandler) createResourcefunc(r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
+func (h *MockHandler) createResourcefunc(auth context.Context, r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
 	status.Id = "mock-id"
 	status.Created = &now
 	status.LastForceSyncTime = &now
@@ -28,30 +29,30 @@ func (h *MockHandler) createResourcefunc(r *Reconciler, logger logr.Logger, inst
 	return nil
 }
 
-func (h *MockHandler) getResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+func (h *MockHandler) getResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
 	return nil
 }
-func (h *MockHandler) updateResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+func (h *MockHandler) updateResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
 	return nil
 }
-func (h *MockHandler) deleteResourcefunc(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+func (h *MockHandler) deleteResourcefunc(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
 	return nil
 }
 
-func apiDelete(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	return getHandler(instance.Spec.Type).deleteResourcefunc(r, instance)
+func apiDelete(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	return getHandler(instance.Spec.Type).deleteResourcefunc(auth, r, instance)
 }
 
-func apiGet(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	return getHandler(instance.Spec.Type).getResourcefunc(r, instance)
+func apiGet(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	return getHandler(instance.Spec.Type).getResourcefunc(auth, r, instance)
 }
 
-func apiUpdate(r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
-	return getHandler(instance.Spec.Type).updateResourcefunc(r, instance)
+func apiUpdate(auth context.Context, r *Reconciler, instance *v1alpha1.DatadogGenericResource) error {
+	return getHandler(instance.Spec.Type).updateResourcefunc(auth, r, instance)
 }
 
-func apiCreateAndUpdateStatus(r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
-	return getHandler(instance.Spec.Type).createResourcefunc(r, logger, instance, status, now, hash)
+func apiCreateAndUpdateStatus(auth context.Context, r *Reconciler, logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
+	return getHandler(instance.Spec.Type).createResourcefunc(auth, r, logger, instance, status, now, hash)
 }
 
 func getHandler(resourceType v1alpha1.SupportedResourcesType) ResourceHandler {

--- a/internal/controller/datadoggenericresource/utils_test.go
+++ b/internal/controller/datadoggenericresource/utils_test.go
@@ -1,6 +1,7 @@
 package datadoggenericresource
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -25,13 +26,13 @@ func Test_apiCreateAndUpdateStatus(t *testing.T) {
 	status := &v1alpha1.DatadogGenericResourceStatus{}
 
 	// Valid subresource case
-	err := apiCreateAndUpdateStatus(mockReconciler, *logger, instance, status, metav1.Now(), "test-hash")
+	err := apiCreateAndUpdateStatus(context.TODO(), mockReconciler, *logger, instance, status, metav1.Now(), "test-hash")
 	assert.NoError(t, err)
 
 	// Invalid subresource case
 	instance.Spec.Type = "unsupportedType"
 	assert.PanicsWithError(t, "unsupported type: unsupportedType", func() {
-		apiCreateAndUpdateStatus(mockReconciler, *logger, instance, status, metav1.Now(), "test-hash")
+		apiCreateAndUpdateStatus(context.TODO(), mockReconciler, *logger, instance, status, metav1.Now(), "test-hash")
 	})
 }
 
@@ -43,7 +44,7 @@ func Test_apiGet(t *testing.T) {
 		},
 	}
 
-	err := apiGet(mockReconciler, instance)
+	err := apiGet(context.TODO(), mockReconciler, instance)
 	assert.NoError(t, err)
 }
 
@@ -55,7 +56,7 @@ func Test_apiUpdate(t *testing.T) {
 		},
 	}
 
-	err := apiUpdate(mockReconciler, instance)
+	err := apiUpdate(context.TODO(), mockReconciler, instance)
 	assert.NoError(t, err)
 }
 
@@ -67,7 +68,7 @@ func Test_apiDelete(t *testing.T) {
 		},
 	}
 
-	err := apiDelete(mockReconciler, instance)
+	err := apiDelete(context.TODO(), mockReconciler, instance)
 	assert.NoError(t, err)
 }
 

--- a/internal/controller/datadoggenericresource_controller.go
+++ b/internal/controller/datadoggenericresource_controller.go
@@ -22,12 +22,12 @@ import (
 
 // DatadogGenericResourceReconciler reconciles a DatadogGenericResource object
 type DatadogGenericResourceReconciler struct {
-	Client   client.Client
-	Creds    config.Creds
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	internal *ddgr.Reconciler
+	Client      client.Client
+	CredManager *config.CredentialManager
+	Log         logr.Logger
+	Scheme      *runtime.Scheme
+	Recorder    record.EventRecorder
+	internal    *ddgr.Reconciler
 }
 
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadoggenericresources,verbs=get;list;watch;create;update;patch;delete
@@ -40,7 +40,7 @@ func (r *DatadogGenericResourceReconciler) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatadogGenericResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	internal, err := ddgr.NewReconciler(r.Client, r.Creds, r.Scheme, r.Log, r.Recorder)
+	internal, err := ddgr.NewReconciler(r.Client, r.CredManager, r.Scheme, r.Log, r.Recorder)
 	if err != nil {
 		return err
 	}
@@ -56,9 +56,4 @@ func (r *DatadogGenericResourceReconciler) SetupWithManager(mgr ctrl.Manager) er
 		return err
 	}
 	return nil
-}
-
-// Callback function for credential change from credential manager
-func (r *DatadogGenericResourceReconciler) onCredentialChange(newCreds config.Creds) error {
-	return r.internal.UpdateDatadogClient(newCreds)
 }

--- a/internal/controller/datadoggenericresource_controller.go
+++ b/internal/controller/datadoggenericresource_controller.go
@@ -22,12 +22,12 @@ import (
 
 // DatadogGenericResourceReconciler reconciles a DatadogGenericResource object
 type DatadogGenericResourceReconciler struct {
-	Client      client.Client
-	CredManager *config.CredentialManager
-	Log         logr.Logger
-	Scheme      *runtime.Scheme
-	Recorder    record.EventRecorder
-	internal    *ddgr.Reconciler
+	Client       client.Client
+	CredsManager *config.CredentialManager
+	Log          logr.Logger
+	Scheme       *runtime.Scheme
+	Recorder     record.EventRecorder
+	internal     *ddgr.Reconciler
 }
 
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadoggenericresources,verbs=get;list;watch;create;update;patch;delete
@@ -40,7 +40,7 @@ func (r *DatadogGenericResourceReconciler) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DatadogGenericResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	internal, err := ddgr.NewReconciler(r.Client, r.CredManager, r.Scheme, r.Log, r.Recorder)
+	internal, err := ddgr.NewReconciler(r.Client, r.CredsManager, r.Scheme, r.Log, r.Recorder)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -67,7 +67,7 @@ type Reconciler struct {
 	client                 client.Client
 	datadogClient          *datadogV1.MonitorsApi
 	datadogAuth            context.Context
-	credManager            *config.CredentialManager
+	credsManager           *config.CredentialManager
 	log                    logr.Logger
 	scheme                 *runtime.Scheme
 	recorder               record.EventRecorder
@@ -76,11 +76,11 @@ type Reconciler struct {
 }
 
 // NewReconciler returns a new Reconciler object
-func NewReconciler(client client.Client, credManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder, operatorMetricsEnabled bool, metricForwardersMgr pkgutils.MetricsForwardersManager) (*Reconciler, error) {
+func NewReconciler(client client.Client, credsManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder, operatorMetricsEnabled bool, metricForwardersMgr pkgutils.MetricsForwardersManager) (*Reconciler, error) {
 	return &Reconciler{
 		client:                 client,
 		datadogClient:          datadogclient.InitMonitorClient(),
-		credManager:            credManager,
+		credsManager:           credsManager,
 		scheme:                 scheme,
 		log:                    log,
 		recorder:               recorder,
@@ -146,7 +146,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 	shouldUpdate := false
 
 	// Get fresh credentials and create auth context for this reconcile
-	creds, err := r.credManager.GetCredentials()
+	creds, err := r.credsManager.GetCredentials()
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get credentials: %w", err)
 	}

--- a/internal/controller/datadogmonitor/controller_test.go
+++ b/internal/controller/datadogmonitor/controller_test.go
@@ -30,9 +30,7 @@ import (
 	datadogV1 "github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
-	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 )
 
 const (
@@ -958,94 +956,4 @@ func testAuditMonitor(c client.Client) *datadoghqv1alpha1.DatadogMonitor {
 	}
 	_ = c.Create(context.TODO(), dm)
 	return dm
-}
-
-// TestReconciler_UpdateDatadogClient tests the UpdateDatadogClient method of the Reconciler
-func TestReconciler_UpdateDatadogClient(t *testing.T) {
-	testLogger := zap.New(zap.UseDevMode(true))
-	recorder := record.NewFakeRecorder(10)
-	scheme := scheme.Scheme
-	client := fake.NewClientBuilder().Build()
-	metricForwardersMgr := datadog.NewForwardersManager(client, nil, false, nil)
-
-	tests := []struct {
-		name     string
-		newCreds config.Creds
-		wantErr  bool
-	}{
-		{
-			name: "valid credentials update",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "test-app-key",
-			},
-			wantErr: false,
-		},
-		{
-			name: "empty API key",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "test-app-key",
-			},
-			wantErr: true,
-		},
-		{
-			name: "empty App key",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-		{
-			name: "both keys empty",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create reconciler with initial valid credentials
-			initialCreds := config.Creds{
-				APIKey: "initial-api-key",
-				AppKey: "initial-app-key",
-			}
-			r, err := NewReconciler(client, initialCreds, scheme, testLogger, recorder, false, metricForwardersMgr)
-			assert.NoError(t, err)
-
-			// Store original client and auth references
-			originalClient := r.datadogClient
-			originalAuth := r.datadogAuth
-
-			// Call UpdateDatadogClient
-			err = r.UpdateDatadogClient(tt.newCreds)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				// Verify original client and auth are preserved on error
-				if originalClient != r.datadogClient {
-					t.Errorf("Expected clients to be the same, but they are different")
-				}
-				if originalAuth != r.datadogAuth {
-					t.Errorf("Expected client auth to be the same, but they are different")
-				}
-				assert.Equal(t, originalClient, r.datadogClient)
-				assert.Equal(t, originalAuth, r.datadogAuth)
-			} else {
-				assert.NoError(t, err)
-				// Verify client and auth are recreated
-				// r.datadogAuth
-				if originalClient == r.datadogClient {
-					t.Errorf("Expected clients to be different, but they are the same")
-				}
-				if originalAuth == r.datadogAuth {
-					t.Errorf("Expected auths to be different, but they are the same")
-				}
-			}
-		})
-	}
 }

--- a/internal/controller/datadogmonitor/controller_test.go
+++ b/internal/controller/datadogmonitor/controller_test.go
@@ -30,6 +30,7 @@ import (
 	datadogV1 "github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 )
 
@@ -417,13 +418,15 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 			apiClient := datadogapi.NewAPIClient(testConfig)
 			client := datadogV1.NewMonitorsApi(apiClient)
 
-			testAuth := setupTestAuth(httpServer.URL)
+			t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+			t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+			t.Setenv("DD_URL", httpServer.URL)
 
 			// Set up
 			r := &Reconciler{
 				client:        fake.NewClientBuilder().WithStatusSubresource(&datadoghqv1alpha1.DatadogMonitor{}).Build(),
 				datadogClient: client,
-				datadogAuth:   testAuth,
+				credsManager:  config.NewCredentialManager(),
 				scheme:        s,
 				recorder:      recorder,
 				log:           logf.Log.WithName(tt.name),

--- a/internal/controller/datadogmonitor/controller_test.go
+++ b/internal/controller/datadogmonitor/controller_test.go
@@ -32,6 +32,7 @@ import (
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+	"github.com/DataDog/datadog-operator/pkg/datadogclient"
 )
 
 const (
@@ -422,10 +423,15 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 			t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
 			t.Setenv("DD_URL", httpServer.URL)
 
+			// Parse URL once for the test
+			apiURL, parseErr := datadogclient.ParseURL(logf.Log)
+			assert.NoError(t, parseErr)
+
 			// Set up
 			r := &Reconciler{
 				client:        fake.NewClientBuilder().WithStatusSubresource(&datadoghqv1alpha1.DatadogMonitor{}).Build(),
 				datadogClient: client,
+				apiURL:        apiURL,
 				credsManager:  config.NewCredentialManager(),
 				scheme:        s,
 				recorder:      recorder,

--- a/internal/controller/datadogmonitor/finalizer.go
+++ b/internal/controller/datadogmonitor/finalizer.go
@@ -21,11 +21,11 @@ const (
 	datadogMonitorFinalizer = "finalizer.monitor.datadoghq.com"
 )
 
-func (r *Reconciler) handleFinalizer(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (ctrl.Result, error) {
+func (r *Reconciler) handleFinalizer(auth context.Context, logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) (ctrl.Result, error) {
 	// Check if the DatadogMonitor instance is marked to be deleted, which is indicated by the deletion timestamp being set.
 	if dm.GetDeletionTimestamp() != nil {
 		if controllerutil.ContainsFinalizer(dm, datadogMonitorFinalizer) {
-			r.finalizeDatadogMonitor(logger, dm)
+			r.finalizeDatadogMonitor(auth, logger, dm)
 
 			controllerutil.RemoveFinalizer(dm, datadogMonitorFinalizer)
 			err := r.client.Update(context.TODO(), dm)
@@ -51,9 +51,9 @@ func (r *Reconciler) handleFinalizer(logger logr.Logger, dm *datadoghqv1alpha1.D
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) finalizeDatadogMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) {
+func (r *Reconciler) finalizeDatadogMonitor(auth context.Context, logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) {
 	if dm.Status.Primary {
-		err := deleteMonitor(r.datadogAuth, r.datadogClient, dm.Status.ID)
+		err := deleteMonitor(auth, r.datadogClient, dm.Status.ID)
 		if err != nil {
 			logger.Error(err, "failed to finalize monitor", "Monitor ID", fmt.Sprint(dm.Status.ID))
 

--- a/internal/controller/datadogmonitor/finalizer_test.go
+++ b/internal/controller/datadogmonitor/finalizer_test.go
@@ -90,7 +90,7 @@ func Test_handleFinalizer(t *testing.T) {
 			testMonitor := &datadoghqv1alpha1.DatadogMonitor{}
 			_ = r.client.Get(context.TODO(), client.ObjectKey{Namespace: "foo", Name: test.objectName}, testMonitor)
 
-			_, err := r.handleFinalizer(reqLogger, testMonitor)
+			_, err := r.handleFinalizer(context.TODO(), reqLogger, testMonitor)
 
 			assert.NoError(t, err)
 			if test.finalizerShouldExist {

--- a/internal/controller/datadogmonitor_controller.go
+++ b/internal/controller/datadogmonitor_controller.go
@@ -27,7 +27,7 @@ import (
 // DatadogMonitorReconciler reconciles a DatadogMonitor object.
 type DatadogMonitorReconciler struct {
 	Client                 client.Client
-	Creds                  config.Creds
+	CredManager            *config.CredentialManager
 	Log                    logr.Logger
 	Scheme                 *runtime.Scheme
 	Recorder               record.EventRecorder
@@ -46,7 +46,7 @@ func (r *DatadogMonitorReconciler) Reconcile(ctx context.Context, instance *data
 
 // SetupWithManager creates a new DatadogMonitor controller.
 func (r *DatadogMonitorReconciler) SetupWithManager(mgr ctrl.Manager, metricForwardersMgr datadog.MetricsForwardersManager) error {
-	internal, err := datadogmonitor.NewReconciler(r.Client, r.Creds, r.Scheme, r.Log, r.Recorder, r.operatorMetricsEnabled, metricForwardersMgr)
+	internal, err := datadogmonitor.NewReconciler(r.Client, r.CredManager, r.Scheme, r.Log, r.Recorder, r.operatorMetricsEnabled, metricForwardersMgr)
 	if err != nil {
 		return err
 	}
@@ -70,9 +70,4 @@ func (r *DatadogMonitorReconciler) SetupWithManager(mgr ctrl.Manager, metricForw
 	}
 
 	return nil
-}
-
-// Callback function for credential change from credential manager
-func (r *DatadogMonitorReconciler) onCredentialChange(newCreds config.Creds) error {
-	return r.internal.UpdateDatadogClient(newCreds)
 }

--- a/internal/controller/datadogmonitor_controller.go
+++ b/internal/controller/datadogmonitor_controller.go
@@ -27,7 +27,7 @@ import (
 // DatadogMonitorReconciler reconciles a DatadogMonitor object.
 type DatadogMonitorReconciler struct {
 	Client                 client.Client
-	CredManager            *config.CredentialManager
+	CredsManager           *config.CredentialManager
 	Log                    logr.Logger
 	Scheme                 *runtime.Scheme
 	Recorder               record.EventRecorder
@@ -46,7 +46,7 @@ func (r *DatadogMonitorReconciler) Reconcile(ctx context.Context, instance *data
 
 // SetupWithManager creates a new DatadogMonitor controller.
 func (r *DatadogMonitorReconciler) SetupWithManager(mgr ctrl.Manager, metricForwardersMgr datadog.MetricsForwardersManager) error {
-	internal, err := datadogmonitor.NewReconciler(r.Client, r.CredManager, r.Scheme, r.Log, r.Recorder, r.operatorMetricsEnabled, metricForwardersMgr)
+	internal, err := datadogmonitor.NewReconciler(r.Client, r.CredsManager, r.Scheme, r.Log, r.Recorder, r.operatorMetricsEnabled, metricForwardersMgr)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/datadogslo/controller.go
+++ b/internal/controller/datadogslo/controller.go
@@ -48,17 +48,17 @@ type Reconciler struct {
 	client        client.Client
 	datadogClient *datadogV1.ServiceLevelObjectivesApi
 	datadogAuth   context.Context
-	credManager   *config.CredentialManager
+	credsManager  *config.CredentialManager
 	log           logr.Logger
 	recorder      record.EventRecorder
 }
 
-func NewReconciler(client client.Client, credManager *config.CredentialManager, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
+func NewReconciler(client client.Client, credsManager *config.CredentialManager, log logr.Logger, recorder record.EventRecorder) (*Reconciler, error) {
 	// possibly set URL here
 	return &Reconciler{
 		client:        client,
 		datadogClient: datadogclient.InitSLOClient(),
-		credManager:   credManager,
+		credsManager:  credsManager,
 		log:           log,
 		recorder:      recorder,
 	}, nil
@@ -119,7 +119,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, req reconcile.Reques
 	shouldUpdate := false
 
 	// Get fresh credentials and create auth context for this reconcile
-	creds, err := r.credManager.GetCredentials()
+	creds, err := r.credsManager.GetCredentials()
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get credentials: %w", err)
 	}

--- a/internal/controller/datadogslo/controller_test.go
+++ b/internal/controller/datadogslo/controller_test.go
@@ -29,7 +29,6 @@ import (
 	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/DataDog/datadog-operator/internal/controller/utils"
-	"github.com/DataDog/datadog-operator/pkg/config"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 )
@@ -240,91 +239,4 @@ func setupTestAuth(apiURL string) context.Context {
 	})
 
 	return testAuth
-}
-
-// TestReconciler_UpdateDatadogClient tests the UpdateDatadogClient method of the Reconciler
-func TestReconciler_UpdateDatadogClient(t *testing.T) {
-	testLogger := zap.New(zap.UseDevMode(true))
-	recorder := record.NewFakeRecorder(10)
-	client := fake.NewClientBuilder().Build()
-
-	tests := []struct {
-		name     string
-		newCreds config.Creds
-		wantErr  bool
-	}{
-		{
-			name: "valid credentials update",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "test-app-key",
-			},
-			wantErr: false,
-		},
-		{
-			name: "empty API key",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "test-app-key",
-			},
-			wantErr: true,
-		},
-		{
-			name: "empty App key",
-			newCreds: config.Creds{
-				APIKey: "test-api-key",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-		{
-			name: "both keys empty",
-			newCreds: config.Creds{
-				APIKey: "",
-				AppKey: "",
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create reconciler with initial valid credentials
-			initialCreds := config.Creds{
-				APIKey: "initial-api-key",
-				AppKey: "initial-app-key",
-			}
-			r, err := NewReconciler(client, initialCreds, testLogger, recorder)
-			assert.NoError(t, err)
-
-			// Store original client and auth references
-			originalClient := r.datadogClient
-			originalAuth := r.datadogAuth
-
-			// Call UpdateDatadogClient
-			err = r.UpdateDatadogClient(tt.newCreds)
-
-			if tt.wantErr {
-				assert.Error(t, err)
-				// Verify original client and auth are preserved on error
-				if originalClient != r.datadogClient {
-					t.Errorf("Expected clients to be the same, but they are different")
-				}
-				if originalAuth != r.datadogAuth {
-					t.Errorf("Expected client auth to be the same, but they are different")
-				}
-				assert.Equal(t, originalClient, r.datadogClient)
-				assert.Equal(t, originalAuth, r.datadogAuth)
-			} else {
-				assert.NoError(t, err)
-				// Verify client and auth are recreated
-				if originalClient == r.datadogClient {
-					t.Errorf("Expected clients to be different, but they are the same")
-				}
-				if originalAuth == r.datadogAuth {
-					t.Errorf("Expected auths to be different, but they are the same")
-				}
-			}
-		})
-	}
 }

--- a/internal/controller/datadogslo/controller_test.go
+++ b/internal/controller/datadogslo/controller_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/DataDog/datadog-operator/internal/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/config"
+	"github.com/DataDog/datadog-operator/pkg/datadogclient"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 )
@@ -143,9 +144,15 @@ func TestReconciler_Reconcile(t *testing.T) {
 				tt.mockOn(t, &m)
 			}
 			recorder := record.NewFakeRecorder(5)
+
+			// Parse URL once for the test
+			apiURL, err := datadogclient.ParseURL(testLogger)
+			assert.NoError(t, err)
+
 			r := &Reconciler{
 				client:        m.k8sClient,
 				datadogClient: client,
+				apiURL:        apiURL,
 				credsManager:  config.NewCredentialManager(),
 				recorder:      recorder,
 				log:           testLogger,

--- a/internal/controller/datadogslo_controller.go
+++ b/internal/controller/datadogslo_controller.go
@@ -22,12 +22,12 @@ import (
 )
 
 type DatadogSLOReconciler struct {
-	Client      client.Client
-	CredManager *config.CredentialManager
-	Log         logr.Logger
-	Scheme      *runtime.Scheme
-	Recorder    record.EventRecorder
-	internal    *datadogslo.Reconciler
+	Client       client.Client
+	CredsManager *config.CredentialManager
+	Log          logr.Logger
+	Scheme       *runtime.Scheme
+	Recorder     record.EventRecorder
+	internal     *datadogslo.Reconciler
 }
 
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadogslos,verbs=get;list;watch;create;update;patch;delete
@@ -40,7 +40,7 @@ func (r *DatadogSLOReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 }
 
 func (r *DatadogSLOReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	internal, err := datadogslo.NewReconciler(r.Client, r.CredManager, r.Log, r.Recorder)
+	internal, err := datadogslo.NewReconciler(r.Client, r.CredsManager, r.Log, r.Recorder)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/datadogslo_controller.go
+++ b/internal/controller/datadogslo_controller.go
@@ -22,12 +22,12 @@ import (
 )
 
 type DatadogSLOReconciler struct {
-	Client   client.Client
-	Creds    config.Creds
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	internal *datadogslo.Reconciler
+	Client      client.Client
+	CredManager *config.CredentialManager
+	Log         logr.Logger
+	Scheme      *runtime.Scheme
+	Recorder    record.EventRecorder
+	internal    *datadogslo.Reconciler
 }
 
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadogslos,verbs=get;list;watch;create;update;patch;delete
@@ -40,7 +40,7 @@ func (r *DatadogSLOReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 }
 
 func (r *DatadogSLOReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	internal, err := datadogslo.NewReconciler(r.Client, r.Creds, r.Log, r.Recorder)
+	internal, err := datadogslo.NewReconciler(r.Client, r.CredManager, r.Log, r.Recorder)
 	if err != nil {
 		return err
 	}
@@ -57,8 +57,3 @@ func (r *DatadogSLOReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 var _ reconcile.Reconciler = (*DatadogSLOReconciler)(nil)
-
-// Callback function for credential change from credential manager
-func (r *DatadogSLOReconciler) onCredentialChange(newCreds config.Creds) error {
-	return r.internal.UpdateDatadogClient(newCreds)
-}

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -181,7 +181,7 @@ func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, pInfo kubernet
 
 	monitorReconciler := &DatadogMonitorReconciler{
 		Client:                 mgr.GetClient(),
-		CredManager:            options.CredsManager,
+		CredsManager:           options.CredsManager,
 		Log:                    ctrl.Log.WithName("controllers").WithName(monitorControllerName),
 		Scheme:                 mgr.GetScheme(),
 		Recorder:               mgr.GetEventRecorderFor(monitorControllerName),
@@ -198,11 +198,11 @@ func startDatadogDashboard(logger logr.Logger, mgr manager.Manager, pInfo kubern
 	}
 
 	dashboardReconciler := &DatadogDashboardReconciler{
-		Client:      mgr.GetClient(),
-		CredManager: options.CredsManager,
-		Log:         ctrl.Log.WithName("controllers").WithName(dashboardControllerName),
-		Scheme:      mgr.GetScheme(),
-		Recorder:    mgr.GetEventRecorderFor(dashboardControllerName),
+		Client:       mgr.GetClient(),
+		CredsManager: options.CredsManager,
+		Log:          ctrl.Log.WithName("controllers").WithName(dashboardControllerName),
+		Scheme:       mgr.GetScheme(),
+		Recorder:     mgr.GetEventRecorderFor(dashboardControllerName),
 	}
 
 	return dashboardReconciler.SetupWithManager(mgr)
@@ -215,11 +215,11 @@ func startDatadogGenericResource(logger logr.Logger, mgr manager.Manager, pInfo 
 	}
 
 	genericResourceReconciler := &DatadogGenericResourceReconciler{
-		Client:      mgr.GetClient(),
-		CredManager: options.CredsManager,
-		Log:         ctrl.Log.WithName("controllers").WithName(genericResourceControllerName),
-		Scheme:      mgr.GetScheme(),
-		Recorder:    mgr.GetEventRecorderFor(genericResourceControllerName),
+		Client:       mgr.GetClient(),
+		CredsManager: options.CredsManager,
+		Log:          ctrl.Log.WithName("controllers").WithName(genericResourceControllerName),
+		Scheme:       mgr.GetScheme(),
+		Recorder:     mgr.GetEventRecorderFor(genericResourceControllerName),
 	}
 
 	return genericResourceReconciler.SetupWithManager(mgr)
@@ -232,11 +232,11 @@ func startDatadogSLO(logger logr.Logger, mgr manager.Manager, pInfo kubernetes.P
 	}
 
 	sloReconciler := &DatadogSLOReconciler{
-		Client:      mgr.GetClient(),
-		CredManager: options.CredsManager,
-		Log:         ctrl.Log.WithName("controllers").WithName(sloControllerName),
-		Scheme:      mgr.GetScheme(),
-		Recorder:    mgr.GetEventRecorderFor(sloControllerName),
+		Client:       mgr.GetClient(),
+		CredsManager: options.CredsManager,
+		Log:          ctrl.Log.WithName("controllers").WithName(sloControllerName),
+		Scheme:       mgr.GetScheme(),
+		Recorder:     mgr.GetEventRecorderFor(sloControllerName),
 	}
 
 	return sloReconciler.SetupWithManager(mgr)

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -181,16 +181,11 @@ func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, pInfo kubernet
 
 	monitorReconciler := &DatadogMonitorReconciler{
 		Client:                 mgr.GetClient(),
-		Creds:                  options.Creds,
+		CredManager:            options.CredsManager,
 		Log:                    ctrl.Log.WithName("controllers").WithName(monitorControllerName),
 		Scheme:                 mgr.GetScheme(),
 		Recorder:               mgr.GetEventRecorderFor(monitorControllerName),
 		operatorMetricsEnabled: options.OperatorMetricsEnabled,
-	}
-
-	// set CredentialManager callback - only if secret refresh is enabled
-	if options.CredsManager != nil && options.SecretRefreshInterval > 0 {
-		options.CredsManager.RegisterCallback(monitorReconciler.onCredentialChange)
 	}
 
 	return monitorReconciler.SetupWithManager(mgr, metricForwardersMgr)
@@ -203,15 +198,11 @@ func startDatadogDashboard(logger logr.Logger, mgr manager.Manager, pInfo kubern
 	}
 
 	dashboardReconciler := &DatadogDashboardReconciler{
-		Client:   mgr.GetClient(),
-		Creds:    options.Creds,
-		Log:      ctrl.Log.WithName("controllers").WithName(dashboardControllerName),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(dashboardControllerName),
-	}
-
-	if options.CredsManager != nil && options.SecretRefreshInterval > 0 {
-		options.CredsManager.RegisterCallback(dashboardReconciler.onCredentialChange)
+		Client:      mgr.GetClient(),
+		CredManager: options.CredsManager,
+		Log:         ctrl.Log.WithName("controllers").WithName(dashboardControllerName),
+		Scheme:      mgr.GetScheme(),
+		Recorder:    mgr.GetEventRecorderFor(dashboardControllerName),
 	}
 
 	return dashboardReconciler.SetupWithManager(mgr)
@@ -224,15 +215,11 @@ func startDatadogGenericResource(logger logr.Logger, mgr manager.Manager, pInfo 
 	}
 
 	genericResourceReconciler := &DatadogGenericResourceReconciler{
-		Client:   mgr.GetClient(),
-		Creds:    options.Creds,
-		Log:      ctrl.Log.WithName("controllers").WithName(genericResourceControllerName),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(genericResourceControllerName),
-	}
-
-	if options.CredsManager != nil && options.SecretRefreshInterval > 0 {
-		options.CredsManager.RegisterCallback(genericResourceReconciler.onCredentialChange)
+		Client:      mgr.GetClient(),
+		CredManager: options.CredsManager,
+		Log:         ctrl.Log.WithName("controllers").WithName(genericResourceControllerName),
+		Scheme:      mgr.GetScheme(),
+		Recorder:    mgr.GetEventRecorderFor(genericResourceControllerName),
 	}
 
 	return genericResourceReconciler.SetupWithManager(mgr)
@@ -245,16 +232,13 @@ func startDatadogSLO(logger logr.Logger, mgr manager.Manager, pInfo kubernetes.P
 	}
 
 	sloReconciler := &DatadogSLOReconciler{
-		Client:   mgr.GetClient(),
-		Creds:    options.Creds,
-		Log:      ctrl.Log.WithName("controllers").WithName(sloControllerName),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(sloControllerName),
+		Client:      mgr.GetClient(),
+		CredManager: options.CredsManager,
+		Log:         ctrl.Log.WithName("controllers").WithName(sloControllerName),
+		Scheme:      mgr.GetScheme(),
+		Recorder:    mgr.GetEventRecorderFor(sloControllerName),
 	}
 
-	if options.CredsManager != nil && options.SecretRefreshInterval > 0 {
-		options.CredsManager.RegisterCallback(sloReconciler.onCredentialChange)
-	}
 	return sloReconciler.SetupWithManager(mgr)
 }
 


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

Refactor secret refreshes to remove client recreation (which doesn't need to happen). Also removed callback system since all that needs to be remade is the `auth`. Auth is now remade on every reconcile and passed down as a parameter, instead of a state. 

NOTE: Currently `apiURL` is kept as a field inside the reconcilers. This might require a change once `creds.go` has been refactored. 
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

1. Create a backend script that rotates keys every so often. Here's an example:
```
#!/bin/bash

# Predefined API keys to rotate through (Replace with actual API/APP Keys)
API_KEYS=(
  "API_KEY1"
  "API_KEY2"  
)

APP_KEYS=(
  "APP_KEY1"
  "APP_KEY2"
)

# Time-based rotation: change every minute for testing, cycle through array  
MINUTE=$(date +%M)
API_INDEX=$((MINUTE % ${#API_KEYS[@]}))
APP_INDEX=$((MINUTE % ${#APP_KEYS[@]}))

# Read JSON input from stdin (required by secret backend protocol)
read -r INPUT

# Output JSON in the required format
cat <<EOF
{"api-key":{"value":"${API_KEYS[$API_INDEX]}"},"app-key":{"value":"${APP_KEYS[$APP_INDEX]}"}}
EOF
```
2. Add a volume mount to the manager container with the name of the script as your path. We will be making a configmap out of it. 
Add volumeMount to `manager.yaml`
```
        volumeMounts:
        - name: secret-script
          mountPath: /usr/local/bin/secret/secret_backend.sh
          subPath: secret_backend.sh
```
and volume to pod spec
```
      volumes:
      - name: secret-script
        configMap:
          name: secret-backend-script
          defaultMode: 0755
 ```
 
 3. You should have your kind cluster created already. Create a configmap from your `secret_backend` script.
 ` kubectl create configmap secret-backend-script --from-file=secret_backend.sh`
 
4. Enable all custom resources (or whichever custom resource you want to test client recreation with).
5. Add API/APP key in env vars. Make sure it is encrypted:
```
        - name: DD_API_KEY
          value: "ENC[api-key]"
        - name: DD_APP_KEY
          value: "ENC[app-key]"
```
6. `make deploy` with this configuration in `manager.yaml` (feel free to change refreshInterval; it's short for testing purposes). 
 ```
        - --secretBackendCommand=/usr/local/bin/secret/secret_backend.sh
        - --secretRefreshInterval=30s
 ```
 if the operator fails to find the configMap, run 4. again and delete the pod. 
 
 7. Deploy your custom resources you want to manage: create, delete, update to see if they work. Also, both APIs given should be utilized (you can see this in the API keys of datadog). 

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
