### PR TITLE
Allow injection-platform team to use MQ

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -6,6 +6,7 @@ merge_method: squash
 merge_freeze: false
 github_teams_restrictions:
   - agent-all
+  - injection-platform
   - container-app
   - container-ecosystems
   - container-platform
@@ -23,5 +24,5 @@ kind: mergegate
 rules:
   - require: commit-signatures
     excluded_emails:
-      - 'github-actions[bot]@users.noreply.github.com' # github-actions[bot]
-      - '152526959+datadog-githubops-containers[bot]@users.noreply.github.com' # datadog-githubops-containers[bot]
+      - "github-actions[bot]@users.noreply.github.com" # github-actions[bot]
+      - "152526959+datadog-githubops-containers[bot]@users.noreply.github.com" # datadog-githubops-containers[bot]


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

Allow @DataDog/injection-platform to use mq for operator

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits