### PR TITLE
Update default Agent version to 7.73.0

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -15,9 +15,9 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.72.4"
+	AgentLatestVersion = "7.73.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.72.4"
+	ClusterAgentLatestVersion = "7.73.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.17"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry


### PR DESCRIPTION
### What does this PR do?

* Defaults Agent/DCA to 7.73.0

### Motivation

* Release

### Additional Notes

Original PR is https://github.com/DataDog/datadog-operator/pull/2390 but can't be backported since ddot was only added for 1.22 https://github.com/DataDog/datadog-operator/pull/2317

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
