### PR TITLE
Pass context for ddai

### DIFF
--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -178,7 +178,7 @@ func updateEDSStatusV2WithAgent(eds *edsv1alpha1.ExtendedDaemonSet, newStatus *d
 }
 
 func (r *Reconciler) deleteV2DaemonSet(ctx context.Context, ddai *datadoghqv1alpha1.DatadogAgentInternal, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) error {
-	err := r.client.Delete(context.TODO(), ds)
+	err := r.client.Delete(ctx, ds)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -194,7 +194,7 @@ func (r *Reconciler) deleteV2DaemonSet(ctx context.Context, ddai *datadoghqv1alp
 }
 
 func (r *Reconciler) deleteV2ExtendedDaemonSet(ctx context.Context, ddai *datadoghqv1alpha1.DatadogAgentInternal, eds *edsv1alpha1.ExtendedDaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) error {
-	err := r.client.Delete(context.TODO(), eds)
+	err := r.client.Delete(ctx, eds)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -136,7 +136,7 @@ func (r *Reconciler) updateStatusIfNeededV2(ctx context.Context, agentdeployment
 	if !IsEqualStatus(&agentdeployment.Status, newStatus) {
 		updateAgentDeployment := agentdeployment.DeepCopy()
 		updateAgentDeployment.Status = *newStatus
-		if err := r.client.Status().Update(context.TODO(), updateAgentDeployment); err != nil {
+		if err := r.client.Status().Update(ctx, updateAgentDeployment); err != nil {
 			if apierrors.IsConflict(err) {
 				logger.V(1).Info("unable to update DatadogAgent status due to update conflict")
 				return reconcile.Result{RequeueAfter: time.Second}, nil

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
@@ -67,7 +67,7 @@ func (r *Reconciler) createOrUpdateDeployment(ctx context.Context, ddai *v1alpha
 
 	currentDeployment := &appsv1.Deployment{}
 	alreadyExists := true
-	err = r.client.Get(context.TODO(), nsName, currentDeployment)
+	err = r.client.Get(ctx, nsName, currentDeployment)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("deployment is not found")
@@ -90,7 +90,7 @@ func (r *Reconciler) createOrUpdateDeployment(ctx context.Context, ddai *v1alpha
 				return reconcile.Result{}, e
 			}
 			// use merge patch to replace the entire existing owner reference list
-			err = r.client.Patch(context.TODO(), currentDeployment, client.RawPatch(types.MergePatchType, patch))
+			err = r.client.Patch(ctx, currentDeployment, client.RawPatch(types.MergePatchType, patch))
 			if err != nil {
 				logger.Error(err, "Unable to patch Deployment owner reference")
 				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch Deployment owner reference")
@@ -129,7 +129,7 @@ func (r *Reconciler) createOrUpdateDeployment(ctx context.Context, ddai *v1alpha
 		updateDeployment.Labels = mergeAnnotationsLabels(ctx, currentDeployment.GetLabels(), deployment.GetLabels(), keepLabelsFilter)
 
 		now := metav1.NewTime(time.Now())
-		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateDeployment, currentDeployment.ObjectMeta)
+		err = kubernetes.UpdateFromObject(ctx, r.client, updateDeployment, currentDeployment.ObjectMeta)
 		if err != nil {
 			updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to update Deployment")
 			return reconcile.Result{}, err
@@ -140,7 +140,7 @@ func (r *Reconciler) createOrUpdateDeployment(ctx context.Context, ddai *v1alpha
 	} else {
 		now := metav1.NewTime(time.Now())
 
-		err = r.client.Create(context.TODO(), deployment)
+		err = r.client.Create(ctx, deployment)
 		if err != nil {
 			updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, createSucceeded, "Unable to create Deployment")
 			return reconcile.Result{}, err
@@ -173,7 +173,7 @@ func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1
 
 	currentDaemonset := &appsv1.DaemonSet{}
 	alreadyExists := true
-	err = r.client.Get(context.TODO(), nsName, currentDaemonset)
+	err = r.client.Get(ctx, nsName, currentDaemonset)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("daemonset is not found")
@@ -196,7 +196,7 @@ func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1
 				return reconcile.Result{}, e
 			}
 			// use merge patch to replace the entire existing owner reference list
-			err = r.client.Patch(context.TODO(), currentDaemonset, client.RawPatch(types.MergePatchType, patch))
+			err = r.client.Patch(ctx, currentDaemonset, client.RawPatch(types.MergePatchType, patch))
 			if err != nil {
 				logger.Error(err, "Unable to patch Daemonset owner reference")
 				updateStatusFunc(currentDaemonset.Name, currentDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to patch Daemonset owner reference")
@@ -277,7 +277,7 @@ func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1
 		delete(updateDaemonset.Labels, agentprofile.OldProfileLabelKey)
 
 		logger.Info("Updating Daemonset")
-		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateDaemonset, currentDaemonset.ObjectMeta)
+		err = kubernetes.UpdateFromObject(ctx, r.client, updateDaemonset, currentDaemonset.ObjectMeta)
 		if err != nil {
 			updateStatusFunc(updateDaemonset.Name, updateDaemonset, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to update Daemonset")
 			return reconcile.Result{}, err
@@ -296,7 +296,7 @@ func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1
 		now := metav1.Now()
 		logger.Info("Creating Daemonset")
 
-		err = r.client.Create(context.TODO(), daemonset)
+		err = r.client.Create(ctx, daemonset)
 		if err != nil {
 			updateStatusFunc(daemonset.Name, nil, newStatus, now, metav1.ConditionFalse, createSucceeded, "Unable to create Daemonset")
 			return reconcile.Result{}, err
@@ -334,7 +334,7 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(ctx context.Context, ddai *
 
 	currentEDS := &edsv1alpha1.ExtendedDaemonSet{}
 	alreadyExists := true
-	err = r.client.Get(context.TODO(), nsName, currentEDS)
+	err = r.client.Get(ctx, nsName, currentEDS)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("ExtendedDaemonSet is not found")
@@ -357,7 +357,7 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(ctx context.Context, ddai *
 				return reconcile.Result{}, e
 			}
 			// use merge patch to replace the entire existing owner reference list
-			err = r.client.Patch(context.TODO(), currentEDS, client.RawPatch(types.MergePatchType, patch))
+			err = r.client.Patch(ctx, currentEDS, client.RawPatch(types.MergePatchType, patch))
 			if err != nil {
 				logger.Error(err, "Unable to patch ExtendedDaemonSet owner reference")
 				updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, patchSucceeded, "Unable to patch ExtendedDaemonSet owner reference")
@@ -392,7 +392,7 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(ctx context.Context, ddai *
 		updateEDS.Labels = mergeAnnotationsLabels(ctx, currentEDS.GetLabels(), eds.GetLabels(), keepLabelsFilter)
 
 		now := metav1.NewTime(time.Now())
-		err = kubernetes.UpdateFromObject(context.TODO(), r.client, updateEDS, currentEDS.ObjectMeta)
+		err = kubernetes.UpdateFromObject(ctx, r.client, updateEDS, currentEDS.ObjectMeta)
 		if err != nil {
 			updateStatusFunc(updateEDS, newStatus, now, metav1.ConditionFalse, updateSucceeded, "Unable to update ExtendedDaemonSet")
 			return reconcile.Result{}, err
@@ -403,7 +403,7 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(ctx context.Context, ddai *
 	} else {
 		now := metav1.NewTime(time.Now())
 
-		err = r.client.Create(context.TODO(), eds)
+		err = r.client.Create(ctx, eds)
 		if err != nil {
 			updateStatusFunc(nil, newStatus, now, metav1.ConditionFalse, createSucceeded, "Unable to create ExtendedDaemonSet")
 			return reconcile.Result{}, err

--- a/internal/controller/datadogagentinternal/finalizer.go
+++ b/internal/controller/datadogagentinternal/finalizer.go
@@ -40,7 +40,7 @@ func (r *Reconciler) handleFinalizer(ctx context.Context, ddai client.Object, fi
 			// Remove datadogAgentFinalizer. Once all finalizers have been
 			// removed, the object will be deleted.
 			controllerutil.RemoveFinalizer(ddai, constants.DatadogAgentInternalFinalizer)
-			err := r.client.Update(context.TODO(), ddai)
+			err := r.client.Update(ctx, ddai)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
@@ -67,11 +67,11 @@ func (r *Reconciler) finalizeDDAI(ctx context.Context, obj client.Object) error 
 
 	// Namespaced resources from the store are deleted thanks to owner references.
 	// Cluster level resources must be deleted manually since they cannot have an owner reference.
-	if err := r.cleanUpClusterLevelResources(obj); err != nil {
+	if err := r.cleanUpClusterLevelResources(ctx, obj); err != nil {
 		return err
 	}
 
-	if err := r.profilesCleanup(); err != nil {
+	if err := r.profilesCleanup(ctx); err != nil {
 		return err
 	}
 
@@ -85,7 +85,7 @@ func (r *Reconciler) addFinalizer(ctx context.Context, ddai client.Object) error
 	controllerutil.AddFinalizer(ddai, constants.DatadogAgentInternalFinalizer)
 
 	// Update CR
-	err := r.client.Update(context.TODO(), ddai)
+	err := r.client.Update(ctx, ddai)
 	if err != nil {
 		logger.Error(err, "Failed to update DatadogAgentInternal with finalizer")
 		return err
@@ -96,9 +96,9 @@ func (r *Reconciler) addFinalizer(ctx context.Context, ddai client.Object) error
 // profilesCleanup performs the cleanups required for the profiles feature. The
 // only thing that we need to do is to ensure that no nodes are left with the
 // profile label.
-func (r *Reconciler) profilesCleanup() error {
+func (r *Reconciler) profilesCleanup(ctx context.Context) error {
 	nodeList := corev1.NodeList{}
-	if err := r.client.List(context.TODO(), &nodeList); err != nil {
+	if err := r.client.List(ctx, &nodeList); err != nil {
 		return err
 	}
 
@@ -121,7 +121,7 @@ func (r *Reconciler) profilesCleanup() error {
 		modifiedNode := node.DeepCopy()
 		modifiedNode.Labels = newLabels
 
-		err := r.client.Patch(context.TODO(), modifiedNode, client.MergeFrom(&node))
+		err := r.client.Patch(ctx, modifiedNode, client.MergeFrom(&node))
 		if err != nil && !errors.IsNotFound(err) {
 			return err
 		}
@@ -130,28 +130,28 @@ func (r *Reconciler) profilesCleanup() error {
 	return nil
 }
 
-func (r *Reconciler) cleanUpClusterLevelResources(ddai client.Object) error {
+func (r *Reconciler) cleanUpClusterLevelResources(ctx context.Context, ddai client.Object) error {
 	// Cluster level resources must be deleted manually since they cannot have an owner reference
-	if err := deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRolesKind, r.platformInfo)); err != nil {
+	if err := deleteObjectsForResource(ctx, r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRolesKind, r.platformInfo)); err != nil {
 		return err
 	}
-	if err := deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRoleBindingKind, r.platformInfo)); err != nil {
+	if err := deleteObjectsForResource(ctx, r.client, ddai, kubernetes.ObjectFromKind(kubernetes.ClusterRoleBindingKind, r.platformInfo)); err != nil {
 		return err
 	}
-	if err := deleteObjectsForResource(r.client, ddai, kubernetes.ObjectFromKind(kubernetes.APIServiceKind, r.platformInfo)); err != nil {
+	if err := deleteObjectsForResource(ctx, r.client, ddai, kubernetes.ObjectFromKind(kubernetes.APIServiceKind, r.platformInfo)); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func deleteObjectsForResource(c client.Client, ddai client.Object, kind client.Object) error {
+func deleteObjectsForResource(ctx context.Context, c client.Client, ddai client.Object, kind client.Object) error {
 	matchingLabels := client.MatchingLabels{
 		store.OperatorStoreLabelKey:              "true",
 		kubernetes.AppKubernetesPartOfLabelKey:   object.NewPartOfLabelValue(ddai).String(),
 		kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
 	}
-	if err := c.DeleteAllOf(context.TODO(), kind, matchingLabels); err != nil {
+	if err := c.DeleteAllOf(ctx, kind, matchingLabels); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### What does this PR do?

Pass context for k8s requests and instead of using `context.TODO`

### Motivation

Better practice, and needed to connect apm traces

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits