### PR TITLE
Clarify TagCardinality usage with origin detection 

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -666,6 +666,7 @@ type DogstatsdFeatureConfig struct {
 	OriginDetectionEnabled *bool `json:"originDetectionEnabled,omitempty"`
 
 	// TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+	// This setting only applies when OriginDetectionEnabled is true.
 	// See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
 	// Cardinality default: low
 	// +optional

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -952,7 +952,7 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_DogstatsdFeatureConfig(ref c
 					},
 					"tagCardinality": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low",
+							Description: "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). This setting only applies when OriginDetectionEnabled is true. See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -1345,6 +1345,7 @@ spec:
                         tagCardinality:
                           description: |-
                             TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                            This setting only applies when OriginDetectionEnabled is true.
                             See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                             Cardinality default: low
                           type: string
@@ -9344,6 +9345,7 @@ spec:
                             tagCardinality:
                               description: |-
                                 TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                                This setting only applies when OriginDetectionEnabled is true.
                                 See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                                 Cardinality default: low
                               type: string

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -1363,7 +1363,7 @@
                   "type": "boolean"
                 },
                 "tagCardinality": {
-                  "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
+                  "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nThis setting only applies when OriginDetectionEnabled is true.\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
                   "type": "string"
                 },
                 "unixDomainSocketConfig": {
@@ -9222,7 +9222,7 @@
                       "type": "boolean"
                     },
                     "tagCardinality": {
-                      "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
+                      "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nThis setting only applies when OriginDetectionEnabled is true.\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
                       "type": "string"
                     },
                     "unixDomainSocketConfig": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -1345,6 +1345,7 @@ spec:
                             tagCardinality:
                               description: |-
                                 TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                                This setting only applies when OriginDetectionEnabled is true.
                                 See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                                 Cardinality default: low
                               type: string

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -1367,7 +1367,7 @@
                       "type": "boolean"
                     },
                     "tagCardinality": {
-                      "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
+                      "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nThis setting only applies when OriginDetectionEnabled is true.\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
                       "type": "string"
                     },
                     "unixDomainSocketConfig": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1345,6 +1345,7 @@ spec:
                         tagCardinality:
                           description: |-
                             TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                            This setting only applies when OriginDetectionEnabled is true.
                             See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                             Cardinality default: low
                           type: string
@@ -9394,6 +9395,7 @@ spec:
                             tagCardinality:
                               description: |-
                                 TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                                This setting only applies when OriginDetectionEnabled is true.
                                 See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
                                 Cardinality default: low
                               type: string

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1363,7 +1363,7 @@
                   "type": "boolean"
                 },
                 "tagCardinality": {
-                  "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
+                  "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nThis setting only applies when OriginDetectionEnabled is true.\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
                   "type": "string"
                 },
                 "unixDomainSocketConfig": {
@@ -9287,7 +9287,7 @@
                       "type": "boolean"
                     },
                     "tagCardinality": {
-                      "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
+                      "description": "TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).\nThis setting only applies when OriginDetectionEnabled is true.\nSee also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables\nCardinality default: low",
                       "type": "string"
                     },
                     "unixDomainSocketConfig": {

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -101,7 +101,7 @@ spec:
 | features.dogstatsd.mapperProfiles.configMap.name | Is the name of the ConfigMap. |
 | features.dogstatsd.nonLocalTraffic | NonLocalTraffic enables non-local traffic for Dogstatsd. Default: true |
 | features.dogstatsd.originDetectionEnabled | OriginDetectionEnabled enables origin detection for container tagging. See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging |
-| features.dogstatsd.tagCardinality | TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low |
+| features.dogstatsd.tagCardinality | TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). This setting only applies when OriginDetectionEnabled is true. See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low |
 | features.dogstatsd.unixDomainSocketConfig.enabled | Enables Unix Domain Socket. Default: true |
 | features.dogstatsd.unixDomainSocketConfig.path | Defines the socket path used when enabled. |
 | features.ebpfCheck.enabled | Enables the eBPF check. Default: false |

--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -187,7 +187,7 @@ spec:
 : OriginDetectionEnabled enables origin detection for container tagging. See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
 
 `features.dogstatsd.tagCardinality`
-: TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low
+: TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`). This setting only applies when OriginDetectionEnabled is true. See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables Cardinality default: low
 
 `features.dogstatsd.unixDomainSocketConfig.enabled`
 : Enables Unix Domain Socket. Default: true


### PR DESCRIPTION
### What does this PR do?

adjust the operator configuration doc so that it mentions that `originDetectionEnabled` needs to be true to use `tagCardinality`

### Motivation

customer support ticket
in favor https://github.com/DataDog/datadog-operator/pull/2525

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits