### PR TITLE
Use OIDC-based auth for codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: validation
 on: [push, pull_request]
 # Permission forced by repo-level setting; only elevate on job-level
 permissions:
-  id-token: write # needed for Codecov OIDC-based auth
+  id-token: write # needed for codecov, allows the action to get a JWT signed by GitHub
   contents: read
   # packages: read
 env:


### PR DESCRIPTION
### What does this PR do?

Use OIDC-based auth for uploading coverage reports to codecov (instead of providing CODECOV_TOKEN). Improve security. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
