### PR TITLE
Copy finalizer when updating DDAI

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -604,6 +604,13 @@ func (r *Reconciler) createOrUpdateDDAI(ddai *v1alpha1.DatadogAgentInternal) err
 
 	if currentDDAI.Annotations[constants.MD5DDAIDeploymentAnnotationKey] != ddai.Annotations[constants.MD5DDAIDeploymentAnnotationKey] {
 		r.log.Info("updating DatadogAgentInternal", "ns", ddai.Namespace, "name", ddai.Name)
+
+		// Preserve finalizers from the current DDAI to prevent their deletion
+		if len(currentDDAI.Finalizers) > 0 {
+			ddai.Finalizers = currentDDAI.Finalizers
+			r.log.V(1).Info("copying finalizers from the current DDAI", "finalizers", ddai.Finalizers)
+		}
+
 		if err := kubernetes.UpdateFromObject(context.TODO(), r.client, ddai, currentDDAI.ObjectMeta); err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

When updating the DDAI, we remove all finalizers. This manually adds the finalizers back in if they are present
This happens when a DDAI is updated, then deleted before the finalizer is added back in

### Motivation

Error logs in metrics forwarder

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Difficult to reproduce the issue. Requires update + deletion of DDAI to happen very close together, which is uncommon. In previous operator versions (with the issue), in the logs, we should see:
* log about `updating DatadogAgentInternal`
* NO log about `Adding Finalizer for the DatadogAgentInternal`
* log about `Deleting unused DDAI`
* logs with the error `DatadogAgentInternal.datadoghq.com "<ddai-name>" not found` in the metrics forwarder periodically

With the fix, we shouldn't see the error log. On every reconcile requiring a DDAI update, this debug log should be present though: `copying finalizers from the current DDAI`

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits