### PR TITLE
Run amd64 image build to fix mergequeue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,6 @@ generate_code:
 
 build_operator_image_amd64:
   stage: image
-  rules: !reference [.on_build_images]
   tags:
     - "arch:amd64"
   image: $JOB_DOCKER_IMAGE
@@ -115,6 +114,7 @@ build_operator_image_amd64:
 
 build_operator_image_fips_amd64:
   extends: build_operator_image_amd64
+  rules: !reference [.on_build_images]
   variables:
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-amd64
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64
@@ -180,6 +180,7 @@ build_operator_check_image_arm64:
 
 build_bundle_image:
   stage: image
+  rules: !reference [.on_build_images]
   tags:
     - "arch:amd64"
   image: $JOB_DOCKER_IMAGE


### PR DESCRIPTION
### What does this PR do?

- Mergequeue pipelines were failing at the `trigger_e2e_operator_image` step. This is because the job depends on the operator build image with suffix `-amd` to be created, since `trigger_e2e_operator_image` copies that into the CI pipeline
- Added condition to the `build_bundle_image` job so it gets skipped on mergequeue pipelines, as it's not needed

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

previous mergequeue pipeline, which failed the `trigger_e2e_operator_image` step : https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/80709887

current mergequeue pipeline, run off this branch: https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/83169170

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
