### PR TITLE
[AGENTONB-2890] Revert "[CXP-2639][datadog-operator] Remove envvar ovveride for controlling whether process checks run in core or process agent"

### DIFF
--- a/docs/deprecated_configs.md
+++ b/docs/deprecated_configs.md
@@ -15,4 +15,8 @@ This document lists configuration options that are deprecated or will be depreca
 The `runProcessChecksInCoreAgent` field in the Global configuration is being deprecated. This field previously controlled whether the Process Agent or Core Agent collects process and container checks and featurres.
 
 ### Migration Path
-Process checks are now run in the Core Agent by default for Agent v7.60 or above. Otherwise, the Process Agent is still used.
+Process checks are now run in the core Agent by default. 
+
+If this field was set to `true`, it can be removed with no behavior change. If you are using Agent v7.60 or below, you can use environment variable overrides or upgrade your Agent version.
+
+If this field was set to `false`, use the environment variable override (`DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED=false`) to disable this functionality.

--- a/internal/controller/datadogagent/feature/apm/feature_test.go
+++ b/internal/controller/datadogagent/feature/apm/feature_test.go
@@ -359,7 +359,8 @@ func TestAPMFeature(t *testing.T) {
 				WithComponentOverride(
 					v2alpha1.NodeAgentComponentName,
 					v2alpha1.DatadogAgentComponentOverride{
-						Image: &v2alpha1.AgentImageConfig{Tag: "7.59.0"},
+						Image: &v2alpha1.AgentImageConfig{Tag: "7.60.0"},
+						Env:   []corev1.EnvVar{{Name: "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", Value: "false"}},
 					},
 				).
 				Build(),

--- a/internal/controller/datadogagent/feature/livecontainer/feature_test.go
+++ b/internal/controller/datadogagent/feature/livecontainer/feature_test.go
@@ -56,6 +56,21 @@ func TestLiveContainerFeature(t *testing.T) {
 			WantConfigure: true,
 			Agent:         testExpectedAgent(apicommon.ProcessAgentContainerName, false),
 		},
+		{
+			Name: "live container collection disabled on core agent via env var override",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithLiveContainerCollectionEnabled(true).
+				WithComponentOverride(
+					v2alpha1.NodeAgentComponentName,
+					v2alpha1.DatadogAgentComponentOverride{
+						Image: &v2alpha1.AgentImageConfig{Tag: "7.60.0"},
+						Env:   []corev1.EnvVar{{Name: "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", Value: "false"}},
+					},
+				).
+				Build(),
+			WantConfigure: true,
+			Agent:         testExpectedAgent(apicommon.ProcessAgentContainerName, false),
+		},
 	}
 
 	tests.Run(t, buildLiveContainerFeature)

--- a/internal/controller/datadogagent/feature/liveprocess/feature_test.go
+++ b/internal/controller/datadogagent/feature/liveprocess/feature_test.go
@@ -64,6 +64,21 @@ func Test_liveProcessFeature_Configure(t *testing.T) {
 			Agent:         testExpectedAgent(apicommon.ProcessAgentContainerName, false, false),
 		},
 		{
+			Name: "live process collection disabled in core agent via env var override",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithLiveProcessEnabled(true).
+				WithComponentOverride(
+					v2alpha1.NodeAgentComponentName,
+					v2alpha1.DatadogAgentComponentOverride{
+						Image: &v2alpha1.AgentImageConfig{Tag: "7.60.0"},
+						Env:   []corev1.EnvVar{{Name: "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", Value: "false"}},
+					},
+				).
+				Build(),
+			WantConfigure: true,
+			Agent:         testExpectedAgent(apicommon.ProcessAgentContainerName, false, false),
+		},
+		{
 			Name: "live process collection enabled on single container",
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithLiveProcessEnabled(true).

--- a/internal/controller/datadogagent/feature/processdiscovery/feature_test.go
+++ b/internal/controller/datadogagent/feature/processdiscovery/feature_test.go
@@ -48,6 +48,21 @@ func Test_processDiscoveryFeature_Configure(t *testing.T) {
 			Agent:         testExpectedAgent(apicommon.CoreAgentContainerName, true),
 		},
 		{
+			Name: "process discovery disabled in core agent via env vars",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithProcessDiscoveryEnabled(true).
+				WithComponentOverride(
+					v2alpha1.NodeAgentComponentName,
+					v2alpha1.DatadogAgentComponentOverride{
+						Image: &v2alpha1.AgentImageConfig{Tag: "7.60.0"},
+						Env:   []corev1.EnvVar{{Name: "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", Value: "false"}},
+					},
+				).
+				Build(),
+			WantConfigure: true,
+			Agent:         testExpectedAgent(apicommon.ProcessAgentContainerName, false),
+		},
+		{
 			Name: "process discovery without min version to run in core agent",
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithProcessDiscoveryEnabled(true).

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -6,6 +6,8 @@
 package utils
 
 import (
+	"strconv"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -39,10 +41,24 @@ func agentSupportsRunInCoreAgent(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 // ShouldRunProcessChecksInCoreAgent determines whether allow process checks to run in core agent based on
 // environment variables and the agent version.
 func ShouldRunProcessChecksInCoreAgent(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
+
+	// Prioritize env var override
+	if nodeAgent, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok {
+		for _, env := range nodeAgent.Env {
+			if env.Name == common.DDProcessConfigRunInCoreAgent {
+				val, err := strconv.ParseBool(env.Value)
+				if err == nil {
+					return val
+				}
+			}
+		}
+	}
+
 	// Check if agent version supports process checks running in core agent
 	if !agentSupportsRunInCoreAgent(ddaSpec) {
 		return false
 	}
+
 	return true
 }
 


### PR DESCRIPTION
Reverts DataDog/datadog-operator#2551

After manual QA, it was uncovered that this change does not fully work as intended. Setting `DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED==false` as an envvar override results in the process checks not running at all since the process agent does not come up.