### PR TITLE
Add DPACP to orchestrator explorer OOTB CRD collection

### DIFF
--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	currentDatadogPodAutoscalerResource = "datadoghq.com/v1alpha2/datadogpodautoscalers"
-	oldDatadogPodAutoscalerResource     = "datadoghq.com/v1alpha1/datadogpodautoscalers"
+	currentDatadogPodAutoscalerResource               = "datadoghq.com/v1alpha2/datadogpodautoscalers"
+	oldDatadogPodAutoscalerResource                   = "datadoghq.com/v1alpha1/datadogpodautoscalers"
+	currentDatadogPodAutoscalerClusterProfileResource = "datadoghq.com/v1alpha2/datadogpodautoscalerclusterprofiles"
 )
 
 func init() {
@@ -117,7 +118,7 @@ func (f *orchestratorExplorerFeature) Configure(dda metav1.Object, ddaSpec *v2al
 		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.GetName(), ddaSpec)
 
 		// Handle automatic addition of OOTB resources
-		// Autoscaling: Add DPA resource if enabled and replace older versions if present
+		// Autoscaling: Add DPA and DPACP resources if enabled and replace older versions if present
 		autoscaling := ddaSpec.Features.Autoscaling
 		if autoscaling != nil && autoscaling.Workload != nil && apiutils.BoolValue(autoscaling.Workload.Enabled) {
 			addRequired := true
@@ -130,6 +131,7 @@ func (f *orchestratorExplorerFeature) Configure(dda metav1.Object, ddaSpec *v2al
 			if addRequired {
 				f.customResources = append(f.customResources, currentDatadogPodAutoscalerResource)
 			}
+			f.customResources = append(f.customResources, currentDatadogPodAutoscalerClusterProfileResource)
 		}
 
 		// Unique the custom resources as the check will output a warning if there are duplicates

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
@@ -102,6 +102,7 @@ instances:
   - skip_leader_election: false
     crd_collectors:
       - datadoghq.com/v1alpha1/watermarkpodautoscalers
+      - datadoghq.com/v1alpha2/datadogpodautoscalerclusterprofiles
       - datadoghq.com/v1alpha2/datadogpodautoscalers
 `
 


### PR DESCRIPTION
### What does this PR do?

Add DPACP CRD collection support in the orchestrator explorer feature. 

### Motivation

make the the DPACP CR collected OOTB to each autoscaling product onboarding

### Additional Notes

* It should not be an issue to try collecting a CRD that doesn't exist in the cluster.
* This CRD will be added part of the operator release v1.26.0 by #2794

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits