### PR TITLE
[feature/cpsm] Add watch permission

### DIFF
--- a/internal/controller/datadogagent/feature/cspm/rbac.go
+++ b/internal/controller/datadogagent/feature/cspm/rbac.go
@@ -28,7 +28,7 @@ func getRBACPolicyRules() []rbacv1.PolicyRule {
 				rbac.ClusterRoleBindingResource,
 				rbac.RoleBindingResource,
 			},
-			Verbs: []string{rbac.ListVerb},
+			Verbs: []string{rbac.ListVerb, rbac.WatchVerb},
 		},
 		{
 			APIGroups: []string{rbac.NetworkingAPIGroup},


### PR DESCRIPTION
### What does this PR do?

This PR adds watch permission in the RBAC required by the CSPM feature.

This is needed because this PR in the Agent https://github.com/DataDog/datadog-agent/pull/45029 added an optimization in the CSPM feature and now it requires "watch" permissions for role bindings and cluster role bindings.

### Minimum Agent Versions

The permission will be needed starting from Cluster Agent v7.76.0.

### Describe your test plan

Deployed locally and verified that the cluster role associated with the feature has the "watch" permission.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits