### PR TITLE
[autoscaling] DPA Improvements: add vertical control + minor fixes

### DIFF
--- a/api/datadoghq/common/zz_generated.deepcopy.go
+++ b/api/datadoghq/common/zz_generated.deepcopy.go
@@ -58,6 +58,11 @@ func (in *DatadogPodAutoscalerConstraints) DeepCopyInto(out *DatadogPodAutoscale
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaxReplicas != nil {
+		in, out := &in.MaxReplicas, &out.MaxReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Containers != nil {
 		in, out := &in.Containers, &out.Containers
 		*out = make([]DatadogPodAutoscalerContainerConstraints, len(*in))
@@ -89,6 +94,30 @@ func (in *DatadogPodAutoscalerContainerConstraints) DeepCopyInto(out *DatadogPod
 		in, out := &in.Requests, &out.Requests
 		*out = new(DatadogPodAutoscalerContainerResourceConstraints)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.MinAllowed != nil {
+		in, out := &in.MinAllowed, &out.MinAllowed
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.MaxAllowed != nil {
+		in, out := &in.MaxAllowed, &out.MaxAllowed
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.ControlledResources != nil {
+		in, out := &in.ControlledResources, &out.ControlledResources
+		*out = make([]v1.ResourceName, len(*in))
+		copy(*out, *in)
+	}
+	if in.ControlledValues != nil {
+		in, out := &in.ControlledValues, &out.ControlledValues
+		*out = new(DatadogPodAutoscalerContainerControlledValues)
+		**out = **in
 	}
 }
 

--- a/api/datadoghq/v1alpha2/datadogpodautoscaler_conversion_test.go
+++ b/api/datadoghq/v1alpha2/datadogpodautoscaler_conversion_test.go
@@ -58,7 +58,7 @@ func TestNewDatadogPodAutoscalerFromV1Alpha1(t *testing.T) {
 			},
 			Constraints: &common.DatadogPodAutoscalerConstraints{
 				MinReplicas: utils.NewPointer[int32](1),
-				MaxReplicas: 10,
+				MaxReplicas: utils.NewPointer[int32](10),
 				Containers: []common.DatadogPodAutoscalerContainerConstraints{
 					{
 						Name:    "foo",
@@ -126,7 +126,7 @@ func TestNewDatadogPodAutoscalerFromV1Alpha1(t *testing.T) {
 			},
 			Constraints: &common.DatadogPodAutoscalerConstraints{
 				MinReplicas: utils.NewPointer[int32](1),
-				MaxReplicas: 10,
+				MaxReplicas: utils.NewPointer[int32](10),
 				Containers: []common.DatadogPodAutoscalerContainerConstraints{
 					{
 						Name:    "foo",
@@ -199,7 +199,7 @@ func TestNewDatadogPodAutoscalerToV1Alpha1(t *testing.T) {
 			},
 			Constraints: &common.DatadogPodAutoscalerConstraints{
 				MinReplicas: utils.NewPointer[int32](1),
-				MaxReplicas: 10,
+				MaxReplicas: utils.NewPointer[int32](10),
 				Containers: []common.DatadogPodAutoscalerContainerConstraints{
 					{
 						Name:    "foo",
@@ -267,7 +267,7 @@ func TestNewDatadogPodAutoscalerToV1Alpha1(t *testing.T) {
 			},
 			Constraints: &common.DatadogPodAutoscalerConstraints{
 				MinReplicas: utils.NewPointer[int32](1),
-				MaxReplicas: 10,
+				MaxReplicas: utils.NewPointer[int32](10),
 				Containers: []common.DatadogPodAutoscalerContainerConstraints{
 					{
 						Name:    "foo",

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -88,14 +88,51 @@ spec:
                           DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.
                           If no constraints are set, it enables resource scaling for all containers without any constraints.
                         properties:
+                          controlledResources:
+                            description: |-
+                              Specifies the resources for which recommendations will be computed.
+                              If not specified, it defaults to CPU and Memory.
+                              If an empty list is provided, no resource will be controlled (equivalent to Enabled=false).
+                            items:
+                              description: ResourceName is the name identifying various resources in a ResourceList.
+                              type: string
+                            type: array
+                          controlledValues:
+                            description: |-
+                              Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).
+                              The default is "RequestsAndLimits".
+                            enum:
+                              - RequestsAndLimits
+                              - RequestsOnly
+                            type: string
                           enabled:
                             description: Enabled, if false, allows one to disable resource autoscaling for the container. Defaults to true.
                             type: boolean
+                          maxAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: MaxAllowed is the upper limit for the requests of the container.
+                            type: object
+                          minAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: MinAllowed is the lower limit for the requests of the container.
+                            type: object
                           name:
                             description: Name is the name of the container. Can be "*" to apply to all containers.
                             type: string
                           requests:
-                            description: Requests defines the constraints for the requests of the container.
+                            description: |-
+                              Requests defines the constraints for the requests of the container.
+                              WARNING: Deprecated
                             properties:
                               maxAllowed:
                                 additionalProperties:
@@ -123,14 +160,13 @@ spec:
                     maxReplicas:
                       description: MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.
                       format: int32
+                      minimum: 1
                       type: integer
                     minReplicas:
                       description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
                       format: int32
                       minimum: 1
                       type: integer
-                  required:
-                    - maxReplicas
                   type: object
                 owner:
                   description: |-
@@ -319,6 +355,7 @@ spec:
                             description: Name is the name of the resource.
                             enum:
                               - cpu
+                              - memory
                             type: string
                           value:
                             description: Value is the value of the objective
@@ -489,6 +526,7 @@ spec:
                             description: Name is the name of the resource.
                             enum:
                               - cpu
+                              - memory
                             type: string
                           value:
                             description: Value is the value of the objective.
@@ -950,14 +988,51 @@ spec:
                           DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.
                           If no constraints are set, it enables resource scaling for all containers without any constraints.
                         properties:
+                          controlledResources:
+                            description: |-
+                              Specifies the resources for which recommendations will be computed.
+                              If not specified, it defaults to CPU and Memory.
+                              If an empty list is provided, no resource will be controlled (equivalent to Enabled=false).
+                            items:
+                              description: ResourceName is the name identifying various resources in a ResourceList.
+                              type: string
+                            type: array
+                          controlledValues:
+                            description: |-
+                              Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).
+                              The default is "RequestsAndLimits".
+                            enum:
+                              - RequestsAndLimits
+                              - RequestsOnly
+                            type: string
                           enabled:
                             description: Enabled, if false, allows one to disable resource autoscaling for the container. Defaults to true.
                             type: boolean
+                          maxAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: MaxAllowed is the upper limit for the requests of the container.
+                            type: object
+                          minAllowed:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: MinAllowed is the lower limit for the requests of the container.
+                            type: object
                           name:
                             description: Name is the name of the container. Can be "*" to apply to all containers.
                             type: string
                           requests:
-                            description: Requests defines the constraints for the requests of the container.
+                            description: |-
+                              Requests defines the constraints for the requests of the container.
+                              WARNING: Deprecated
                             properties:
                               maxAllowed:
                                 additionalProperties:
@@ -985,14 +1060,13 @@ spec:
                     maxReplicas:
                       description: MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.
                       format: int32
+                      minimum: 1
                       type: integer
                     minReplicas:
                       description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
                       format: int32
                       minimum: 1
                       type: integer
-                  required:
-                    - maxReplicas
                   type: object
                 fallback:
                   default: {}
@@ -1031,6 +1105,7 @@ spec:
                                     description: Name is the name of the resource.
                                     enum:
                                       - cpu
+                                      - memory
                                     type: string
                                   value:
                                     description: Value is the value of the objective
@@ -1201,6 +1276,7 @@ spec:
                                     description: Name is the name of the resource.
                                     enum:
                                       - cpu
+                                      - memory
                                     type: string
                                   value:
                                     description: Value is the value of the objective.
@@ -1277,6 +1353,7 @@ spec:
                             description: Name is the name of the resource.
                             enum:
                               - cpu
+                              - memory
                             type: string
                           value:
                             description: Value is the value of the objective
@@ -1447,6 +1524,7 @@ spec:
                             description: Name is the name of the resource.
                             enum:
                               - cpu
+                              - memory
                             type: string
                           value:
                             description: Value is the value of the objective.

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -27,9 +27,83 @@
                 "additionalProperties": false,
                 "description": "DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.\nIf no constraints are set, it enables resource scaling for all containers without any constraints.",
                 "properties": {
+                  "controlledResources": {
+                    "description": "Specifies the resources for which recommendations will be computed.\nIf not specified, it defaults to CPU and Memory.\nIf an empty list is provided, no resource will be controlled (equivalent to Enabled=false).",
+                    "items": {
+                      "description": "ResourceName is the name identifying various resources in a ResourceList.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "controlledValues": {
+                    "description": "Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).\nThe default is \"RequestsAndLimits\".",
+                    "enum": [
+                      "RequestsAndLimits",
+                      "RequestsOnly"
+                    ],
+                    "type": "string"
+                  },
                   "enabled": {
                     "description": "Enabled, if false, allows one to disable resource autoscaling for the container. Defaults to true.",
                     "type": "boolean"
+                  },
+                  "maxAllowed": {
+                    "additionalProperties": false,
+                    "description": "MaxAllowed is the upper limit for the requests of the container.",
+                    "properties": {
+                      "cpu": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "memory": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "minAllowed": {
+                    "additionalProperties": false,
+                    "description": "MinAllowed is the lower limit for the requests of the container.",
+                    "properties": {
+                      "cpu": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "memory": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      }
+                    },
+                    "type": "object"
                   },
                   "name": {
                     "description": "Name is the name of the container. Can be \"*\" to apply to all containers.",
@@ -37,7 +111,7 @@
                   },
                   "requests": {
                     "additionalProperties": false,
-                    "description": "Requests defines the constraints for the requests of the container.",
+                    "description": "Requests defines the constraints for the requests of the container.\nWARNING: Deprecated",
                     "properties": {
                       "maxAllowed": {
                         "additionalProperties": false,
@@ -111,6 +185,7 @@
             "maxReplicas": {
               "description": "MaxReplicas is the upper limit for the number of POD replicas. Needs to be \u003e= minReplicas.",
               "format": "int32",
+              "minimum": 1,
               "type": "integer"
             },
             "minReplicas": {
@@ -120,9 +195,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "maxReplicas"
-          ],
           "type": "object"
         },
         "owner": {
@@ -333,7 +405,8 @@
                   "name": {
                     "description": "Name is the name of the resource.",
                     "enum": [
-                      "cpu"
+                      "cpu",
+                      "memory"
                     ],
                     "type": "string"
                   },
@@ -564,7 +637,8 @@
                   "name": {
                     "description": "Name is the name of the resource.",
                     "enum": [
-                      "cpu"
+                      "cpu",
+                      "memory"
                     ],
                     "type": "string"
                   },

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -181,9 +181,83 @@
                 "additionalProperties": false,
                 "description": "DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.\nIf no constraints are set, it enables resource scaling for all containers without any constraints.",
                 "properties": {
+                  "controlledResources": {
+                    "description": "Specifies the resources for which recommendations will be computed.\nIf not specified, it defaults to CPU and Memory.\nIf an empty list is provided, no resource will be controlled (equivalent to Enabled=false).",
+                    "items": {
+                      "description": "ResourceName is the name identifying various resources in a ResourceList.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "controlledValues": {
+                    "description": "Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).\nThe default is \"RequestsAndLimits\".",
+                    "enum": [
+                      "RequestsAndLimits",
+                      "RequestsOnly"
+                    ],
+                    "type": "string"
+                  },
                   "enabled": {
                     "description": "Enabled, if false, allows one to disable resource autoscaling for the container. Defaults to true.",
                     "type": "boolean"
+                  },
+                  "maxAllowed": {
+                    "additionalProperties": false,
+                    "description": "MaxAllowed is the upper limit for the requests of the container.",
+                    "properties": {
+                      "cpu": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "memory": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "minAllowed": {
+                    "additionalProperties": false,
+                    "description": "MinAllowed is the lower limit for the requests of the container.",
+                    "properties": {
+                      "cpu": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      },
+                      "memory": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "integer"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                      }
+                    },
+                    "type": "object"
                   },
                   "name": {
                     "description": "Name is the name of the container. Can be \"*\" to apply to all containers.",
@@ -191,7 +265,7 @@
                   },
                   "requests": {
                     "additionalProperties": false,
-                    "description": "Requests defines the constraints for the requests of the container.",
+                    "description": "Requests defines the constraints for the requests of the container.\nWARNING: Deprecated",
                     "properties": {
                       "maxAllowed": {
                         "additionalProperties": false,
@@ -265,6 +339,7 @@
             "maxReplicas": {
               "description": "MaxReplicas is the upper limit for the number of POD replicas. Needs to be \u003e= minReplicas.",
               "format": "int32",
+              "minimum": 1,
               "type": "integer"
             },
             "minReplicas": {
@@ -274,9 +349,6 @@
               "type": "integer"
             }
           },
-          "required": [
-            "maxReplicas"
-          ],
           "type": "object"
         },
         "fallback": {
@@ -321,7 +393,8 @@
                           "name": {
                             "description": "Name is the name of the resource.",
                             "enum": [
-                              "cpu"
+                              "cpu",
+                              "memory"
                             ],
                             "type": "string"
                           },
@@ -552,7 +625,8 @@
                           "name": {
                             "description": "Name is the name of the resource.",
                             "enum": [
-                              "cpu"
+                              "cpu",
+                              "memory"
                             ],
                             "type": "string"
                           },
@@ -658,7 +732,8 @@
                   "name": {
                     "description": "Name is the name of the resource.",
                     "enum": [
-                      "cpu"
+                      "cpu",
+                      "memory"
                     ],
                     "type": "string"
                   },
@@ -889,7 +964,8 @@
                   "name": {
                     "description": "Name is the name of the resource.",
                     "enum": [
-                      "cpu"
+                      "cpu",
+                      "memory"
                     ],
                     "type": "string"
                   },


### PR DESCRIPTION
### What does this PR do?

Add fields to CRD to control vertical resources (cpu, memory) and vertical values (requests, limits) per container.
Remove requirement of `MaxReplicas` as it's not needed in vertical-only mode.
Add a condition to highlight vertical scaling limited.

### Motivation

Improve UX and tuning capabilities.

### Additional Notes

### Minimum Agent Versions

Cluster Agent 7.77

### Describe your test plan

No QA

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits