### PR TITLE
update(devcontainer): update claude and golang version to 1.25.9

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainer-community/devcontainer-features/yq:1": {},
         "ghcr.io/clamoriniere/claude-devcontainer-features/claude-code:1.0.6": {}
-    },
+},
+"remoteUser": "vscode",
     "mounts": [
         "source=${localWorkspaceFolder}/.devcontainer/claude-data/,target=/home/vscode/.claude,type=bind"
     ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,8 @@
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainer-community/devcontainer-features/yq:1": {},
         "ghcr.io/clamoriniere/claude-devcontainer-features/claude-code:1.0.6": {}
-},
-"remoteUser": "vscode",
+    },
+    "remoteUser": "vscode",
     "mounts": [
         "source=${localWorkspaceFolder}/.devcontainer/claude-data/,target=/home/vscode/.claude,type=bind"
     ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,14 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/go:dev-1.25",
+    "image": "golang:1.25.9",
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
             "moby": false
         },
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
         "ghcr.io/devcontainers-extra/features/kind:1": {},
-        "ghcr.io/devcontainers/features/node:1": {},
-        "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainer-community/devcontainer-features/yq:1": {},
+        "ghcr.io/clamoriniere/claude-devcontainer-features/claude-code:1.0.6": {}
     },
     "mounts": [
         "source=${localWorkspaceFolder}/.devcontainer/claude-data/,target=/home/vscode/.claude,type=bind"
@@ -36,5 +37,8 @@
                 "golang.Go"
             ]
         }
+    },
+    "containerEnv": {
+        "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
     }
 }


### PR DESCRIPTION
### What does this PR do?

To be able to use the last version of claud code, we need to use for now a customer feature release until this PR is merged https://github.com/anthropics/devcontainer-features/pull/37

### Motivation

* I want to use the last claude code version
* update the devcontainer to be compatible with the golang upgrade version done in #2877

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits