### PR TITLE
[Nightly fix] Add back ddr_workflow_id

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -792,6 +792,7 @@ publish_nightly_workflow:
     strategy: depend
   variables:
     OPERATOR_NIGHTLY: "true"
+    DDR_WORKFLOW_ID: $DDR_WORKFLOW_ID
 
 # On success, this will cause CNAB to trigger a Deployment to Release Candidate clusters and open a corresponding pull request
 publish_release_candidate_workflow:


### PR DESCRIPTION
### What does this PR do?

Add back ddr_workflow_id

### Motivation

Possibly the last missing step: pipeline got green all the way but bundle was not deployed due to missing the ID: 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits