### PR TITLE
[CONS-7872] Always update status hash to match updated spec in update

### DIFF
--- a/internal/controller/datadoggenericresource/controller.go
+++ b/internal/controller/datadoggenericresource/controller.go
@@ -173,12 +173,13 @@ func (r *Reconciler) get(instance *v1alpha1.DatadogGenericResource) error {
 }
 
 func (r *Reconciler) update(logger logr.Logger, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, now metav1.Time, hash string) error {
+	// Update hash to reflect the spec we're attempting to sync (whether it succeeds or fails)
+	status.CurrentHash = hash
+
 	err := apiUpdate(r, instance)
 	if err != nil {
 		logger.Error(err, "error updating generic resource", "generic resource Id", instance.Status.Id)
 		updateErrStatus(status, now, v1alpha1.DatadogSyncStatusUpdateError, "UpdatingGenericResource", err)
-		// Update hash to reflect the spec that was attempted to be updated instead of letting the previous hash remain
-		status.CurrentHash = hash
 		return err
 	}
 
@@ -188,7 +189,6 @@ func (r *Reconciler) update(logger logr.Logger, instance *v1alpha1.DatadogGeneri
 	// Set condition and status
 	condition.UpdateStatusConditions(&status.Conditions, now, condition.DatadogConditionTypeUpdated, metav1.ConditionTrue, "UpdatingGenericResource", "DatadogGenericResource Update")
 	status.SyncStatus = v1alpha1.DatadogSyncStatusOK
-	status.CurrentHash = hash
 	status.LastForceSyncTime = &now
 
 	logger.Info("Updated Datadog Generic Resource", "Generic Resource Id", instance.Status.Id)

--- a/internal/controller/datadogslo/controller.go
+++ b/internal/controller/datadogslo/controller.go
@@ -284,11 +284,12 @@ func (r *Reconciler) get(instance *v1alpha1.DatadogSLO) (*datadogV1.SLOResponseD
 }
 
 func (r *Reconciler) update(logger logr.Logger, instance *v1alpha1.DatadogSLO, status *v1alpha1.DatadogSLOStatus, now metav1.Time, hash string) error {
+	// Update hash to reflect the spec we're attempting to sync (whether it succeeds or fails)
+	status.CurrentHash = hash
+
 	if _, err := updateSLO(r.datadogAuth, r.datadogClient, instance); err != nil {
 		logger.Error(err, "error updating SLO", "SLO ID", instance.Status.ID)
 		updateErrStatus(status, now, v1alpha1.DatadogSLOSyncStatusUpdateError, "UpdatingSLO", err)
-		// Update hash to reflect the spec that was attempted to be updated instead of letting the previous hash remain
-		status.CurrentHash = hash
 		return err
 	}
 	r.recordEvent(instance, buildEventInfo(instance.Name, instance.Namespace, datadog.UpdateEvent))
@@ -296,7 +297,6 @@ func (r *Reconciler) update(logger logr.Logger, instance *v1alpha1.DatadogSLO, s
 	// Set condition and status
 	condition.UpdateStatusConditions(&status.Conditions, now, condition.DatadogConditionTypeUpdated, metav1.ConditionTrue, "UpdatingSLO", "DatadogSLO Updated")
 	status.SyncStatus = v1alpha1.DatadogSLOSyncStatusOK
-	status.CurrentHash = hash
 	status.LastForceSyncTime = &now
 
 	logger.Info("Updated DatadogSLO", "SLO ID", instance.Status.ID)


### PR DESCRIPTION
### What does this PR do?

* For `DatadogDashboard`, `DatadogSLO` and `DatadogGenericResource`, adds updated hash to object when we try to update **whether or not the update succeeds from the API**

### Motivation

* Fixes flow from valid spec A to invalid spec B (valid JSON/object but invalid API-wise, e.g. malformed query) to valid spec A: we'd return early without updating the hash before so the custom resource hash would not reflect the one used for status update, and returning to the same hash would mean we do not trigger reconciliation since status hash = computed hash

### Additional Notes

* This does not apply to `DatadogMonitor` as we have a step to validate the monitor with the API used in the status while the other controllers do not validate "early": their validation comes from the API directly

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Using either controller, apply the example from `examples`, sync it correctly, retrieve the `status.hash` modify the json spec so the query becomes malformed (while still remaining valid JSON), e.g. for a composite monitor generated by GenericResource, add `a` at the end of the query, verify the `status.hash` was updated, object erroring out. Finally, go back to **original** query (remove the `a` for instance), and verify the hash is back to original + the custom resource is OK, not erroring out

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
