### PR TITLE
Update `system-probe` seccomp profile to fix container creation issue on OpenShift

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -251,6 +251,8 @@ func DefaultSyscallsForSystemProbe() []string {
 		"setitimer",
 		"setns",
 		"setpgid",
+		"setresgid",
+		"setresuid",
 		"setrlimit",
 		"setsid",
 		"setsidaccept4",


### PR DESCRIPTION
### What does this PR do?

Adds `setresgid` and `setresuid` syscalls to `system-probe` seccomp profile.

### Motivation

On the latest version of OpenShift, deploying the datadog-agent leaves the node agents in the `CreateContainerError` state forever with the following error:

```console
$ kubectl --namespace datadog-agent-helm get pods
NAME                                                     READY   STATUS                 RESTARTS   AGE
[…]
pod/datadog-agent-linux-pc5mh                            4/5     CreateContainerError   0          26m
```
```console
$ kubectl --namespace datadog-agent-helm describe pod/datadog-agent-linux-pc5mh
[…]
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
[…]
  Warning  Failed     8s (x8 over 50s)   kubelet            Error: container create failed: setresuid to `0`: Operation not permitted
```

### Additional Notes

Corresponding PR on the Helm chart: DataDog/helm-charts#2442

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [X] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [X] PR has a milestone or the `qa/skip-qa` label
- [X] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits