### PR TITLE
Disable e2e-autoscaling test when pushing images to staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -405,6 +405,9 @@ e2e_autoscaling:
     # Disable on Conductor-triggered jobs (ex: nightly) — must be first so it wins
     - if: '$DDR == "true"'
       when: never
+    # Disable on manual pipelines to test staging images
+    - if: $PUSH_IMAGES_TO_STAGING == 'true'
+      when: never
     # Run automatically on changes to autoscaling code
     - if: $CI_COMMIT_BRANCH
       changes:


### PR DESCRIPTION
### What does this PR do?

* Removes the `e2e-autoscaling` step for manual pipelines

### Motivation

* Avoid being blocked by this long test when pushing images to staging (n.b.: the e2e regular tests have `allow_failure: true` so they can be cancelled manually if needed unlike this one, where cancelling it prevents from going to next step)

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Verified in https://gitlab.ddbuild.io/DataDog/datadog-operator/-/pipelines/99702629 that `e2e-autoscaling` is no longer present when PUSH_IMAGES_TO_STAGING is set

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits