### PR TITLE
Fix CCR hostname mismatch causing ghost hosts in Remote Configuration

### DIFF
--- a/internal/controller/datadogagent/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default.go
@@ -259,7 +259,7 @@ func defaultEnvVars(dda metav1.Object) []corev1.EnvVar {
 			Value: "false",
 		},
 		{
-			Name: constants.DDHostName,
+			Name: DDCCRNodeName,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: common.FieldPathSpecNodeName,

--- a/internal/controller/datadogagent/component/clusterchecksrunner/default_test.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +26,34 @@ func Test_getDefaultServiceAccountName(t *testing.T) {
 	}
 
 	assert.Equal(t, "my-datadog-agent-cluster-checks-runner", getDefaultServiceAccountName(&dda))
+}
+
+func Test_defaultEnvVars_hasCCRNodeName(t *testing.T) {
+	dda := v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-datadog-agent",
+			Namespace: "some-namespace",
+		},
+	}
+
+	envVars := defaultEnvVars(&dda)
+
+	// DD_CCR_NODE_NAME should be set from spec.nodeName via downward API
+	var foundCCRNodeName bool
+	var foundDDHostname bool
+	for _, env := range envVars {
+		if env.Name == DDCCRNodeName {
+			foundCCRNodeName = true
+			assert.NotNil(t, env.ValueFrom)
+			assert.NotNil(t, env.ValueFrom.FieldRef)
+			assert.Equal(t, common.FieldPathSpecNodeName, env.ValueFrom.FieldRef.FieldPath)
+		}
+		if env.Name == constants.DDHostName {
+			foundDDHostname = true
+		}
+	}
+	assert.True(t, foundCCRNodeName, "DD_CCR_NODE_NAME should be present in default env vars")
+	assert.False(t, foundDDHostname, "DD_HOSTNAME should not be directly set in default env vars")
 }
 
 func Test_getPodDisruptionBudget(t *testing.T) {

--- a/internal/controller/datadogagent/component/clusterchecksrunner/envvar.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/envvar.go
@@ -10,4 +10,5 @@ const (
 	DDClcRunnerHost            = "DD_CLC_RUNNER_HOST"
 	DDClcRunnerID              = "DD_CLC_RUNNER_ID"
 	DDEnableMetadataCollection = "DD_ENABLE_METADATA_COLLECTION"
+	DDCCRNodeName              = "DD_CCR_NODE_NAME"
 )

--- a/internal/controller/datadogagent/global/clusterchecksrunner.go
+++ b/internal/controller/datadogagent/global/clusterchecksrunner.go
@@ -6,9 +6,28 @@
 package global
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	ccr "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusterchecksrunner"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
 func applyClusterChecksRunnerResources(manager feature.PodTemplateManagers, ddaSpec *v2alpha1.DatadogAgentSpec) {
+	// Construct DD_HOSTNAME from the intermediate DD_CCR_NODE_NAME env var.
+	// If a cluster name is configured, append it as a suffix to match the
+	// hostname format used by the node agent, preventing ghost hosts in
+	// Remote Configuration.
+	hostnameValue := fmt.Sprintf("$(%s)", ccr.DDCCRNodeName)
+	if ddaSpec.Global != nil && ddaSpec.Global.ClusterName != nil && *ddaSpec.Global.ClusterName != "" {
+		hostnameValue = fmt.Sprintf("$(%s)-%s", ccr.DDCCRNodeName, *ddaSpec.Global.ClusterName)
+	}
+
+	manager.EnvVar().AddEnvVar(&corev1.EnvVar{
+		Name:  constants.DDHostName,
+		Value: hostnameValue,
+	})
 }

--- a/internal/controller/datadogagent/global/clusterchecksrunner_test.go
+++ b/internal/controller/datadogagent/global/clusterchecksrunner_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package global
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	ccr "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusterchecksrunner"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
+	mergerfake "github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger/fake"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestApplyClusterChecksRunnerResources_WithClusterName(t *testing.T) {
+	clusterName := "my-cluster-name"
+	ddaSpec := &v2alpha1.DatadogAgentSpec{
+		Global: &v2alpha1.GlobalConfig{
+			ClusterName: &clusterName,
+		},
+	}
+
+	manager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
+	applyClusterChecksRunnerResources(manager, ddaSpec)
+
+	envVars := manager.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
+	assert.Len(t, envVars, 1)
+	assert.Equal(t, constants.DDHostName, envVars[0].Name)
+	assert.Equal(t, fmt.Sprintf("$(%s)-%s", ccr.DDCCRNodeName, clusterName), envVars[0].Value)
+}
+
+func TestApplyClusterChecksRunnerResources_WithoutClusterName(t *testing.T) {
+	ddaSpec := &v2alpha1.DatadogAgentSpec{
+		Global: &v2alpha1.GlobalConfig{},
+	}
+
+	manager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
+	applyClusterChecksRunnerResources(manager, ddaSpec)
+
+	envVars := manager.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
+	assert.Len(t, envVars, 1)
+	assert.Equal(t, constants.DDHostName, envVars[0].Name)
+	assert.Equal(t, fmt.Sprintf("$(%s)", ccr.DDCCRNodeName), envVars[0].Value)
+}
+
+func TestApplyClusterChecksRunnerResources_NilGlobal(t *testing.T) {
+	ddaSpec := &v2alpha1.DatadogAgentSpec{}
+
+	manager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
+	applyClusterChecksRunnerResources(manager, ddaSpec)
+
+	envVars := manager.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
+	assert.Len(t, envVars, 1)
+	assert.Equal(t, constants.DDHostName, envVars[0].Name)
+	assert.Equal(t, fmt.Sprintf("$(%s)", ccr.DDCCRNodeName), envVars[0].Value)
+}


### PR DESCRIPTION
## Summary

- Replace `DD_HOSTNAME` in CCR default env vars with an intermediate `DD_CCR_NODE_NAME` env var that holds the raw node name from the downward API (`spec.nodeName`)
- Implement `applyClusterChecksRunnerResources()` to construct `DD_HOSTNAME` using k8s env var substitution: `$(DD_CCR_NODE_NAME)-<clusterName>` when cluster name is configured, or `$(DD_CCR_NODE_NAME)` otherwise
- This prevents the RC backend from creating ghost hosts due to hostname format mismatch between CCR and node agent

**Note:** An alternative approach worth considering is to *not* set `DD_HOSTNAME` at all and instead let the CCR agent resolve its hostname through its normal resolution path (which already respects `DD_CLUSTER_NAME`). This would avoid duplicating hostname construction logic in the operator. This PR takes the env var substitution approach as a starting point for discussion.

## Test plan

- [x] Unit test: `DD_CCR_NODE_NAME` is set from `spec.nodeName` in default env vars
- [x] Unit test: `DD_HOSTNAME` is not directly in default env vars
- [x] Unit test: `DD_HOSTNAME` includes cluster name suffix when cluster name is configured
- [x] Unit test: `DD_HOSTNAME` falls back to just node name when cluster name is not configured
- [x] Unit test: nil global config is handled gracefully
- [ ] Verify generated CCR deployment has correct env var structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)