### PR TITLE
Only use operator_nightly variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -790,17 +790,8 @@ publish_nightly_workflow:
     project: DataDog/k8s-datadog-agent-ops
     branch: main
     strategy: depend
-    forward:
-      pipeline_variables: true
   variables:
     OPERATOR_NIGHTLY: "true"
-    # Conductor-related variables
-    APPS: $APPS
-    BAZEL_TARGET: $BAZEL_TARGET
-    DDR: $DDR
-    TARGET_ENV: $TARGET_ENV
-    CONDUCTOR_TARGET: $CONDUCTOR_TARGET
-    DDR_WORKFLOW_ID: $DDR_WORKFLOW_ID
 
 # On success, this will cause CNAB to trigger a Deployment to Release Candidate clusters and open a corresponding pull request
 publish_release_candidate_workflow:


### PR DESCRIPTION
### What does this PR do?

* This reverts commit 3e75166da1b0dd02ef2f6a1f7bfffe594ce021af.
* New attempt: 7a0db21d3e04428502b7d56d72c205c6876d1b15

### Motivation

Still got the issue about circular dependency. Let's only add the operator_nightly variable which is used to trigger the  `update_operator_nightly_image` on KDAO side, and we simply use KDAO variables

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits