### PR TITLE
[CSPM] instruct the running container that CSPM is running in system-probe

### DIFF
--- a/internal/controller/datadogagent/feature/cspm/envvar.go
+++ b/internal/controller/datadogagent/feature/cspm/envvar.go
@@ -6,8 +6,9 @@
 package cspm
 
 const (
-	DDComplianceConfigDir             = "DD_COMPLIANCE_CONFIG_DIR"
-	DDComplianceConfigCheckInterval   = "DD_COMPLIANCE_CONFIG_CHECK_INTERVAL"
-	DDComplianceConfigEnabled         = "DD_COMPLIANCE_CONFIG_ENABLED"
-	DDComplianceHostBenchmarksEnabled = "DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED"
+	DDComplianceConfigDir              = "DD_COMPLIANCE_CONFIG_DIR"
+	DDComplianceConfigCheckInterval    = "DD_COMPLIANCE_CONFIG_CHECK_INTERVAL"
+	DDComplianceConfigEnabled          = "DD_COMPLIANCE_CONFIG_ENABLED"
+	DDComplianceHostBenchmarksEnabled  = "DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED"
+	DDComplianceConfigRunInSystemProbe = "DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE"
 )

--- a/internal/controller/datadogagent/feature/cspm/feature.go
+++ b/internal/controller/datadogagent/feature/cspm/feature.go
@@ -364,6 +364,12 @@ func (f *cspmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, prov
 	}
 	managers.EnvVar().AddEnvVarToContainer(targetContainer, hostBenchmarksEnabledEnvVar)
 
+	runInSystemProbeEnvVar := &corev1.EnvVar{
+		Name:  DDComplianceConfigRunInSystemProbe,
+		Value: apiutils.BoolToString(&f.runInSystemProbe),
+	}
+	managers.EnvVar().AddEnvVarToContainer(targetContainer, runInSystemProbeEnvVar)
+
 	return nil
 }
 

--- a/internal/controller/datadogagent/feature/cspm/feature_test.go
+++ b/internal/controller/datadogagent/feature/cspm/feature_test.go
@@ -199,6 +199,10 @@ func cspmAgentNodeWantFunc(runInSystemProbe bool) *test.ComponentTest {
 					Name:  DDComplianceHostBenchmarksEnabled,
 					Value: "true",
 				},
+				{
+					Name:  DDComplianceConfigRunInSystemProbe,
+					Value: apiutils.BoolToString(&runInSystemProbe),
+				},
 			}
 
 			targetContainerEnvVars := mgr.EnvVarMgr.EnvVarsByC[targetContainer]


### PR DESCRIPTION


### What does this PR do?

Follow up to https://github.com/DataDog/datadog-operator/pull/2480 instructing the running container (it can be the security agent or system-probe) about the status of "running in system-probe". This will make the transition easier and prevent some misconfigurations.

Agent side PR: https://github.com/DataDog/datadog-agent/pull/45510

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits