### PR TITLE
Remove excessive enabled/configured feature logging

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_helpers.go
@@ -71,7 +71,6 @@ func (r *Reconciler) manageFeatureDependencies(logger logr.Logger, features []fe
 	var errs []error
 
 	for _, feat := range features {
-		logger.V(1).Info("Managing dependencies", "featureID", feat.ID())
 		if err := feat.ManageDependencies(resourceManagers, provider); err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
@@ -61,7 +61,6 @@ func (r *Reconciler) manageGlobalDependencies(logger logr.Logger, ddai *datadogh
 func (r *Reconciler) manageFeatureDependencies(logger logr.Logger, features []feature.Feature, resourceManagers feature.ResourceManagers) error {
 	var errs []error
 	for _, feat := range features {
-		logger.V(1).Info("Managing dependencies", "featureID", feat.ID())
 		if err := feat.ManageDependencies(resourceManagers, ""); err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
### What does this PR do?

List all enabled/configured features in one log instead of logging for each feature. Remove managing dependencies log line since it uses the same enabled features list

### Motivation

https://datadoghq.atlassian.net/browse/AGENTONB-2798

### Additional Notes

This does not cover excessive logging for features in their `feature.go` file

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Run the operator with DEBUG logging and check that `Enabled features` and `Configured features` log once per reconcile and list all enabled/configured features. These log formats are expected:
```
{"level":"DEBUG","ts":"2026-01-23T22:10:31.814Z","logger":"controllers.DatadogAgentInternal","msg":"Enabled features","features":["admission_controller","apm","cluster_checks","control_plane_monitoring","default","dogstatsd","event_collection","ksm","live_container","log_collection","orchestrator_explorer","process_discovery","remote_config"]}
{"level":"DEBUG","ts":"2026-01-23T22:10:31.814Z","logger":"controllers.DatadogAgentInternal","msg":"Configured features","features":null}
```

These log formats should not be present: `Feature enabled`, `Feature configured`, `Managing dependencies`
```
{"level":"DEBUG","ts":"2026-01-23T19:53:40.055Z","logger":"controllers.DatadogAgentInternal","msg":"Feature enabled","namespace":"default","name":"datadog-agent","reconcileID":"63bcbac8-7eb1-4255-b1d4-380aec41adcd","kind":"DatadogAgentInternal","featureID":"admission_controller"}
{"level":"DEBUG","ts":"2026-01-23T19:53:40.055Z","logger":"controllers.DatadogAgentInternal","msg":"Feature configured","namespace":"default","name":"datadog-agent","reconcileID":"63bcbac8-7eb1-4255-b1d4-380aec41adcd","kind":"DatadogAgentInternal","featureID":"admission_controller"}
{"level":"DEBUG","ts":"2026-01-23T19:53:40.056Z","logger":"controllers.DatadogAgentInternal","msg":"Managing dependencies","namespace":"default","name":"datadog-agent","reconcileID":"63bcbac8-7eb1-4255-b1d4-380aec41adcd","kind":"DatadogAgentInternal","featureID":"cluster_checks"}
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits