### PR TITLE
Fix flaky e2e tests: Docker Hub rate limiting and logs verification

### DIFF
--- a/test/e2e/manifests/autodiscovery-annotation.yaml
+++ b/test/e2e/manifests/autodiscovery-annotation.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.2
+        image: public.ecr.aws/nginx/nginx:1.27-alpine
         ports:
         - containerPort: 80
           protocol: TCP

--- a/test/e2e/tests/k8s_suite/k8s_suite_test.go
+++ b/test/e2e/tests/k8s_suite/k8s_suite_test.go
@@ -274,6 +274,9 @@ serviceAccount:
 
 		updateEnv("e2e-operator-logs-collection", provisionerOptions)
 
+		err = s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+		s.Assert().NoError(err)
+
 		// Verify logs collection on agent pod
 		s.Assert().EventuallyWithTf(func(c *assert.CollectT) {
 			utils.VerifyAgentPods(s.T(), c, common.NamespaceName, s.Env().KubernetesCluster.Client(), "app.kubernetes.io/instance=datadog-agent-logs-agent")
@@ -287,7 +290,7 @@ serviceAccount:
 				utils.VerifyAgentPodLogs(c, output)
 			}
 
-			s.verifyAPILogs()
+			s.verifyAPILogs(c)
 		}, 900*time.Second, 15*time.Second, "could not validate logs collection in time")
 	})
 
@@ -342,7 +345,6 @@ serviceAccount:
 			// This works because we have a single Agent pod (so located on same node as tracegen)
 			// Otherwise, we would need to deploy tracegen on the same node as the Agent pod / as a DaemonSet
 			for _, pod := range agentPods.Items {
-
 				output, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec(common.NamespaceName, pod.Name, "agent", []string{"agent", "status", "apm agent", "-j"})
 				assert.NoError(c, err)
 
@@ -355,10 +357,10 @@ serviceAccount:
 	})
 }
 
-func (s *k8sSuite) verifyAPILogs() {
+func (s *k8sSuite) verifyAPILogs(t assert.TestingT) {
 	logs, err := s.Env().FakeIntake.Client().FilterLogs("agent")
-	s.Assert().NoError(err)
-	s.Assert().NotEmptyf(logs, fmt.Sprintf("Expected fake intake-ingested logs to not be empty: %s", err))
+	assert.NoError(t, err)
+	assert.NotEmptyf(t, logs, "Expected fake intake-ingested logs to not be empty")
 }
 
 func (s *k8sSuite) verifyAPITraces(c *assert.CollectT) {


### PR DESCRIPTION
## Summary

This PR fixes two sources of e2e test flakiness identified through analysis of CI pipeline failures over the last 30 days.

### Flakiness Analysis

Based on Datadog CI pipeline data, I identified **765+ e2e job failures** in the last 30 days.

### Fix 1: Replace nginx image to avoid Docker Hub rate limiting

**Problem:** The autodiscovery test uses `nginx:1.14.2` from Docker Hub, which triggers rate limiting errors (`429 Too Many Requests`) in CI environments without authentication.

**Error example:**
```
429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit.
```

**Solution:** Replace with `public.ecr.aws/nginx/nginx:1.27-alpine` from AWS ECR public gallery, which doesn't have rate limits.

**File:** `test/e2e/manifests/autodiscovery-annotation.yaml`

### Fix 2: Fix `verifyAPILogs()` retry pattern

**Problem:** The `verifyAPILogs()` function used `s.Assert().NoError(err)` which fails immediately instead of allowing `EventuallyWithTf` to retry.

**Error example:**
```
Expected fake intake-ingested logs to not be empty
```

**Root cause:** Inside `EventuallyWithTf`, assertions must use the `*assert.CollectT` parameter to collect errors for retry. Using `s.Assert()` (which uses the suite's `*testing.T`) causes immediate test failure without retry.

**Solution:**
1. Change function signature to accept `assert.TestingT` interface
2. Use `assert.NoError(t, err)` instead of `s.Assert().NoError(err)`
3. Pass the `CollectT` from the caller: `s.verifyAPILogs(c)`
4. Add `FlushServerAndResetAggregators()` before the test for consistency

**File:** `test/e2e/tests/k8s_suite/k8s_suite_test.go`

## Test plan

- [ ] Verify e2e tests compile: `go build ./test/e2e/...`
- [ ] Verify go vet passes: `go vet ./test/e2e/...`
- [ ] Monitor CI e2e job failure rates after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)