### PR TITLE
(conductor) Target all_staging for nightly and remove deprecated alpha

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -709,7 +709,7 @@ publish_nightly_workflow:
   variables:
     OPERATOR_NIGHTLY: "true"
     SKIP_PLAN_CHECK: "true"
-    ENVIRONMENTS: "experimental"
+    ENVIRONMENTS: "experimental,staging"
     CHART: "datadog-operator"
     OPTION_AUTOMATIC_ROLLOUT: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_operator_nightly.operator_nightly.publish"
@@ -737,7 +737,7 @@ publish_release_candidate_workflow:
   variables:
     OPERATOR_RC: "true"
     SKIP_PLAN_CHECK: "true"
-    ENVIRONMENTS: "experimental,alpha,staging"
+    ENVIRONMENTS: "experimental,staging"
     CHART: "datadog-operator"
     OPTION_AUTOMATIC_ROLLOUT: "true"
     EXPLICIT_WORKFLOWS: "//workflows:deploy_operator_rc.operator_rc"


### PR DESCRIPTION
### What does this PR do?

* Adds `staging` to nightly envs
* Removes `alpha` from envs: it's been removed a while, we only use experimental and staging now

### Motivation

* Deploy nightlies to more clusters

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
