### PR TITLE
Add code-coverage.datadog.yml

### DIFF
--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,0 +1,11 @@
+schema-version: v1
+ignore:
+  - "test/"
+  - "**/zz_generated.*.go"
+gates:
+  - type: patch_coverage_percentage
+    config:
+      threshold: 80
+flags:
+  unittests:
+    carryforward: false


### PR DESCRIPTION
Follow-up to #2773.

Adds `code-coverage.datadog.yml` mirroring the existing `.github/codecov.yml` config:
- Ignore paths: `test/` and `**/zz_generated.*.go`
- 80% patch coverage gate (matching Codecov's patch threshold)

This was accidentally omitted from the initial migration PR. The equivalent file was added to the `extendeddaemonset` repo (which has the same Codecov config).