### PR TITLE
Add EKS auto-mode pre-flight check to kubectl plugin install command

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/eksautomode.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/eksautomode.go
@@ -1,0 +1,26 @@
+package guess
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+)
+
+// IsEKSAutoModeEnabled checks if EKS auto-mode is active on the cluster
+// by looking for the nodeclasses resource in the eks.amazonaws.com/v1 API group.
+func IsEKSAutoModeEnabled(discoveryClient discovery.DiscoveryInterface) (bool, error) {
+	resources, err := discoveryClient.ServerResourcesForGroupVersion("eks.amazonaws.com/v1")
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to query eks.amazonaws.com/v1 API group: %w", err)
+	}
+
+	return lo.ContainsBy(resources.APIResources, func(r metav1.APIResource) bool {
+		return r.Name == "nodeclasses"
+	}), nil
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/eksautomode_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/eksautomode_test.go
@@ -1,0 +1,60 @@
+package guess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestIsEKSAutoModeEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		resources []*metav1.APIResourceList
+		expected  bool
+	}{
+		{
+			name: "EKS auto-mode is active",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "eks.amazonaws.com/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "nodeclasses", Kind: "NodeClass"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "EKS auto-mode is not active (group not found)",
+			resources: []*metav1.APIResourceList{},
+			expected:  false,
+		},
+		{
+			name: "EKS auto-mode is not active (group exists but no nodeclasses)",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "eks.amazonaws.com/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "nodeconfigs", Kind: "NodeConfig"},
+					},
+				},
+			},
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeDiscovery := &fakediscovery.FakeDiscovery{
+				Fake: &k8stesting.Fake{
+					Resources: tc.resources,
+				},
+			}
+
+			result, err := IsEKSAutoModeEnabled(fakeDiscovery)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -218,6 +218,12 @@ func (o *options) run(cmd *cobra.Command) error {
 		}
 	}
 
+	if autoModeEnabled, err := guess.IsEKSAutoModeEnabled(o.DiscoveryClient); err != nil {
+		return fmt.Errorf("failed to check for EKS auto-mode: %w", err)
+	} else if autoModeEnabled {
+		return displayEKSAutoModeMessage(cmd, clusterName)
+	}
+
 	display.PrintBox(cmd.OutOrStdout(), "Installing Karpenter on cluster "+clusterName+".")
 
 	cli, err := clients.Build(ctx, o.ConfigFlags, o.Clientset)
@@ -395,7 +401,7 @@ func createNodePoolResources(ctx context.Context, cmd *cobra.Command, cli *clien
 	return nil
 }
 
-func displaySuccessMessage(cmd *cobra.Command, clusterName string, createResources CreateKarpenterResources) error {
+func openAutoscalingSettingsURL(cmd *cobra.Command, clusterName string) string {
 	autoscalingSettingsURL := (&url.URL{
 		Scheme:   "https",
 		Host:     "app.datadoghq.com",
@@ -409,7 +415,28 @@ func displaySuccessMessage(cmd *cobra.Command, clusterName string, createResourc
 		log.Printf("Failed to open URL in browser: %v", err)
 	}
 
-	coloredURL := color.New(color.Bold, color.Underline, color.FgBlue).Sprint(autoscalingSettingsURL)
+	return color.New(color.Bold, color.Underline, color.FgBlue).Sprint(autoscalingSettingsURL)
+}
+
+func displayEKSAutoModeMessage(cmd *cobra.Command, clusterName string) error {
+	coloredURL := openAutoscalingSettingsURL(cmd, clusterName)
+
+	display.PrintBox(cmd.OutOrStdout(),
+		"EKS auto-mode is already active on cluster "+clusterName+".",
+		"",
+		"Karpenter is built into EKS auto-mode",
+		"and does not need to be installed separately.",
+		"",
+		"Navigate to the Autoscaling settings page",
+		"and select cluster to start generating recommendations:",
+		coloredURL,
+	)
+
+	return nil
+}
+
+func displaySuccessMessage(cmd *cobra.Command, clusterName string, createResources CreateKarpenterResources) error {
+	coloredURL := openAutoscalingSettingsURL(cmd, clusterName)
 
 	switch createResources {
 	case CreateKarpenterResourcesNone:


### PR DESCRIPTION
## Summary

- Detect EKS auto-mode before installing Karpenter by checking for the `nodeclasses` CRD in the `eks.amazonaws.com` API group via the Kubernetes discovery API
- When auto-mode is active, skip the entire Karpenter installation and display a message directing the user to the Datadog autoscaling settings page
- Factor out the URL construction/browser logic into a shared `openAutoscalingSettingsURL` helper

## Test plan

- [x] Unit tests for `IsEKSAutoModeEnabled` (auto-mode active, group not found, group exists without nodeclasses)
- [x] `go build ./cmd/kubectl-datadog/...`
- [x] Manual test on an EKS cluster with auto-mode enabled
- [x] Manual test on an EKS cluster without auto-mode (should proceed with install as before)