### PR TITLE
Add dependency to trigger_e2e_operator_image gitlab job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,6 +256,8 @@ build_bundle_image:
 trigger_e2e_operator_image:
   stage: e2e
   rules: !reference [.on_run_e2e_base]
+  needs:
+    - build_operator_image_amd64
   trigger:
     project: DataDog/public-images
     branch: main


### PR DESCRIPTION
### What does this PR do?

Adds dependency job to the `trigger_e2e_operator_image` gitlab job. It now requires the `build_operator_image_amd64` job in order to run.

### Motivation

The `trigger_e2e_operator_image` job relies on the docker image created by the `build_operator_image_amd64` job. Previously, the `trigger_e2e` job would run on branches did not run the prerequisite `build_operator` job. This CI failure blocks mergequeue from merging these branches. 

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
