### PR TITLE
[AGENTONB-1702] Early exit if no credentials despite controllers requiring them

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -257,8 +257,10 @@ func run(opts *options) error {
 
 	credsManager := config.NewCredentialManager()
 	creds, err := credsManager.GetCredentials()
-	if err != nil && opts.datadogMonitorEnabled {
-		return setupErrorf(setupLog, err, "Unable to get credentials for DatadogMonitor")
+
+	// Checks if credentials are mandatory due to a resource controller being enabled
+	if checkErr := checkRequiredCredentials(opts, err); checkErr != nil {
+		return checkErr
 	}
 
 	if opts.secretRefreshInterval > 0 && opts.secretBackendCommand == "" {
@@ -500,6 +502,24 @@ func customSetupHealthChecks(logger logr.Logger, mgr manager.Manager, maximumGor
 func setupErrorf(logger logr.Logger, err error, msg string, keysAndValues ...any) error {
 	setupLog.Error(err, msg, keysAndValues...)
 	return fmt.Errorf("%s, err:%w", msg, err)
+}
+
+// checkRequiredCredentials checks if credentials are required by any enabled controllers
+// and returns an error if they are required but the provided error indicates they
+// could not be obtained.
+func checkRequiredCredentials(opts *options, credErr error) error {
+	// Check if credentials are required by any enabled controllers
+	requireCreds := opts.datadogMonitorEnabled || opts.datadogDashboardEnabled || opts.datadogSLOEnabled || opts.datadogGenericResourceEnabled
+
+	if requireCreds && credErr != nil {
+		return setupErrorf(setupLog, credErr, "Unable to retrieve Datadog API credentials required by one or more enabled controllers",
+			"DatadogMonitor", opts.datadogMonitorEnabled,
+			"DatadogDashboard", opts.datadogDashboardEnabled,
+			"DatadogSLO", opts.datadogSLOEnabled,
+			"DatadogGenericResource", opts.datadogGenericResourceEnabled)
+	}
+
+	return nil
 }
 
 func setupAndStartOperatorMetadataForwarder(logger logr.Logger, client client.Reader, kubernetesVersion string, options *options, credsManager *config.CredentialManager) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,199 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-operator/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRequiredCredentials(t *testing.T) {
+	credErr := errors.New("empty API key and/or App key")
+	expectedErr := fmt.Errorf("Unable to retrieve Datadog API credentials required by one or more enabled controllers, err:%w", credErr)
+
+	tests := []struct {
+		name                          string
+		datadogMonitorEnabled         bool
+		datadogDashboardEnabled       bool
+		datadogSLOEnabled             bool
+		datadogGenericResourceEnabled bool
+		setupEnv                      func()
+		cleanupEnv                    func()
+		wantErr                       error
+	}{
+		{
+			name:                          "no controllers enabled, no credentials required",
+			datadogMonitorEnabled:         false,
+			datadogDashboardEnabled:       false,
+			datadogSLOEnabled:             false,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			cleanupEnv: func() {},
+			wantErr:    nil,
+		},
+		{
+			name:                          "monitor controller enabled, credentials present",
+			datadogMonitorEnabled:         true,
+			datadogDashboardEnabled:       false,
+			datadogSLOEnabled:             false,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Setenv("DD_API_KEY", "test-api-key")
+				os.Setenv("DD_APP_KEY", "test-app-key")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			wantErr: nil,
+		},
+		{
+			name:                          "monitor controller enabled, credentials missing",
+			datadogMonitorEnabled:         true,
+			datadogDashboardEnabled:       false,
+			datadogSLOEnabled:             false,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			cleanupEnv: func() {},
+			wantErr:    expectedErr,
+		},
+		{
+			name:                          "dashboard controller enabled, credentials missing",
+			datadogMonitorEnabled:         false,
+			datadogDashboardEnabled:       true,
+			datadogSLOEnabled:             false,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			cleanupEnv: func() {},
+			wantErr:    expectedErr,
+		},
+		{
+			name:                          "SLO controller enabled, credentials missing",
+			datadogMonitorEnabled:         false,
+			datadogDashboardEnabled:       false,
+			datadogSLOEnabled:             true,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			cleanupEnv: func() {},
+			wantErr:    expectedErr,
+		},
+		{
+			name:                          "generic resource controller enabled, credentials missing",
+			datadogMonitorEnabled:         false,
+			datadogDashboardEnabled:       false,
+			datadogSLOEnabled:             false,
+			datadogGenericResourceEnabled: true,
+			setupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			cleanupEnv: func() {},
+			wantErr:    expectedErr,
+		},
+		{
+			name:                          "multiple controllers enabled, credentials present",
+			datadogMonitorEnabled:         true,
+			datadogDashboardEnabled:       true,
+			datadogSLOEnabled:             true,
+			datadogGenericResourceEnabled: true,
+			setupEnv: func() {
+				os.Setenv("DD_API_KEY", "test-api-key")
+				os.Setenv("DD_APP_KEY", "test-app-key")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			wantErr: nil,
+		},
+		{
+			name:                          "multiple controllers enabled, credentials missing",
+			datadogMonitorEnabled:         true,
+			datadogDashboardEnabled:       false,
+			datadogSLOEnabled:             true,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			cleanupEnv: func() {},
+			wantErr:    expectedErr,
+		},
+		{
+			name:                          "only API key present, controller enabled - should fail",
+			datadogMonitorEnabled:         true,
+			datadogDashboardEnabled:       false,
+			datadogSLOEnabled:             false,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Setenv("DD_API_KEY", "test-api-key")
+				os.Unsetenv("DD_APP_KEY")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+			},
+			wantErr: expectedErr,
+		},
+		{
+			name:                          "only APP key present, controller enabled - should fail",
+			datadogMonitorEnabled:         false,
+			datadogDashboardEnabled:       true,
+			datadogSLOEnabled:             false,
+			datadogGenericResourceEnabled: false,
+			setupEnv: func() {
+				os.Unsetenv("DD_API_KEY")
+				os.Setenv("DD_APP_KEY", "test-app-key")
+			},
+			cleanupEnv: func() {
+				os.Unsetenv("DD_APP_KEY")
+			},
+			wantErr: expectedErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupEnv()
+			defer tt.cleanupEnv()
+
+			opts := &options{
+				datadogMonitorEnabled:         tt.datadogMonitorEnabled,
+				datadogDashboardEnabled:       tt.datadogDashboardEnabled,
+				datadogSLOEnabled:             tt.datadogSLOEnabled,
+				datadogGenericResourceEnabled: tt.datadogGenericResourceEnabled,
+			}
+
+			credsManager := config.NewCredentialManager()
+			_, err := credsManager.GetCredentials()
+			err = checkRequiredCredentials(opts, err)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Errors out and quits the manager process if credentials are not present despite being required for controllers to work

### Motivation

This pattern existed for `DatadogMonitor` solely, but other resource controllers can benefit from it

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Start with usual deploy (e.g. `make deploy`) without creds and ensure manager process runs since no resource controllers but Agent is enabled ootb
* Enable generic resource controller and verifies it errors out and CLBOs:
    ```json
    {"level":"ERROR","ts":"2025-12-09T14:56:10.809Z","logger":"setup","msg":"Unable to retrieve Datadog API credentials required by one or more enabled controllers","DatadogMonitor":false,"DatadogDashboard":false,"DatadogSLO":false,"DatadogGenericResource":true,"error":"empty API key and/or App key","stacktrace":"main.setupErrorf\n\t/workspace/cmd/main.go:509\nmain.run\n\t/workspace/cmd/main.go:265\nmain.main\n\t/workspace/cmd/main.go:204\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:285"}
    ```
    ```console
    ╰─❯ k get pod
    NAME                                        READY   STATUS             RESTARTS      AGE
    datadog-operator-manager-67b79b87df-4t6zc   0/1     CrashLoopBackOff   2 (20s ago)   44s
    ```
* Add api key and app key foo and verifies it recovers/is able to run without the error


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
