### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload coverage to Datadog
         if: always()
         continue-on-error: true
-        uses: DataDog/coverage-upload-github-action@v1
+        uses: DataDog/coverage-upload-github-action@d2cf302a39c05e0ad22063360a2bf6ce0cc4906c # v1
         with:
           api_key: ${{ secrets.DD_API_KEY }}
           files: .


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR is the first step: it adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

## Changes

- Added `DataDog/coverage-upload-github-action@v1` step to the `build` job in `main.yml`, running after the existing Codecov upload
- Uploads both `cover.out` and `cover_integration.out` with the `unittests` flag (mirroring Codecov)
- The existing Codecov uploads are **unchanged** — nothing is removed or modified
- The upload uses `if: always()` and `continue-on-error: true` so it cannot block CI

## Why are we doing this?

As part of a company-wide effort, we're consolidating code coverage reporting into Datadog's own Code Coverage product. This gives us:
- Coverage data integrated directly into Datadog CI Visibility
- PR gates and coverage checks natively in Datadog
- No dependency on a third-party service (Codecov) for coverage reporting

## Validation

Pending — the Datadog upload requires `DD_API_KEY` which is not available to fork PRs. Coverage comparison will be possible after merge or when CI runs from the base repo.

## Next steps (not in this PR)

Once this PR is merged and we've confirmed Datadog coverage is stable over several commits:
1. Remove the Codecov upload steps and `CODECOV_TOKEN` secret
2. Optionally configure PR gates in `code-coverage.datadog.yml`

## No action needed from reviewers beyond normal review

This is a low-risk, additive change. The new upload step runs independently of the existing CI pipeline and cannot cause test failures.