### PR TITLE
Trim metadata logging and add logging fields

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -147,8 +147,8 @@ type metricsForwarder struct {
 // newMetricsForwarder returns a new Datadog MetricsForwarder instance
 func newMetricsForwarder(k8sClient client.Client, decryptor secrets.Decryptor, obj client.Object, platforminfo *kubernetes.PlatformInfo, datadogAgentInternalEnabled bool, credsManager *config.CredentialManager) *metricsForwarder {
 
-	logger := log.WithValues("CustomResource.Namespace", obj.GetNamespace(), "CustomResource.Name", obj.GetName())
 	objKind := getObjKind(obj)
+	logger := log.WithValues("kind", objKind, "namespace", obj.GetNamespace(), "name", obj.GetName())
 
 	return &metricsForwarder{
 		id:                          getObjID(obj),

--- a/pkg/controller/utils/metadata/crd_metadata.go
+++ b/pkg/controller/utils/metadata/crd_metadata.go
@@ -117,7 +117,6 @@ func (cmf *CRDMetadataForwarder) sendMetadata() error {
 	crdsToSend := cmf.getCRDsToSend(allCRDs)
 
 	if len(crdsToSend) == 0 {
-		cmf.logger.V(1).Info("No changes or heartbeats due")
 		return nil
 	}
 
@@ -143,10 +142,6 @@ func (cmf *CRDMetadataForwarder) sendCRDMetadata(ctx context.Context, crdInstanc
 
 	payload := cmf.buildPayload(clusterUID, crdInstance)
 
-	cmf.logger.V(1).Info("Sending metadata HTTP request",
-		"kind", crdInstance.Kind,
-		"name", crdInstance.Name)
-
 	req, err := cmf.createRequest(payload)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
@@ -165,8 +160,8 @@ func (cmf *CRDMetadataForwarder) sendCRDMetadata(ctx context.Context, crdInstanc
 		return fmt.Errorf("failed to read metadata response body: %w", err)
 	}
 
-	cmf.logger.V(1).Info("Read metadata response",
-		"status code", resp.StatusCode,
+	cmf.logger.V(2).Info("Sent metadata",
+		"statusCode", resp.StatusCode,
 		"body", string(body),
 		"kind", crdInstance.Kind,
 		"name", crdInstance.Name)
@@ -326,7 +321,7 @@ func (cmf *CRDMetadataForwarder) getCRDsToSend(crds []CRDInstance) []CRDInstance
 		key := buildCacheKey(crd)
 		newHash, err := hashCRD(crd)
 		if err != nil {
-			cmf.logger.V(1).Info("Failed to hash CRD", "error", err, "key", key)
+			cmf.logger.V(1).Info("Failed to hash CRD", "error", err, "kind", crd.Kind, "namespace", crd.Namespace, "name", crd.Name)
 			continue
 		}
 
@@ -339,7 +334,7 @@ func (cmf *CRDMetadataForwarder) getCRDsToSend(crds []CRDInstance) []CRDInstance
 				hash:     newHash,
 				lastSent: now,
 			}
-			cmf.logger.V(1).Info("New CRD detected", "key", key)
+			cmf.logger.V(1).Info("New CRD detected", "kind", crd.Kind, "namespace", crd.Namespace, "name", crd.Name)
 			continue
 		}
 
@@ -350,7 +345,7 @@ func (cmf *CRDMetadataForwarder) getCRDsToSend(crds []CRDInstance) []CRDInstance
 				hash:     newHash,
 				lastSent: now,
 			}
-			cmf.logger.V(1).Info("CRD change detected", "key", key)
+			cmf.logger.V(1).Info("CRD change detected", "kind", crd.Kind, "namespace", crd.Namespace, "name", crd.Name)
 			continue
 		}
 
@@ -359,8 +354,8 @@ func (cmf *CRDMetadataForwarder) getCRDsToSend(crds []CRDInstance) []CRDInstance
 		if timeSinceLastSend >= crdMetadataHeartbeatTTL {
 			toSend = append(toSend, crd)
 			cmf.crdCache[key].lastSent = now
-			cmf.logger.V(1).Info("CRD heartbeat due", "key", key,
-				"time_since_last_send", timeSinceLastSend.Round(time.Second))
+			cmf.logger.V(2).Info("CRD heartbeat due", "kind", crd.Kind, "namespace", crd.Namespace, "name", crd.Name,
+				"timeSinceLastSend", timeSinceLastSend.Round(time.Second))
 			continue
 		}
 	}
@@ -379,7 +374,7 @@ func (cmf *CRDMetadataForwarder) cleanupDeletedCRDs(currentCRDs []CRDInstance, s
 	}
 
 	for key := range cmf.crdCache {
-		cachedKind, _, found := strings.Cut(key, "/")
+		cachedKind, rest, found := strings.Cut(key, "/")
 		if !found {
 			continue
 		}
@@ -388,7 +383,8 @@ func (cmf *CRDMetadataForwarder) cleanupDeletedCRDs(currentCRDs []CRDInstance, s
 		if successfulKinds[cachedKind] {
 			if !currentKeys[key] {
 				delete(cmf.crdCache, key)
-				cmf.logger.V(1).Info("Removed deleted CRD from cache", "key", key)
+				cachedNS, cachedName, _ := strings.Cut(rest, "/")
+				cmf.logger.V(1).Info("Removed deleted CRD from cache", "kind", cachedKind, "namespace", cachedNS, "name", cachedName)
 			}
 		}
 	}

--- a/pkg/controller/utils/metadata/helm_metadata.go
+++ b/pkg/controller/utils/metadata/helm_metadata.go
@@ -182,13 +182,13 @@ func (hmf *HelmMetadataForwarder) Start(ctx context.Context) error {
 			AddFunc: func(obj any) {
 				if key, keyErr := toolscache.MetaNamespaceKeyFunc(obj); keyErr == nil {
 					hmf.queue.Add(key)
-					hmf.logger.V(1).Info("Enqueued ConfigMap for processing", "key", key)
+					hmf.logger.V(2).Info("Enqueued ConfigMap for processing", "key", key)
 				}
 			},
 			DeleteFunc: func(obj any) {
 				if key, keyErr := toolscache.DeletionHandlingMetaNamespaceKeyFunc(obj); keyErr == nil {
 					hmf.queue.Add(deletePrefix + key)
-					hmf.logger.V(1).Info("Enqueued ConfigMap deletion for processing", "key", key)
+					hmf.logger.V(2).Info("Enqueued ConfigMap deletion for processing", "key", key)
 				}
 			},
 		},
@@ -356,7 +356,7 @@ func (hmf *HelmMetadataForwarder) handleHelmResource(ctx context.Context, name, 
 
 	// Filter for allowed charts (after decoding)
 	if !allowedCharts[release.Chart.Metadata.Name] {
-		hmf.logger.V(1).Info("Skipping non-allowed chart",
+		hmf.logger.V(2).Info("Skipping non-allowed chart",
 			"chart", release.Chart.Metadata.Name,
 			"release", releaseName)
 		return
@@ -373,7 +373,7 @@ func (hmf *HelmMetadataForwarder) handleHelmResource(ctx context.Context, name, 
 
 	// Check if we should update (prevent old revisions)
 	if entry.snapshot != nil && entry.snapshot.Revision >= revision {
-		hmf.logger.V(1).Info("Skipping old/same revision",
+		hmf.logger.V(2).Info("Skipping old/same revision",
 			"key", key,
 			"existing", entry.snapshot.Revision,
 			"new", revision)
@@ -471,8 +471,6 @@ func (hmf *HelmMetadataForwarder) tickerLoop(ctx context.Context) {
 
 // sendAllSnapshots sends all release snapshots
 func (hmf *HelmMetadataForwarder) sendAllSnapshots() {
-	hmf.logger.V(1).Info("Ticker: sending all Helm release snapshots")
-
 	count := 0
 	errors := 0
 
@@ -505,7 +503,7 @@ func (hmf *HelmMetadataForwarder) sendAllSnapshots() {
 	})
 
 	if count > 0 {
-		hmf.logger.V(1).Info("Ticker: sent Helm release snapshots",
+		hmf.logger.V(2).Info("Ticker: sent Helm release snapshots",
 			"sent", count,
 			"errors", errors)
 	}

--- a/pkg/controller/utils/metadata/operator_metadata.go
+++ b/pkg/controller/utils/metadata/operator_metadata.go
@@ -121,7 +121,7 @@ func (omf *OperatorMetadataForwarder) sendMetadata() error {
 
 	defer resp.Body.Close()
 
-	omf.logger.V(1).Info("Sent metadata", "status code", resp.StatusCode)
+	omf.logger.V(2).Info("Sent metadata", "statusCode", resp.StatusCode)
 	return nil
 }
 
@@ -177,7 +177,7 @@ func (omf *OperatorMetadataForwarder) updateResourceCounts() {
 		if err := omf.k8sClient.List(ctx, ddaList); err == nil {
 			omf.OperatorMetadata.ResourceCounts["datadogagent"] = len(ddaList.Items)
 		} else {
-			omf.logger.V(1).Info("Failed to list DatadogAgents, keeping old value", "error", err, "old_count", omf.OperatorMetadata.ResourceCounts["datadogagent"])
+			omf.logger.V(1).Info("Failed to list DatadogAgents, keeping old value", "error", err, "oldCount", omf.OperatorMetadata.ResourceCounts["datadogagent"])
 		}
 	}
 
@@ -186,7 +186,7 @@ func (omf *OperatorMetadataForwarder) updateResourceCounts() {
 		if err := omf.k8sClient.List(ctx, ddaiList); err == nil {
 			omf.OperatorMetadata.ResourceCounts["datadogagentinternal"] = len(ddaiList.Items)
 		} else {
-			omf.logger.V(1).Info("Failed to list DatadogAgentInternals, keeping old value", "error", err, "old_count", omf.OperatorMetadata.ResourceCounts["datadogagentinternal"])
+			omf.logger.V(1).Info("Failed to list DatadogAgentInternals, keeping old value", "error", err, "oldCount", omf.OperatorMetadata.ResourceCounts["datadogagentinternal"])
 		}
 	}
 
@@ -195,7 +195,7 @@ func (omf *OperatorMetadataForwarder) updateResourceCounts() {
 		if err := omf.k8sClient.List(ctx, monitorList); err == nil {
 			omf.OperatorMetadata.ResourceCounts["datadogmonitor"] = len(monitorList.Items)
 		} else {
-			omf.logger.V(1).Info("Failed to list DatadogMonitors, keeping old value", "error", err, "old_count", omf.OperatorMetadata.ResourceCounts["datadogmonitor"])
+			omf.logger.V(1).Info("Failed to list DatadogMonitors, keeping old value", "error", err, "oldCount", omf.OperatorMetadata.ResourceCounts["datadogmonitor"])
 		}
 	}
 
@@ -204,7 +204,7 @@ func (omf *OperatorMetadataForwarder) updateResourceCounts() {
 		if err := omf.k8sClient.List(ctx, dashboardList); err == nil {
 			omf.OperatorMetadata.ResourceCounts["datadogdashboard"] = len(dashboardList.Items)
 		} else {
-			omf.logger.V(1).Info("Failed to list DatadogDashboards, keeping old value", "error", err, "old_count", omf.OperatorMetadata.ResourceCounts["datadogdashboard"])
+			omf.logger.V(1).Info("Failed to list DatadogDashboards, keeping old value", "error", err, "oldCount", omf.OperatorMetadata.ResourceCounts["datadogdashboard"])
 		}
 	}
 
@@ -213,7 +213,7 @@ func (omf *OperatorMetadataForwarder) updateResourceCounts() {
 		if err := omf.k8sClient.List(ctx, sloList); err == nil {
 			omf.OperatorMetadata.ResourceCounts["datadogslo"] = len(sloList.Items)
 		} else {
-			omf.logger.V(1).Info("Failed to list DatadogSLOs, keeping old value", "error", err, "old_count", omf.OperatorMetadata.ResourceCounts["datadogslo"])
+			omf.logger.V(1).Info("Failed to list DatadogSLOs, keeping old value", "error", err, "oldCount", omf.OperatorMetadata.ResourceCounts["datadogslo"])
 		}
 	}
 
@@ -222,7 +222,7 @@ func (omf *OperatorMetadataForwarder) updateResourceCounts() {
 		if err := omf.k8sClient.List(ctx, genericList); err == nil {
 			omf.OperatorMetadata.ResourceCounts["datadoggenericresource"] = len(genericList.Items)
 		} else {
-			omf.logger.V(1).Info("Failed to list DatadogGenericResources, keeping old value", "error", err, "old_count", omf.OperatorMetadata.ResourceCounts["datadoggenericresource"])
+			omf.logger.V(1).Info("Failed to list DatadogGenericResources, keeping old value", "error", err, "oldCount", omf.OperatorMetadata.ResourceCounts["datadoggenericresource"])
 		}
 	}
 
@@ -231,8 +231,8 @@ func (omf *OperatorMetadataForwarder) updateResourceCounts() {
 		if err := omf.k8sClient.List(ctx, profileList); err == nil {
 			omf.OperatorMetadata.ResourceCounts["datadogagentprofile"] = len(profileList.Items)
 		} else {
-			omf.logger.V(1).Info("Failed to list DatadogAgentProfiles, keeping old value", "error", err, "old_count", omf.OperatorMetadata.ResourceCounts["datadogagentprofile"])
+			omf.logger.V(1).Info("Failed to list DatadogAgentProfiles, keeping old value", "error", err, "oldCount", omf.OperatorMetadata.ResourceCounts["datadogagentprofile"])
 		}
 	}
-	omf.logger.V(1).Info("Updated resource counts", "counts", omf.OperatorMetadata.ResourceCounts)
+	omf.logger.V(2).Info("Updated resource counts", "counts", omf.OperatorMetadata.ResourceCounts)
 }

--- a/pkg/controller/utils/metadata/shared_metadata.go
+++ b/pkg/controller/utils/metadata/shared_metadata.go
@@ -76,8 +76,6 @@ func (sm *SharedMetadata) createRequest(payload []byte) (*http.Request, error) {
 	}
 	payloadHeader := sm.GetHeaders(*apiKey)
 
-	sm.logger.V(1).Info("Sending metadata to URL", "url", *requestURL)
-
 	reader := bytes.NewReader(payload)
 	req, err := http.NewRequestWithContext(context.TODO(), "POST", *requestURL, reader)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Use the same logging fields as DDAI controller (see https://github.com/DataDog/datadog-operator/pull/2519). Also increase the logging verbosity of some logs and remove extraneous logs as it's a lot of logging at the debug level.

### Motivation

https://datadoghq.atlassian.net/browse/CONTP-1334

### Additional Notes

There is still excessive logging for `DatadogMetricForwarders`. That needs to be changed in a future PR

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Check the operator logs for `New CRD detected`. Previously, you'd see:
```json
{"level":"DEBUG","ts":"2026-03-09T14:06:26.946Z","logger":"metadata.crd","msg":"New CRD detected","key":"DatadogAgent/default/datadog-agent"}
```
Now you should see:
```json
{"level":"DEBUG","ts":"2026-03-09T20:29:26.401Z","logger":"metadata.crd","msg":"New CRD detected","kind":"DatadogAgent","namespace":"default","name":"datadog-agent"}
```

Overall, there should also be fewer logs from the `metadata.*` logger compared to previous releases.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits