### PR TITLE
Remove some variables from the publish_release_candidate_workflow job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -723,10 +723,4 @@ publish_release_candidate_workflow:
     forward:
       pipeline_variables: true
   variables:
-    OPERATOR_RC: "true"
-    SKIP_PLAN_CHECK: "true"
-    ENVIRONMENTS: "experimental,staging"
-    CHART: "datadog-operator"
-    OPTION_AUTOMATIC_ROLLOUT: "true"
-    EXPLICIT_WORKFLOWS: "//workflows:deploy_operator_rc.operator_rc"
     OPERATOR_IMAGE_TAG: $CI_COMMIT_REF_SLUG


### PR DESCRIPTION
### What does this PR do?

Remove some variables from the publish_release_candidate_workflow job

### Motivation

Following https://github.com/DataDog/k8s-datadog-agent-ops/pull/7349, we no longer these variables

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits