### PR TITLE
Use exporter's sending queue batch instead of a batch processor

### DIFF
--- a/examples/datadogagent/datadog-agent-with-otel-agent-configmap-multi-item.yaml
+++ b/examples/datadogagent/datadog-agent-with-otel-agent-configmap-multi-item.yaml
@@ -14,8 +14,8 @@ spec:
           name: otel-grpc
         - containerPort: 4318
           name: otel-http
-      conf: 
-        configMap: 
+      conf:
+        configMap:
           name: custom-config-map
           items:
             - key: otel-config.yaml
@@ -39,27 +39,24 @@ data:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
+  otel-config-two.yaml: |-
     exporters:
       debug:
         verbosity: detailed
       datadog:
         api:
           key: ${env:DD_API_KEY}
-  otel-config-two.yaml: |-
-    processors:
-      batch:
+        sending_queue:
+          batch:
   otel-config-three.yaml: |-
     service:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [batch]
           exporters: [datadog]
         metrics:
           receivers: [otlp]
-          processors: [batch]
           exporters: [datadog]
         logs:
           receivers: [otlp]
-          processors: [batch]
           exporters: [datadog]

--- a/examples/datadogagent/datadog-agent-with-otel-agent-configmap.yaml
+++ b/examples/datadogagent/datadog-agent-with-otel-agent-configmap.yaml
@@ -14,8 +14,8 @@ spec:
           name: otel-grpc
         - containerPort: 4318
           name: otel-http
-      conf: 
-        configMap: 
+      conf:
+        configMap:
           name: custom-config-map
 ---
 apiVersion: v1
@@ -39,20 +39,16 @@ data:
       datadog:
         api:
           key: ${env:DD_API_KEY}
-    processors:
-      batch:
-    connectors:
+        sending_queue:
+          batch:
     service:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [batch]
           exporters: [datadog]
         metrics:
           receivers: [otlp]
-          processors: [batch]
           exporters: [datadog]
         logs:
           receivers: [otlp]
-          processors: [batch]
           exporters: [datadog]

--- a/examples/datadogagent/datadog-agent-with-otel-agent.yaml
+++ b/examples/datadogagent/datadog-agent-with-otel-agent.yaml
@@ -14,7 +14,7 @@ spec:
           name: otel-grpc
         - containerPort: 4318
           name: otel-http
-      conf: 
+      conf:
         configData: |-
             receivers:
               otlp:
@@ -29,20 +29,16 @@ spec:
               datadog:
                 api:
                   key: ${env:DD_API_KEY}
-            processors:
-              batch:
-            connectors:
+                sending_queue:
+                  batch:
             service:
               pipelines:
                 traces:
                   receivers: [otlp]
-                  processors: [batch]
                   exporters: [datadog]
                 metrics:
                   receivers: [otlp]
-                  processors: [batch]
                   exporters: [datadog]
                 logs:
                   receivers: [otlp]
-                  processors: [batch]
                   exporters: [datadog]

--- a/internal/controller/datadogagent/feature/otelcollector/configmap_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/configmap_test.go
@@ -22,7 +22,7 @@ func Test_buildOtelCollectorConfigMap(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "-otel-agent-config",
 			Annotations: map[string]string{
-				"checksum/otel_agent-custom-config": "c4efec532ac1feb5548c7bf9a000f3bd",
+				"checksum/otel_agent-custom-config": "8e715f9526c27c6cd06ba9a9d8913451",
 			},
 		},
 		Data: map[string]string{

--- a/internal/controller/datadogagent/feature/otelcollector/defaultconfig/defaultconfig.go
+++ b/internal/controller/datadogagent/feature/otelcollector/defaultconfig/defaultconfig.go
@@ -17,17 +17,16 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 exporters:
-  debug:
-    verbosity: detailed
   datadog:
     api:
       key: ${env:DD_API_KEY}
       site: ${env:DD_SITE}
+    sending_queue:
+      batch:
+       flush_timeout: 10s
 processors:
   infraattributes:
     cardinality: 2
-  batch:
-    timeout: 10s
   filter/drop-prometheus-internal-metrics:
     metrics:
       exclude:
@@ -46,17 +45,17 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [infraattributes, batch]
+      processors: [infraattributes]
       exporters: [datadog, datadog/connector]
     metrics:
       receivers: [otlp, datadog/connector]
-      processors: [infraattributes, batch]
-      exporters: [datadog]    
+      processors: [infraattributes]
+      exporters: [datadog]
     metrics/prometheus:
       receivers: [prometheus]
-      processors: [filter/drop-prometheus-internal-metrics, infraattributes, batch]
+      processors: [filter/drop-prometheus-internal-metrics, infraattributes]
       exporters: [datadog]
     logs:
       receivers: [otlp]
-      processors: [infraattributes, batch]
+      processors: [infraattributes]
       exporters: [datadog]`

--- a/internal/controller/datadogagent/feature/otelcollector/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature_test.go
@@ -98,7 +98,7 @@ var (
 	}
 )
 
-var defaultAnnotations = map[string]string{"checksum/otel_agent-custom-config": "c4efec532ac1feb5548c7bf9a000f3bd"}
+var defaultAnnotations = map[string]string{"checksum/otel_agent-custom-config": "8e715f9526c27c6cd06ba9a9d8913451"}
 
 func Test_otelCollectorFeature_Configure(t *testing.T) {
 	tests := test.FeatureTestSuite{
@@ -198,7 +198,7 @@ func Test_otelCollectorFeature_Configure(t *testing.T) {
 				httpPort: 5555,
 			},
 				defaultExpectedEnvVars,
-				map[string]string{"checksum/otel_agent-custom-config": "ced0b89ba76af21bcaf3126cb2095c90"},
+				map[string]string{"checksum/otel_agent-custom-config": "1b4f73fd3576db6a939bbfe788cc1f80"},
 				defaultVolumeMounts,
 				defaultVolumes(defaultLocalObjectReferenceName),
 			),


### PR DESCRIPTION
### What does this PR do?
Remove batch processors from configurations, in favor of the exporter's sending queue's batch

### Motivation
[OTAGENT-763](https://datadoghq.atlassian.net/browse/OTAGENT-763?atlOrigin=eyJpIjoiZmNhMGU3M2U4ZmRkNDI2NzgxODU0Nzg2N2NhMDk0ZmUiLCJwIjoiaiJ9)

### Minimum Agent Versions
Agent: v7.67.0

### Describe your test plan

CI passing

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label


[OTAGENT-763]: https://datadoghq.atlassian.net/browse/OTAGENT-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ