### PR TITLE
[CONTP-1059] feat(dca): Adds /metrics get permissions to DCA

### DIFF
--- a/internal/controller/datadogagent/component/clusteragent/rbac.go
+++ b/internal/controller/datadogagent/component/clusteragent/rbac.go
@@ -75,7 +75,7 @@ func getLeaderElectionPolicyRuleDCA(dda metav1.Object) []rbacv1.PolicyRule {
 
 // GetDefaultClusterAgentClusterRolePolicyRules returns the default policy rules for the Cluster Agent
 // Can be used by the Agent if the Cluster Agent is disabled
-func GetDefaultClusterAgentClusterRolePolicyRules(dda metav1.Object) []rbacv1.PolicyRule {
+func GetDefaultClusterAgentClusterRolePolicyRules(_ metav1.Object) []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{rbac.CoreAPIGroup},
@@ -101,7 +101,7 @@ func GetDefaultClusterAgentClusterRolePolicyRules(dda metav1.Object) []rbacv1.Po
 			Verbs:     []string{rbac.GetVerb, rbac.ListVerb},
 		},
 		{
-			NonResourceURLs: []string{rbac.VersionURL, rbac.HealthzURL},
+			NonResourceURLs: []string{rbac.VersionURL, rbac.HealthzURL, rbac.MetricsURL},
 			Verbs:           []string{rbac.GetVerb},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

Gives the DCA permissions to GET `/metrics` k8s api server resource. Needed for work to [collect feature gate data](https://github.com/DataDog/datadog-agent/pull/43733) in the cluster agent.

### Describe your test plan


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
