### PR TITLE
(No-op) SA1019: Remove deprecated functions usage

### DIFF
--- a/cmd/check-operator/upgrade/upgrade.go
+++ b/cmd/check-operator/upgrade/upgrade.go
@@ -162,7 +162,7 @@ func isReconcileError(conditions []metav1.Condition) error {
 // Run use to run the command.
 func (o *Options) Run() error {
 	o.printOutf("Start checking rolling-update status")
-	checkFunc := func() (bool, error) {
+	checkFunc := func(ctx context.Context) (bool, error) {
 		var agentDone, dcaDone, ccrDone, reconcileError bool
 		var status common.StatusWrapper
 		o.printOutf("v2alpha1 is available")
@@ -213,7 +213,7 @@ func (o *Options) Run() error {
 		return false, nil
 	}
 
-	return wait.Poll(o.checkPeriod, o.checkTimeout, checkFunc)
+	return wait.PollUntilContextTimeout(context.Background(), o.checkPeriod, o.checkTimeout, false, checkFunc)
 }
 
 func (o *Options) isAgentDone(status *v2alpha1.DaemonSetStatus) bool {

--- a/cmd/helpers/secrets/secrets.go
+++ b/cmd/helpers/secrets/secrets.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,7 +43,7 @@ type secretsRequest struct {
 
 // ReadSecrets implements a secrets reader from a directory/mount
 func readSecrets(r io.Reader, w io.Writer, dir string) error {
-	in, err := ioutil.ReadAll(r)
+	in, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}
@@ -142,7 +141,7 @@ func readSecretFile(path string) (string, error) {
 	}
 
 	var bytes []byte
-	bytes, err = ioutil.ReadAll(file)
+	bytes, err = io.ReadAll(file)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/kubectl-datadog/agent/check/check.go
+++ b/cmd/kubectl-datadog/agent/check/check.go
@@ -248,7 +248,7 @@ func (o *options) execInPod(pod *corev1.Pod, cmd []string, container string) (st
 	}
 
 	var stdout, stderr bytes.Buffer
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
 		Stdin:  nil,
 		Stdout: &stdout,
 		Stderr: &stderr,

--- a/cmd/kubectl-datadog/flare/flare.go
+++ b/cmd/kubectl-datadog/flare/flare.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -459,7 +458,7 @@ func (o *options) execInPod(command []string, pod *corev1.Pod) ([]byte, error) {
 	}
 
 	var stdout bytes.Buffer
-	if err := exec.Stream(remotecommand.StreamOptions{Stdout: &stdout}); err != nil {
+	if err := exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{Stdout: &stdout}); err != nil {
 		return []byte{}, err
 	}
 
@@ -524,7 +523,7 @@ func (o *options) sendFlare(archivePath, version string, cmd *cobra.Command) (st
 		}
 	}()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return "", err
 	}

--- a/hack/generate-docs/generate-docs.go
+++ b/hack/generate-docs/generate-docs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -217,7 +216,7 @@ func mustReadFile(path string) []byte {
 		}
 	}()
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		panic(fmt.Sprintf("cannot read file %q: %s", path, err))
 	}


### PR DESCRIPTION
### What does this PR do?

* Replaces all deprecated functions with the modern equivalent

### Motivation

* Same as https://github.com/DataDog/datadog-operator/pull/2420 : Reduce number of staticcheck linter (disabled for now) violations

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
