### PR TITLE
Cleanup metadata forwarder logging

### DIFF
--- a/pkg/controller/utils/metadata/operator_metadata.go
+++ b/pkg/controller/utils/metadata/operator_metadata.go
@@ -86,7 +86,7 @@ func (omf *OperatorMetadataForwarder) Start() {
 	go func() {
 		for range ticker.C {
 			if err := omf.sendMetadata(); err != nil {
-				omf.logger.Error(err, "Error while sending metadata")
+				omf.logger.Info("Error while sending metadata", "error", err)
 			}
 		}
 	}()
@@ -138,7 +138,7 @@ func (omf *OperatorMetadataForwarder) GetPayload(clusterUID string) []byte {
 
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
-		omf.logger.Error(err, "Error marshaling payload to json")
+		omf.logger.V(1).Info("Error marshaling payload to json", "error", err)
 	}
 
 	return jsonPayload

--- a/pkg/controller/utils/metadata/shared_metadata.go
+++ b/pkg/controller/utils/metadata/shared_metadata.go
@@ -93,7 +93,7 @@ func (sm *SharedMetadata) createRequest(payload []byte) (*http.Request, error) {
 	reader := bytes.NewReader(payload)
 	req, err := http.NewRequestWithContext(context.TODO(), "POST", *requestURL, reader)
 	if err != nil {
-		sm.logger.Error(err, "Error creating request", "url", *requestURL, "reader", reader)
+		sm.logger.V(1).Info("Error creating request", "error", err, "url", *requestURL)
 		return nil, err
 	}
 	req.Header = payloadHeader


### PR DESCRIPTION
### What does this PR do?

* remove payload logging from the operator and helm metadata forwarders 
* remove notScrubbed variable from helm metadata forwarder which was only used for payload logging
* log errors at the debug level instead of Error

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
* setup the metadata forwarders so the metadata API requests fail. For example, don't configure the api/app key in the operator and do not apply a DDA manifest (to simulate metadata collection failure)
* let the operator start up, and check that the errors relating to failure to send metadata are at the debug or info level:
```
{"level":"DEBUG","ts":"2025-12-10T21:39:36.369Z","logger":"metadata.operator","msg":"Could not get credentials","error":"DatadogAgent not found"}
{"level":"INFO","ts":"2025-12-10T21:39:36.369Z","logger":"metadata.operator","msg":"Error while sending metadata","error":"error creating request: DatadogAgent not found"}
{"level":"DEBUG","ts":"2025-12-10T21:39:36.469Z","logger":"metadata.helm","msg":"Processing Helm release","release":"datadog-operator","namespace":"default","chart":"datadog-operator","chart_version":"2.15.2"}
{"level":"DEBUG","ts":"2025-12-10T21:39:36.470Z","logger":"metadata.helm","msg":"Built metadata payload","release":"datadog-operator","namespace":"default","chart":"datadog-operator","payload_size":2708}
{"level":"DEBUG","ts":"2025-12-10T21:39:36.471Z","logger":"metadata.helm","msg":"Could not get credentials","error":"DatadogAgent not found"}
{"level":"INFO","ts":"2025-12-10T21:39:36.471Z","logger":"metadata.helm","msg":"Error while sending metadata","error":"failed to send 1/1 helm release payloads"}
{"level":"DEBUG","ts":"2025-12-10T21:40:36.360Z","logger":"metadata.helm","msg":"Using cached Helm releases","count":1}
{"level":"DEBUG","ts":"2025-12-10T21:40:36.360Z","logger":"metadata.helm","msg":"Discovered Helm releases","count":1}
{"level":"DEBUG","ts":"2025-12-10T21:40:36.360Z","logger":"metadata.helm","msg":"Processing Helm release","release":"datadog-operator","namespace":"default","chart":"datadog-operator","chart_version":"2.15.2"}
{"level":"DEBUG","ts":"2025-12-10T21:40:36.360Z","logger":"metadata.helm","msg":"Built metadata payload","release":"datadog-operator","namespace":"default","chart":"datadog-operator","payload_size":2708}
{"level":"DEBUG","ts":"2025-12-10T21:40:36.365Z","logger":"metadata.operator","msg":"Could not get credentials","error":"DatadogAgent not found"}
{"level":"INFO","ts":"2025-12-10T21:40:36.365Z","logger":"metadata.operator","msg":"Error while sending metadata","error":"error creating request: DatadogAgent not found"}
{"level":"DEBUG","ts":"2025-12-10T21:40:36.365Z","logger":"metadata.helm","msg":"Could not get credentials","error":"DatadogAgent not found"}
{"level":"INFO","ts":"2025-12-10T21:40:36.365Z","logger":"metadata.helm","msg":"Error while sending metadata","error":"failed to send 1/1 helm release payloads"}
```
* Now set up metadata collection properly with an API/APP key (ex: apply DDA)
* Check operator logs, verify that logs outputting the full payload of the helm or operator metadata request are not present.
### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
