### PR TITLE
Add common env vars to OTel Agent

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -439,7 +439,7 @@ func processAgentContainer(dda metav1.Object) corev1.Container {
 	}
 }
 
-func otelAgentContainer(_ metav1.Object) corev1.Container {
+func otelAgentContainer(dda metav1.Object) corev1.Container {
 	return corev1.Container{
 		Name:  string(apicommon.OtelAgent),
 		Image: fullAgentImage(),
@@ -448,7 +448,7 @@ func otelAgentContainer(_ metav1.Object) corev1.Container {
 			"--core-config=" + agentCustomConfigVolumePath,
 			"--sync-delay=30s",
 		},
-		Env:          []corev1.EnvVar{},
+		Env: commonEnvVars(dda),
 		VolumeMounts: volumeMountsForOtelAgent(),
 		// todo(mackjmr): remove once support for annotations is removed.
 		// the otel-agent feature adds these ports if none are supplied by


### PR DESCRIPTION
### What does this PR do?

#2294 breaks the otel-agent, as it adds `DD_AUTH_TOKEN_FILE_PATH` to core agent but not otel-agent, which leads the otel-agent a bad certificate error that makes otel-agent crash. 

This PR adds  `DD_AUTH_TOKEN_FILE_PATH` to otel-agent bu adding the common env vars.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Launch OTel Agent and ensure it doesn't crash with:
```
Error: failed to sync config at startup, is the core agent listening on 'https://localhost:5009/config/v1' ?
```

Error on core agent side:
```
2025-11-18 13:33:46 UTC | CORE | ERROR | (net/http/server.go:1983 in serve) | Error from the Agent HTTP server 'IPC API Server': http: TLS handshake error from 127.0.0.1:49314: remote error: tls: bad certificate
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
