### PR TITLE
Check milestone latest state and trigger workflow

### DIFF
--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -1,12 +1,15 @@
 name: pull request linter
 on:
   pull_request_target:
-   types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, labeled, unlabeled, synchronize]
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, milestoned, demilestoned]
 
 permissions: {}
 
 jobs:
   build:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,9 +26,19 @@ jobs:
         disable-reviews: true
   check-milestone:
     name: Check Milestone
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     steps:
-      - if: github.event.pull_request.milestone == null && !contains(toJson(github.event.pull_request.labels.*.name), 'qa/skip-qa')
-        run: echo "::error::Missing milestone or \`qa/skip-qa\` label" && exit 1
+      - name: Check milestone and labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }})
+          MILESTONE=$(echo "$PR_JSON" | jq -r '.milestone.title // empty')
+          HAS_SKIP_QA=$(echo "$PR_JSON" | jq -r '[.labels[].name] | any(. == "qa/skip-qa")')
+          if [ -z "$MILESTONE" ] && [ "$HAS_SKIP_QA" != "true" ]; then
+            echo "::error::Missing milestone or \`qa/skip-qa\` label"
+            exit 1
+          fi


### PR DESCRIPTION
### What does this PR do?

Check current milestone (as opposed to milestone at PR initial state) and rerun workflow upon milestone/demilestone events

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits