### PR TITLE
Fix submit preflight redhat container flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ preflight-redhat-container: bin/$(PLATFORM)/preflight
 # Runs only on Linux and requires `docker login` to scan.connect.redhat.com
 .PHONY: preflight-redhat-container-submit
 preflight-redhat-container-submit: bin/$(PLATFORM)/preflight
-	bin/$(PLATFORM)/preflight check container ${IMG} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-project-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
+	bin/$(PLATFORM)/preflight check container ${IMG} --submit --pyxis-api-token=${RH_PARTNER_API_TOKEN} --certification-component-id=${RH_PARTNER_PROJECT_ID} -d ~/.docker/config.json
 
 .PHONY: patch-crds
 patch-crds: bin/$(PLATFORM)/yq ## Patch-crds


### PR DESCRIPTION
### What does this PR do?

`certification-project-id` was deprecated and replaced by `certification-component-id` in [openshift-preflight v1.15.1](https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/tag/1.15.1), which broke our submit preflight command, since we relied on the deprecated flag. 
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

[Previous publish job failed](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/1303157867)
After changing the flag, [passed](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/1304192950) and published 

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
