### PR TITLE
chore: disable automated dependency updater config [incident-51602]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,28 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# # To get started with Dependabot version updates, you'll need to specify which
+# # package ecosystems to update and where the package manifests are located.
+# # Please see the documentation for all configuration options:
+# # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    labels:
-      - tooling
-      - qa/skip-qa
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-      - qa/skip-qa
-  - package-ecosystem: gomod
-    directory: /test/e2e
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-      - qa/skip-qa
+# version: 2
+# updates:
+#   - package-ecosystem: github-actions
+#     directory: /
+#     schedule:
+#       interval: weekly
+#     labels:
+#       - tooling
+#       - qa/skip-qa
+#   - package-ecosystem: gomod
+#     directory: /
+#     schedule:
+#       interval: weekly
+#     labels:
+#       - dependencies
+#       - qa/skip-qa
+#   - package-ecosystem: gomod
+#     directory: /test/e2e
+#     schedule:
+#       interval: weekly
+#     labels:
+#       - dependencies
+#       - qa/skip-qa


### PR DESCRIPTION
As part of #incident-51602, we are temporarily disabling all automated dependency updaters to reduce exposure to potential zero-day vulnerabilities in recent releases.

This PR disables the Dependabot/Renovate configuration not managed by ADMS by commenting out (YAML) or renaming (JSON) the config file. Please do not re-enable until further notice.