### PR TITLE
Make unregisterForwarder idempotent and send to debug when forwarder already removed

### DIFF
--- a/pkg/controller/utils/datadog/forwarders_manager_test.go
+++ b/pkg/controller/utils/datadog/forwarders_manager_test.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadog
+
+import "testing"
+
+func TestForwardersManager_unregisterForwarder_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	fm := &ForwardersManager{
+		metricsForwarders: make(map[string]*metricsForwarder),
+	}
+
+	id := "DatadogAgentInternal/foo/test"
+	fm.metricsForwarders[id] = &metricsForwarder{
+		stopChan: make(chan struct{}),
+	}
+
+	// First unregister removes it.
+	if err := fm.unregisterForwarder(id); err != nil {
+		t.Fatalf("expected no error when unregistering existing forwarder, got: %v", err)
+	}
+
+	// Second unregister should still be a no-op.
+	if err := fm.unregisterForwarder(id); err != nil {
+		t.Fatalf("expected no error when unregistering already-unregistered forwarder, got: %v", err)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

* Instead of erroring when the forwader is not found, simply send to debug

### Motivation

* We call multiple times Unregister due to requeues on DDAIs when deleting causing noisy error log
```json
{"level":"ERROR","ts":"2026-01-09T10:14:58.963Z","logger":"DatadogMetricForwarders","msg":"cannot unregister metrics forwarder","ID":"DatadogAgentInternal/system/datadog-agent","error":"DatadogAgentInternal/system/datadog-agent not found","stacktrace":"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*ForwardersManager).Unregister\n\t/workspace/pkg/controller/utils/datadog/forwarders_manager.go:86\ngithub.com/DataDog/datadog-operator/internal/controller/datadogagentinternal.(*Reconciler).finalizeDDAI\n\t/workspace/internal/controller/datadogagentinternal/finalizer.go:64\ngithub.com/DataDog/datadog-operator/internal/controller/datadogagentinternal.(*Reconciler).handleFinalizer\n\t/workspace/internal/controller/datadogagentinternal/finalizer.go:36\ngithub.com/DataDog/datadog-operator/internal/controller/datadogagentinternal.(*Reconciler).internalReconcileV2\n\t/workspace/internal/controller/datadogagentinternal/controller_reconcile_v2.go:38\ngithub.com/DataDog/datadog-operator/internal/controller/datadogagentinternal.(*Reconciler).Reconcile\n\t/workspace/internal/controller/datadogagentinternal/controller.go:114\ngithub.com/DataDog/datadog-operator/internal/controller.(*DatadogAgentInternalReconciler).Reconcile\n\t/workspace/internal/controller/datadogagentinternal_controller.go:54\nsigs.k8s.io/controller-runtime/pkg/reconcile.(*objectReconcilerAdapter[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/reconcile/reconcile.go:154\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255"}
```

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Deploy operator with debug log level
2. Apply DDA manifest
3. Delete DDA object
4. Check that no error logs for forwarder appear
5. Verify the debug log 
```json
{"level":"DEBUG","ts":"2026-01-09T10:40:27.296Z","logger":"DatadogMetricForwarders","msg":"Metrics forwarder already unregistered","ID":"DatadogAgentInternal/system/datadog-agent"}
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits