### PR TITLE
DO NOT MERGE: Experimental privileged mode for private action runner

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -590,6 +590,7 @@ func privateActionRunnerContainer(dda metav1.Object) corev1.Container {
 		VolumeMounts: volumeMountsForPrivateActionRunner(),
 		SecurityContext: &corev1.SecurityContext{
 			ReadOnlyRootFilesystem: apiutils.NewBoolPointer(true),
+			Privileged:             apiutils.NewBoolPointer(true),
 		},
 	}
 }

--- a/internal/controller/datadogagent/component/agent/default_test.go
+++ b/internal/controller/datadogagent/component/agent/default_test.go
@@ -220,6 +220,7 @@ func TestPrivateActionRunnerContainer(t *testing.T) {
 	}, parContainer.Command)
 
 	assert.True(t, *parContainer.SecurityContext.ReadOnlyRootFilesystem)
+	assert.True(t, *parContainer.SecurityContext.Privileged)
 	mountNames := make(map[string]bool)
 	for _, m := range parContainer.VolumeMounts {
 		mountNames[m.Name] = true


### PR DESCRIPTION
Experimental changes - do not merge.

Enables privileged mode on the private action runner container's SecurityContext and updates tests.