### PR TITLE
Add chart name to label selector for helm metadata

### DIFF
--- a/pkg/controller/utils/metadata/helm_metadata.go
+++ b/pkg/controller/utils/metadata/helm_metadata.go
@@ -43,7 +43,6 @@ var (
 	allowedCharts = map[string]bool{
 		"datadog":          true,
 		"datadog-operator": true,
-		"datadog-agent":    true, // internal agent chart
 	}
 )
 
@@ -355,69 +354,68 @@ func (hmf *HelmMetadataForwarder) discoverAllHelmReleases(ctx context.Context) (
 
 	namespacesToSearch := getWatchNamespacesForHelm(hmf.logger)
 	for _, namespace := range namespacesToSearch {
-		listOpts := []client.ListOption{
-			client.MatchingLabels{"owner": "helm"},
-		}
-		if namespace != "" {
-			listOpts = append(listOpts, client.InNamespace(namespace))
-		}
+		for chartName := range allowedCharts {
+			listOpts := []client.ListOption{
+				client.MatchingLabels{
+					"owner": "helm",
+					"name":  chartName,
+				},
+			}
+			if namespace != "" {
+				listOpts = append(listOpts, client.InNamespace(namespace))
+			}
 
-		secretList := &corev1.SecretList{}
-		if err := hmf.k8sClient.List(ctx, secretList, listOpts...); err != nil {
-			hmf.logger.Error(err, "Error listing Secrets for Helm releases", "namespace", namespace)
-			allErrors = append(allErrors, fmt.Errorf("secrets in namespace %s: %w", namespace, err))
-		} else {
-			hmf.logger.V(1).Info("Scanning Secrets for Helm releases", "namespace", namespace, "total_secrets", len(secretList.Items))
-			for _, secret := range secretList.Items {
-				if !strings.HasPrefix(secret.Name, releasePrefix) {
-					continue
-				}
-
-				if release, releaseName, revision, ok := hmf.parseHelmResource(secret.Name, secret.Data["release"]); ok {
-					if !allowedCharts[release.Chart.Metadata.Name] {
+			secretList := &corev1.SecretList{}
+			if err := hmf.k8sClient.List(ctx, secretList, listOpts...); err != nil {
+				hmf.logger.Error(err, "Error listing Secrets for Helm releases", "namespace", namespace, "chart", chartName)
+				allErrors = append(allErrors, fmt.Errorf("secrets in namespace %s for chart %s: %w", namespace, chartName, err))
+			} else {
+				hmf.logger.V(1).Info("Scanning Secrets for Helm releases", "namespace", namespace, "chart", chartName, "total_secrets", len(secretList.Items))
+				for _, secret := range secretList.Items {
+					if !strings.HasPrefix(secret.Name, releasePrefix) {
 						continue
 					}
-					key := fmt.Sprintf("%s/%s", secret.Namespace, releaseName)
-					if existing, exists := latestReleases[key]; !exists || revision > existing.revision {
-						latestReleases[key] = struct {
-							release  HelmReleaseMinimal
-							uid      string
-							revision int
-						}{
-							release:  *release,
-							uid:      string(secret.UID),
-							revision: revision,
+
+					if release, releaseName, revision, ok := hmf.parseHelmResource(secret.Name, secret.Data["release"]); ok {
+						key := fmt.Sprintf("%s/%s", secret.Namespace, releaseName)
+						if existing, exists := latestReleases[key]; !exists || revision > existing.revision {
+							latestReleases[key] = struct {
+								release  HelmReleaseMinimal
+								uid      string
+								revision int
+							}{
+								release:  *release,
+								uid:      string(secret.UID),
+								revision: revision,
+							}
 						}
 					}
 				}
 			}
-		}
 
-		cmList := &corev1.ConfigMapList{}
-		if err := hmf.k8sClient.List(ctx, cmList, listOpts...); err != nil {
-			hmf.logger.Error(err, "Error listing ConfigMaps for Helm releases", "namespace", namespace)
-			allErrors = append(allErrors, fmt.Errorf("configmaps in namespace %s: %w", namespace, err))
-		} else {
-			hmf.logger.V(1).Info("Scanning ConfigMaps for Helm releases", "namespace", namespace, "total_configmaps", len(cmList.Items))
-			for _, cm := range cmList.Items {
-				if !strings.HasPrefix(cm.Name, releasePrefix) {
-					continue
-				}
-
-				if release, releaseName, revision, ok := hmf.parseHelmResource(cm.Name, []byte(cm.Data["release"])); ok {
-					if !allowedCharts[release.Chart.Metadata.Name] {
+			cmList := &corev1.ConfigMapList{}
+			if err := hmf.k8sClient.List(ctx, cmList, listOpts...); err != nil {
+				hmf.logger.Error(err, "Error listing ConfigMaps for Helm releases", "namespace", namespace, "chart", chartName)
+				allErrors = append(allErrors, fmt.Errorf("configmaps in namespace %s for chart %s: %w", namespace, chartName, err))
+			} else {
+				hmf.logger.V(1).Info("Scanning ConfigMaps for Helm releases", "namespace", namespace, "chart", chartName, "total_configmaps", len(cmList.Items))
+				for _, cm := range cmList.Items {
+					if !strings.HasPrefix(cm.Name, releasePrefix) {
 						continue
 					}
-					key := fmt.Sprintf("%s/%s", cm.Namespace, releaseName)
-					if existing, exists := latestReleases[key]; !exists || revision > existing.revision {
-						latestReleases[key] = struct {
-							release  HelmReleaseMinimal
-							uid      string
-							revision int
-						}{
-							release:  *release,
-							uid:      string(cm.UID),
-							revision: revision,
+
+					if release, releaseName, revision, ok := hmf.parseHelmResource(cm.Name, []byte(cm.Data["release"])); ok {
+						key := fmt.Sprintf("%s/%s", cm.Namespace, releaseName)
+						if existing, exists := latestReleases[key]; !exists || revision > existing.revision {
+							latestReleases[key] = struct {
+								release  HelmReleaseMinimal
+								uid      string
+								revision int
+							}{
+								release:  *release,
+								uid:      string(cm.UID),
+								revision: revision,
+							}
 						}
 					}
 				}


### PR DESCRIPTION
### What does this PR do?

Listing all charts in a cluster was causing period cpu spikes -- this PR filters by chart name up front rather than after the list of helm releases has been retrieved.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

- Install multiple helm charts, including at least one that gets tracked by the metadata forwarder (`datadog` or `datadog-operator`) and at least one that doesn't (wpa, datadog-crds, eds, etc)
- Check that the debug logs of the metadata forwarder only finds releases in secrets or configmaps that correspond to allowed charts. 
ex: previously, i had 11 secrets detected due to one release being datadog-crds. Now I see the debug log message corresponding only to the number of secrets for datadog-operator:
<img width="699" height="231" alt="image" src="https://github.com/user-attachments/assets/ff8817cd-28a2-4ed7-960f-ecbe439ba8c6" />

before:
 `Scanning Secrets for Helm releases","namespace":"default","total_secrets":11}`
after:
```
{"level":"DEBUG","ts":"2025-11-26T20:07:44.725Z","logger":"metadata","msg":"Scanning Secrets for Helm releases","namespace":"default","chart":"datadog","total_secrets":0}
{"level":"DEBUG","ts":"2025-11-26T20:07:44.739Z","logger":"metadata","msg":"Scanning Secrets for Helm releases","namespace":"default","chart":"datadog-operator","total_secrets":10}
```

e2e testing:
- check that CPU spikes decrease compared to previous versions
- https://ddstaging.datadoghq.com/notebook/13521117/sarah-nov-26-2025-14-51

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
