### PR TITLE
Update kubectl-plugin.md with autoscaling sub-commands (technical preview)

### DIFF
--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -84,13 +84,13 @@ Available Commands:
 
 ### Autoscaling sub-commands (Technical Preview)
 
-> **Note:** The `autoscaling` commands are part of the Datadog cluster autoscaling feature, which is currently in **technical preview**. APIs and behaviors may change in future releases.
+> **Note:** The `autoscaling` commands are part of the Datadog Cluster Autoscaling feature, which is in **technical preview**. APIs and behaviors may change in future releases.
 
 These commands install and configure [Karpenter](https://karpenter.sh/) on an EKS cluster so that Datadog can manage cluster autoscaling.
 
 #### `autoscaling cluster install`
 
-Installs Karpenter on an EKS cluster and configures it for use with Datadog cluster autoscaling. The command:
+Installs Karpenter on an EKS cluster and configures it for use with Datadog Cluster Autoscaling. The command:
 
 1. Creates the required AWS CloudFormation stacks.
 2. Configures EKS authentication (aws-auth ConfigMap, EKS Pod Identity, or API-based access entries depending on the cluster).


### PR DESCRIPTION
## Summary

- Documents the `kubectl datadog autoscaling cluster install` and `autoscaling cluster uninstall` commands introduced for Datadog cluster autoscaling (Karpenter on EKS)
- Marks the autoscaling section as **Technical Preview**
- Updates the top-level available commands list to reflect newly added commands (`autoscaling`, `completion`, `helm2dda`, `metrics`)

## Test plan

- [ ] Verify the rendered Markdown looks correct on GitHub
- [ ] Check that the `--help` outputs in the doc match the actual plugin binary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)