### PR TITLE
Add container autoscaling as codeowners for kubectl plugin doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 # Documentation
 README.md               @DataDog/documentation @DataDog/container-ecosystems @DataDog/container-platform
 /docs/                  @DataDog/documentation @DataDog/container-ecosystems @DataDog/container-platform
+/docs/kubectl-plugin.md @DataDog/documentation @DataDog/container-ecosystems @DataDog/container-platform @DataDog/container-autoscaling
 
 
 # Features owners


### PR DESCRIPTION
### What does this PR do?

Add container autoscaling as codeowners for kubectl plugin doc

### Motivation

https://github.com/DataDog/datadog-operator/pull/2678 adds autoscaling commands to doc

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits