### PR TITLE
[ARTSEC-INT] Update datadog-agent-buildimages to v102144341-64dad9f8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ variables:
   RH_PARTNER_REGISTRY_KEY_SSM_KEY: redhat_registry_key
   RH_PARTNER_API_KEY_SSM_KEY: redhat_api_key
   # Image version from datadog-agent-buildimages (same as datadog-agent main branch)
-  CI_IMAGE_LINUX: v88930157-ef91d52f
+  CI_IMAGE_LINUX: v102144341-64dad9f8
   CI_IMAGE_LINUX_SUFFIX: ""
   PUSH_IMAGES_TO_STAGING:
     description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."


### PR DESCRIPTION
### What does this PR do?

Update CI. Tied to contrib https://github.com/DataDog/datadog-operator/pull/2761

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits