### PR TITLE
re-enable dependabot with 14-day cooldown

### DIFF
--- a/github/dependabot.yml
+++ b/github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  labels:
+  - tooling
+  - qa/skip-qa
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  labels:
+  - dependencies
+  - qa/skip-qa
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /test/e2e
+  schedule:
+    interval: weekly
+  labels:
+  - dependencies
+  - qa/skip-qa
+  cooldown:
+    default-days: 14


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a mandatory 14-day cooldown on dependencies to reduce the risk of zero-day vulnerabilities.

This PR re-enables your Dependabot configuration and introduces the cooldown setting. If you notice any other Dependabot configurations in your repo that are missing the cooldown, please ensure it is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.