### PR TITLE
Bump golang to 1.25.5 (#2382)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 env:
-  GO_VERSION: 1.25.3
+  GO_VERSION: 1.25.5
 on:
   push:
 # Permission forced by repo-level setting; only elevate on job-level

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.25.3
+  GO_VERSION: 1.25.5
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   # packages: read
 env:
-  GO_VERSION: 1.25.3
+  GO_VERSION: 1.25.5
 jobs:
   build-linux-binary:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/yaml-mapper.yml
+++ b/.github/workflows/yaml-mapper.yml
@@ -12,7 +12,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.25.3
+  GO_VERSION: 1.25.5
 jobs:
   yaml-mapper-test:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/images/mirror/library/golang:1.25.3
+image: registry.ddbuild.io/images/mirror/library/golang:1.25.5
 variables:
   PROJECTNAME: "datadog-operator"
   PROJECTNAME_CHECK: "datadog-operator-check"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG FIPS_ENABLED=false
 
 # Build the manager binary
-FROM golang:1.25.3 AS builder
+FROM golang:1.25.5 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator/api
 
 go 1.25
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.34.0

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.3 AS builder
+FROM golang:1.25.5 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator
 
 go 1.25
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 replace github.com/DataDog/extendeddaemonset v0.10.0-rc.4 => github.com/DataDog/extendeddaemonset/api v0.0.0-20250108205105-6c4d337b78a1
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.3
+go 1.25.5
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 use (
 	.

--- a/hack/update-golang.sh
+++ b/hack/update-golang.sh
@@ -14,6 +14,13 @@ source "$SCRIPTS_DIR/os-env.sh"
 JQ="$ROOT/bin/$PLATFORM/jq"
 YQ="$ROOT/bin/$PLATFORM/yq"
 
+# Set SED command based on OS
+if [[ "$OS" == "darwin" ]]; then
+    SED="gsed"
+else
+    SED="sed"
+fi
+
 # Ensure jq and yq are available
 if [[ ! -x "$JQ" ]]; then
     echo "Error: jq is not executable or found at $JQ"
@@ -43,7 +50,7 @@ new_minor_version=$major.$minor
 go_work_file="$ROOT/go.work"
 if [[ -f $go_work_file ]]; then
     echo "Processing $go_work_file..."
-    sed -i -E "s/^go [^ ].*/go $GOVERSION/gm" "$go_work_file"
+    $SED -i -E "s/^go [^ ].*/go $GOVERSION/gm" "$go_work_file"
 else
     echo "Warning: $go_work_file not found, skipping."
 fi
@@ -52,7 +59,7 @@ fi
 dev_container_file="$ROOT/.devcontainer/devcontainer.json"
 if [[ -f $dev_container_file ]]; then
     echo "Processing $dev_container_file..."
-    sed -i -E "s|(mcr\.microsoft\.com/devcontainers/go:)[^\"]+|\1dev-$new_minor_version|" "$dev_container_file"
+    $SED -i -E "s|(mcr\.microsoft\.com/devcontainers/go:)[^\"]+|\1dev-$new_minor_version|" "$dev_container_file"
 else
     echo "Warning: $dev_container_file not found, skipping."
 fi
@@ -62,7 +69,7 @@ dockerfile_files="$ROOT/Dockerfile $ROOT/check-operator.Dockerfile"
 for file in $dockerfile_files; do
     if [[ -f $file ]]; then
         echo "Processing $file..."
-        sed -i -E "s|(FROM golang:)[^ ]+|\1$GOVERSION|" "$file"
+        $SED -i -E "s|(FROM golang:)[^ ]+|\1$GOVERSION|" "$file"
     else
         echo "Warning: $file not found, skipping."
     fi
@@ -72,7 +79,7 @@ done
 gitlab_file="$ROOT/.gitlab-ci.yml"
 if [[ -f $gitlab_file ]]; then
     echo "Processing $gitlab_file..."
-    sed -i -E "s|(image: registry\.ddbuild\.io/images/mirror/library/golang:)[^ ]+|\1$GOVERSION|" "$gitlab_file"
+    $SED -i -E "s|(image: registry\.ddbuild\.io/images/mirror/library/golang:)[^ ]+|\1$GOVERSION|" "$gitlab_file"
 else
     echo "Warning: $gitlab_file not found, skipping."
 fi

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator/test/e2e
 
 go 1.25
 
-toolchain go1.25.3
+toolchain go1.25.5
 
 replace (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types => github.com/DataDog/datadog-agent/comp/core/tagger/types v0.63.0-rc.1


### PR DESCRIPTION
* Bump golang to 1.25.5

* revert devcontainer change

* fix missing go update

---------

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
