### PR TITLE
CRD: add configuration reference link to the schema

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -2185,7 +2185,7 @@ type DatadogAgentStatus struct {
 	RemoteConfigConfiguration *RemoteConfigConfiguration `json:"remoteConfigConfiguration,omitempty"`
 }
 
-// DatadogAgent Deployment with the Datadog Operator.
+// DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -250,7 +250,7 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_DatadogAgent(ref common.Refe
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DatadogAgent Deployment with the Datadog Operator.",
+				Description: "DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {

--- a/bundle/manifests/datadog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/datadog-operator.clusterserviceversion.yaml
@@ -229,7 +229,7 @@ spec:
         kind: DatadogAgentProfile
         name: datadogagentprofiles.datadoghq.com
         version: v1alpha1
-      - description: DatadogAgent Deployment with the Datadog Operator.
+      - description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
         displayName: Datadog Agent
         kind: DatadogAgent
         name: datadogagents.datadoghq.com

--- a/bundle/manifests/datadoghq.com_datadogagents.yaml
+++ b/bundle/manifests/datadoghq.com_datadogagents.yaml
@@ -32,7 +32,7 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: DatadogAgent Deployment with the Datadog Operator.
+        description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -32,7 +32,7 @@ spec:
       name: v2alpha1
       schema:
         openAPIV3Schema:
-          description: DatadogAgent Deployment with the Datadog Operator.
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
           properties:
             apiVersion:
               description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1,6 +1,6 @@
 {
   "additionalProperties": false,
-  "description": "DatadogAgent Deployment with the Datadog Operator.",
+  "description": "DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",

--- a/config/manifests/bases/datadog-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/datadog-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ spec:
       kind: DatadogAgentProfile
       name: datadogagentprofiles.datadoghq.com
       version: v1alpha1
-    - description: DatadogAgent Deployment with the Datadog Operator.
+    - description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
       displayName: Datadog Agent
       kind: DatadogAgent
       name: datadogagents.datadoghq.com

--- a/marketplaces/charts/google-marketplace/chart/datadog-mp/templates/manifests.yaml
+++ b/marketplaces/charts/google-marketplace/chart/datadog-mp/templates/manifests.yaml
@@ -17849,7 +17849,7 @@ spec:
       name: v2alpha1
       schema:
         openAPIV3Schema:
-          description: DatadogAgent Deployment with the Datadog Operator.
+          description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
           properties:
             apiVersion:
               description: |-


### PR DESCRIPTION
### What does this PR do?

Add configuration reference link to the schema

### Motivation

CRD installed from https://github.com/DataDog/helm-charts has property descriptions removed (https://github.com/DataDog/helm-charts/pull/450) to overcome CRD size limit which renders `kubectl explain` useless.

With this change (and a modification to description removal logic to preserve schema description https://github.com/DataDog/helm-charts/pull/2197) cluster administrator can easier locate Agent configuration documentation via `kubectl explain`:
```
% kubectl explain datadogagent
GROUP:      datadoghq.com
KIND:       DatadogAgent
VERSION:    v2alpha1

DESCRIPTION:
    DatadogAgent defines Agent configuration, see reference
    https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
...
```

### Additional Notes

The same link was used in #2266.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
