### PR TITLE
[PAR] Add host mounts and caps to PAR container

### DIFF
--- a/internal/controller/datadogagent/common/const.go
+++ b/internal/controller/datadogagent/common/const.go
@@ -158,6 +158,10 @@ const (
 	HostRunPath       = "/run"
 	HostRunMountPath  = "/host/run"
 
+	HostVarLogVolumeName = "host-varlog"
+	HostVarLogHostPath   = "/var/log"
+	HostVarLogMountPath  = "/host/var/log"
+
 	RunPathVolumeName  = "pointerdir"
 	RunPathVolumeMount = "/opt/datadog-agent/run"
 )

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -15,6 +15,7 @@ import (
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
@@ -286,6 +287,21 @@ func (f *privateActionRunnerFeature) ManageNodeAgent(managers feature.PodTemplat
 		ReadOnly:  true,
 	}
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.PrivateActionRunnerContainerName)
+
+	managers.SecurityContext().AddCapabilitiesToContainer([]corev1.Capability{"NET_RAW"}, apicommon.PrivateActionRunnerContainerName)
+
+	// Mount host paths for process inspection and log access (read-only)
+	osReleaseVol, osReleaseMount := volume.GetVolumes(common.SystemProbeOSReleaseDirVolumeName, common.SystemProbeOSReleaseDirVolumePath, common.SystemProbeOSReleaseDirMountPath, true)
+	managers.Volume().AddVolume(&osReleaseVol)
+	managers.VolumeMount().AddVolumeMountToContainer(&osReleaseMount, apicommon.PrivateActionRunnerContainerName)
+
+	varLogVol, varLogMount := volume.GetVolumes(common.HostVarLogVolumeName, common.HostVarLogHostPath, common.HostVarLogMountPath, true)
+	managers.Volume().AddVolume(&varLogVol)
+	managers.VolumeMount().AddVolumeMountToContainer(&varLogMount, apicommon.PrivateActionRunnerContainerName)
+
+	procdirVol, procdirMount := volume.GetVolumes(common.ProcdirVolumeName, common.ProcdirHostPath, common.ProcdirMountPath, true)
+	managers.Volume().AddVolume(&procdirVol)
+	managers.VolumeMount().AddVolumeMountToContainer(&procdirMount, apicommon.PrivateActionRunnerContainerName)
 
 	checksumKey, checksumValue, err := checksumAnnotation(f.nodeConfigData)
 	if err != nil {

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
@@ -105,22 +105,49 @@ func Test_privateActionRunnerFeature_ManageNodeAgent(t *testing.T) {
 	err := f.ManageNodeAgent(managers, "")
 	assert.NoError(t, err)
 
-	// Verify volume is mounted
+	// Verify volumes: configmap + 3 host paths
 	volumes := managers.VolumeMgr.Volumes
-	assert.Len(t, volumes, 1, "Should have exactly one volume")
+	assert.Len(t, volumes, 4, "Should have 4 volumes")
+
 	vol := volumes[0]
 	assert.Equal(t, "test-dda-privateactionrunner-config", vol.Name, "Volume name should match")
 	assert.NotNil(t, vol.VolumeSource.ConfigMap, "Volume should be a ConfigMap volume")
 	assert.Equal(t, "test-dda-privateactionrunner", vol.VolumeSource.ConfigMap.Name, "ConfigMap name should match")
 
-	// Verify volume mount
+	assert.Equal(t, "host-osrelease", volumes[1].Name)
+	assert.Equal(t, "/etc/os-release", volumes[1].VolumeSource.HostPath.Path)
+
+	assert.Equal(t, "host-varlog", volumes[2].Name)
+	assert.Equal(t, "/var/log", volumes[2].VolumeSource.HostPath.Path)
+
+	assert.Equal(t, "procdir", volumes[3].Name)
+	assert.Equal(t, "/proc", volumes[3].VolumeSource.HostPath.Path)
+
+	// Verify volume mounts: configmap + 3 host paths
 	volumeMounts := managers.VolumeMountMgr.VolumeMountsByC[apicommon.PrivateActionRunnerContainerName]
-	assert.Len(t, volumeMounts, 1, "Should have exactly one volume mount")
+	assert.Len(t, volumeMounts, 4, "Should have 4 volume mounts")
+
 	mount := volumeMounts[0]
 	assert.Equal(t, "test-dda-privateactionrunner-config", mount.Name, "Mount name should match")
 	assert.Equal(t, "/etc/datadog-agent/privateactionrunner.yaml", mount.MountPath, "Mount path should be the hardcoded path")
 	assert.Equal(t, "privateactionrunner.yaml", mount.SubPath, "SubPath should mount the file directly")
 	assert.True(t, mount.ReadOnly, "Mount should be read-only")
+
+	assert.Equal(t, "host-osrelease", volumeMounts[1].Name)
+	assert.Equal(t, "/host/etc/os-release", volumeMounts[1].MountPath)
+	assert.True(t, volumeMounts[1].ReadOnly)
+
+	assert.Equal(t, "host-varlog", volumeMounts[2].Name)
+	assert.Equal(t, "/host/var/log", volumeMounts[2].MountPath)
+	assert.True(t, volumeMounts[2].ReadOnly)
+
+	assert.Equal(t, "procdir", volumeMounts[3].Name)
+	assert.Equal(t, "/host/proc", volumeMounts[3].MountPath)
+	assert.True(t, volumeMounts[3].ReadOnly)
+
+	// Verify NET_RAW capability
+	capabilities := managers.SecurityContextMgr.CapabilitiesByC[apicommon.PrivateActionRunnerContainerName]
+	assert.Contains(t, capabilities, corev1.Capability("NET_RAW"), "PAR container should have NET_RAW capability")
 
 	// Verify hash
 	assert.NotEmpty(t, managers.AnnotationMgr.Annotations)


### PR DESCRIPTION
### What does this PR do?

Adds three read-only host path mounts and the `NET_RAW` Linux capability to the Private Action Runner (PAR) container on the node agent.

Host mounts added (node agent only, not cluster agent):
- `/etc/os-release` → `/host/etc/os-release` (OS identification)
- `/var/log` → `/host/var/log` (host and container log access)
- `/proc` → `/host/proc` (host process inspection)

A new `HostVarLogVolumeName/HostPath/MountPath` constant triple is added to `common/const.go`; the other two paths reuse existing constants shared with system-probe.

### Motivation

The PAR container needs those mounts and caps for the mcp tools we want to expose.

### Additional Notes

- All mounts are read-only.
- Changes are scoped exclusively to the PAR inside the node agent, cluster-agent is not affected.

### Minimum Agent Versions

7.78

### Describe your test plan

- Updated `Test_privateActionRunnerFeature_ManageNodeAgent` to assert all new volumes, mounts, and the `NET_RAW` capability.
- `go test ./internal/controller/datadogagent/feature/privateactionrunner/...` passes.
- `go build ./...` and `go vet ./...` pass.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits