### PR TITLE
Metadata forwarder creds refactor (#2351)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -255,17 +255,6 @@ func run(opts *options) error {
 	secrets.SetSecretBackendCommand(opts.secretBackendCommand)
 	secrets.SetSecretBackendArgs(opts.secretBackendArgs)
 
-	credsManager := config.NewCredentialManager()
-	creds, err := credsManager.GetCredentials()
-	if err != nil && opts.datadogMonitorEnabled {
-		return setupErrorf(setupLog, err, "Unable to get credentials for DatadogMonitor")
-	}
-
-	if opts.secretRefreshInterval > 0 && opts.secretBackendCommand == "" {
-		setupLog.Error(nil, "secretRefreshInterval is set but secretBackendCommand is not configured")
-	} else if opts.secretBackendCommand != "" && opts.secretRefreshInterval > 0 {
-		go credsManager.StartCredentialRefreshRoutine(opts.secretRefreshInterval, setupLog)
-	}
 	renewDeadline := opts.leaderElectionLeaseDuration / 2
 	retryPeriod := opts.leaderElectionLeaseDuration / 4
 
@@ -306,6 +295,19 @@ func run(opts *options) error {
 	if err != nil {
 		return setupErrorf(setupLog, err, "Unable to start manager")
 
+	}
+
+	// Client is needed when Creds should be resolved from DDA so cached client is fine
+	credsManager := config.NewCredentialManagerWithDecryptor(mgr.GetClient(), secrets.NewSecretBackend())
+	creds, err := credsManager.GetCredentials()
+	if err != nil && opts.datadogMonitorEnabled {
+		return setupErrorf(setupLog, err, "Unable to get credentials for DatadogMonitor")
+	}
+
+	if opts.secretRefreshInterval > 0 && opts.secretBackendCommand == "" {
+		setupLog.Error(nil, "secretRefreshInterval is set but secretBackendCommand is not configured")
+	} else if opts.secretBackendCommand != "" && opts.secretRefreshInterval > 0 {
+		go credsManager.StartCredentialRefreshRoutine(opts.secretRefreshInterval, setupLog)
 	}
 
 	// Custom setup

--- a/internal/controller/datadogagent/testutils/client_utils.go
+++ b/internal/controller/datadogagent/testutils/client_utils.go
@@ -42,6 +42,7 @@ func TestScheme() *runtime.Scheme {
 	s.AddKnownTypes(apiregistrationv1.SchemeGroupVersion, &apiregistrationv1.APIService{})
 	s.AddKnownTypes(networkingv1.SchemeGroupVersion, &networkingv1.NetworkPolicy{})
 	s.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgent{})
+	s.AddKnownTypes(v2alpha1.GroupVersion, &v2alpha1.DatadogAgentList{})
 	s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.DatadogAgentInternal{})
 	s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.DatadogAgentInternalList{})
 	s.AddKnownTypes(apiextensionv1.SchemeGroupVersion, &apiextensionv1.CustomResourceDefinition{})

--- a/pkg/config/creds_test.go
+++ b/pkg/config/creds_test.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	testutils_test "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 	"github.com/go-logr/logr"
-
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_getCredentials(t *testing.T) {
@@ -203,7 +205,9 @@ func Test_getCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			credsManager := NewCredentialManager()
+			s := testutils_test.TestScheme()
+			client := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v2alpha1.DatadogAgent{}).Build()
+			credsManager := NewCredentialManager(client)
 			decryptor := tt.setupFunc(credsManager)
 			credsManager.secretBackend = decryptor
 			got, err := credsManager.GetCredentials()
@@ -271,8 +275,9 @@ func Test_refresh(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer tt.resetFunc()
-
-			cm := NewCredentialManager()
+			s := testutils_test.TestScheme()
+			client := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&v2alpha1.DatadogAgent{}).Build()
+			cm := NewCredentialManager(client)
 			decryptor := tt.setupFunc(cm)
 			cm.secretBackend = decryptor
 

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -210,7 +210,7 @@ func Test_setupFromOperator(t *testing.T) {
 				k8sClient:    fake.NewFakeClient(),
 				decryptor:    d,
 				creds:        sync.Map{},
-				credsManager: config.NewCredentialManager(),
+				credsManager: config.NewCredentialManager(fake.NewFakeClient()),
 			}
 			if tt.loadFunc != nil {
 				tt.loadFunc(mf, d)
@@ -424,7 +424,7 @@ func Test_setupFromDDA(t *testing.T) {
 				k8sClient:    fake.NewFakeClient(),
 				decryptor:    d,
 				creds:        sync.Map{},
-				credsManager: config.NewCredentialManager(),
+				credsManager: config.NewCredentialManager(fake.NewFakeClient()),
 			}
 
 			err := mf.setupFromDDA(tt.args.dda, tt.args.credsSetFromOperator)
@@ -599,7 +599,7 @@ func Test_getCredentialsFromDDA(t *testing.T) {
 				k8sClient:    tt.fields.client,
 				decryptor:    d,
 				creds:        sync.Map{},
-				credsManager: config.NewCredentialManager(),
+				credsManager: config.NewCredentialManager(fake.NewFakeClient()),
 			}
 			if tt.args.loadFunc != nil {
 				tt.args.loadFunc(mf, d)

--- a/pkg/controller/utils/metadata/credential_setup_test.go
+++ b/pkg/controller/utils/metadata/credential_setup_test.go
@@ -1,0 +1,365 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metadata
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	testutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
+	"github.com/DataDog/datadog-operator/pkg/config"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+)
+
+// mockDecryptor implements secrets.Decryptor interface for testing
+type mockDecryptor struct{}
+
+func (m *mockDecryptor) Decrypt(encrypted []string) (map[string]string, error) {
+	decrypted := make(map[string]string)
+	for _, enc := range encrypted {
+		if strings.HasPrefix(enc, "ENC[") && strings.HasSuffix(enc, "]") {
+			// Extract content between ENC[ and ]
+			content := enc[4 : len(enc)-1]
+			decrypted[enc] = content + "-decrypted"
+		} else {
+			decrypted[enc] = enc // Pass through if not encrypted
+		}
+	}
+	return decrypted, nil
+}
+
+func TestSetupRequestPrerequisites(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupEnv        func()
+		setupDDA        func() []client.Object
+		wantAPIKey      string
+		wantURL         string
+		wantClusterName string
+		wantErr         bool
+	}{
+		// Pure operator credential tests
+		{
+			name: "operator creds with default site",
+			setupEnv: func() {
+				os.Setenv(constants.DDAPIKey, "operator-api-key")
+				os.Setenv(constants.DDAppKey, "operator-app-key")
+				os.Setenv(constants.DDHostName, "test-hostname")
+				os.Setenv(constants.DDClusterName, "test-cluster")
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{} // No DDA needed
+			},
+			wantAPIKey:      "operator-api-key",
+			wantURL:         "https://app.datadoghq.com/api/v1/metadata",
+			wantClusterName: "test-cluster",
+			wantErr:         false,
+		},
+		{
+			name: "operator creds with custom site via DD_SITE",
+			setupEnv: func() {
+				os.Setenv(constants.DDAPIKey, "operator-api-key")
+				os.Setenv(constants.DDAppKey, "operator-app-key")
+				os.Setenv(constants.DDHostName, "test-hostname")
+				os.Setenv(constants.DDClusterName, "test-cluster")
+				os.Setenv("DD_SITE", "datadoghq.eu")
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{} // No DDA needed
+			},
+			wantAPIKey:      "operator-api-key",
+			wantURL:         "https://app.datadoghq.eu/api/v1/metadata",
+			wantClusterName: "test-cluster",
+			wantErr:         false,
+		},
+		{
+			name: "operator creds with custom URL via DD_URL",
+			setupEnv: func() {
+				os.Setenv(constants.DDAPIKey, "operator-api-key")
+				os.Setenv(constants.DDAppKey, "operator-app-key")
+				os.Setenv(constants.DDHostName, "test-hostname")
+				os.Setenv(constants.DDClusterName, "test-cluster")
+				os.Setenv("DD_URL", "https://custom.datadoghq.com")
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{} // No DDA needed
+			},
+			wantAPIKey:      "operator-api-key",
+			wantURL:         "https://custom.datadoghq.com/api/v1/metadata",
+			wantClusterName: "test-cluster",
+			wantErr:         false,
+		},
+		// Pure DDA credential tests
+		{
+			name: "DDA with plaintext API key and default site",
+			setupEnv: func() {
+				os.Setenv(constants.DDHostName, "test-hostname")
+				// No operator credentials
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{
+					&v2alpha1.DatadogAgent{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-dda",
+							Namespace: "default",
+						},
+						Spec: v2alpha1.DatadogAgentSpec{
+							Global: &v2alpha1.GlobalConfig{
+								ClusterName: apiutils.NewStringPointer("dda-cluster-name"),
+								Credentials: &v2alpha1.DatadogCredentials{
+									APIKey: apiutils.NewStringPointer("dda-api-key"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wantAPIKey:      "dda-api-key",
+			wantURL:         "https://app.datadoghq.com/api/v1/metadata",
+			wantClusterName: "dda-cluster-name",
+			wantErr:         false,
+		},
+		{
+			name: "DDA with API key and custom site",
+			setupEnv: func() {
+				os.Setenv(constants.DDHostName, "test-hostname")
+				// No operator credentials
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{
+					&v2alpha1.DatadogAgent{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-dda",
+							Namespace: "default",
+						},
+						Spec: v2alpha1.DatadogAgentSpec{
+							Global: &v2alpha1.GlobalConfig{
+								ClusterName: apiutils.NewStringPointer("dda-eu-cluster"),
+								Credentials: &v2alpha1.DatadogCredentials{
+									APIKey: apiutils.NewStringPointer("dda-api-key"),
+								},
+								Site: apiutils.NewStringPointer("datadoghq.eu"),
+							},
+						},
+					},
+				}
+			},
+			wantAPIKey:      "dda-api-key",
+			wantURL:         "https://app.datadoghq.eu/api/v1/metadata",
+			wantClusterName: "dda-eu-cluster",
+			wantErr:         false,
+		},
+		{
+			name: "DDA with secret reference",
+			setupEnv: func() {
+				os.Setenv(constants.DDHostName, "test-hostname")
+				// No operator credentials
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{
+					&v2alpha1.DatadogAgent{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-dda",
+							Namespace: "default",
+						},
+						Spec: v2alpha1.DatadogAgentSpec{
+							Global: &v2alpha1.GlobalConfig{
+								ClusterName: apiutils.NewStringPointer("dda-secret-cluster"),
+								Credentials: &v2alpha1.DatadogCredentials{
+									APISecret: &v2alpha1.SecretConfig{
+										SecretName: "datadog-secret",
+										KeyName:    "api-key",
+									},
+									AppSecret: &v2alpha1.SecretConfig{
+										SecretName: "datadog-secret",
+										KeyName:    "app-key",
+									},
+								},
+							},
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "datadog-secret",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"api-key": []byte("secret-api-key"),
+						},
+					},
+				}
+			},
+			wantAPIKey:      "secret-api-key",
+			wantURL:         "https://app.datadoghq.com/api/v1/metadata",
+			wantClusterName: "dda-secret-cluster",
+			wantErr:         false,
+		},
+		{
+			name: "DDA with encrypted API key",
+			setupEnv: func() {
+				os.Setenv(constants.DDHostName, "test-hostname")
+				// No operator credentials
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{
+					&v2alpha1.DatadogAgent{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-dda",
+							Namespace: "default",
+						},
+						Spec: v2alpha1.DatadogAgentSpec{
+							Global: &v2alpha1.GlobalConfig{
+								ClusterName: apiutils.NewStringPointer("dda-encrypted-cluster"),
+								Credentials: &v2alpha1.DatadogCredentials{
+									APIKey: apiutils.NewStringPointer("ENC[encrypted-api-key]"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wantAPIKey:      "encrypted-api-key-decrypted", // Mock decrypts "ENC[encrypted-api-key]" to this
+			wantURL:         "https://app.datadoghq.com/api/v1/metadata",
+			wantClusterName: "dda-encrypted-cluster",
+			wantErr:         false,
+		},
+		// Mixed/fallback tests
+		{
+			name: "operator creds without cluster name falls back to DDA cluster name but operator API key",
+			setupEnv: func() {
+				os.Setenv(constants.DDAPIKey, "operator-api-key")
+				os.Setenv(constants.DDAppKey, "operator-app-key")
+				os.Setenv(constants.DDHostName, "test-hostname")
+				// Note: No DD_CLUSTER_NAME set to trigger fallback
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{
+					&v2alpha1.DatadogAgent{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-dda",
+							Namespace: "default",
+						},
+						Spec: v2alpha1.DatadogAgentSpec{
+							Global: &v2alpha1.GlobalConfig{
+								ClusterName: apiutils.NewStringPointer("dda-cluster-name"),
+								Credentials: &v2alpha1.DatadogCredentials{
+									APIKey: apiutils.NewStringPointer("dda-fallback-key"),
+								},
+							},
+						},
+					},
+				}
+			},
+			wantAPIKey:      "operator-api-key", // Uses operator API key
+			wantURL:         "https://app.datadoghq.com/api/v1/metadata",
+			wantClusterName: "dda-cluster-name", // Gets cluster name from DDA
+			wantErr:         false,
+		},
+		// Error cases
+		{
+			name: "missing hostname should fail",
+			setupEnv: func() {
+				os.Setenv(constants.DDAPIKey, "operator-api-key")
+				os.Setenv(constants.DDAppKey, "operator-app-key")
+				// No DDHostName set
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{} // No DDA
+			},
+			wantClusterName: "", // Not relevant for error case
+			wantErr:         true,
+		},
+		{
+			name: "no credentials anywhere should fail",
+			setupEnv: func() {
+				os.Setenv(constants.DDHostName, "test-hostname")
+				// No operator credentials
+			},
+			setupDDA: func() []client.Object {
+				return []client.Object{} // No DDA
+			},
+			wantClusterName: "", // Not relevant for error case
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			tt.setupEnv()
+
+			// Create test client with DDA resources
+			scheme := testutils.TestScheme()
+			clientObjects := tt.setupDDA()
+
+			// Add kube-system namespace for cluster UID
+			kubeSystem := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-system",
+					UID:  "test-cluster-uid",
+				},
+			}
+			clientObjects = append(clientObjects, kubeSystem)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v2alpha1.DatadogAgent{}).WithObjects(clientObjects...).Build()
+
+			credsManager := config.NewCredentialManagerWithDecryptor(client, &mockDecryptor{})
+			omf := &OperatorMetadataForwarder{
+				SharedMetadata: NewSharedMetadata(
+					zap.New(zap.UseDevMode(true)),
+					client,
+					"v1.28.0",
+					"v1.0.0",
+					credsManager,
+				),
+				OperatorMetadata: OperatorMetadata{},
+			}
+
+			// Call setupRequestPrerequisites
+			req, err := omf.createRequest([]byte("test"))
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NotNil(t, req)
+
+			// Verify no error
+			require.NoError(t, err)
+
+			// Verify API key is set correctly
+			apiKey, requestURL, _ := omf.getApiKeyAndURL()
+			assert.Equal(t, tt.wantAPIKey, *apiKey, "API key should match expected value")
+
+			// Verify URL is set correctly
+			assert.Equal(t, tt.wantURL, *requestURL, "Request URL should match expected value")
+
+			// Verify cluster name is set correctly
+			assert.Equal(t, tt.wantClusterName, omf.GetOrCreateClusterName(), "Cluster name should match expected value")
+
+			// Verify headers are set with correct API key
+			assert.Equal(t, "Datadog Operator/0.0.0", req.Header.Get("User-Agent"), "User-Agent header should be set")
+			assert.Equal(t, tt.wantAPIKey, req.Header.Get("Dd-Api-Key"), "Header should contain correct API key")
+			assert.Equal(t, "application/json", req.Header.Get("Content-Type"), "Content-Type header should be set")
+			assert.Equal(t, "application/json", req.Header.Get("Accept"), "Accept header should be set")
+
+			// Verify cluster UID is set
+			clusterUID, err := omf.GetOrCreateClusterUID()
+			assert.NoError(t, err)
+			assert.NotEmpty(t, clusterUID, "Cluster UID should be set")
+		})
+	}
+}

--- a/pkg/controller/utils/metadata/helm_metadata_test.go
+++ b/pkg/controller/utils/metadata/helm_metadata_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-operator/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -28,7 +29,7 @@ func Test_HelmMetadataForwarder_getPayload(t *testing.T) {
 	expectedChartVersion := "3.10.0"
 	expectedAppVersion := "7.50.0"
 
-	hmf := NewHelmMetadataForwarder(zap.New(zap.UseDevMode(true)), nil, expectedKubernetesVersion, expectedOperatorVersion, config.NewCredentialManager())
+	hmf := NewHelmMetadataForwarder(zap.New(zap.UseDevMode(true)), nil, expectedKubernetesVersion, expectedOperatorVersion, config.NewCredentialManager(fake.NewFakeClient()))
 
 	// Set required fields
 	hmf.hostName = expectedHostname
@@ -132,7 +133,7 @@ func Test_HelmMetadataForwarder_getPayload(t *testing.T) {
 }
 
 func Test_parseHelmResource(t *testing.T) {
-	hmf := NewHelmMetadataForwarder(zap.New(zap.UseDevMode(true)), nil, "v1.28.0", "v1.19.0", config.NewCredentialManager())
+	hmf := NewHelmMetadataForwarder(zap.New(zap.UseDevMode(true)), nil, "v1.28.0", "v1.19.0", config.NewCredentialManager(fake.NewFakeClient()))
 
 	// Create a minimal valid Helm release JSON
 	releaseData := HelmReleaseMinimal{
@@ -278,7 +279,7 @@ func Test_allHelmReleasesCache(t *testing.T) {
 }
 
 func Test_mergeValues(t *testing.T) {
-	hmf := NewHelmMetadataForwarder(zap.New(zap.UseDevMode(true)), nil, "v1.28.0", "v1.19.0", config.NewCredentialManager())
+	hmf := NewHelmMetadataForwarder(zap.New(zap.UseDevMode(true)), nil, "v1.28.0", "v1.19.0", config.NewCredentialManager(fake.NewFakeClient()))
 
 	tests := []struct {
 		name      string

--- a/pkg/controller/utils/metadata/operator_metadata.go
+++ b/pkg/controller/utils/metadata/operator_metadata.go
@@ -6,12 +6,10 @@
 package metadata
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -20,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/pkg/config"
-	"github.com/DataDog/datadog-operator/pkg/version"
 )
 
 const (
@@ -32,8 +29,6 @@ const (
 type OperatorMetadataForwarder struct {
 	*SharedMetadata
 
-	// Operator-specific fields
-	payloadHeader    http.Header
 	OperatorMetadata OperatorMetadata
 }
 
@@ -71,36 +66,28 @@ type OperatorMetadata struct {
 
 // NewOperatorMetadataForwarder creates a new instance of the operator metadata forwarder
 func NewOperatorMetadataForwarder(logger logr.Logger, k8sClient client.Reader, kubernetesVersion string, operatorVersion string, credsManager *config.CredentialManager) *OperatorMetadataForwarder {
+	forwarderLogger := logger.WithName("operator")
 	return &OperatorMetadataForwarder{
-		SharedMetadata:   NewSharedMetadata(logger, k8sClient, kubernetesVersion, operatorVersion, credsManager),
+		SharedMetadata:   NewSharedMetadata(forwarderLogger, k8sClient, kubernetesVersion, operatorVersion, credsManager),
 		OperatorMetadata: OperatorMetadata{},
 	}
 }
 
 // Start starts the operator metadata forwarder
 func (omf *OperatorMetadataForwarder) Start() {
-	err := omf.setCredentials()
-	if err != nil {
-		omf.logger.Error(err, "Could not set credentials; not starting operator metadata forwarder")
-		return
-	}
-
 	if omf.hostName == "" {
-		omf.logger.Error(ErrEmptyHostName, "Could not set host name; not starting operator metadata forwarder")
+		omf.logger.Error(ErrEmptyHostName, "Could not set host name; not starting metadata forwarder")
 		return
 	}
-
-	omf.payloadHeader = omf.getHeaders()
-
 	omf.updateResourceCounts()
 
-	omf.logger.Info("Starting operator metadata forwarder")
+	omf.logger.Info("Starting metadata forwarder")
 
 	ticker := time.NewTicker(defaultInterval)
 	go func() {
 		for range ticker.C {
 			if err := omf.sendMetadata(); err != nil {
-				omf.logger.Error(err, "Error while sending operator metadata")
+				omf.logger.Error(err, "Error while sending metadata")
 			}
 		}
 	}()
@@ -116,35 +103,25 @@ func (omf *OperatorMetadataForwarder) Start() {
 func (omf *OperatorMetadataForwarder) sendMetadata() error {
 	clusterUID, err := omf.GetOrCreateClusterUID()
 	if err != nil {
-		omf.logger.Error(err, "Failed to get cluster UID")
-		return err
+		return fmt.Errorf("error getting cluster UID: %w", err)
 	}
 	payload := omf.GetPayload(clusterUID)
-
-	omf.logger.Info("Operator metadata payload", "payload", string(payload))
-
-	omf.logger.V(1).Info("Sending operator metadata to URL", "url", omf.requestURL)
-
-	reader := bytes.NewReader(payload)
-	req, err := http.NewRequestWithContext(context.TODO(), "POST", omf.requestURL, reader)
+	req, err := omf.createRequest(payload)
 	if err != nil {
-		omf.logger.Error(err, "Error creating request", "url", omf.requestURL, "reader", reader)
-		return err
+		return fmt.Errorf("error creating request: %w", err)
 	}
-	req.Header = omf.payloadHeader
-
 	resp, err := omf.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error sending operator metadata request: %w", err)
+		return fmt.Errorf("error sending metadata request: %w", err)
 	}
 
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed to read operator metadata response body: %w", err)
+		return fmt.Errorf("failed to read metadata response body: %w", err)
 	}
 
-	omf.logger.V(1).Info("Read operator metadata response", "status code", resp.StatusCode, "body", string(body))
+	omf.logger.V(1).Info("Read metadata response", "status code", resp.StatusCode, "body", string(body))
 	return nil
 }
 
@@ -152,7 +129,7 @@ func (omf *OperatorMetadataForwarder) GetPayload(clusterUID string) []byte {
 	now := time.Now().Unix()
 
 	omf.OperatorMetadata.ClusterID = clusterUID
-	omf.OperatorMetadata.ClusterName = omf.clusterName
+	omf.OperatorMetadata.ClusterName = omf.GetOrCreateClusterName()
 	omf.OperatorMetadata.OperatorVersion = omf.operatorVersion
 	omf.OperatorMetadata.KubernetesVersion = omf.kubernetesVersion
 
@@ -160,7 +137,7 @@ func (omf *OperatorMetadataForwarder) GetPayload(clusterUID string) []byte {
 		Hostname:    omf.hostName,
 		Timestamp:   now,
 		ClusterID:   clusterUID,
-		ClusterName: omf.clusterName,
+		ClusterName: omf.GetOrCreateClusterName(),
 		Metadata:    omf.OperatorMetadata,
 	}
 
@@ -170,16 +147,6 @@ func (omf *OperatorMetadataForwarder) GetPayload(clusterUID string) []byte {
 	}
 
 	return jsonPayload
-}
-
-func (omf *OperatorMetadataForwarder) setCredentials() error {
-	return omf.SharedMetadata.setCredentials()
-}
-
-func (omf *OperatorMetadataForwarder) getHeaders() http.Header {
-	headers := omf.GetBaseHeaders()
-	headers.Set(userAgentHTTPHeaderKey, fmt.Sprintf("Datadog Operator/%s", version.GetVersion()))
-	return headers
 }
 
 // updateResourceCounts refreshes resource counts and stores them in OperatorMetadata.ResourceCounts

--- a/pkg/controller/utils/metadata/shared_metadata.go
+++ b/pkg/controller/utils/metadata/shared_metadata.go
@@ -6,26 +6,24 @@
 package metadata
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/secrets"
+	"github.com/DataDog/datadog-operator/pkg/version"
 )
 
 const (
@@ -41,8 +39,6 @@ const (
 )
 
 var (
-	// ErrEmptyAPIKey empty APIKey error
-	ErrEmptyAPIKey = errors.New("empty api key")
 	// ErrEmptyHostName empty HostName error
 	ErrEmptyHostName = errors.New("empty host name")
 )
@@ -53,19 +49,15 @@ type SharedMetadata struct {
 	logger    logr.Logger
 
 	// Shared metadata fields
-	apiKey            string
 	clusterUID        string
 	clusterName       string
 	operatorVersion   string
 	kubernetesVersion string
-	requestURL        string
 	hostName          string
 	httpClient        *http.Client
 
 	// Shared credential management
 	credsManager *config.CredentialManager
-	decryptor    secrets.Decryptor
-	creds        sync.Map
 }
 
 // NewSharedMetadata creates a new instance of shared metadata
@@ -75,14 +67,37 @@ func NewSharedMetadata(logger logr.Logger, k8sClient client.Reader, kubernetesVe
 		logger:            logger,
 		operatorVersion:   operatorVersion,
 		kubernetesVersion: kubernetesVersion,
-		requestURL:        getURL(),
 		hostName:          os.Getenv(constants.DDHostName),
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
 		credsManager: credsManager,
-		decryptor:    secrets.NewSecretBackend(),
 	}
+}
+
+func (sm *SharedMetadata) createRequest(payload []byte) (*http.Request, error) {
+	if sm.hostName == "" {
+		sm.logger.Error(ErrEmptyHostName, "Could not set host name; not starting metadata forwarder")
+		return nil, ErrEmptyHostName
+	}
+
+	apiKey, requestURL, err := sm.getApiKeyAndURL()
+	if err != nil {
+		sm.logger.Error(err, "Could not get credentials")
+		return nil, err
+	}
+	payloadHeader := sm.GetHeaders(*apiKey)
+
+	sm.logger.V(1).Info("Sending metadata to URL", "url", *requestURL)
+
+	reader := bytes.NewReader(payload)
+	req, err := http.NewRequestWithContext(context.TODO(), "POST", *requestURL, reader)
+	if err != nil {
+		sm.logger.Error(err, "Error creating request", "url", *requestURL, "reader", reader)
+		return nil, err
+	}
+	req.Header = payloadHeader
+	return req, nil
 }
 
 // GetOrCreateClusterUID retrieves the cluster UID from kube-system namespace
@@ -101,84 +116,57 @@ func (sm *SharedMetadata) GetOrCreateClusterUID() (string, error) {
 	return sm.clusterUID, nil
 }
 
-func (sm *SharedMetadata) setupFromOperator() error {
+func (sm *SharedMetadata) GetOrCreateClusterName() string {
+	if sm.clusterName != "" {
+		return sm.clusterName
+	}
+
+	// Set cluster name - try operator first, then DDA
+	// TODO: not ideal really; maybe we could drop cluster name from metadata or extract it as part of rest of metadata instead of tieing with credentials
 	sm.clusterName = os.Getenv(constants.DDClusterName)
-
-	if sm.credsManager == nil {
-		return fmt.Errorf("credentials Manager is undefined")
-	}
-
-	creds, err := sm.credsManager.GetCredentials()
-	if err != nil {
-		return err
-	}
-
-	// API key
-	sm.apiKey = creds.APIKey
-
-	return nil
-}
-
-func (sm *SharedMetadata) setupFromDDA(dda *v2alpha1.DatadogAgent) error {
 	if sm.clusterName == "" {
-		if dda.Spec.Global != nil && dda.Spec.Global.ClusterName != nil {
+		// Fallback to DDA cluster name
+		dda, err := sm.getDatadogAgent()
+		if err == nil && dda.Spec.Global != nil && dda.Spec.Global.ClusterName != nil {
 			sm.clusterName = *dda.Spec.Global.ClusterName
 		}
 	}
-
-	if sm.apiKey == "" {
-		apiKey, err := sm.getCredentialsFromDDA(dda)
-		if err != nil {
-			return err
-		}
-		sm.apiKey = apiKey
-
-		// if API key is set from DDA, also update request URL if needed
-		if dda.Spec.Global != nil && dda.Spec.Global.Site != nil {
-			mdfURL := url.URL{
-				Scheme: defaultURLScheme,
-				Host:   defaultURLHostPrefix + *dda.Spec.Global.Site,
-				Path:   defaultURLPath,
-			}
-			sm.requestURL = mdfURL.String()
-		}
-	}
-
-	return nil
+	return sm.clusterName
 }
 
-// setCredentials attempts to set up credentials and cluster name from the operator configuration first.
-// If cluster name is empty (even when credentials are successfully retrieved from operator),
-// it falls back to setting up from DatadogAgent to ensure we have a valid cluster name.
-func (sm *SharedMetadata) setCredentials() error {
-	err := sm.setupFromOperator()
-	if err == nil && sm.clusterName != "" {
-		return nil
-	}
-
-	dda, err := sm.getDatadogAgent()
+// getApiKeyAndURL retrieves the API key and request URL from the operator or DDA
+// and sets the cluster name from the operator or DDA in the SharedMetadata struct
+func (sm *SharedMetadata) getApiKeyAndURL() (*string, *string, error) {
+	creds, err := sm.credsManager.GetCredsWithDDAFallback(sm.getDatadogAgent)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	return sm.setupFromDDA(dda)
+	mdfURL := url.URL{
+		Scheme: defaultURLScheme,
+		Host:   defaultURLHost,
+		Path:   defaultURLPath,
+	}
+	if creds.Site != nil {
+		mdfURL.Host = defaultURLHostPrefix + *creds.Site
+	}
+
+	if creds.URL != nil {
+		tempURL, err := url.Parse(*creds.URL)
+		if err == nil {
+			mdfURL.Host = tempURL.Host
+			mdfURL.Scheme = tempURL.Scheme
+		}
+	}
+	requestURL := mdfURL.String()
+	return &creds.APIKey, &requestURL, nil
 }
 
 // getDatadogAgent retrieves the DatadogAgent using Get client method
 func (sm *SharedMetadata) getDatadogAgent() (*v2alpha1.DatadogAgent, error) {
-	// Note: If there are no DDAs present when the Operator starts, the metadata forwarder does not re-try to get credentials from a future DDA
 	ddaList := v2alpha1.DatadogAgentList{}
 
-	// Create new client because manager client requires manager to start first
-	cfg := ctrl.GetConfigOrDie()
-	s := runtime.NewScheme()
-	newclient, err := client.New(cfg, client.Options{Scheme: s})
-	if err != nil {
-		return nil, err
-	}
-	_ = v2alpha1.AddToScheme(s)
-
-	if err := newclient.List(context.TODO(), &ddaList); err != nil {
+	if err := sm.k8sClient.List(context.TODO(), &ddaList); err != nil {
 		return nil, err
 	}
 
@@ -189,126 +177,12 @@ func (sm *SharedMetadata) getDatadogAgent() (*v2alpha1.DatadogAgent, error) {
 	return &ddaList.Items[0], nil
 }
 
-func (sm *SharedMetadata) getCredentialsFromDDA(dda *v2alpha1.DatadogAgent) (string, error) {
-	if dda.Spec.Global == nil || dda.Spec.Global.Credentials == nil {
-		return "", fmt.Errorf("credentials not configured in the DatadogAgent")
-	}
-
-	defaultSecretName := secrets.GetDefaultCredentialsSecretName(dda)
-
-	var err error
-	apiKey := ""
-
-	if dda.Spec.Global != nil && dda.Spec.Global.Credentials != nil && dda.Spec.Global.Credentials.APIKey != nil && *dda.Spec.Global.Credentials.APIKey != "" {
-		apiKey = *dda.Spec.Global.Credentials.APIKey
-	} else {
-		_, secretName, secretKeyName := secrets.GetAPIKeySecret(dda.Spec.Global.Credentials, defaultSecretName)
-		apiKey, err = sm.getKeyFromSecret(dda.Namespace, secretName, secretKeyName)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	if apiKey == "" {
-		return "", ErrEmptyAPIKey
-	}
-
-	return sm.resolveSecretsIfNeeded(apiKey)
-}
-
-// getKeyFromSecret is used to retrieve an API or App key from a secret object
-func (sm *SharedMetadata) getKeyFromSecret(namespace, secretName, dataKey string) (string, error) {
-	secret := &corev1.Secret{}
-	err := sm.k8sClient.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: secretName}, secret)
-	if err != nil {
-		return "", err
-	}
-
-	return string(secret.Data[dataKey]), nil
-}
-
-// resolveSecretsIfNeeded calls the secret backend if creds are encrypted
-func (sm *SharedMetadata) resolveSecretsIfNeeded(apiKey string) (string, error) {
-	if !secrets.IsEnc(apiKey) {
-		// Credentials are not encrypted
-		return apiKey, nil
-	}
-
-	// Try to get secrets from the local cache
-	if decAPIKey, cacheHit := sm.getSecretsFromCache(apiKey); cacheHit {
-		// Creds are found in local cache
-		return decAPIKey, nil
-	}
-
-	// Cache miss, call the secret decryptor
-	decrypted, err := sm.decryptor.Decrypt([]string{apiKey})
-	if err != nil {
-		sm.logger.Error(err, "cannot decrypt secrets")
-		return "", err
-	}
-
-	// Update the local cache with the decrypted secrets
-	sm.resetSecretsCache(decrypted)
-
-	return decrypted[apiKey], nil
-}
-
-// getSecretsFromCache returns the cached and decrypted values of encrypted creds
-func (sm *SharedMetadata) getSecretsFromCache(encAPIKey string) (string, bool) {
-	decAPIKey, found := sm.creds.Load(encAPIKey)
-	if !found {
-		return "", false
-	}
-
-	return decAPIKey.(string), true
-}
-
-// resetSecretsCache updates the local secret cache with new secret values
-func (sm *SharedMetadata) resetSecretsCache(newSecrets map[string]string) {
-	sm.cleanSecretsCache()
-	for k, v := range newSecrets {
-		sm.creds.Store(k, v)
-	}
-}
-
-// cleanSecretsCache deletes all cached secrets
-func (sm *SharedMetadata) cleanSecretsCache() {
-	sm.creds.Range(func(k, v any) bool {
-		sm.creds.Delete(k)
-		return true
-	})
-}
-
 // GetBaseHeaders returns the common HTTP headers for API requests
-func (sm *SharedMetadata) GetBaseHeaders() http.Header {
+func (sm *SharedMetadata) GetHeaders(apiKey string) http.Header {
 	header := http.Header{}
-	header.Set(apiHTTPHeaderKey, sm.apiKey)
+	header.Set(apiHTTPHeaderKey, apiKey)
 	header.Set(contentTypeHeaderKey, "application/json")
 	header.Set(acceptHeaderKey, "application/json")
+	header.Set(userAgentHTTPHeaderKey, fmt.Sprintf("Datadog Operator/%s", version.GetVersion()))
 	return header
-}
-
-func getURL() string {
-	mdfURL := url.URL{
-		Scheme: defaultURLScheme,
-		Host:   defaultURLHost,
-		Path:   defaultURLPath,
-	}
-
-	// check site env var
-	// example: datadoghq.com
-	if siteFromEnvVar := os.Getenv("DD_SITE"); siteFromEnvVar != "" {
-		mdfURL.Host = defaultURLHostPrefix + siteFromEnvVar
-	}
-	// check url env var
-	// example: https://app.datadoghq.com
-	if urlFromEnvVar := os.Getenv("DD_URL"); urlFromEnvVar != "" {
-		tempURL, err := url.Parse(urlFromEnvVar)
-		if err == nil {
-			mdfURL.Host = tempURL.Host
-			mdfURL.Scheme = tempURL.Scheme
-		}
-	}
-
-	return mdfURL.String()
 }


### PR DESCRIPTION
* Move setup from Start to sendMetadta

* Move DDA creds code to creds.go; add GetCredsWithDDAFallback and use it in shared_metadata.go

* Add DDA decrypt test case; add a new constructor the creds.go

* dropped API key field; moved creds resolution mostly to creds.go

* Move from setup to request time creds resolution; consolidate http request logic; reduce shared state or duplicate cache; adjusted some of the tests

* Init resource counts; remove payload logging

* include forwarder name to logger name; remove name duplication in log lines

* Update pkg/config/creds.go



* reduce DDA reads

* fix after merge

* linter error fix

---------

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
