### PR TITLE
Fix: use `monitorStateSyncStatus` for k8s display column

### DIFF
--- a/api/datadoghq/v1alpha1/datadogmonitor_types.go
+++ b/api/datadoghq/v1alpha1/datadogmonitor_types.go
@@ -376,7 +376,7 @@ type DatadogMonitorDowntimeStatus struct {
 // +kubebuilder:printcolumn:name="monitor state",type="string",JSONPath=".status.monitorState"
 // +kubebuilder:printcolumn:name="last state transition",type="string",JSONPath=".status.monitorStateLastTransitionTime"
 // +kubebuilder:printcolumn:name="last state sync",type="string",format="date",JSONPath=".status.monitorStateLastUpdateTime"
-// +kubebuilder:printcolumn:name="sync status",type="string",JSONPath=".status.syncStatus"
+// +kubebuilder:printcolumn:name="sync status",type="string",JSONPath=".status.monitorStateSyncStatus"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +k8s:openapi-gen=true
 // +genclient

--- a/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogmonitors.yaml
@@ -28,7 +28,7 @@ spec:
           jsonPath: .status.monitorStateLastUpdateTime
           name: last state sync
           type: string
-        - jsonPath: .status.syncStatus
+        - jsonPath: .status.monitorStateSyncStatus
           name: sync status
           type: string
         - jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
### What does this PR do?

Refer to https://github.com/DataDog/datadog-operator/pull/2554 - same but from local branch instead of fork for CI

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits