### PR TITLE
Allow e2e-autoscaling test to use Github token to avoid rate limits

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -401,6 +401,9 @@ e2e_autoscaling:
   needs:
     - "go_e2e_deps"
   timeout: 90m
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     # Disable on Conductor-triggered jobs (ex: nightly) — must be first so it wins
     - if: '$DDR == "true"'


### PR DESCRIPTION
### What does this PR do?

Title, same as for other e2e tests

### Motivation

When authenticated, higher rate limit from Github for e2e: https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/1480931434#L114
```console
$ export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-operator --policy self.gitlab.e2e)
Error: http error with status code 403: {"code":7, "message":"token is not allowed"}
```

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Launched the test and verified the export command does not fail for the token https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/1482170462#L182

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits