### PR TITLE
[nightly] Move rules ordering to disable e2e-autoscaling & check-golang

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,10 @@ unit_tests:
 check-golang-version:
   stage: build
   tags: ["arch:amd64"]
+  rules:
+    - if: '$DDR == "true"'
+      when: never
+    - when: on_success
   before_script:
     - make install-tools
   script:
@@ -398,6 +402,9 @@ e2e_autoscaling:
     - "go_e2e_deps"
   timeout: 60m
   rules:
+    # Disable on Conductor-triggered jobs (ex: nightly) — must be first so it wins
+    - if: '$DDR == "true"'
+      when: never
     # Run automatically on changes to autoscaling code
     - if: $CI_COMMIT_BRANCH
       changes:
@@ -407,9 +414,6 @@ e2e_autoscaling:
           - "test/e2e/provisioners/eks.go"
           - "test/e2e/common/autoscaling.go"
       when: on_success
-    # Disable on Conductor-triggered jobs (ex: nightly)
-    - if: '$DDR == "true"'
-      when: never
     # Allow manual run otherwise
     - when: manual
       allow_failure: true


### PR DESCRIPTION
### What does this PR do?

Follow-up to https://github.com/DataDog/datadog-operator/pull/2620

### Motivation

Pipeline still failed as e2e-autoscaling was still run. This is because gitlab rules are evaluated in order, so we wouldn't enter the `DDR` rule

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits