### PR TITLE
Remove the -vn flags from the `cp` command of the `init-volume`

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -597,7 +597,7 @@ func initVolumeContainer() corev1.Container {
 		Name:    "init-volume",
 		Image:   agentImage(),
 		Command: []string{"bash", "-c"},
-		Args:    []string{"cp -vnr /etc/datadog-agent /opt"},
+		Args:    []string{"cp -r /etc/datadog-agent /opt"},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      common.ConfigVolumeName,

--- a/internal/controller/datadogagent/component/otelagentgateway/default.go
+++ b/internal/controller/datadogagent/component/otelagentgateway/default.go
@@ -65,7 +65,7 @@ func defaultPodSpec(dda metav1.Object) corev1.PodSpec {
 				Name:    "init-volume",
 				Image:   images.GetLatestDdotCollectorImage(),
 				Command: []string{"bash", "-c"},
-				Args:    []string{"cp -vnr /etc/datadog-agent /opt"},
+				Args:    []string{"cp -r /etc/datadog-agent /opt"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      common.ConfigVolumeName,


### PR DESCRIPTION
### What does this PR do?

Remove the -vn flags from the `cp` command of the `init-volume` container. This is consistent with the [helm template](https://github.com/DataDog/helm-charts/blob/129a52f489f315b3d7cfecc8f1f867a3a4177d50/charts/datadog/templates/_containers-init-linux.yaml#L7-L8).

### Motivation

This reduces logging from the init-volume container and makes the behavior consistent across the operator and the helm template.

### Additional Notes

Anything else we should know when reviewing?

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits