### PR TITLE
Use `monitorStateSyncStatus` for monitor k8s display column

### DIFF
--- a/api/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/api/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -376,7 +376,7 @@ type DatadogMonitorDowntimeStatus struct {
 // +kubebuilder:printcolumn:name="monitor state",type="string",JSONPath=".status.monitorState"
 // +kubebuilder:printcolumn:name="last state transition",type="string",JSONPath=".status.monitorStateLastTransitionTime"
 // +kubebuilder:printcolumn:name="last state sync",type="string",format="date",JSONPath=".status.monitorStateLastUpdateTime"
-// +kubebuilder:printcolumn:name="sync status",type="string",JSONPath=".status.syncStatus"
+// +kubebuilder:printcolumn:name="sync status",type="string",JSONPath=".status.monitorStateSyncStatus"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:openapi-gen=true
 // +genclient

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -28,7 +28,7 @@ spec:
           jsonPath: .status.monitorStateLastUpdateTime
           name: last state sync
           type: string
-        - jsonPath: .status.syncStatus
+        - jsonPath: .status.monitorStateSyncStatus
           name: sync status
           type: string
         - jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
### What does this PR do?

Currently, the Datadog monitor object print column points to the `.status.syncStatus` which is no longer exists, changed in https://github.com/DataDog/datadog-operator/pull/1355. It should point to the `.status.monitorStateSyncStatus` so it can show up properly when viewing in k8s.

### Motivation

The sync status is just blank when doing a `kubectl get datadogmonitors` 😢 
<img width="1035" height="81" alt="image" src="https://github.com/user-attachments/assets/78587ea9-6ccf-4bad-87d2-d0eb6842d32f" />

It was causing some confusion when the "Monitor State" column would say "Alert" folks were assuming that the monitor was failing to sync vs. the monitor being in the alert state in Datadog. I think having both columns filled in properly will fix this.

### Additional Notes

When running `make generate-manifests` locally I get a vastly different result for the CRD output with different indentation and line wrapping, might be a local linting thing? Either way someone may want to double check the output, pretty sure it is correct though.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?
- No it's just changing k8s display columns

### Describe your test plan

Generate the CRD with `make generate-manifests` and deploy the CRD directly with `k apply -f config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml` (we use helm to deploy our operator otherwise I would use the `make deploy`)

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits