### PR TITLE
Fix dependabot :dependabot: configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-      - qa/skip-qa

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,24 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: weekly
     labels:
       - tooling
       - qa/skip-qa
-    groups:
-      gh-actions-packages:
-        patterns:
-          - "*"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - qa/skip-qa
+  - package-ecosystem: gomod
+    directory: /test/e2e
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - qa/skip-qa


### PR DESCRIPTION
### What does this PR do?

Fix dependabot configuration.
Notably, the repo had these two files:
* https://github.com/DataDog/datadog-operator/blob/64ea874c05cf07c6283460a3c483c1e15f0af1d4/.github/dependabot.yml
* https://github.com/DataDog/datadog-operator/blob/64ea874c05cf07c6283460a3c483c1e15f0af1d4/.github/dependabot.yaml

whereas [dependabot only reads `.github/dependabot.yml`](https://docs.github.com/code-security/reference/supply-chain-security/dependabot-options-reference).

### Motivation

There is no dependabot :dependabot: PR opened despite some not up-to-date dependencies.

### Additional Notes

### Minimum Agent Versions

N/A

### Describe your test plan

Wait one week and see if dependabot :dependabot: wakes up.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
- [X] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits