### PR TITLE
Fix DatadogMonitor metrics forwarder goroutine leak on CR deletion

### DIFF
--- a/internal/controller/datadogmonitor/finalizer.go
+++ b/internal/controller/datadogmonitor/finalizer.go
@@ -52,6 +52,10 @@ func (r *Reconciler) handleFinalizer(logger logr.Logger, dm *datadoghqv1alpha1.D
 }
 
 func (r *Reconciler) finalizeDatadogMonitor(logger logr.Logger, dm *datadoghqv1alpha1.DatadogMonitor) {
+	if r.operatorMetricsEnabled {
+		r.forwarders.Unregister(dm)
+	}
+
 	if dm.Status.Primary {
 		err := deleteMonitor(r.datadogAuth, r.datadogClient, dm.Status.ID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add `r.forwarders.Unregister(dm)` call in `finalizeDatadogMonitor()` to stop the metrics forwarder goroutine when a DatadogMonitor CR is deleted
- Guarded by `r.operatorMetricsEnabled` check, matching the existing pattern in `finalizeDadV2()` for the DatadogAgent controller
- Placed before `deleteMonitor()` to ensure cleanup happens even if `deleteMonitor()` returns early on error

Fixes #2803

## Test plan
- [x] Existing `Test_handleFinalizer` tests pass (deletion case uses `operatorMetricsEnabled=false` by default)
- [x] `go vet ./...` passes
- [x] `go build ./internal/controller/datadogmonitor/...` passes
- [x] All datadogmonitor package tests pass