### PR TITLE
Replace `Mode` field of DPA with addition to `Strategy` field

### DIFF
--- a/api/datadoghq/common/datadogpodautoscaler_types.go
+++ b/api/datadoghq/common/datadogpodautoscaler_types.go
@@ -24,7 +24,7 @@ const (
 )
 
 // DatadogPodAutoscalerUpdateStrategy defines the mode of the update policy.
-// +kubebuilder:validation:Enum:=Auto;Disabled
+// +kubebuilder:validation:Enum:=Auto;Disabled;TriggerRollout
 type DatadogPodAutoscalerUpdateStrategy string
 
 const (
@@ -33,17 +33,9 @@ const (
 
 	// DatadogPodAutoscalerDisabledUpdateStrategy will disable the update of the target workload.
 	DatadogPodAutoscalerDisabledUpdateStrategy DatadogPodAutoscalerUpdateStrategy = "Disabled"
-)
 
-// DatadogPodAutoscalerUpdateMode controls the ability to trigger rollouts.
-// +kubebuilder:validation:Enum:=Auto;TriggerRollout
-type DatadogPodAutoscalerUpdateMode string
-
-const (
-	// DatadogPodAutoscalerAutoUpdateMode is the default mode.
-	DatadogPodAutoscalerAutoUpdateMode DatadogPodAutoscalerUpdateMode = "Auto"
-	// DatadogPodAutoscalerTriggerRolloutMode allows to trigger a full pod rollout to apply vertical recommendations.
-	DatadogPodAutoscalerTriggerRolloutMode DatadogPodAutoscalerUpdateMode = "TriggerRollout"
+	// DatadogPodAutoscalerTriggerRolloutUpdateStrategy triggers a full pod rollout to apply vertical recommendations.
+	DatadogPodAutoscalerTriggerRolloutUpdateStrategy DatadogPodAutoscalerUpdateStrategy = "TriggerRollout"
 )
 
 // DatadogPodAutoscalerUpdatePolicy defines the policy to update the target workload.
@@ -51,11 +43,6 @@ const (
 type DatadogPodAutoscalerUpdatePolicy struct {
 	// Strategy defines the mode of the update policy.
 	Strategy DatadogPodAutoscalerUpdateStrategy `json:"strategy,omitempty"`
-
-	// Mode controls the ability to trigger rollouts.
-	// +optional
-	// +kubebuilder:default=Auto
-	Mode DatadogPodAutoscalerUpdateMode `json:"mode,omitempty"`
 
 	// Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
 	// Must be greater than 0 and less than or equal to 3600 (1 hour).

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -252,13 +252,6 @@ spec:
                     update:
                       description: Update defines the policy to update target resource.
                       properties:
-                        mode:
-                          default: Auto
-                          description: Mode controls the ability to trigger rollouts.
-                          enum:
-                            - Auto
-                            - TriggerRollout
-                          type: string
                         resizePendingPeriod:
                           default: 600
                           description: |-
@@ -282,6 +275,7 @@ spec:
                           enum:
                             - Auto
                             - Disabled
+                            - TriggerRollout
                           type: string
                       type: object
                     upscale:
@@ -1001,13 +995,6 @@ spec:
                     update:
                       description: Update defines the policy for updating the target resource.
                       properties:
-                        mode:
-                          default: Auto
-                          description: Mode controls the ability to trigger rollouts.
-                          enum:
-                            - Auto
-                            - TriggerRollout
-                          type: string
                         resizePendingPeriod:
                           default: 600
                           description: |-
@@ -1031,6 +1018,7 @@ spec:
                           enum:
                             - Auto
                             - Disabled
+                            - TriggerRollout
                           type: string
                       type: object
                   type: object

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -285,15 +285,6 @@
               "additionalProperties": false,
               "description": "Update defines the policy to update target resource.",
               "properties": {
-                "mode": {
-                  "default": "Auto",
-                  "description": "Mode controls the ability to trigger rollouts.",
-                  "enum": [
-                    "Auto",
-                    "TriggerRollout"
-                  ],
-                  "type": "string"
-                },
                 "resizePendingPeriod": {
                   "default": 600,
                   "description": "Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.\nMust be greater than 0 and less than or equal to 3600 (1 hour).",
@@ -314,7 +305,8 @@
                   "description": "Strategy defines the mode of the update policy.",
                   "enum": [
                     "Auto",
-                    "Disabled"
+                    "Disabled",
+                    "TriggerRollout"
                   ],
                   "type": "string"
                 }

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -157,15 +157,6 @@
               "additionalProperties": false,
               "description": "Update defines the policy for updating the target resource.",
               "properties": {
-                "mode": {
-                  "default": "Auto",
-                  "description": "Mode controls the ability to trigger rollouts.",
-                  "enum": [
-                    "Auto",
-                    "TriggerRollout"
-                  ],
-                  "type": "string"
-                },
                 "resizePendingPeriod": {
                   "default": 600,
                   "description": "Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.\nMust be greater than 0 and less than or equal to 3600 (1 hour).",
@@ -186,7 +177,8 @@
                   "description": "Strategy defines the mode of the update policy.",
                   "enum": [
                     "Auto",
-                    "Disabled"
+                    "Disabled",
+                    "TriggerRollout"
                   ],
                   "type": "string"
                 }


### PR DESCRIPTION
### What does this PR do?

Removal of `Mode` field in the `DatadogPodAutoscaler` CRD. It's functionality is replaced with an extension of the `Strategy` field with a new enum value `DatadogPodAutoscalerTriggerRolloutUpdateStrategy`. 

### Motivation

Cleanup of `Mode` field.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits