### PR TITLE
[OTAGENT-886] Set `deployment_type` for DDOT Gateway deployments

### DIFF
--- a/examples/datadogagent/datadog-agent-with-otelagentgateway.yaml
+++ b/examples/datadogagent/datadog-agent-with-otelagentgateway.yaml
@@ -46,6 +46,7 @@ data:
       datadog:
         api:
           key: ${env:DD_API_KEY}
+        deployment_type: gateway
     service:
       extensions: [datadog]
       pipelines:

--- a/internal/controller/datadogagent/feature/otelagentgateway/configmap_test.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/configmap_test.go
@@ -22,7 +22,7 @@ func Test_buildOtelAgentGatewayConfigMap(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "-otel-agent-gateway-config",
 			Annotations: map[string]string{
-				"checksum/otel_agent_gateway-custom-config": "271b7a21b7215c549ce1d617f2064a3f",
+				"checksum/otel_agent_gateway-custom-config": "2fdb890243586329dc7af899ae02d5ca",
 			},
 		},
 		Data: map[string]string{

--- a/internal/controller/datadogagent/feature/otelagentgateway/defaultconfig/defaultconfig.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/defaultconfig/defaultconfig.go
@@ -23,6 +23,7 @@ extensions:
     api:
       key: ${env:DD_API_KEY}
       site: ${env:DD_SITE}
+    deployment_type: gateway
 service:
   pipelines:
     traces:

--- a/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
@@ -56,7 +56,7 @@ var (
 	}
 )
 
-var defaultAnnotations = map[string]string{"checksum/otel_agent_gateway-custom-config": "271b7a21b7215c549ce1d617f2064a3f"}
+var defaultAnnotations = map[string]string{"checksum/otel_agent_gateway-custom-config": "2fdb890243586329dc7af899ae02d5ca"}
 
 func Test_otelAgentGatewayFeature_Configure(t *testing.T) {
 	tests := test.FeatureTestSuite{
@@ -155,7 +155,7 @@ func Test_otelAgentGatewayFeature_Configure(t *testing.T) {
 				grpcPort: 4444,
 				httpPort: 5555,
 			},
-				map[string]string{"checksum/otel_agent_gateway-custom-config": "69dcc5c01755641076ba5748c90ba409"},
+				map[string]string{"checksum/otel_agent_gateway-custom-config": "a5f82f402ace53fe25e2680792fccb9f"},
 				defaultVolumeMounts,
 				defaultVolumes(defaultLocalObjectReferenceName),
 			),


### PR DESCRIPTION
### What does this PR do?

Sets `deployment_type: gateway` for DDOT Gateway deployments in the datadog extension.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.75.0

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits