### PR TITLE
[CASCL-647] Set the disruption part of the NodePools created by `kubectl datadog autoscaling cluster install`

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/install/k8s/nodepool.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/k8s/nodepool.go
@@ -77,6 +77,15 @@ func CreateOrUpdateNodePool(ctx context.Context, client client.Client, np guess.
 					Taints:       np.GetTaints(),
 				},
 			},
+			Disruption: karpv1.Disruption{
+				Budgets: []karpv1.Budget{
+					{
+						Nodes: "10%",
+					},
+				},
+				ConsolidateAfter:    karpv1.MustParseNillableDuration("5m"),
+				ConsolidationPolicy: karpv1.ConsolidationPolicyWhenEmptyOrUnderutilized,
+			},
 		},
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Set the `disruption` part of the `NodePool`s created by `kubectl datadog autoscaling cluster install`.

### Motivation

Karpenter needs the `disruption` part to be properly configured to be able to free some capacity.

### Additional Notes

### Minimum Agent Versions

### Describe your test plan

Run `kubectl datadog autoscaling cluster install` like described in #2301 and check that:
```console
$ kubectl get nodepool/dd-karpenter-coicy -o yaml
```
```yaml
[…]
spec:
  disruption:
    budgets:
    - nodes: 10%
    consolidateAfter: 5m
    consolidationPolicy: WhenEmptyOrUnderutilized
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
