### PR TITLE
[ACTP] Fix PAR ConfigMap name for profile DDAIs

### DIFF
--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -206,11 +206,11 @@ func (f *privateActionRunnerFeature) ManageDependencies(managers feature.Resourc
 }
 
 func (f *privateActionRunnerFeature) getConfigMapName() string {
-	return fmt.Sprintf("%s-privateactionrunner", f.owner.GetName())
+	return fmt.Sprintf("%s-privateactionrunner", constants.GetDDAName(f.owner))
 }
 
 func (f *privateActionRunnerFeature) getClusterAgentConfigMapName() string {
-	return fmt.Sprintf("%s-clusteragent-privateactionrunner", f.owner.GetName())
+	return fmt.Sprintf("%s-clusteragent-privateactionrunner", constants.GetDDAName(f.owner))
 }
 
 func (f *privateActionRunnerFeature) getRbacResourcesName() string {

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
@@ -128,6 +128,50 @@ func Test_privateActionRunnerFeature_ManageNodeAgent(t *testing.T) {
 	assert.Equal(t, "7aca0ab8a2cb083533a5552c17a50aa3", managers.AnnotationMgr.Annotations["checksum/private_action_runner-custom-config"])
 }
 
+// Test_privateActionRunnerFeature_ProfileDDAI_ConfigMapNames verifies that when PAR is
+// enabled on a profile DDAI (whose name differs from the parent DDA), the ConfigMaps are
+// named after the DDA (not the DDAI) so all profile DDAIs share the same ConfigMap.
+func Test_privateActionRunnerFeature_ProfileDDAI_ConfigMapNames(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(testScheme)
+	_ = v2alpha1.AddToScheme(testScheme)
+
+	// Simulate a profile DDAI: name differs from parent DDA, but DDA name is in the label.
+	profileDDAI := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "compute-nodeless-200m-v2",
+			Namespace: "default",
+			Labels: map[string]string{
+				apicommon.DatadogAgentNameLabelKey: "datadog-agent",
+			},
+			Annotations: map[string]string{
+				"agent.datadoghq.com/private-action-runner-enabled":         "true",
+				"cluster-agent.datadoghq.com/private-action-runner-enabled": "true",
+			},
+		},
+	}
+
+	f := buildPrivateActionRunnerFeature(nil)
+	f.Configure(profileDDAI, &v2alpha1.DatadogAgentSpec{}, nil)
+
+	storeOptions := &store.StoreOptions{Scheme: testScheme}
+	resourceManagers := feature.NewResourceManagers(store.NewStore(profileDDAI, storeOptions))
+	err := f.ManageDependencies(resourceManagers, "")
+	require.NoError(t, err)
+
+	// Node agent ConfigMap must use the DDA name so all DDAIs share the same ConfigMap.
+	_, found := resourceManagers.Store().Get(kubernetes.ConfigMapKind, "default", "datadog-agent-privateactionrunner")
+	assert.True(t, found, "node agent ConfigMap should use DDA name, not profile DDAI name")
+	_, wrongFound := resourceManagers.Store().Get(kubernetes.ConfigMapKind, "default", "compute-nodeless-200m-v2-privateactionrunner")
+	assert.False(t, wrongFound, "node agent ConfigMap must NOT use profile DDAI name")
+
+	// Cluster agent ConfigMap must use the DDA name for the same reason.
+	_, caFound := resourceManagers.Store().Get(kubernetes.ConfigMapKind, "default", "datadog-agent-clusteragent-privateactionrunner")
+	assert.True(t, caFound, "cluster agent ConfigMap should use DDA name, not profile DDAI name")
+	_, caWrongFound := resourceManagers.Store().Get(kubernetes.ConfigMapKind, "default", "compute-nodeless-200m-v2-clusteragent-privateactionrunner")
+	assert.False(t, caWrongFound, "cluster agent ConfigMap must NOT use profile DDAI name")
+}
+
 func Test_privateActionRunnerFeature_ID(t *testing.T) {
 	f := buildPrivateActionRunnerFeature(nil)
 	assert.Equal(t, string(feature.PrivateActionRunnerIDType), string(f.ID()))


### PR DESCRIPTION
## Description

When the PrivateActionRunner feature is enabled on a profile DDAI, the DaemonSets created for those profiles fail to start because the ConfigMap they reference is never created.

Root cause: `getConfigMapName()` and `getClusterAgentConfigMapName()` used `f.owner.GetName()` (the DDAI name, e.g. `compute-nodeless-200m-v2`) to build the ConfigMap name. Only the default DDAI runs `ManageDependencies` and creates the ConfigMap, so profile DDAIs end up referencing a ConfigMap that does not exist.

Fix: use `constants.GetDDAName(f.owner)` instead, which reads the `DatadogAgentNameLabelKey` label set on every DDAI at creation time and returns the parent DDA name. This means all DDAIs (default + profile) converge on the same ConfigMap name, which the default DDAI creates once.

## Changes

- Use `constants.GetDDAName()` in `getConfigMapName()` and `getClusterAgentConfigMapName()` so the name is derived from the parent DDA, not the DDAI
- Add `Test_privateActionRunnerFeature_ProfileDDAI_ConfigMapNames` to explicitly cover the profile DDAI case and guard against regression

## Testing

- New unit test verifies that a profile DDAI (with `DatadogAgentNameLabelKey` label pointing to parent DDA) produces ConfigMap names based on the DDA name, not the profile DDAI name
- All existing PAR tests continue to pass

Tested locally as well with a 2 nodes kind cluster with these 2 profiles:
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: test-profile
spec:
  profileAffinity:
    profileNodeAffinity:
      - key: kubernetes.io/hostname
        operator: In
        values:
          - desktop-worker
  config:
    override:
      nodeAgent:
        containers:
          agent:
            resources:
              requests:
                cpu: 200m
---
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: test-profile-2
spec:
  profileAffinity:
    profileNodeAffinity:
      - key: kubernetes.io/hostname
        operator: In
        values:
          - desktop-control-plane
  config:
    override:
      nodeAgent:
        containers:
          agent:
            resources:
              requests:
                cpu: 300m
```