### PR TITLE
Update DCA clusterRole and clusterRoleBinding names

### DIFF
--- a/internal/controller/datadogagent/component/clusteragent/default.go
+++ b/internal/controller/datadogagent/component/clusteragent/default.go
@@ -43,7 +43,7 @@ func GetClusterAgentVersion(dda metav1.Object) string {
 
 // GetClusterAgentRbacResourcesName return the Cluster-Agent RBAC resource name
 func GetClusterAgentRbacResourcesName(dda metav1.Object) string {
-	return fmt.Sprintf("%s-%s", dda.GetName(), constants.DefaultClusterAgentResourceSuffix)
+	return fmt.Sprintf("%s-%s-%s", dda.GetNamespace(), dda.GetName(), constants.DefaultClusterAgentResourceSuffix)
 }
 
 // getDefaultServiceAccountName return the default Cluster-Agent ServiceAccountName

--- a/internal/controller/datadogagent/feature/autoscaling/feature_test.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature_test.go
@@ -104,7 +104,7 @@ func newAgent(workloadEnabled, clusterEnabled, admissionEnabled bool) *v2alpha1.
 
 func testRBACResources(t testing.TB, store store.StoreClient) {
 	// RBAC
-	rbacName := fmt.Sprintf("%s-%s", ddaName, "cluster-agent-autoscaling")
+	rbacName := fmt.Sprintf("%s-%s-%s", ddaNamespace, ddaName, "cluster-agent-autoscaling")
 
 	// validate clusterRole policy rules
 	crObj, found := store.Get(kubernetes.ClusterRolesKind, "", rbacName)


### PR DESCRIPTION
### What does this PR do?

Updates the cluster-agent cluster role and cluster role binding names to be prefixed with namespace. This pattern aligns with the feature-specific RBAC names (i.e. orchestrator explorer, KSM, etc). 

### Motivation

To prevent name collision with the datadog helm chart: after completing the Helm > Operator migration and user uninstalls the datadog chart release, the helm uninstall also uninstalls the operator-managed DCA clusterRole and clusterRoleBinding resources due to them sharing the same name with the helm-managed resources. 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Install previous operator version
2. Observe the cluster agent clusterRole and clusterRoleBinding names
3. Update operator deployment to use custom operator image containing this change
4. Wait a few minutes and observe that the new cluster agent clusterRole and clusterRoleBinding have been created and the names follow the pattern `<namespace>-datadog-cluster-agent` 
5. Check that the cluster agent role has been 

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits