### PR TITLE
Add globaly HostPID when system-probe is enabled

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -8,7 +8,6 @@ package agent
 import (
 	"fmt"
 	"path/filepath"
-	"slices"
 	"strconv"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
@@ -54,9 +53,6 @@ func NewDefaultAgentPodTemplateSpec(dda metav1.Object, agentComponent feature.Re
 		agentContainers = agentOptimizedContainers(dda, requiredContainers)
 	}
 
-	// Check if system-probe container is required, and enable HostPID if so
-	hostPID := slices.Contains(requiredContainers, apicommon.SystemProbeContainerName)
-
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      labels,
@@ -71,7 +67,6 @@ func NewDefaultAgentPodTemplateSpec(dda metav1.Object, agentComponent feature.Re
 			InitContainers:     initContainers(dda, requiredContainers),
 			Containers:         agentContainers,
 			Volumes:            volumesForAgent(dda, requiredContainers),
-			HostPID:            hostPID,
 		},
 	}
 }

--- a/internal/controller/datadogagent/feature/cws/feature.go
+++ b/internal/controller/datadogagent/feature/cws/feature.go
@@ -182,6 +182,9 @@ func (f *cwsFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplate
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	// enable HostPID for system-probe
+	managers.PodTemplateSpec().Spec.HostPID = true
+
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
 

--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -88,6 +88,9 @@ func (f *npmFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplate
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	// enable HostPID for system-probe
+	managers.PodTemplateSpec().Spec.HostPID = true
+
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
 

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -101,6 +101,9 @@ func (f *usmFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplate
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	// enable HostPID for system-probe
+	managers.PodTemplateSpec().Spec.HostPID = true
+
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where when system-probe is enabled, it might lack HostPID namespace configuration.

If not present system-probe/cws won't be able to resolve any groups/containers and would flood logs like:
```
WARN | (pkg/security/resolvers/process/resolver_ebpf.go:390 in enrichEventFromProcfs) | snapshot failed for 1: couldn't parse container and cgroup context: file does not exist
WARN | (pkg/security/resolvers/cgroup/resolver.go:235 in resolvePidCgroupFallback) | Fallback to resolve cgroup for 1, missing parend PPID: 0
```

### Motivation

Fix customer deployments (many zendesk tickets for the same issue).

### Describe your test plan

Change has been QA using minikube with the customer values to ensure we got the issue without the fix, and it get fixed with the fix.

Here's the used values file:
```
kind: DatadogAgent
apiVersion: datadoghq.com/v2alpha1
metadata:
  name: datadog
  namespace: openshift-operators # set as the same namespace where the Datadog Operator was deployed
spec:
  features:
    apm:
      enabled: false
      hostPortConfig:
        enabled: true
      unixDomainSocketConfig:
        enabled: false
    clusterChecks:
      enabled: true
      useClusterChecksRunners: true
    dogstatsd:
      unixDomainSocketConfig:
        enabled: false
    eventCollection:
      collectKubernetesEvents: true
    liveContainerCollection:
      enabled: true
    liveProcessCollection:
      enabled: true
    logCollection:
      autoMultiLineDetection: true
      containerCollectAll: true
      enabled: true
    npm:
      collectDNSStats: true
      enableConntrack: true
      enabled: true
  global:
    credentials:
      apiSecret:
        keyName: api-key
        secretName: datadog-secret
      appSecret:
        keyName: app-key
        secretName: datadog-secret
    clusterName: mas-prd.stlmsd.com
    kubelet:
      tlsVerify: false
  override:
    clusterAgent:
      containers:
        cluster-agent:
          securityContext:
            readOnlyRootFilesystem: false
      replicas: 2
      serviceAccountName: datadog-agent-scc
    nodeAgent:
      serviceAccountName: datadog-agent-scc
      hostNetwork: true
      securityContext:
        runAsUser: 0
        seLinuxOptions:
          level: s0
          role: system_r
          type: spc_t
          user: system_u
      tolerations:
        - key: node-role.kubernetes.io/master
          operator: Exists
          effect: NoSchedule
        - key: node-role.kubernetes.io/infra
          operator: Exists
          effect: NoSchedule

```


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
