### PR TITLE
Add Operator env var to default to Datadog registry (#2669)

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -930,6 +930,20 @@ func getDsContainers(c client.Client, resourcesNamespace, dsName string) map[api
 	return dsContainers
 }
 
+func getDeploymentContainers(c client.Client, resourcesNamespace, deploymentName string) map[apicommon.AgentContainerName]corev1.Container {
+	deployment := &appsv1.Deployment{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: deploymentName}, deployment); err != nil {
+		return nil
+	}
+
+	containers := map[apicommon.AgentContainerName]corev1.Container{}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		containers[apicommon.AgentContainerName(container.Name)] = container
+	}
+
+	return containers
+}
+
 func Test_AutopilotOverrides(t *testing.T) {
 	const resourcesName, resourcesNamespace, dsName = "foo", "bar", "foo-agent"
 
@@ -1853,4 +1867,143 @@ func getDefaultDDAI(dda *v2alpha1.DatadogAgent) v1alpha1.DatadogAgentInternal {
 		},
 	}
 	return expectedDDAI
+}
+
+func Test_RegistryDefaultingBySite(t *testing.T) {
+	const resourcesName = "foo"
+	const resourcesNamespace = "bar"
+	const dsName = "foo-agent"
+	const dcaName = "foo-cluster-agent"
+	const ccrName = "foo-cluster-checks-runner"
+
+	defaultRequeueDuration := 15 * time.Second
+
+	type registryTestCase struct {
+		name         string
+		site         string
+		envVars      map[string]string
+		wantRegistry string
+	}
+
+	tests := []registryTestCase{
+		{
+			name:         "Europe site defaults to EU registry",
+			site:         "datadoghq.eu",
+			wantRegistry: images.DefaultEuropeImageRegistry,
+		},
+		{
+			name:         "Europe site with DD_REGISTRY_OVERRIDE_EU=true uses Datadog registry",
+			site:         "datadoghq.eu",
+			envVars:      map[string]string{"DD_REGISTRY_OVERRIDE_EU": "true"},
+			wantRegistry: images.DatadogContainerRegistry,
+		},
+		{
+			name:         "Asia site defaults to Asia registry",
+			site:         "ap1.datadoghq.com",
+			wantRegistry: images.DefaultAsiaImageRegistry,
+		},
+		{
+			name:         "Asia site with DD_REGISTRY_OVERRIDE_ASIA=true uses Datadog registry",
+			site:         "ap1.datadoghq.com",
+			envVars:      map[string]string{"DD_REGISTRY_OVERRIDE_ASIA": "true"},
+			wantRegistry: images.DatadogContainerRegistry,
+		},
+		{
+			name:         "Azure site defaults to Azure registry",
+			site:         "us3.datadoghq.com",
+			wantRegistry: images.DefaultAzureImageRegistry,
+		},
+		{
+			name:         "Azure site with DD_REGISTRY_OVERRIDE_AZURE=true uses Datadog registry",
+			site:         "us3.datadoghq.com",
+			envVars:      map[string]string{"DD_REGISTRY_OVERRIDE_AZURE": "true"},
+			wantRegistry: images.DatadogContainerRegistry,
+		},
+		{
+			name:         "Gov site defaults to Gov registry",
+			site:         "ddog-gov.com",
+			wantRegistry: images.DefaultGovImageRegistry,
+		},
+		{
+			name:         "default site without DD_REGISTRY_OVERRIDE_DEFAULT uses GCR registry",
+			site:         "datadoghq.com",
+			wantRegistry: images.DefaultImageRegistry,
+		},
+		{
+			name:         "default site with DD_REGISTRY_OVERRIDE_DEFAULT=true uses Datadog registry",
+			site:         "datadoghq.com",
+			envVars:      map[string]string{"DD_REGISTRY_OVERRIDE_DEFAULT": "true"},
+			wantRegistry: images.DatadogContainerRegistry,
+		},
+		// Verify that override env vars are site-scoped: setting overrides for other sites
+		// must not affect the current site's registry selection.
+		{
+			name: "EU site ignores non-EU override env vars",
+			site: "datadoghq.eu",
+			envVars: map[string]string{
+				"DD_REGISTRY_OVERRIDE_ASIA":    "true",
+				"DD_REGISTRY_OVERRIDE_AZURE":   "true",
+				"DD_REGISTRY_OVERRIDE_DEFAULT": "true",
+			},
+			wantRegistry: images.DefaultEuropeImageRegistry,
+		},
+		{
+			name: "default site ignores non-default override env vars",
+			site: "datadoghq.com",
+			envVars: map[string]string{
+				"DD_REGISTRY_OVERRIDE_EU":    "true",
+				"DD_REGISTRY_OVERRIDE_ASIA":  "true",
+				"DD_REGISTRY_OVERRIDE_AZURE": "true",
+			},
+			wantRegistry: images.DefaultImageRegistry,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			site := tt.site
+			wantRegistry := tt.wantRegistry
+
+			tc := testCase{
+				loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+					dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+						WithClusterChecks(true, true).
+						Build()
+					dda.Spec.Global.Site = apiutils.NewStringPointer(site)
+					_ = c.Create(context.TODO(), dda)
+					return dda
+				},
+				want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
+				wantErr: false,
+				wantFunc: func(t *testing.T, c client.Client) {
+					// Node Agent
+					agentContainers := getDsContainers(c, resourcesNamespace, dsName)
+					assert.Equal(t,
+						fmt.Sprintf("%s/%s:%s", wantRegistry, images.DefaultAgentImageName, images.AgentLatestVersion),
+						agentContainers[apicommon.CoreAgentContainerName].Image,
+					)
+
+					// Cluster Agent
+					dcaContainers := getDeploymentContainers(c, resourcesNamespace, dcaName)
+					assert.Equal(t,
+						fmt.Sprintf("%s/%s:%s", wantRegistry, images.DefaultClusterAgentImageName, images.ClusterAgentLatestVersion),
+						dcaContainers[apicommon.ClusterAgentContainerName].Image,
+					)
+
+					// Cluster Checks Runner
+					ccrContainers := getDeploymentContainers(c, resourcesNamespace, ccrName)
+					assert.Equal(t,
+						fmt.Sprintf("%s/%s:%s", wantRegistry, images.DefaultAgentImageName, images.AgentLatestVersion),
+						ccrContainers[apicommon.ClusterChecksRunnersContainerName].Image,
+					)
+				},
+			}
+
+			runDDAReconcilerTest(t, tc, ReconcilerOptions{})
+		})
+	}
 }

--- a/internal/controller/datadogagent/defaults/datadogagent_default.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default.go
@@ -6,6 +6,8 @@
 package defaults
 
 import (
+	"os"
+
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
@@ -159,15 +161,31 @@ func defaultGlobalConfig(ddaSpec *v2alpha1.DatadogAgentSpec) {
 	if ddaSpec.Global.Registry == nil {
 		switch *ddaSpec.Global.Site {
 		case defaultEuropeSite:
-			ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultEuropeImageRegistry)
+			if os.Getenv("DD_REGISTRY_OVERRIDE_EU") == "true" {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DatadogContainerRegistry)
+			} else {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultEuropeImageRegistry)
+			}
 		case defaultAsiaSite:
-			ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultAsiaImageRegistry)
+			if os.Getenv("DD_REGISTRY_OVERRIDE_ASIA") == "true" {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DatadogContainerRegistry)
+			} else {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultAsiaImageRegistry)
+			}
 		case defaultAzureSite:
-			ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultAzureImageRegistry)
+			if os.Getenv("DD_REGISTRY_OVERRIDE_AZURE") == "true" {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DatadogContainerRegistry)
+			} else {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultAzureImageRegistry)
+			}
 		case defaultGovSite:
 			ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultGovImageRegistry)
 		default:
-			ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultImageRegistry)
+			if os.Getenv("DD_REGISTRY_OVERRIDE_DEFAULT") == "true" {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DatadogContainerRegistry)
+			} else {
+				ddaSpec.Global.Registry = apiutils.NewStringPointer(images.DefaultImageRegistry)
+			}
 		}
 	}
 

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -22,6 +22,8 @@ const (
 	DdotCollectorLatestVersion = "7.76.1"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.20"
+	// Datadog container registry
+	DatadogContainerRegistry = "registry.datadoghq.com"
 	// GCRContainerRegistry corresponds to the datadoghq GCR registry
 	GCRContainerRegistry = "gcr.io/datadoghq"
 	// DockerHubContainerRegistry corresponds to the datadoghq docker.io registry


### PR DESCRIPTION
* Add Operator env var to default to Datadog registry

* Switch to site specific env vars

### What does this PR do?

backport https://github.com/DataDog/datadog-operator/pull/2669 to 1.24

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits