### PR TITLE
[CONTP-1283] Fix missing workqueue_* metrics in /metrics endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,8 +31,10 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	ctrlzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -289,6 +291,16 @@ func run(opts *options) error {
 			DatadogDashboardEnabled:       opts.datadogDashboardEnabled,
 			DatadogGenericResourceEnabled: opts.datadogGenericResourceEnabled,
 		}),
+		// UsePriorityQueue makes all controllers use the priority queue, which
+		// directly registers workqueue metrics into controller-runtime's metrics
+		// registry (ctrlmetrics.Registry) rather than routing them through the
+		// global workqueue.SetProvider() call. This is necessary because
+		// k8s.io/kube-aggregator (transitively via k8s.io/component-base) wins
+		// the sync.Once in SetProvider, routing standard workqueue metrics to the
+		// k8s legacy registry instead of controller-runtime's registry.
+		Controller: ctrlconfig.Controller{
+			UsePriorityQueue: ptr.To(true),
+		},
 	})
 	if err != nil {
 		return setupErrorf(setupLog, err, "Unable to start manager")


### PR DESCRIPTION
### What does this PR do?

Restores the 7 standard `workqueue_*` Prometheus metrics that disappeared from the operator's `/metrics` endpoint after the controller-runtime upgrade to v0.20+:

- `workqueue_depth`
- `workqueue_adds_total`
- `workqueue_queue_duration_seconds`
- `workqueue_work_duration_seconds`
- `workqueue_retries_total`
- `workqueue_unfinished_work_seconds`
- `workqueue_longest_running_processor_seconds`

### Motivation

Fixes #2771. These metrics are essential for observing controller backlog, processing latency, and retry storms.

### Additional Notes

**Root cause** — a `sync.Once` race in `workqueue.SetProvider()`:

`cmd/main.go` imports `k8s.io/kube-aggregator`, which transitively pulls in `k8s.io/apiserver/pkg/storageversion`, which directly imports `k8s.io/component-base/metrics/prometheus/workqueue`. Because Go initialises packages depth-first and `kube-aggregator` appears before `sigs.k8s.io/controller-runtime` in the import list, `component-base`'s `init()` wins the `sync.Once` in `workqueue.SetProvider()`. This routes all workqueue metrics to the k8s *legacy* Prometheus registry, not to controller-runtime's `ctrlmetrics.Registry` — the registry hardcoded in the metrics server (line 221 of `pkg/metrics/server/server.go`).

The metric *descriptor* vectors are registered in `ctrlmetrics.Registry` by `sigs.k8s.io/controller-runtime/pkg/internal/metrics`, but no label combinations are ever populated because the workqueue itself is using the component-base provider. Prometheus therefore emits nothing for those metric names.

**Why other approaches don't work:**
- Reordering imports has no effect — Go `init()` ordering is determined by the dependency graph, not import list order.
- Adding our own `SetProvider()` call in `main()` is too late — all `init()` functions run before `main()` starts.
- Registering the 7 metrics manually into `ctrlmetrics.Registry` causes a `MustRegister` panic because `pkg/internal/metrics.init()` already registered some of them with different labels (`workqueue_depth` uses `{name, controller, priority}` vs `{name, controller}`).
- There is no `Registry` field on `metricsserver.Options` to substitute a combined gatherer.

**Fix** — enable `UsePriorityQueue` globally on the manager:

The [priority queue](https://github.com/kubernetes-sigs/controller-runtime/issues/2374) **bypasses `SetProvider` entirely**: it directly instantiates `metrics.WorkqueueMetricsProvider{}` on each queue, writing observations to `ctrlmetrics.Registry`. Setting `UsePriorityQueue: ptr.To(true)` in `config.Controller` applies this to every controller managed by the operator.

**Behavioural impact:**
- No change in reconciliation order — all reconcile events are enqueued at the default priority (0 for normal events; -100 `LowPriority` for initial list-watch/resync events via `WithLowPriorityWhenUnchanged`). Processing order is unchanged.
- `workqueue_depth` gains an additional `priority` label (`"-100"` during initial sync, `"0"` for subsequent events). The other 6 metrics keep the existing `{name, controller}` label set.
- `UsePriorityQueue` is marked *beta* in controller-runtime but is the path forward — used in Kubebuilder scaffolding and controller-runtime's own examples.

### Minimum Agent Versions

N/A — operator-only change.

### Describe your test plan

1. Build and run the operator locally.
2. `k port-forward deploy/datadog-operator-manager 8080:8080` (adapt depending on your namespace, deployment name, etc.)
3. Verify `workqueue_` metrics are present

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits