### PR TITLE
Improve Dockerfile to fasten build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# 
+#
 ARG FIPS_ENABLED=false
 
 # Build the manager binary
@@ -14,16 +14,9 @@ COPY go.work.sum go.work.sum
 COPY api/go.mod api/go.mod
 COPY api/go.sum api/go.sum
 
-COPY test/e2e/go.mod test/e2e/go.mod
-COPY test/e2e/go.sum test/e2e/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
-WORKDIR /workspace/api
-RUN go mod download
-WORKDIR /workspace/test/e2e
-RUN go mod download
-WORKDIR /workspace
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
@@ -39,14 +32,13 @@ ARG GOARCH
 ARG FIPS_ENABLED
 RUN echo "FIPS_ENABLED is: $FIPS_ENABLED"
 RUN if [ "$FIPS_ENABLED" = "true" ]; then \
-      CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -tags fips -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
+      CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GOOS=linux GOARCH=${GOARCH} go build -tags fips -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
     else \
-      CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
     fi
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o helpers cmd/helpers/main.go
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o yaml-mapper cmd/yaml-mapper/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o helpers cmd/helpers/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o yaml-mapper cmd/yaml-mapper/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS certs
 

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -11,16 +11,9 @@ COPY go.work.sum go.work.sum
 COPY api/go.mod api/go.mod
 COPY api/go.sum api/go.sum
 
-COPY test/e2e/go.mod test/e2e/go.mod
-COPY test/e2e/go.sum test/e2e/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
-WORKDIR /workspace/api
-RUN go mod download
-WORKDIR /workspace/test/e2e
-RUN go mod download
-WORKDIR /workspace
 
 # Copy the go source
 COPY cmd/check-operator/ cmd/check-operator/
@@ -30,7 +23,7 @@ COPY pkg/ pkg/
 # Build
 ARG LDFLAGS
 ARG GOARCH
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o check-operator cmd/check-operator/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o check-operator cmd/check-operator/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 WORKDIR /


### PR DESCRIPTION
### What does this PR do?

* Removed `test/e2e` module download: removed the `COPY test/e2e/go.{mod,sum}` and its `go mod download`. This was the biggest win since it downloaded dependencies only used for e2e tests.
* Single `go mod download`: the workspace-level download resolves both root and `api/` modules, so the separate `WORKDIR` + `RUN` for `api/` was removed.
* Removed `GO111MODULE=on`: unnecessary since Go 1.16+ (https://go.dev/blog/go116-module-changes#modules-on-by-default)

### Motivation

Faster build time (from scratch (no cache), 30s gain), no wasted deps download, clearer Dockerfile

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits