### PR TITLE
Add configmap preprocessor

### DIFF
--- a/internal/controller/datadogagent/component_clusteragent.go
+++ b/internal/controller/datadogagent/component_clusteragent.go
@@ -104,6 +104,13 @@ func (c *ClusterAgentComponent) Reconcile(ctx context.Context, params *Reconcile
 		deployment.Labels[constants.MD5AgentDeploymentProviderLabelKey] = params.Provider
 	}
 
+	// Apply MD5 hashes for ConfigMaps
+	cmAnnotations := params.ResourceManagers.Store().GetComponentAnnotations(c.Name())
+	for key, value := range cmAnnotations {
+		podManagers.Annotation().AddAnnotation(key, value)
+
+	}
+
 	return c.reconciler.createOrUpdateDeployment(params.Logger, params.DDA, deployment, params.Status, updateStatusV2WithClusterAgent)
 }
 

--- a/internal/controller/datadogagent/component_clusterchecksrunner.go
+++ b/internal/controller/datadogagent/component_clusterchecksrunner.go
@@ -99,6 +99,12 @@ func (c *ClusterChecksRunnerComponent) Reconcile(ctx context.Context, params *Re
 		override.Deployment(deployment, componentOverride)
 	}
 
+	// Apply MD5 hashes for ConfigMaps
+	cmAnnotations := params.ResourceManagers.Store().GetComponentAnnotations(c.Name())
+	for key, value := range cmAnnotations {
+		podManagers.Annotation().AddAnnotation(key, value)
+	}
+
 	return c.reconciler.createOrUpdateDeployment(params.Logger, params.DDA, deployment, params.Status, updateStatusV2WithClusterChecksRunner)
 }
 

--- a/internal/controller/datadogagent/controller_reconcile_agent.go
+++ b/internal/controller/datadogagent/controller_reconcile_agent.go
@@ -135,6 +135,12 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 			return reconcile.Result{}, nil
 		}
 
+		// Apply MD5 hashes for ConfigMaps
+		cmAnnotations := resourcesManager.Store().GetComponentAnnotations(datadoghqv2alpha1.NodeAgentComponentName)
+		for key, value := range cmAnnotations {
+			podManagers.Annotation().AddAnnotation(key, value)
+		}
+
 		return r.createOrUpdateExtendedDaemonset(daemonsetLogger, dda, eds, newStatus, updateEDSStatusV2WithAgent)
 	}
 
@@ -234,6 +240,12 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 		}
 		deleteStatusWithAgent(newStatus)
 		return reconcile.Result{}, nil
+	}
+
+	// Apply MD5 hashes for ConfigMaps
+	cmAnnotations := resourcesManager.Store().GetComponentAnnotations(datadoghqv2alpha1.NodeAgentComponentName)
+	for key, value := range cmAnnotations {
+		podManagers.Annotation().AddAnnotation(key, value)
 	}
 
 	return r.createOrUpdateDaemonset(daemonsetLogger, dda, daemonset, newStatus, updateDSStatusV2WithAgent, profile)

--- a/internal/controller/datadogagent/store/preprocess.go
+++ b/internal/controller/datadogagent/store/preprocess.go
@@ -7,11 +7,16 @@ package store
 
 import (
 	"fmt"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
 )
@@ -19,12 +24,13 @@ import (
 // preprocessorFunc defines a function type for preprocessing objects before apply.
 // objStore is the object from the store and objAPIServer is the object from the API server (if it exists).
 // objAPIServer will be nil for creates, non-nil for updates.
-type preprocessorFunc func(objStore, objAPIServer client.Object) (client.Object, error)
+type preprocessorFunc func(ds *Store, objStore, objAPIServer client.Object) (client.Object, error)
 
 var preprocessorRegistry = map[kubernetes.ObjectKind]preprocessorFunc{
 	kubernetes.ClusterRolesKind:          preprocessClusterRole,
 	kubernetes.RolesKind:                 preprocessRole,
 	kubernetes.ServicesKind:              preprocessService,
+	kubernetes.ConfigMapsKind:            preprocessConfigMap,
 	kubernetes.APIServiceKind:            preprocessResourceVersion,
 	kubernetes.CiliumNetworkPoliciesKind: preprocessResourceVersion,
 	kubernetes.PodDisruptionBudgetsKind:  preprocessResourceVersion,
@@ -33,7 +39,7 @@ var preprocessorRegistry = map[kubernetes.ObjectKind]preprocessorFunc{
 // applyPreprocessing applies registered preprocessor for the given kind, if any
 func (ds *Store) applyPreprocessing(kind kubernetes.ObjectKind, objStore, objAPIServer client.Object) (client.Object, error) {
 	if preprocessor, exists := preprocessorRegistry[kind]; exists {
-		return preprocessor(objStore, objAPIServer)
+		return preprocessor(ds, objStore, objAPIServer)
 	}
 	return objStore, nil
 }
@@ -41,7 +47,7 @@ func (ds *Store) applyPreprocessing(kind kubernetes.ObjectKind, objStore, objAPI
 // preprocessClusterRole holds preprocessing rules for ClusterRole
 // - normalizes policy rules to minimize duplicates
 // - ensures deterministic output
-func preprocessClusterRole(objStore, objAPIServer client.Object) (client.Object, error) {
+func preprocessClusterRole(ds *Store, objStore, objAPIServer client.Object) (client.Object, error) {
 	cr, ok := objStore.(*rbacv1.ClusterRole)
 	if !ok {
 		return nil, fmt.Errorf("expected *rbacv1.ClusterRole, got %T", objStore)
@@ -55,7 +61,7 @@ func preprocessClusterRole(objStore, objAPIServer client.Object) (client.Object,
 // preprocessRole holds preprocessing rules for Role
 // - normalizes policy rules to minimize duplicates
 // - ensures deterministic output
-func preprocessRole(objStore, objAPIServer client.Object) (client.Object, error) {
+func preprocessRole(ds *Store, objStore, objAPIServer client.Object) (client.Object, error) {
 	role, ok := objStore.(*rbacv1.Role)
 	if !ok {
 		return nil, fmt.Errorf("expected *rbacv1.Role, got %T", objStore)
@@ -69,7 +75,7 @@ func preprocessRole(objStore, objAPIServer client.Object) (client.Object, error)
 // preprocessService holds preprocessing rules for Service
 // - ClusterIP and ClusterIPs are immutable and must be preserved during updates
 // - sets the resource version from the API server object if it exists to prevent invalid value error
-func preprocessService(objStore, objAPIServer client.Object) (client.Object, error) {
+func preprocessService(ds *Store, objStore, objAPIServer client.Object) (client.Object, error) {
 	svcStore, ok := objStore.(*v1.Service)
 	if !ok {
 		return nil, fmt.Errorf("expected *v1.Service, got %T", objStore)
@@ -86,11 +92,62 @@ func preprocessService(objStore, objAPIServer client.Object) (client.Object, err
 	return svcStore, nil
 }
 
+// preprocessConfigMap holds preprocessing rules for ConfigMap
+func preprocessConfigMap(ds *Store, objStore, objAPIServer client.Object) (client.Object, error) {
+	cm, ok := objStore.(*v1.ConfigMap)
+	if !ok {
+		return nil, fmt.Errorf("expected *v1.ConfigMap, got %T", objStore)
+	}
+
+	// Generate annotation key from config ID
+	id, ok := cm.Labels[constants.ConfigIDLabelKey]
+	if !ok {
+		// For now, return the original configmap to continue to equality check
+		// TODO: replace once all configmaps have config ID and move to preprocess hash
+		// return nil, errors.New("config ID label not found for configmap, unable to store hash")
+		ds.logger.V(2).Info("config ID label not found for configmap, unable to store hash", "configmap", cm.Name)
+		return cm, nil
+	}
+	annotationKey := object.GetChecksumAnnotationKey(id)
+
+	// Compute MD5 hash
+	hash, err := comparison.GenerateMD5ForSpec(cm.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store hash for each component the configmap belongs to
+	components := GetComponentsFromLabels(cm.Labels)
+	for _, component := range components {
+		if ds.componentAnnotations[component] == nil {
+			ds.componentAnnotations[component] = make(map[string]string)
+		}
+		ds.componentAnnotations[component][annotationKey] = hash
+	}
+
+	// Add hash annotation to configmap
+	cm.SetAnnotations(object.MergeAnnotationsLabels(ds.logger, cm.GetAnnotations(), map[string]string{annotationKey: hash}, "*"))
+
+	return cm, nil
+}
+
 // preprocessResourceVersion sets the resource version from the API server object if it exists
 // Required for APIService, CiliumNetworkPolicies, and PodDisruptionBudgets
-func preprocessResourceVersion(objStore, objAPIServer client.Object) (client.Object, error) {
+func preprocessResourceVersion(ds *Store, objStore, objAPIServer client.Object) (client.Object, error) {
 	if objAPIServer != nil {
 		objStore.SetResourceVersion(objAPIServer.GetResourceVersion())
 	}
 	return objStore, nil
+}
+
+// GetComponentsFromLabels extracts component names from labels
+func GetComponentsFromLabels(labels map[string]string) []v2alpha1.ComponentName {
+	var components []v2alpha1.ComponentName
+	for key := range labels {
+		if strings.HasPrefix(key, constants.OperatorComponentLabelKeyPrefix) {
+			componentName := strings.TrimPrefix(key, constants.OperatorComponentLabelKeyPrefix)
+			components = append(components, v2alpha1.ComponentName(componentName))
+		}
+	}
+	return components
 }

--- a/internal/controller/datadogagentinternal/component_clusteragent.go
+++ b/internal/controller/datadogagentinternal/component_clusteragent.go
@@ -97,6 +97,12 @@ func (c *ClusterAgentComponent) Reconcile(ctx context.Context, params *Reconcile
 		override.Deployment(deployment, componentOverride)
 	}
 
+	// Apply MD5 hashes for ConfigMaps
+	cmAnnotations := params.ResourceManagers.Store().GetComponentAnnotations(c.Name())
+	for key, value := range cmAnnotations {
+		podManagers.Annotation().AddAnnotation(key, value)
+	}
+
 	return c.reconciler.createOrUpdateDeployment(params.Logger, params.DDAI, deployment, params.Status, updateStatusV2WithClusterAgent)
 }
 

--- a/internal/controller/datadogagentinternal/component_clusterchecksrunner.go
+++ b/internal/controller/datadogagentinternal/component_clusterchecksrunner.go
@@ -100,6 +100,12 @@ func (c *ClusterChecksRunnerComponent) Reconcile(ctx context.Context, params *Re
 		override.Deployment(deployment, componentOverride)
 	}
 
+	// Apply MD5 hashes for ConfigMaps
+	cmAnnotations := params.ResourceManagers.Store().GetComponentAnnotations(c.Name())
+	for key, value := range cmAnnotations {
+		podManagers.Annotation().AddAnnotation(key, value)
+	}
+
 	return c.reconciler.createOrUpdateDeployment(params.Logger, params.DDAI, deployment, params.Status, updateStatusV2WithClusterChecksRunner)
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -103,6 +103,12 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 			return reconcile.Result{}, nil
 		}
 
+		// Apply MD5 hashes for ConfigMaps
+		cmAnnotations := resourcesManager.Store().GetComponentAnnotations(datadoghqv2alpha1.NodeAgentComponentName)
+		for key, value := range cmAnnotations {
+			podManagers.Annotation().AddAnnotation(key, value)
+		}
+
 		return r.createOrUpdateExtendedDaemonset(daemonsetLogger, ddai, eds, newStatus, updateEDSStatusV2WithAgent)
 	}
 
@@ -159,6 +165,12 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 		}
 		deleteStatusWithAgent(newStatus)
 		return reconcile.Result{}, nil
+	}
+
+	// Apply MD5 hashes for ConfigMaps
+	cmAnnotations := resourcesManager.Store().GetComponentAnnotations(datadoghqv2alpha1.NodeAgentComponentName)
+	for key, value := range cmAnnotations {
+		podManagers.Annotation().AddAnnotation(key, value)
 	}
 
 	return r.createOrUpdateDaemonset(daemonsetLogger, ddai, daemonset, newStatus, updateDSStatusV2WithAgent)

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -75,6 +75,10 @@ const (
 	MD5DDAIDeploymentAnnotationKey = "agent.datadoghq.com/ddaispechash"
 	// MD5ChecksumAnnotationKey annotation key is used to identify customConfig configurations
 	MD5ChecksumAnnotationKey = "checksum/%s-custom-config"
+	// OperatorComponentLabelKey is used to identify the component of the resource
+	OperatorComponentLabelKeyPrefix = "operator.datadoghq.com/component."
+	// ConfigIDLabelKey stores a config ID for dependencies to generate a MD5 checksum annotation key
+	ConfigIDLabelKey = "operator.datadoghq.com/config-id"
 )
 
 // Profiles

--- a/pkg/constants/utils.go
+++ b/pkg/constants/utils.go
@@ -233,3 +233,7 @@ func GetDDAName(dda metav1.Object) string {
 	}
 	return dda.GetName()
 }
+
+func GetOperatorComponentLabelKey(component v2alpha1.ComponentName) string {
+	return OperatorComponentLabelKeyPrefix + string(component)
+}

--- a/pkg/kubernetes/const.go
+++ b/pkg/kubernetes/const.go
@@ -59,6 +59,8 @@ const (
 	ServicesKind = "services"
 	// ValidatingWebhookConfigurationsKind is the ValidatingWebhookConfigurations resource kind
 	ValidatingWebhookConfigurationsKind = "validatingwebhookconfigurations"
+	// ConfigMapsKind is the ConfigMaps resource kind
+	ConfigMapsKind = "configmaps"
 )
 
 // getResourcesKind return the list of all possible ObjectKind supported as DatadogAgent dependencies
@@ -77,6 +79,7 @@ func getResourcesKind(withCiliumResources bool) []ObjectKind {
 		ServiceAccountsKind,
 		ServicesKind,
 		ValidatingWebhookConfigurationsKind,
+		ConfigMapsKind,
 	}
 
 	if withCiliumResources {


### PR DESCRIPTION
### What does this PR do?

Adds a preprocessor for configmaps and moves ksm config md5 hash generation to preprocessor.
To generate the hash annotation, the following labels were added to the configmaps:
* `operator.datadoghq.com/config-id`: identifying id for the custom config, e.g. `ksm`. Used to create the annotation key for the hash
* `operator.datadoghq.com/component.<componentName>`: component name. Used to tell the operator which components the hash should be added to

Open to discussing different label names. The component label was chosen so that you could still search for specific component dependencies using `kubectl get pod -l operator.datadoghq.com/component.clusterAgent` and add multiple component labels to a pod

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Default KSM settings:
* Check that the cm and dca pod labels have the same hash annotation as each other
* Check that the cm has the labels `operator.datadoghq.com/config-id=ksm` and `operator.datadoghq.com/component.clusterAgent=true`

Override KSM config using configdata:
```yaml
    kubeStateMetricsCore:
      conf:
        configData: |
          cluster_check: true
          init_config:
          instances:
            - skip_leader_election: true
              collectors:
              - pods
```
* Check that the cm and dca pod labels have the same hash annotation as each other and that it has changed from the previous test using default settings
* Check that the cm has the labels `operator.datadoghq.com/config-id=ksm` and `operator.datadoghq.com/component.clusterAgent=true`

Enable cluster checks runner:
```yaml
    clusterChecks:
      enabled: true
      useClusterChecksRunners: true
```
* Check that the cm and dca pod labels have the same hash annotation as each other
* Check that the cm has the labels `operator.datadoghq.com/config-id=ksm` and `operator.datadoghq.com/component.clusterAgent=true` (not `clusterChecksRunner`)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits