### PR TITLE
Fix component logging and downgrade to debug

### DIFF
--- a/internal/controller/datadogagent/override/dependencies.go
+++ b/internal/controller/datadogagent/override/dependencies.go
@@ -86,7 +86,7 @@ func overrideRBAC(logger logr.Logger, manager feature.ResourceManagers, override
 	// Delete created RBACs if CreateRbac is set to false
 	if !createRBAC(override) {
 		rbacManager := manager.RBACManager()
-		logger.Info("Deleting RBACs for %s", component, nil)
+		logger.V(1).Info("Deleting RBACs", "component", string(component))
 		errs = append(errs, rbacManager.DeleteServiceAccountByComponent(string(component), namespace))
 		errs = append(errs, rbacManager.DeleteRoleByComponent(string(component), namespace))
 		errs = append(errs, rbacManager.DeleteClusterRoleByComponent(string(component)))


### PR DESCRIPTION
### What does this PR do?

When you set:
```yaml
#(...)
  override:
    nodeAgent:
      createRbac: false
```

You get a noisy DPANIC log emitted each reconciliation loop:
```json
 {"level":"DPANIC","ts":"2026-03-24T23:21:42.244Z","logger":"controllers.DatadogAgentInternal","msg":"non-string key argument passed to logging, ignoring all later arguments","namespace":"datadog","name":"datadog","reconcileID":"a73d0584-c36d-4ed5-902d-360d31286d6d","kind":"DatadogAgentInternal","invalid key":"clusterAgent","stacktrace":"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override.overrideRBAC ...rest of the stack trace..."}
```

The logger call is expecting pair of strings here, but current gets `object, nil` giving that error. This currently only causes this noisy log and should not affect the reconciliation.

Fix the log and also downgrade it to debug as its otherwise logged every single loop. New log:

```json
{"level":"DEBUG","ts":"2026-03-25T01:17:40.062Z","logger":"controllers.DatadogAgentInternal","msg":"Deleting RBACs","namespace":"default","name":"datadog","reconcileID":"f34355ba-da95-4334-9cc2-a3d7b1b6931a","kind":"DatadogAgentInternal","component":"clusterAgent"}
{"level":"DEBUG","ts":"2026-03-25T01:17:40.062Z","logger":"controllers.DatadogAgentInternal","msg":"Deleting RBACs","namespace":"default","name":"datadog","reconcileID":"f34355ba-da95-4334-9cc2-a3d7b1b6931a","kind":"DatadogAgentInternal","component":"nodeAgent"}
```

### Motivation

What inspired you to submit this pull request?
https://datadoghq.atlassian.net/browse/CONS-8184
### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits