### PR TITLE
[datadog-operator] Update Github Workflow for Milestone

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,6 @@ Write there any instructions and details you may have to test your PR.
 ### Checklist
 
 - [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
-- [ ] PR has a milestone or the `qa/skip-qa` label
 - [ ] All commits are signed (see: [signing commits][1])
 
 [1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -1,0 +1,59 @@
+name: Add Milestone on a Merged PR
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+      - "v[0-9]+.[0-9]+"
+
+permissions: {}
+
+jobs:
+  add-milestone-pr:
+    name: Add Milestone on PR
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Get current milestone from branch
+        id: current-milestone
+        run: |
+          BASE_BRANCH="${{ github.base_ref }}"
+
+          if [[ "$BASE_BRANCH" == "main" ]]; then
+            # For main, use the open milestone with the highest creation order (latest upcoming release).
+            MILESTONE=$(gh api repos/${{ github.repository }}/milestones \
+              --jq '[.[] | select(.state == "open")] | sort_by(.number) | last | .title')
+          elif [[ "$BASE_BRANCH" =~ ^v([0-9]+)\.([0-9]+)$ ]]; then
+            # For release branches like v1.25, derive the milestone as v1.25.0.
+            MILESTONE="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.0"
+          else
+            echo "Error: Unexpected branch '$BASE_BRANCH'."
+            exit 1
+          fi
+
+          if [ -z "$MILESTONE" ]; then
+            echo "Error: Couldn't determine a current milestone for branch '$BASE_BRANCH'."
+            exit 1
+          fi
+
+          if [[ ! $MILESTONE =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Malformed milestone '$MILESTONE'. It should be of the form 'vX.Y.Z'."
+            exit 1
+          fi
+
+          echo "MILESTONE=$MILESTONE" >> "$GITHUB_OUTPUT"
+
+      - name: Set the merged PR milestone to current milestone
+        run: |
+          echo "Setting milestone $MILESTONE to PR $NUMBER."
+          gh issue edit "$NUMBER" --milestone "$MILESTONE"
+        env:
+          NUMBER: ${{ github.event.number }}
+          MILESTONE: ${{ steps.current-milestone.outputs.MILESTONE }}

--- a/.github/workflows/pr-linter.yml
+++ b/.github/workflows/pr-linter.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize, milestoned, demilestoned]
+    types: [opened, labeled, unlabeled, synchronize]
 
 permissions: {}
 
@@ -24,21 +24,3 @@ jobs:
         valid-labels: 'bug, enhancement, refactoring, documentation, tooling, dependencies'
         pull-request-number: '${{ github.event.pull_request.number }}'
         disable-reviews: true
-  check-milestone:
-    name: Check Milestone
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    steps:
-      - name: Check milestone and labels
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }})
-          MILESTONE=$(echo "$PR_JSON" | jq -r '.milestone.title // empty')
-          HAS_SKIP_QA=$(echo "$PR_JSON" | jq -r '[.labels[].name] | any(. == "qa/skip-qa")')
-          if [ -z "$MILESTONE" ] && [ "$HAS_SKIP_QA" != "true" ]; then
-            echo "::error::Missing milestone or \`qa/skip-qa\` label"
-            exit 1
-          fi


### PR DESCRIPTION
### What does this PR do?

Update the Github Workflows surrounding PR Milestones.

* Decouples the `qa/skip-qa` label from the `Milestone`. Targeting a particular release should be independent of whether or not QA is required. By default, QA remains automatically required and only familiar Operator users will add the label to skip QA.

* Every PR will have a milestone associated to it determine on the base branch that it merged onto to. (Merge onto main gets latest Milestone, Merge onto rc branch gets the rc milestone). This mirrors the [datadog-agent milestone workflow](https://github.com/DataDog/datadog-agent/blob/main/.github/workflows/add-milestone.yml) which adds a milestone post merge.

### Describe your test plan

The `add-milestone` action was mostly copied from the Agent. The main difference is how we're querying for the milestone itself. The Agent stores the active milestone explicitly within a file in the code base. Theoretically we could do the same by looking at `config/manager/kustomization.yaml` for the `newTag` field. However, @claude decided to instead directly query the open milestones within the repo and pick the latest when merging onto main. Testing the commands locally seem good:

Getting the Milestone when merging onto main:
```
gh api repos/datadog/datadog-operator/milestones --jq '[.[] | select(.state == "open")] | sort_by(.number) | last | .title'
```

Getting the Milestone when not merging onto main:
```
 bash -c '                                                                                                                                                            
  BASE_BRANCH="v1.25"                                                                                                                                                  
  if [[ "$BASE_BRANCH" =~ ^v([0-9]+)\.([0-9]+)$ ]]; then                                                                                                               
    echo "Full match: ${BASH_REMATCH[0]}"
    echo "Major: ${BASH_REMATCH[1]}"                                                                                                                                   
    echo "Minor: ${BASH_REMATCH[2]}"                                                                                                                                   
    echo "Milestone: v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.0"                                                                                                         
  fi'
```
 
### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits