### PR TITLE
Use context based logger

### DIFF
--- a/internal/controller/datadogagentinternal/component_clusteragent.go
+++ b/internal/controller/datadogagentinternal/component_clusteragent.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -77,10 +78,10 @@ func (c *ClusterAgentComponent) ForceDeleteComponent(ddai *v1alpha1.DatadogAgent
 	return false
 }
 
-func (c *ClusterAgentComponent) CleanupDependencies(ctx context.Context, logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error) {
+func (c *ClusterAgentComponent) CleanupDependencies(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error) {
 	// Delete associated RBACs as well
 	rbacManager := resourcesManager.RBACManager()
-	logger.Info("Deleting Cluster Agent RBACs")
+	ctrl.LoggerFrom(ctx).Info("Deleting Cluster Agent RBACs")
 	if err := rbacManager.DeleteServiceAccountByComponent(string(datadoghqv2alpha1.ClusterAgentComponentName), ddai.Namespace); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/datadogagentinternal/component_clusterchecksrunner.go
+++ b/internal/controller/datadogagentinternal/component_clusterchecksrunner.go
@@ -90,6 +90,6 @@ func (c *ClusterChecksRunnerComponent) ForceDeleteComponent(ddai *v1alpha1.Datad
 	return false
 }
 
-func (c *ClusterChecksRunnerComponent) CleanupDependencies(ctx context.Context, logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error) {
+func (c *ClusterChecksRunnerComponent) CleanupDependencies(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error) {
 	return reconcile.Result{}, nil
 }

--- a/internal/controller/datadogagentinternal/component_otelagentgateway.go
+++ b/internal/controller/datadogagentinternal/component_otelagentgateway.go
@@ -77,6 +77,6 @@ func (c *OtelAgentGatewayComponent) ForceDeleteComponent(ddai *v1alpha1.DatadogA
 	return false
 }
 
-func (c *OtelAgentGatewayComponent) CleanupDependencies(ctx context.Context, logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error) {
+func (c *OtelAgentGatewayComponent) CleanupDependencies(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error) {
 	return reconcile.Result{}, nil
 }

--- a/internal/controller/datadogagentinternal/component_reconciler.go
+++ b/internal/controller/datadogagentinternal/component_reconciler.go
@@ -95,7 +95,7 @@ type ComponentReconciler interface {
 	ForceDeleteComponent(ddai *v1alpha1.DatadogAgentInternal, requiredComponents feature.RequiredComponents) bool
 
 	// CleanupDependencies deletes any dependencies associated with the component
-	CleanupDependencies(ctx context.Context, logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error)
+	CleanupDependencies(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers) (reconcile.Result, error)
 }
 
 // ReconcileComponentParams bundles common parameters needed by all components
@@ -217,7 +217,7 @@ func (r *ComponentRegistry) reconcileComponent(ctx context.Context, params *Reco
 		override.Deployment(deployment, componentOverride)
 	}
 
-	res, err := r.reconciler.createOrUpdateDeployment(objLogger, params.DDAI, deployment, params.Status, component.UpdateStatus)
+	res, err := r.reconciler.createOrUpdateDeployment(ctx, params.DDAI, deployment, params.Status, component.UpdateStatus)
 
 	if err == nil {
 		// Update condition to success since the deployment was created or updated successfully
@@ -244,15 +244,20 @@ func (r *ComponentRegistry) Cleanup(ctx context.Context, params *ReconcileCompon
 		override.Deployment(deployment, componentOverride)
 	}
 
-	objLogger := ctrl.LoggerFrom(ctx).WithValues("object.kind", "Deployment", "object.namespace", deployment.Namespace, "object.name", deployment.Name)
-	result, err := r.reconciler.deleteDeploymentWithEvent(ctx, objLogger, params.DDAI, deployment)
+	ctx = ctrl.LoggerInto(ctx, ctrl.LoggerFrom(ctx).WithValues(
+		"object.kind", "Deployment",
+		"object.namespace", deployment.Namespace,
+		"object.name", deployment.Name,
+	))
+
+	result, err := r.reconciler.deleteDeploymentWithEvent(ctx, params.DDAI, deployment)
 
 	if err != nil {
 		return result, err
 	}
 
 	// Do status and other resource cleanup if the deployment was deleted successfully
-	if result, err = component.CleanupDependencies(ctx, objLogger, params.DDAI, params.ResourceManagers); err != nil {
+	if result, err = component.CleanupDependencies(ctx, params.DDAI, params.ResourceManagers); err != nil {
 		return result, err
 	}
 	component.DeleteStatus(params.Status, component.GetConditionType())

--- a/internal/controller/datadogagentinternal/controller.go
+++ b/internal/controller/datadogagentinternal/controller.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -116,9 +116,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, ddai *v1alpha1.DatadogAgentI
 	return resp, err
 }
 
-func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, logger logr.Logger) *feature.Options {
+func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, ctx context.Context) *feature.Options {
 	return &feature.Options{
-		Logger: logger,
+		Logger: ctrl.LoggerFrom(ctx),
 	}
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -32,14 +32,15 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
-func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents feature.RequiredComponents, features []feature.Feature,
+func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents feature.RequiredComponents, features []feature.Feature,
 	ddai *datadoghqv1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) (reconcile.Result, error) {
 	var result reconcile.Result
 	var eds *edsv1alpha1.ExtendedDaemonSet
 	var daemonset *appsv1.DaemonSet
 	var podManagers feature.PodTemplateManagers
 
-	daemonsetLogger := logger.WithValues("component", datadoghqv2alpha1.NodeAgentComponentName)
+	daemonsetLogger := ctrl.LoggerFrom(ctx).WithValues("component", datadoghqv2alpha1.NodeAgentComponentName)
+	ctx = ctrl.LoggerInto(ctx, daemonsetLogger)
 
 	// requiredComponents needs to be taken into account in case a feature(s) changes and
 	// a requiredComponent becomes disabled, in addition to taking into account override.Disabled
@@ -98,13 +99,13 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 					true,
 				)
 			}
-			if err := r.deleteV2ExtendedDaemonSet(objLogger, ddai, eds, newStatus); err != nil {
+			if err := r.deleteV2ExtendedDaemonSet(ctx, ddai, eds, newStatus); err != nil {
 				return reconcile.Result{}, err
 			}
 			return reconcile.Result{}, nil
 		}
 
-		return r.createOrUpdateExtendedDaemonset(objLogger, ddai, eds, newStatus, updateEDSStatusV2WithAgent)
+		return r.createOrUpdateExtendedDaemonset(ctx, ddai, eds, newStatus, updateEDSStatusV2WithAgent)
 	}
 
 	// Start by creating the Default Agent daemonset
@@ -156,14 +157,14 @@ func (r *Reconciler) reconcileV2Agent(logger logr.Logger, requiredComponents fea
 				true,
 			)
 		}
-		if err := r.deleteV2DaemonSet(objLogger, ddai, daemonset, newStatus); err != nil {
+		if err := r.deleteV2DaemonSet(ctx, ddai, daemonset, newStatus); err != nil {
 			return reconcile.Result{}, err
 		}
 		deleteStatusWithAgent(newStatus)
 		return reconcile.Result{}, nil
 	}
 
-	return r.createOrUpdateDaemonset(objLogger, ddai, daemonset, newStatus, updateDSStatusV2WithAgent)
+	return r.createOrUpdateDaemonset(ctx, ddai, daemonset, newStatus, updateDSStatusV2WithAgent)
 }
 
 func updateDSStatusV2WithAgent(dsName string, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string) {
@@ -176,7 +177,7 @@ func updateEDSStatusV2WithAgent(eds *edsv1alpha1.ExtendedDaemonSet, newStatus *d
 	condition.UpdateDatadogAgentInternalStatusConditions(newStatus, updateTime, common.AgentReconcileConditionType, status, reason, message, true)
 }
 
-func (r *Reconciler) deleteV2DaemonSet(logger logr.Logger, ddai *datadoghqv1alpha1.DatadogAgentInternal, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) error {
+func (r *Reconciler) deleteV2DaemonSet(ctx context.Context, ddai *datadoghqv1alpha1.DatadogAgentInternal, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) error {
 	err := r.client.Delete(context.TODO(), ds)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -184,7 +185,7 @@ func (r *Reconciler) deleteV2DaemonSet(logger logr.Logger, ddai *datadoghqv1alph
 		}
 		return err
 	}
-	logger.Info("Delete DaemonSet", "daemonSet.Namespace", ds.Namespace, "daemonSet.Name", ds.Name)
+	ctrl.LoggerFrom(ctx).WithValues("object.kind", "DaemonSet", "object.namespace", ds.Namespace, "object.name", ds.Name).Info("Deleted DaemonSet")
 	event := buildEventInfo(ds.Name, ds.Namespace, kubernetes.DaemonSetKind, datadog.DeletionEvent)
 	r.recordEvent(ddai, event)
 	newStatus.Agent = nil
@@ -192,7 +193,7 @@ func (r *Reconciler) deleteV2DaemonSet(logger logr.Logger, ddai *datadoghqv1alph
 	return nil
 }
 
-func (r *Reconciler) deleteV2ExtendedDaemonSet(logger logr.Logger, ddai *datadoghqv1alpha1.DatadogAgentInternal, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) error {
+func (r *Reconciler) deleteV2ExtendedDaemonSet(ctx context.Context, ddai *datadoghqv1alpha1.DatadogAgentInternal, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) error {
 	err := r.client.Delete(context.TODO(), eds)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -200,7 +201,7 @@ func (r *Reconciler) deleteV2ExtendedDaemonSet(logger logr.Logger, ddai *datadog
 		}
 		return err
 	}
-	logger.Info("Delete DaemonSet", "extendedDaemonSet.Namespace", eds.Namespace, "extendedDaemonSet.Name", eds.Name)
+	ctrl.LoggerFrom(ctx).WithValues("object.kind", "ExtendedDaemonSet", "object.namespace", eds.Namespace, "object.name", eds.Name).Info("Deleted ExtendedDaemonSet")
 	event := buildEventInfo(eds.Name, eds.Namespace, kubernetes.ExtendedDaemonSetKind, datadog.DeletionEvent)
 	r.recordEvent(ddai, event)
 	newStatus.Agent = nil

--- a/internal/controller/datadogagentinternal/controller_reconcile_ccr_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_ccr_test.go
@@ -10,7 +10,6 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -257,8 +256,7 @@ func Test_cleanupOldCCRDeployments(t *testing.T) {
 				},
 			}
 
-			logger := logr.Discard()
-			r.setupDependencies(&ddai, logger)
+			r.setupDependencies(ctx, &ddai)
 			err := r.cleanupOldCCRDeployments(ctx, &ddai)
 			assert.NoError(t, err)
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,7 +34,7 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *v1alpha1
 	// }
 
 	// 2. Handle finalizer logic.
-	if result, err := r.handleFinalizer(logger, instance, r.finalizeDDAI); utils.ShouldReturn(result, err) {
+	if result, err := r.handleFinalizer(ctx, instance, r.finalizeDDAI); utils.ShouldReturn(result, err) {
 		return result, err
 	}
 
@@ -53,29 +52,29 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	newStatus := instance.Status.DeepCopy()
 	now := metav1.NewTime(time.Now())
 
-	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instance, &instance.Spec, instance.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(&r.options, logger))
+	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instance, &instance.Spec, instance.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(&r.options, ctx))
 	// update list of enabled features for metrics forwarder
 	r.updateMetricsForwardersFeatures(instance, enabledFeatures)
 
 	// 1. Manage dependencies.
 	// set the original DDAI as the owner of dependencies
-	depsStore, resourceManagers := r.setupDependencies(instance, logger)
+	depsStore, resourceManagers := r.setupDependencies(ctx, instance)
 
 	var err error
 	// only manage dependencies for default DDAIs
 	if !isDDAILabeledWithProfile(instance) {
-		if err = r.manageGlobalDependencies(logger, instance, resourceManagers, requiredComponents); err != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
+		if err = r.manageGlobalDependencies(ctx, instance, resourceManagers, requiredComponents); err != nil {
+			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
-		if err = r.manageFeatureDependencies(logger, enabledFeatures, resourceManagers); err != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
+		if err = r.manageFeatureDependencies(enabledFeatures, resourceManagers); err != nil {
+			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
-		if err = r.overrideDependencies(logger, resourceManagers, instance); err != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
+		if err = r.overrideDependencies(ctx, resourceManagers, instance); err != nil {
+			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
 		// 1. Apply and cleanup dependencies before reconciling components to ensure deps exist at reconciliation time.
 		if err = r.applyAndCleanupDependencies(ctx, depsStore); err != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newStatus, reconcile.Result{}, err, now)
+			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
 	}
 
@@ -93,27 +92,27 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 
 		result, err = r.componentRegistry.ReconcileComponents(ctx, params)
 		if utils.ShouldReturn(result, err) {
-			return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
+			return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
 		}
 	}
 
 	// 2.b. Node Agent
-	result, err = r.reconcileV2Agent(logger, requiredComponents, append(configuredFeatures, enabledFeatures...), instance, resourceManagers, newStatus)
+	result, err = r.reconcileV2Agent(ctx, requiredComponents, append(configuredFeatures, enabledFeatures...), instance, resourceManagers, newStatus)
 	if utils.ShouldReturn(result, err) {
-		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
+		return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
 	}
 	condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.AgentReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
 
 	// 3. Cleanup extraneous resources.
 	if err = r.cleanupExtraneousResources(ctx, instance, newStatus, resourceManagers); err != nil {
 		logger.Error(err, "Error cleaning up extraneous resources")
-		return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
+		return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
 	}
 
 	// 4. Cleanup stale dependencies (only for default DDAIs).
 	if !isDDAILabeledWithProfile(instance) {
 		if cleanupErrs := depsStore.Cleanup(ctx, r.client, true); len(cleanupErrs) > 0 {
-			return r.updateStatusIfNeededV2(logger, instance, newStatus, result, cleanupErrs[0], now)
+			return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, cleanupErrs[0], now)
 		}
 	}
 
@@ -121,17 +120,18 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	if !result.Requeue && result.RequeueAfter == 0 {
 		result.RequeueAfter = defaultRequeuePeriod
 	}
-	return r.updateStatusIfNeededV2(logger, instance, newStatus, result, err, now)
+	return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
 }
 
-func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus, result reconcile.Result, currentError error, now metav1.Time) (reconcile.Result, error) {
+func (r *Reconciler) updateStatusIfNeededV2(ctx context.Context, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus, result reconcile.Result, currentError error, now metav1.Time) (reconcile.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
 	if currentError == nil {
 		condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionFalse, "DatadogAgent_reconcile_ok", "DatadogAgent reconcile ok", false)
 	} else {
 		condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionTrue, "DatadogAgent_reconcile_error", "DatadogAgent reconcile error", false)
 	}
 
-	r.setMetricsForwarderStatusV2(logger, agentdeployment, newStatus)
+	r.setMetricsForwarderStatusV2(ctx, agentdeployment, newStatus)
 
 	if !IsEqualStatus(&agentdeployment.Status, newStatus) {
 		updateAgentDeployment := agentdeployment.DeepCopy()
@@ -150,7 +150,7 @@ func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment 
 }
 
 // setMetricsForwarderStatus sets the metrics forwarder status condition if enabled
-func (r *Reconciler) setMetricsForwarderStatusV2(logger logr.Logger, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus) {
+func (r *Reconciler) setMetricsForwarderStatusV2(ctx context.Context, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus) {
 	if r.options.OperatorMetricsEnabled {
 		if forwarderCondition := r.forwarders.MetricsForwarderStatusForObj(agentdeployment); forwarderCondition != nil {
 			condition.UpdateDatadogAgentInternalStatusConditions(
@@ -163,7 +163,7 @@ func (r *Reconciler) setMetricsForwarderStatusV2(logger logr.Logger, agentdeploy
 				true,
 			)
 		} else {
-			logger.V(1).Info("metrics conditions status could not be set")
+			ctrl.LoggerFrom(ctx).V(1).Info("metrics conditions status could not be set")
 		}
 	}
 }

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
@@ -12,12 +12,12 @@ import (
 	"time"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -42,7 +42,8 @@ type updateDepStatusComponentFunc func(deployment *appsv1.Deployment, newStatus 
 type updateDSStatusComponentFunc func(daemonsetName string, daemonset *appsv1.DaemonSet, newStatus *v1alpha1.DatadogAgentInternalStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string)
 type updateEDSStatusComponentFunc func(eds *edsv1alpha1.ExtendedDaemonSet, newStatus *v1alpha1.DatadogAgentInternalStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string)
 
-func (r *Reconciler) createOrUpdateDeployment(logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, deployment *appsv1.Deployment, newStatus *v1alpha1.DatadogAgentInternalStatus, updateStatusFunc updateDepStatusComponentFunc) (reconcile.Result, error) {
+func (r *Reconciler) createOrUpdateDeployment(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, deployment *appsv1.Deployment, newStatus *v1alpha1.DatadogAgentInternalStatus, updateStatusFunc updateDepStatusComponentFunc) (reconcile.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues("object.kind", "Deployment", "object.namespace", deployment.Namespace, "object.name", deployment.Name)
 	var result reconcile.Result
 	var err error
 
@@ -99,7 +100,7 @@ func (r *Reconciler) createOrUpdateDeployment(logger logr.Logger, ddai *v1alpha1
 		}
 
 		if restartDeployment(deployment, currentDeployment) {
-			if err = deleteObjectAndOrphanDependents(context.TODO(), logger, r.client, deployment, deployment.GetLabels()[apicommon.AgentDeploymentComponentLabelKey]); err != nil {
+			if err = deleteObjectAndOrphanDependents(ctx, r.client, deployment, deployment.GetLabels()[apicommon.AgentDeploymentComponentLabelKey]); err != nil {
 				return result, err
 			}
 			return result, nil
@@ -124,8 +125,8 @@ func (r *Reconciler) createOrUpdateDeployment(logger logr.Logger, ddai *v1alpha1
 		updateDeployment := deployment.DeepCopy()
 		updateDeployment.Spec = *deployment.Spec.DeepCopy()
 		updateDeployment.Spec.Replicas = getReplicas(currentDeployment.Spec.Replicas, updateDeployment.Spec.Replicas)
-		updateDeployment.Annotations = mergeAnnotationsLabels(logger, currentDeployment.GetAnnotations(), deployment.GetAnnotations(), keepAnnotationsFilter)
-		updateDeployment.Labels = mergeAnnotationsLabels(logger, currentDeployment.GetLabels(), deployment.GetLabels(), keepLabelsFilter)
+		updateDeployment.Annotations = mergeAnnotationsLabels(ctx, currentDeployment.GetAnnotations(), deployment.GetAnnotations(), keepAnnotationsFilter)
+		updateDeployment.Labels = mergeAnnotationsLabels(ctx, currentDeployment.GetLabels(), deployment.GetLabels(), keepLabelsFilter)
 
 		now := metav1.NewTime(time.Now())
 		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateDeployment, currentDeployment.ObjectMeta)
@@ -154,7 +155,8 @@ func (r *Reconciler) createOrUpdateDeployment(logger logr.Logger, ddai *v1alpha1
 	return result, err
 }
 
-func (r *Reconciler) createOrUpdateDaemonset(logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, daemonset *appsv1.DaemonSet, newStatus *v1alpha1.DatadogAgentInternalStatus, updateStatusFunc updateDSStatusComponentFunc) (reconcile.Result, error) {
+func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, daemonset *appsv1.DaemonSet, newStatus *v1alpha1.DatadogAgentInternalStatus, updateStatusFunc updateDSStatusComponentFunc) (reconcile.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues("object.kind", "DaemonSet", "object.namespace", daemonset.Namespace, "object.name", daemonset.Name)
 	var result reconcile.Result
 	var err error
 
@@ -204,7 +206,7 @@ func (r *Reconciler) createOrUpdateDaemonset(logger logr.Logger, ddai *v1alpha1.
 		}
 
 		if restartDaemonset(daemonset, currentDaemonset) {
-			if err = deleteObjectAndOrphanDependents(context.TODO(), logger, r.client, daemonset, constants.DefaultAgentResourceSuffix); err != nil {
+			if err = deleteObjectAndOrphanDependents(ctx, r.client, daemonset, constants.DefaultAgentResourceSuffix); err != nil {
 				return result, err
 			}
 			return result, nil
@@ -235,7 +237,7 @@ func (r *Reconciler) createOrUpdateDaemonset(logger logr.Logger, ddai *v1alpha1.
 		// Template.Labels must include Spec.Selector.
 		// See https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector
 		daemonset.Spec.Selector = currentDaemonset.Spec.Selector
-		daemonset.Spec.Template.Labels = ensureSelectorInPodTemplateLabels(logger, daemonset.Spec.Selector, daemonset.Spec.Template.Labels)
+		daemonset.Spec.Template.Labels = ensureSelectorInPodTemplateLabels(ctx, daemonset.Spec.Selector, daemonset.Spec.Template.Labels)
 
 		// From here the PodTemplateSpec should be ready, we can generate the hash that will be used to compare this daemonset with the current one (if it exists).
 		var hash, daemonsetPodTemplateLabelHash string
@@ -268,8 +270,8 @@ func (r *Reconciler) createOrUpdateDaemonset(logger logr.Logger, ddai *v1alpha1.
 		// Copy possibly changed fields
 		updateDaemonset := daemonset.DeepCopy()
 		updateDaemonset.Spec = *daemonset.Spec.DeepCopy()
-		updateDaemonset.Annotations = mergeAnnotationsLabels(logger, currentDaemonset.GetAnnotations(), daemonset.GetAnnotations(), keepAnnotationsFilter)
-		updateDaemonset.Labels = mergeAnnotationsLabels(logger, currentDaemonset.GetLabels(), daemonset.GetLabels(), keepLabelsFilter)
+		updateDaemonset.Annotations = mergeAnnotationsLabels(ctx, currentDaemonset.GetAnnotations(), daemonset.GetAnnotations(), keepAnnotationsFilter)
+		updateDaemonset.Labels = mergeAnnotationsLabels(ctx, currentDaemonset.GetLabels(), daemonset.GetLabels(), keepLabelsFilter)
 		// manually remove the old profile label because mergeAnnotationsLabels
 		// won't filter labels with "datadoghq.com" in the key
 		delete(updateDaemonset.Labels, agentprofile.OldProfileLabelKey)
@@ -307,7 +309,8 @@ func (r *Reconciler) createOrUpdateDaemonset(logger logr.Logger, ddai *v1alpha1.
 	return result, err
 }
 
-func (r *Reconciler) createOrUpdateExtendedDaemonset(logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *v1alpha1.DatadogAgentInternalStatus, updateStatusFunc updateEDSStatusComponentFunc) (reconcile.Result, error) {
+func (r *Reconciler) createOrUpdateExtendedDaemonset(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *v1alpha1.DatadogAgentInternalStatus, updateStatusFunc updateEDSStatusComponentFunc) (reconcile.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues("object.kind", "ExtendedDaemonSet", "object.namespace", eds.Namespace, "object.name", eds.Name)
 	var result reconcile.Result
 	var err error
 
@@ -385,8 +388,8 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(logger logr.Logger, ddai *v
 		// Copy possibly changed fields
 		updateEDS := eds.DeepCopy()
 		updateEDS.Spec = *eds.Spec.DeepCopy()
-		updateEDS.Annotations = mergeAnnotationsLabels(logger, currentEDS.GetAnnotations(), eds.GetAnnotations(), keepAnnotationsFilter)
-		updateEDS.Labels = mergeAnnotationsLabels(logger, currentEDS.GetLabels(), eds.GetLabels(), keepLabelsFilter)
+		updateEDS.Annotations = mergeAnnotationsLabels(ctx, currentEDS.GetAnnotations(), eds.GetAnnotations(), keepAnnotationsFilter)
+		updateEDS.Labels = mergeAnnotationsLabels(ctx, currentEDS.GetLabels(), eds.GetLabels(), keepLabelsFilter)
 
 		now := metav1.NewTime(time.Now())
 		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateEDS, currentEDS.ObjectMeta)
@@ -422,7 +425,8 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(logger logr.Logger, ddai *v
 // value to match the selector.
 // If the selector labels aren't present in the pod template labels, there will
 // be a `selector does not match template labels` error when updating the agent
-func ensureSelectorInPodTemplateLabels(logger logr.Logger, selector *metav1.LabelSelector, labels map[string]string) map[string]string {
+func ensureSelectorInPodTemplateLabels(ctx context.Context, selector *metav1.LabelSelector, labels map[string]string) map[string]string {
+	logger := ctrl.LoggerFrom(ctx)
 	if selector != nil {
 		if labels == nil {
 			labels = map[string]string{}

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common_test.go
@@ -1,15 +1,14 @@
 package datadogagentinternal
 
 import (
+	"context"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Test_ensureSelectorInPodTemplateLabels(t *testing.T) {
-	logger := logf.Log.WithName("Test_ensureSelectorInPodTemplateLabels")
 
 	tests := []struct {
 		name              string
@@ -96,7 +95,7 @@ func Test_ensureSelectorInPodTemplateLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			labels := ensureSelectorInPodTemplateLabels(logger, tt.selector, tt.podTemplateLabels)
+			labels := ensureSelectorInPodTemplateLabels(context.Background(), tt.selector, tt.podTemplateLabels)
 			assert.Equal(t, tt.expectedLabels, labels)
 		})
 	}

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
@@ -3,7 +3,6 @@ package datadogagentinternal
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,11 +31,11 @@ import (
 // STEP 2 of the reconcile loop: reconcile 3 components
 
 // setupDependencies initializes the store and resource managers.
-func (r *Reconciler) setupDependencies(instance *datadoghqv1alpha1.DatadogAgentInternal, logger logr.Logger) (*store.Store, feature.ResourceManagers) {
+func (r *Reconciler) setupDependencies(ctx context.Context, instance *datadoghqv1alpha1.DatadogAgentInternal) (*store.Store, feature.ResourceManagers) {
 	storeOptions := &store.StoreOptions{
 		SupportCilium: r.options.SupportCilium,
 		PlatformInfo:  r.platformInfo,
-		Logger:        logger,
+		Logger:        ctrl.LoggerFrom(ctx),
 		Scheme:        r.scheme,
 	}
 	depsStore := store.NewStore(instance, storeOptions)
@@ -45,7 +44,8 @@ func (r *Reconciler) setupDependencies(instance *datadoghqv1alpha1.DatadogAgentI
 }
 
 // manageGlobalDependencies manages the global dependencies for a component.
-func (r *Reconciler) manageGlobalDependencies(logger logr.Logger, ddai *datadoghqv1alpha1.DatadogAgentInternal, resourceManagers feature.ResourceManagers, requiredComponents feature.RequiredComponents) error {
+func (r *Reconciler) manageGlobalDependencies(ctx context.Context, ddai *datadoghqv1alpha1.DatadogAgentInternal, resourceManagers feature.ResourceManagers, requiredComponents feature.RequiredComponents) error {
+	logger := ctrl.LoggerFrom(ctx)
 	var errs []error
 	// Non component specific dependencies
 	if err := global.ApplyGlobalDependencies(logger, ddai.GetObjectMeta(), &ddai.Spec, resourceManagers, true); len(err) > 0 {
@@ -73,7 +73,7 @@ func (r *Reconciler) manageGlobalDependencies(logger logr.Logger, ddai *datadogh
 }
 
 // manageFeatureDependencies iterates over features to set up dependencies.
-func (r *Reconciler) manageFeatureDependencies(logger logr.Logger, features []feature.Feature, resourceManagers feature.ResourceManagers) error {
+func (r *Reconciler) manageFeatureDependencies(features []feature.Feature, resourceManagers feature.ResourceManagers) error {
 	var errs []error
 	for _, feat := range features {
 		if err := feat.ManageDependencies(resourceManagers, ""); err != nil {
@@ -87,8 +87,8 @@ func (r *Reconciler) manageFeatureDependencies(logger logr.Logger, features []fe
 }
 
 // overrideDependencies wraps the dependency override logic.
-func (r *Reconciler) overrideDependencies(logger logr.Logger, resourceManagers feature.ResourceManagers, instance *datadoghqv1alpha1.DatadogAgentInternal) error {
-	errs := override.Dependencies(logger, resourceManagers, instance.GetObjectMeta(), &instance.Spec)
+func (r *Reconciler) overrideDependencies(ctx context.Context, resourceManagers feature.ResourceManagers, instance *datadoghqv1alpha1.DatadogAgentInternal) error {
+	errs := override.Dependencies(ctrl.LoggerFrom(ctx), resourceManagers, instance.GetObjectMeta(), &instance.Spec)
 	if len(errs) > 0 {
 		return errors.NewAggregate(errs)
 	}
@@ -162,7 +162,7 @@ func (r *Reconciler) applyAndCleanupDependencies(ctx context.Context, depsStore 
 	return nil
 }
 
-func (r *Reconciler) deleteDeploymentWithEvent(ctx context.Context, logger logr.Logger, ddai *v1alpha1.DatadogAgentInternal, deployment *appsv1.Deployment) (reconcile.Result, error) {
+func (r *Reconciler) deleteDeploymentWithEvent(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, deployment *appsv1.Deployment) (reconcile.Result, error) {
 	nsName := types.NamespacedName{
 		Name:      deployment.GetName(),
 		Namespace: deployment.GetNamespace(),
@@ -175,7 +175,7 @@ func (r *Reconciler) deleteDeploymentWithEvent(ctx context.Context, logger logr.
 		}
 		return reconcile.Result{}, err
 	}
-	logger.Info("Deleting Deployment", "deployment.Namespace", existingDeployment.Namespace, "deployment.Name", existingDeployment.Name)
+	ctrl.LoggerFrom(ctx).WithValues("object.kind", "Deployment", "object.namespace", existingDeployment.Namespace, "object.name", existingDeployment.Name).Info("Deleting Deployment")
 	if err := r.client.Delete(ctx, existingDeployment); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -200,8 +200,7 @@ func (r *Reconciler) cleanupOldDCADeployments(ctx context.Context, ddai *v1alpha
 	}
 	for _, deployment := range deploymentList.Items {
 		if deploymentName != deployment.Name {
-			objLogger := ctrl.LoggerFrom(ctx).WithValues("object.kind", "Deployment", "object.namespace", deployment.Namespace, "object.name", deployment.Name)
-			if _, err := r.deleteDeploymentWithEvent(ctx, objLogger, ddai, &deployment); err != nil {
+			if _, err := r.deleteDeploymentWithEvent(ctx, ddai, &deployment); err != nil {
 				return err
 			}
 		}
@@ -223,8 +222,7 @@ func (r *Reconciler) cleanupOldCCRDeployments(ctx context.Context, ddai *v1alpha
 	}
 	for _, deployment := range deploymentList.Items {
 		if deploymentName != deployment.Name {
-			objLogger := ctrl.LoggerFrom(ctx).WithValues("object.kind", "Deployment", "object.namespace", deployment.Namespace, "object.name", deployment.Name)
-			if _, err := r.deleteDeploymentWithEvent(ctx, objLogger, ddai, &deployment); err != nil {
+			if _, err := r.deleteDeploymentWithEvent(ctx, ddai, &deployment); err != nil {
 				return err
 			}
 		}
@@ -259,8 +257,7 @@ func (r *Reconciler) cleanupOldOtelAgentGatewayDeployments(ctx context.Context, 
 	}
 	for _, deployment := range deploymentList.Items {
 		if deploymentName != deployment.Name {
-			objLogger := ctrl.LoggerFrom(ctx).WithValues("object.kind", "Deployment", "object.namespace", deployment.Namespace, "object.name", deployment.Name)
-			if _, err := r.deleteDeploymentWithEvent(ctx, objLogger, ddai, &deployment); err != nil {
+			if _, err := r.deleteDeploymentWithEvent(ctx, ddai, &deployment); err != nil {
 				return err
 			}
 		}

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers_test.go
@@ -1,6 +1,7 @@
 package datadogagentinternal
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -72,7 +72,6 @@ func Test_setupDependencies(t *testing.T) {
 	// Create a dummy DatadogAgent instance.
 	dummyAgent := &datadoghqv1alpha1.DatadogAgentInternal{}
 	dummyPlatformInfo := kubernetes.PlatformInfo{}
-	dummyLogger := logr.Discard()
 	dummyOpts := &ReconcilerOptions{
 		SupportCilium: false,
 	}
@@ -82,14 +81,13 @@ func Test_setupDependencies(t *testing.T) {
 		platformInfo: dummyPlatformInfo,
 		scheme:       scheme,
 	}
-	storeObj, resMgrs := r.setupDependencies(dummyAgent, dummyLogger)
+	storeObj, resMgrs := r.setupDependencies(context.Background(), dummyAgent)
 	require.NotNil(t, storeObj)
 	require.NotNil(t, resMgrs)
 }
 
 // Test_manageFeatureDependencies checks that feature dependency management aggregates errors correctly.
 func Test_manageFeatureDependencies(t *testing.T) {
-	dummyLogger := logr.Discard()
 	dummyResMgrs := feature.NewResourceManagers(nil) // passing nil for simplicity
 
 	// One feature succeeds and one fails.
@@ -103,11 +101,11 @@ func Test_manageFeatureDependencies(t *testing.T) {
 
 	r := &Reconciler{}
 	// Test when all features succeed.
-	err := r.manageFeatureDependencies(dummyLogger, []feature.Feature{f1}, dummyResMgrs)
+	err := r.manageFeatureDependencies([]feature.Feature{f1}, dummyResMgrs)
 	require.NoError(t, err)
 
 	// Test with one failing feature.
-	err = r.manageFeatureDependencies(dummyLogger, []feature.Feature{f1, f2}, dummyResMgrs)
+	err = r.manageFeatureDependencies([]feature.Feature{f1, f2}, dummyResMgrs)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fail dependency")
 }

--- a/internal/controller/datadogagentinternal/finalizer.go
+++ b/internal/controller/datadogagentinternal/finalizer.go
@@ -8,9 +8,9 @@ package datadogagentinternal
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -22,9 +22,9 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
-type finalizerDDAIFunc func(reqLogger logr.Logger, dda client.Object) error
+type finalizerDDAIFunc func(ctx context.Context, dda client.Object) error
 
-func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, ddai client.Object, finalizerDDAI finalizerDDAIFunc) (reconcile.Result, error) {
+func (r *Reconciler) handleFinalizer(ctx context.Context, ddai client.Object, finalizerDDAI finalizerDDAIFunc) (reconcile.Result, error) {
 	// Check if the DatadogAgentInternal instance is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.
 	isDDAIMarkedToBeDeleted := ddai.GetDeletionTimestamp() != nil
@@ -33,7 +33,7 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, ddai client.Object, 
 			// Run finalization logic for datadogAgentFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
-			if err := finalizerDDAI(reqLogger, ddai); err != nil {
+			if err := finalizerDDAI(ctx, ddai); err != nil {
 				return reconcile.Result{}, err
 			}
 
@@ -50,7 +50,7 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, ddai client.Object, 
 
 	// Add finalizer for this CR
 	if !controllerutil.ContainsFinalizer(ddai, constants.DatadogAgentInternalFinalizer) {
-		if err := r.addFinalizer(reqLogger, ddai); err != nil {
+		if err := r.addFinalizer(ctx, ddai); err != nil {
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{Requeue: true}, nil
@@ -59,7 +59,8 @@ func (r *Reconciler) handleFinalizer(reqLogger logr.Logger, ddai client.Object, 
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) finalizeDDAI(reqLogger logr.Logger, obj client.Object) error {
+func (r *Reconciler) finalizeDDAI(ctx context.Context, obj client.Object) error {
+	logger := ctrl.LoggerFrom(ctx)
 	if r.options.OperatorMetricsEnabled {
 		r.forwarders.Unregister(obj)
 	}
@@ -74,18 +75,19 @@ func (r *Reconciler) finalizeDDAI(reqLogger logr.Logger, obj client.Object) erro
 		return err
 	}
 
-	reqLogger.Info("Successfully finalized DatadogAgentInternal")
+	logger.Info("Successfully finalized DatadogAgentInternal")
 	return nil
 }
 
-func (r *Reconciler) addFinalizer(reqLogger logr.Logger, ddai client.Object) error {
-	reqLogger.Info("Adding Finalizer for the DatadogAgentInternal")
+func (r *Reconciler) addFinalizer(ctx context.Context, ddai client.Object) error {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("Adding Finalizer for the DatadogAgentInternal")
 	controllerutil.AddFinalizer(ddai, constants.DatadogAgentInternalFinalizer)
 
 	// Update CR
 	err := r.client.Update(context.TODO(), ddai)
 	if err != nil {
-		reqLogger.Error(err, "Failed to update DatadogAgentInternal with finalizer")
+		logger.Error(err, "Failed to update DatadogAgentInternal with finalizer")
 		return err
 	}
 	return nil

--- a/internal/controller/datadogagentinternal/finalizer_test.go
+++ b/internal/controller/datadogagentinternal/finalizer_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func Test_handleFinalizer(t *testing.T) {
@@ -128,7 +127,7 @@ func Test_handleFinalizer(t *testing.T) {
 
 	reconciler := reconcilerForFinalizerTest(initialKubeObjects)
 
-	_, err := reconciler.handleFinalizer(logf.Log.WithName("Handle DDAI Finalizer test"), ddai, reconciler.finalizeDDAI)
+	_, err := reconciler.handleFinalizer(context.Background(), ddai, reconciler.finalizeDDAI)
 	assert.NoError(t, err)
 
 	// Check that the cluster roles associated with the Datadog Agent have been deleted

--- a/internal/controller/datadogagentinternal/utils.go
+++ b/internal/controller/datadogagentinternal/utils.go
@@ -12,13 +12,13 @@ import (
 	"maps"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/gobwas/glob"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
@@ -27,13 +27,13 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
-func mergeAnnotationsLabels(logger logr.Logger, previousVal map[string]string, newVal map[string]string, filter string) map[string]string {
+func mergeAnnotationsLabels(ctx context.Context, previousVal map[string]string, newVal map[string]string, filter string) map[string]string {
 	var globFilter glob.Glob
 	var err error
 	if filter != "" {
 		globFilter, err = glob.Compile(filter)
 		if err != nil {
-			logger.Error(err, "Unable to parse glob filter for metadata/annotations - discarding everything", "filter", filter)
+			ctrl.LoggerFrom(ctx).Error(err, "Unable to parse glob filter for metadata/annotations - discarding everything", "filter", filter)
 		}
 	}
 
@@ -169,7 +169,8 @@ func getReplicas(currentReplicas, newReplicas *int32) *int32 {
 }
 
 // delete ALL workloads for a given DDA/DDAI and orphan pods
-func deleteObjectAndOrphanDependents(ctx context.Context, logger logr.Logger, c client.Client, obj client.Object, component string) error {
+func deleteObjectAndOrphanDependents(ctx context.Context, c client.Client, obj client.Object, component string) error {
+	logger := ctrl.LoggerFrom(ctx)
 	propagationPolicy := metav1.DeletePropagationOrphan
 	selector := labels.SelectorFromSet(labels.Set{
 		kubernetes.AppKubernetesPartOfLabelKey:     obj.GetLabels()[kubernetes.AppKubernetesPartOfLabelKey],


### PR DESCRIPTION
### What does this PR do?

Pass context instead of logger in functions

### Motivation

https://datadoghq.atlassian.net/browse/CONTP-1334
Follow-up to https://github.com/DataDog/datadog-operator/pull/2519

### Additional Notes

Skipping DDA v2 reconcile methods

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Logs will mostly be the same as before. The main differences are:
* `Delete DaemonSet` → `Deleted DaemonSet` for DS deletion. Triggered when a node agent DS exists and the node agent is then disabled via overrides
* `Delete DaemonSet` → `Deleted ExtendedDaemonSet` for EDS deletion. Triggered when a node agent EDS exists and the node agent is then disabled via overrides

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits