### PR TITLE
[Dockerfile] Update base os from RHEL9 to RHEL10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,24 +32,24 @@ ARG GOARCH
 ARG FIPS_ENABLED
 RUN echo "FIPS_ENABLED is: $FIPS_ENABLED"
 RUN if [ "$FIPS_ENABLED" = "true" ]; then \
-      CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GOOS=linux GOARCH=${GOARCH} go build -tags fips -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
+    CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GOOS=linux GOARCH=${GOARCH} go build -tags fips -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
     else \
-      CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o manager cmd/main.go; \
     fi
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o helpers cmd/helpers/main.go
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o yaml-mapper cmd/yaml-mapper/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS certs
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 
 LABEL name="datadog/operator"
 LABEL vendor="Datadog Inc."
 LABEL summary="The Datadog Operator aims at providing a new way to deploy the Datadog Agent on Kubernetes"
 LABEL description="Datadog provides a modern monitoring and analytics platform. Gather \
-      metrics, logs and traces for full observability of your Kubernetes cluster with \
-      Datadog Operator."
+    metrics, logs and traces for full observability of your Kubernetes cluster with \
+    Datadog Operator."
 LABEL maintainer="Datadog Inc."
 
 # ubi-micro variant does not have CA certificates installed

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -25,7 +25,7 @@ ARG LDFLAGS
 ARG GOARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" -o check-operator cmd/check-operator/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /workspace/check-operator .
 USER 1001


### PR DESCRIPTION
### What does this PR do?

Uses ubi10 instead of ubi9 for the base image

### Motivation

CVE reducing:

```console
Report Summary

┌──────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                Target                │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ tbdatadog/operator:main (redhat 9.7) │  redhat  │       15        │    -    │
├──────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ helpers                              │ gobinary │        0        │    -    │
├──────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ manager                              │ gobinary │        0        │    -    │
├──────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ yaml-mapper                          │ gobinary │        0        │    -    │
└──────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

tbdatadog/operator:main (redhat 9.7)

Total: 15 (UNKNOWN: 0, LOW: 8, MEDIUM: 7, HIGH: 0, CRITICAL: 0)

┌────────────────────────┬────────────────┬──────────┬──────────┬─────────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │ Vulnerability  │ Severity │  Status  │  Installed Version  │ Fixed Version │                            Title                             │
├────────────────────────┼────────────────┼──────────┼──────────┼─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ coreutils-single       │ CVE-2025-5278  │ MEDIUM   │ affected │ 8.32-39.el9         │               │ coreutils: Heap Buffer Under-Read in GNU Coreutils sort via  │
│                        │                │          │          │                     │               │ Key Specification                                            │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2025-5278                    │
├────────────────────────┼────────────────┤          │          ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ glibc                  │ CVE-2026-4046  │          │          │ 2.34-231.el9_7.10   │               │ glibc: glibc: Denial of Service via iconv() function with    │
│                        │                │          │          │                     │               │ specific character sets...                                   │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4046                    │
│                        ├────────────────┤          │          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-4437  │          │          │                     │               │ glibc: glibc: Incorrect DNS response parsing via crafted DNS │
│                        │                │          │          │                     │               │ server response                                              │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4437                    │
│                        ├────────────────┼──────────┤          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-4438  │ LOW      │          │                     │               │ glibc: glibc: Invalid DNS hostname returned via              │
│                        │                │          │          │                     │               │ gethostbyaddr functions                                      │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4438                    │
├────────────────────────┼────────────────┼──────────┤          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│ glibc-common           │ CVE-2026-4046  │ MEDIUM   │          │                     │               │ glibc: glibc: Denial of Service via iconv() function with    │
│                        │                │          │          │                     │               │ specific character sets...                                   │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4046                    │
│                        ├────────────────┤          │          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-4437  │          │          │                     │               │ glibc: glibc: Incorrect DNS response parsing via crafted DNS │
│                        │                │          │          │                     │               │ server response                                              │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4437                    │
│                        ├────────────────┼──────────┤          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-4438  │ LOW      │          │                     │               │ glibc: glibc: Invalid DNS hostname returned via              │
│                        │                │          │          │                     │               │ gethostbyaddr functions                                      │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4438                    │
├────────────────────────┼────────────────┼──────────┤          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│ glibc-minimal-langpack │ CVE-2026-4046  │ MEDIUM   │          │                     │               │ glibc: glibc: Denial of Service via iconv() function with    │
│                        │                │          │          │                     │               │ specific character sets...                                   │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4046                    │
│                        ├────────────────┤          │          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-4437  │          │          │                     │               │ glibc: glibc: Incorrect DNS response parsing via crafted DNS │
│                        │                │          │          │                     │               │ server response                                              │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4437                    │
│                        ├────────────────┼──────────┤          │                     ├───────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-4438  │ LOW      │          │                     │               │ glibc: glibc: Invalid DNS hostname returned via              │
│                        │                │          │          │                     │               │ gethostbyaddr functions                                      │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2026-4438                    │
├────────────────────────┼────────────────┤          │          ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libgcc                 │ CVE-2022-27943 │          │          │ 11.5.0-11.el9       │               │ binutils: libiberty/rust-demangle.c in GNU GCC 11.2 allows   │
│                        │                │          │          │                     │               │ stack exhaustion in demangle_const                           │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2022-27943                   │
├────────────────────────┼────────────────┤          │          ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ ncurses-base           │ CVE-2023-50495 │          │          │ 6.2-12.20210508.el9 │               │ ncurses: segmentation fault via _nc_wrap_entry()             │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2023-50495                   │
├────────────────────────┤                │          │          │                     ├───────────────┤                                                              │
│ ncurses-libs           │                │          │          │                     │               │                                                              │
│                        │                │          │          │                     │               │                                                              │
├────────────────────────┼────────────────┤          │          ├─────────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ pcre2                  │ CVE-2022-41409 │          │          │ 10.40-6.el9         │               │ pcre2: negative repeat value in a pcre2test subject line     │
│                        │                │          │          │                     │               │ leads to inifinite...                                        │
│                        │                │          │          │                     │               │ https://avd.aquasec.com/nvd/cve-2022-41409                   │
├────────────────────────┤                │          │          │                     ├───────────────┤                                                              │
│ pcre2-syntax           │                │          │          │                     │               │                                                              │
│                        │                │          │          │                     │               │                                                              │
│                        │                │          │          │                     │               │                                                              │
└────────────────────────┴────────────────┴──────────┴──────────┴─────────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```

compared to

```console
Report Summary

┌──────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                  Target                  │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ tbdatadog/operator:rhel-10 (redhat 10.1) │  redhat  │        0        │    -    │
├──────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ helpers                                  │ gobinary │        0        │    -    │
├──────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ manager                                  │ gobinary │        0        │    -    │
├──────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ yaml-mapper                              │ gobinary │        0        │    -    │
└──────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits