### PR TITLE
Set `container-autoscaling` as owner of `kubectl datadog autoscaling`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,5 +21,7 @@ README.md               @DataDog/documentation @DataDog/container-ecosystems
 /internal/controller/datadogagent/feature/helmcheck/*              @DataDog/container-integrations
 /internal/controller/datadogagent/feature/autoscaling/*            @DataDog/container-autoscaling
 
-
 /api/**/datadogpodautoscaler*.go              @DataDog/container-autoscaling
+
+# kubectl plugin
+/cmd/kubectl-datadog/autoscaling/             @DataDog/container-autoscaling


### PR DESCRIPTION
### What does this PR do?

Set @DataDog/container-autoscaling as owner of the `kubectl datadog autoscaling` plugin sub-command.

### Motivation

This sub-command is more linked to the work of the autoscaling team.

### Additional Notes

### Minimum Agent Versions

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
