### PR TITLE
Run amd64 image build to fix mergequeue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -296,6 +296,7 @@ e2e:
 e2e_mq:
   extends: e2e
   timeout: 40m
+  retry: 0
   rules:
     # Skip if only .md files are changed
     - if: $CI_COMMIT_BRANCH


### PR DESCRIPTION
### What does this PR do?

Mergequeue pipelines were failing at the trigger_e2e_operator_image step. This is because the job depends on the operator build image with suffix -amd to be created, since trigger_e2e_operator_image copies that into the CI pipeline
Added condition to the build_bundle_image job so it gets skipped on mergequeue pipelines, as it's not needed


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

previous mergequeue pipeline, which failed the trigger_e2e_operator_image step : https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/80709887

new mergequeue pipeline: https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/83605577

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
