### PR TITLE
[CASCL-1292] Add Fargate mode to kubectl-datadog install

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -434,7 +434,7 @@ e2e_autoscaling:
   stage: e2e
   needs:
     - "go_e2e_deps"
-  timeout: 90m
+  timeout: 150m
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ENVTEST_K8S_VERSION = 1.30
 # (E2E provisioning can hang; having a finite timeout ensures we get goroutine dumps
 # instead of the CI job timing out with no actionable logs.)
 E2E_GO_TEST_TIMEOUT ?= 55m
-E2E_AUTOSCALING_GO_TEST_TIMEOUT ?= 80m
+E2E_AUTOSCALING_GO_TEST_TIMEOUT ?= 140m
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/aws/cloudformation.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/aws/cloudformation.go
@@ -39,13 +39,9 @@ func CreateOrUpdateStackWithExisting(ctx context.Context, client *cloudformation
 }
 
 func createOrUpdateStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, params map[string]string, extraTags map[string]string, exists bool) error {
-	parameters := make([]types.Parameter, 0, len(params))
-	for key, value := range params {
-		parameters = append(parameters, types.Parameter{
-			ParameterKey:   aws.String(key),
-			ParameterValue: aws.String(value),
-		})
-	}
+	parameters := lo.MapToSlice(params, func(key, value string) types.Parameter {
+		return types.Parameter{ParameterKey: aws.String(key), ParameterValue: aws.String(value)}
+	})
 	if exists {
 		return updateStack(ctx, client, stackName, templateBody, parameters, buildTags(extraTags))
 	} else {

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/aws/cloudformation.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/aws/cloudformation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/smithy-go"
+	"github.com/samber/lo"
 
 	"github.com/DataDog/datadog-operator/pkg/version"
 )
@@ -22,12 +23,22 @@ const (
 	maxWaitDuration = 30 * time.Minute
 )
 
-func CreateOrUpdateStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, params map[string]string) error {
-	exist, err := DoesStackExist(ctx, client, stackName)
+func CreateOrUpdateStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, params map[string]string, extraTags map[string]string) error {
+	existing, err := GetStack(ctx, client, stackName)
 	if err != nil {
 		return err
 	}
+	return createOrUpdateStack(ctx, client, stackName, templateBody, params, extraTags, existing != nil)
+}
 
+// CreateOrUpdateStackWithExisting is like CreateOrUpdateStack but takes a
+// pre-fetched stack (nil if it does not exist), saving a DescribeStacks call
+// for callers that already looked it up.
+func CreateOrUpdateStackWithExisting(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, params map[string]string, extraTags map[string]string, existing *Stack) error {
+	return createOrUpdateStack(ctx, client, stackName, templateBody, params, extraTags, existing != nil)
+}
+
+func createOrUpdateStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, params map[string]string, extraTags map[string]string, exists bool) error {
 	parameters := make([]types.Parameter, 0, len(params))
 	for key, value := range params {
 		parameters = append(parameters, types.Parameter{
@@ -35,37 +46,95 @@ func CreateOrUpdateStack(ctx context.Context, client *cloudformation.Client, sta
 			ParameterValue: aws.String(value),
 		})
 	}
-
-	if exist {
-		return updateStack(ctx, client, stackName, templateBody, parameters)
+	if exists {
+		return updateStack(ctx, client, stackName, templateBody, parameters, buildTags(extraTags))
 	} else {
-		return createStack(ctx, client, stackName, templateBody, parameters)
+		return createStack(ctx, client, stackName, templateBody, parameters, buildTags(extraTags))
 	}
 }
 
-// DoesStackExist checks if a CloudFormation stack exists.
-func DoesStackExist(ctx context.Context, client *cloudformation.Client, stackName string) (bool, error) {
-	_, err := client.DescribeStacks(
-		ctx,
-		&cloudformation.DescribeStacksInput{
-			StackName: aws.String(stackName),
-		},
-	)
+// buildTags returns the base tags (managed-by, version) plus any extra tags
+// passed by the caller. Base tags are passed last to lo.Assign so they
+// override any extra entry sharing the same key.
+func buildTags(extraTags map[string]string) []types.Tag {
+	base := map[string]string{
+		"managed-by": "kubectl-datadog",
+		"version":    version.GetVersion(),
+	}
+	return lo.MapToSlice(lo.Assign(extraTags, base), func(k, v string) types.Tag {
+		return types.Tag{Key: aws.String(k), Value: aws.String(v)}
+	})
+}
 
+// Stack wraps *types.Stack with map accessors for tags, parameters and
+// outputs. All accessors tolerate a nil receiver and return a nil map.
+type Stack struct {
+	*types.Stack
+}
+
+// GetStack returns the named CloudFormation stack, or (nil, nil) if the stack
+// does not exist. Callers read tags, parameters and outputs from the returned
+// wrapper rather than issuing additional DescribeStacks calls.
+func GetStack(ctx context.Context, client *cloudformation.Client, stackName string) (*Stack, error) {
+	out, err := client.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	})
 	if err != nil {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) &&
 			apiErr.ErrorCode() == "ValidationError" &&
 			strings.Contains(apiErr.ErrorMessage(), "does not exist") {
-			return false, nil
+			return nil, nil
 		}
-		return false, fmt.Errorf("failed to describe stack %s: %w", stackName, err)
+		return nil, fmt.Errorf("failed to describe stack %s: %w", stackName, err)
 	}
-
-	return true, nil
+	if len(out.Stacks) == 0 {
+		return nil, nil
+	}
+	return &Stack{&out.Stacks[0]}, nil
 }
 
-func createStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, parameters []types.Parameter) error {
+// TagMap returns the stack's tags as a map, or nil if the receiver is nil.
+// Method name differs from the embedded `Tags` field to avoid selector
+// ambiguity.
+func (s *Stack) TagMap() map[string]string {
+	if s == nil {
+		return nil
+	}
+	return lo.SliceToMap(s.Tags, func(t types.Tag) (string, string) {
+		return aws.ToString(t.Key), aws.ToString(t.Value)
+	})
+}
+
+// ParameterMap returns the stack's parameters as a map, or nil if the
+// receiver is nil.
+func (s *Stack) ParameterMap() map[string]string {
+	if s == nil {
+		return nil
+	}
+	return lo.SliceToMap(s.Parameters, func(p types.Parameter) (string, string) {
+		return aws.ToString(p.ParameterKey), aws.ToString(p.ParameterValue)
+	})
+}
+
+// OutputMap returns the stack's outputs as a map, or nil if the receiver is
+// nil.
+func (s *Stack) OutputMap() map[string]string {
+	if s == nil {
+		return nil
+	}
+	return lo.SliceToMap(s.Outputs, func(o types.Output) (string, string) {
+		return aws.ToString(o.OutputKey), aws.ToString(o.OutputValue)
+	})
+}
+
+// DoesStackExist checks if a CloudFormation stack exists.
+func DoesStackExist(ctx context.Context, client *cloudformation.Client, stackName string) (bool, error) {
+	stack, err := GetStack(ctx, client, stackName)
+	return stack != nil, err
+}
+
+func createStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, parameters []types.Parameter, tags []types.Tag) error {
 	log.Printf("Creating stack %s…", stackName)
 
 	out, err := client.CreateStack(
@@ -77,16 +146,7 @@ func createStack(ctx context.Context, client *cloudformation.Client, stackName s
 			Capabilities: []types.Capability{
 				types.CapabilityCapabilityNamedIam,
 			},
-			Tags: []types.Tag{
-				{
-					Key:   aws.String("managed-by"),
-					Value: aws.String("kubectl-datadog"),
-				},
-				{
-					Key:   aws.String("version"),
-					Value: aws.String(version.GetVersion()),
-				},
-			},
+			Tags: tags,
 		},
 	)
 	if err != nil {
@@ -112,7 +172,7 @@ func createStack(ctx context.Context, client *cloudformation.Client, stackName s
 	return nil
 }
 
-func updateStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, parameters []types.Parameter) error {
+func updateStack(ctx context.Context, client *cloudformation.Client, stackName string, templateBody string, parameters []types.Parameter, tags []types.Tag) error {
 	log.Printf("Updating stack %s…", stackName)
 
 	out, err := client.UpdateStack(
@@ -124,16 +184,7 @@ func updateStack(ctx context.Context, client *cloudformation.Client, stackName s
 			Capabilities: []types.Capability{
 				types.CapabilityCapabilityNamedIam,
 			},
-			Tags: []types.Tag{
-				{
-					Key:   aws.String("managed-by"),
-					Value: aws.String("kubectl-datadog"),
-				},
-				{
-					Key:   aws.String("version"),
-					Value: aws.String(version.GetVersion()),
-				},
-			},
+			Tags: tags,
 		},
 	)
 	if err != nil {
@@ -209,20 +260,13 @@ func DeleteStack(ctx context.Context, client *cloudformation.Client, stackName s
 }
 
 func describeStack(ctx context.Context, client *cloudformation.Client, stackName string) error {
-	out, err := client.DescribeStacks(
-		ctx,
-		&cloudformation.DescribeStacksInput{
-			StackName: aws.String(stackName),
-		},
-	)
+	stack, err := GetStack(ctx, client, stackName)
 	if err != nil {
 		return err
 	}
-	if len(out.Stacks) == 0 {
+	if stack == nil {
 		return errors.New("no stack found")
 	}
-
-	stack := out.Stacks[0]
 
 	log.Printf("Stack status: %s", stack.StackStatus)
 	if stack.StackStatusReason != nil {
@@ -230,13 +274,13 @@ func describeStack(ctx context.Context, client *cloudformation.Client, stackName
 	}
 
 	log.Print("Stack events:")
-	out2, err := client.DescribeStackEvents(ctx, &cloudformation.DescribeStackEventsInput{
+	events, err := client.DescribeStackEvents(ctx, &cloudformation.DescribeStackEventsInput{
 		StackName: aws.String(stackName),
 	})
 	if err != nil {
 		return err
 	}
-	for _, event := range out2.StackEvents {
+	for _, event := range events.StackEvents {
 		log.Printf("  %s: %s — %s", event.Timestamp.Format(time.RFC3339), event.ResourceStatus, aws.ToString(event.ResourceStatusReason))
 	}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/assets/dd-karpenter-fargate.yaml
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/assets/dd-karpenter-fargate.yaml
@@ -1,0 +1,90 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: IAM role, Fargate profile and execution role for Karpenter controller on Fargate
+Conditions:
+  ShouldDeployNodeAccessEntry: !Equals [!Ref DeployNodeAccessEntry, "true"]
+Parameters:
+  ClusterName:
+    Type: String
+    Description: "EKS cluster name"
+  KarpenterNamespace:
+    Type: String
+    Description: "Namespace where Karpenter will be deployed"
+  OIDCProviderArn:
+    Type: String
+    Description: "ARN of the IAM OIDC provider registered for the cluster"
+  OIDCProviderURL:
+    Type: String
+    Description: "OIDC provider issuer URL without the https:// scheme (e.g. oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF)"
+  FargateSubnets:
+    Type: CommaDelimitedList
+    Description: "Private subnets to use for the Karpenter Fargate profile"
+  DeployNodeAccessEntry:
+    Type: String
+    Description: "Whether to deploy the EKS Access Entry for Karpenter nodes. Requires cluster authentication mode to be API or API_AND_CONFIG_MAP."
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+Resources:
+  FargatePodExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${ClusterName}-karpenter-fargate-pod-execution"
+      # Trust is scoped to our specific Fargate profile name so this role cannot
+      # be used by other Fargate profiles that might exist on the same cluster.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: eks-fargate-pods.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              ArnLike:
+                "aws:SourceArn": !Sub "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:fargateprofile/${ClusterName}/dd-karpenter-${ClusterName}/*"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
+  KarpenterFargateProfile:
+    Type: AWS::EKS::FargateProfile
+    Properties:
+      ClusterName: !Ref ClusterName
+      FargateProfileName: !Sub "dd-karpenter-${ClusterName}"
+      PodExecutionRoleArn: !GetAtt FargatePodExecutionRole.Arn
+      Selectors:
+        - Namespace: !Ref KarpenterNamespace
+      Subnets: !Ref FargateSubnets
+  KarpenterIRSARole:
+    Type: AWS::IAM::Role
+    # Use a JSON-string AssumeRolePolicyDocument because the StringEquals
+    # condition keys include interpolated parameters (${OIDCProviderURL}:sub
+    # and :aud) — YAML maps do not interpolate keys.
+    Properties:
+      RoleName: !Sub "${ClusterName}-karpenter"
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Principal": { "Federated": "${OIDCProviderArn}" },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+              "StringEquals": {
+                "${OIDCProviderURL}:sub": "system:serviceaccount:${KarpenterNamespace}:karpenter",
+                "${OIDCProviderURL}:aud": "sts.amazonaws.com"
+              }
+            }
+          }]
+        }
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/KarpenterControllerPolicy-${ClusterName}"
+  NodeAccessEntry:
+    Type: AWS::EKS::AccessEntry
+    Condition: ShouldDeployNodeAccessEntry
+    Properties:
+      ClusterName: !Ref ClusterName
+      PrincipalArn: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/KarpenterNodeRole-${ClusterName}"
+      Type: EC2_LINUX
+Outputs:
+  KarpenterRoleArn:
+    Description: "ARN of the IAM role used by the Karpenter controller via IRSA"
+    Value: !GetAtt KarpenterIRSARole.Arn

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/assets/dd-karpenter-fargate.yaml
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/assets/dd-karpenter-fargate.yaml
@@ -27,9 +27,13 @@ Parameters:
       - "false"
 Resources:
   FargatePodExecutionRole:
+    # No RoleName set: cluster names can be up to 100 chars while IAM role
+    # names are capped at 64, so `${ClusterName}-karpenter-fargate-pod-execution`
+    # would overflow for clusters with names longer than 32 characters. Letting
+    # CloudFormation generate the physical name keeps installs working for
+    # every valid cluster name.
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${ClusterName}-karpenter-fargate-pod-execution"
       # Trust is scoped to our specific Fargate profile name so this role cannot
       # be used by other Fargate profiles that might exist on the same cluster.
       AssumeRolePolicyDocument:

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/assets/dd-karpenter-fargate.yaml
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/assets/dd-karpenter-fargate.yaml
@@ -27,11 +27,6 @@ Parameters:
       - "false"
 Resources:
   FargatePodExecutionRole:
-    # No RoleName set: cluster names can be up to 100 chars while IAM role
-    # names are capped at 64, so `${ClusterName}-karpenter-fargate-pod-execution`
-    # would overflow for clusters with names longer than 32 characters. Letting
-    # CloudFormation generate the physical name keeps installs working for
-    # every valid cluster name.
     Type: AWS::IAM::Role
     Properties:
       # Trust is scoped to our specific Fargate profile name so this role cannot

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/clusterauthmode.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/clusterauthmode.go
@@ -1,29 +1,16 @@
 package guess
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/eks"
 	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 )
 
-// SupportsAPIAuthenticationMode checks if the EKS cluster's authentication mode
-// supports EKS Access Entries (API or API_AND_CONFIG_MAP).
-func SupportsAPIAuthenticationMode(ctx context.Context, client *eks.Client, clusterName string) (bool, error) {
-	cluster, err := client.DescribeCluster(ctx, &eks.DescribeClusterInput{
-		Name: aws.String(clusterName),
-	})
-	if err != nil {
-		return false, fmt.Errorf("failed to describe cluster %s: %w", clusterName, err)
+// SupportsAPIAuthenticationMode reports whether the EKS cluster's
+// authentication mode supports EKS Access Entries (API or API_AND_CONFIG_MAP).
+func SupportsAPIAuthenticationMode(cluster *ekstypes.Cluster) bool {
+	if cluster == nil || cluster.AccessConfig == nil {
+		return false
 	}
-
-	if cluster.Cluster == nil || cluster.Cluster.AccessConfig == nil {
-		return false, nil
-	}
-
-	authMode := cluster.Cluster.AccessConfig.AuthenticationMode
+	authMode := cluster.AccessConfig.AuthenticationMode
 	return authMode == ekstypes.AuthenticationModeApi ||
-		authMode == ekstypes.AuthenticationModeApiAndConfigMap, nil
+		authMode == ekstypes.AuthenticationModeApiAndConfigMap
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider.go
@@ -59,7 +59,7 @@ func EnsureOIDCProvider(ctx context.Context, iamClient OIDCProviderAPI, issuerUR
 			continue
 		}
 		getOut, getErr := iamClient.GetOpenIDConnectProvider(ctx, &iam.GetOpenIDConnectProviderInput{
-			OpenIDConnectProviderArn: aws.String(providerArn),
+			OpenIDConnectProviderArn: provider.Arn,
 		})
 		if getErr != nil {
 			return "", fmt.Errorf("failed to get OIDC provider %s: %w", providerArn, getErr)
@@ -124,10 +124,7 @@ func waitForOIDCProviderReadable(ctx context.Context, iamClient OIDCProviderAPI,
 // uppercase path ID must NOT collide with a different URL whose path only
 // differs by case.
 func normalizeOIDCURL(url string) string {
-	const httpsPrefix = "https://"
-	if len(url) >= len(httpsPrefix) && strings.EqualFold(url[:len(httpsPrefix)], httpsPrefix) {
-		url = url[len(httpsPrefix):]
-	}
+	url = strings.TrimPrefix(url, "https://")
 	slash := strings.Index(url, "/")
 	if slash < 0 {
 		return strings.ToLower(url)

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 )
+
+const stsAudience = "sts.amazonaws.com"
 
 // GetClusterOIDCIssuerURL returns the cluster's OIDC issuer URL, with its
 // `https://` prefix (as returned by the EKS API). Returns an error if the
@@ -33,6 +36,7 @@ type OIDCProviderAPI interface {
 	ListOpenIDConnectProviders(ctx context.Context, params *iam.ListOpenIDConnectProvidersInput, optFns ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error)
 	GetOpenIDConnectProvider(ctx context.Context, params *iam.GetOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error)
 	CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error)
+	AddClientIDToOpenIDConnectProvider(ctx context.Context, params *iam.AddClientIDToOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.AddClientIDToOpenIDConnectProviderOutput, error)
 }
 
 // EnsureOIDCProvider returns the ARN of an IAM OIDC provider for the given
@@ -65,13 +69,25 @@ func EnsureOIDCProvider(ctx context.Context, iamClient OIDCProviderAPI, issuerUR
 			return "", fmt.Errorf("failed to get OIDC provider %s: %w", providerArn, getErr)
 		}
 		if normalizeOIDCURL(aws.ToString(getOut.Url)) == targetURL {
+			// Ensure the STS audience is registered: the IRSA trust policy we
+			// install conditions on `aud = sts.amazonaws.com`, which requires
+			// that the provider itself lists that client ID. Providers
+			// bootstrapped by other tools (eksctl, Terraform) may omit it.
+			if !slices.Contains(getOut.ClientIDList, stsAudience) {
+				if _, addErr := iamClient.AddClientIDToOpenIDConnectProvider(ctx, &iam.AddClientIDToOpenIDConnectProviderInput{
+					OpenIDConnectProviderArn: provider.Arn,
+					ClientID:                 aws.String(stsAudience),
+				}); addErr != nil {
+					return "", fmt.Errorf("failed to add %s client ID to OIDC provider %s: %w", stsAudience, providerArn, addErr)
+				}
+			}
 			return providerArn, nil
 		}
 	}
 
 	createOut, err := iamClient.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
 		Url:          aws.String(issuerURL),
-		ClientIDList: []string{"sts.amazonaws.com"},
+		ClientIDList: []string{stsAudience},
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create OIDC provider for %s: %w", issuerURL, err)

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider.go
@@ -1,0 +1,136 @@
+package guess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// GetClusterOIDCIssuerURL returns the cluster's OIDC issuer URL, with its
+// `https://` prefix (as returned by the EKS API). Returns an error if the
+// cluster has no OIDC identity configured.
+func GetClusterOIDCIssuerURL(cluster *ekstypes.Cluster) (string, error) {
+	if cluster == nil || cluster.Identity == nil || cluster.Identity.Oidc == nil {
+		return "", fmt.Errorf("cluster has no OIDC identity")
+	}
+	issuer := aws.ToString(cluster.Identity.Oidc.Issuer)
+	if issuer == "" {
+		return "", fmt.Errorf("cluster OIDC issuer URL is empty")
+	}
+	return issuer, nil
+}
+
+// OIDCProviderAPI is the subset of the IAM client used by EnsureOIDCProvider.
+// Defined as an interface to allow mocking in tests.
+type OIDCProviderAPI interface {
+	ListOpenIDConnectProviders(ctx context.Context, params *iam.ListOpenIDConnectProvidersInput, optFns ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error)
+	GetOpenIDConnectProvider(ctx context.Context, params *iam.GetOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error)
+	CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error)
+}
+
+// EnsureOIDCProvider returns the ARN of an IAM OIDC provider for the given
+// issuer URL, creating one if it does not already exist.
+//
+// The AWS::IAM::OIDCProvider CloudFormation resource is not idempotent — it
+// fails with EntityAlreadyExists when a provider with the same URL already
+// exists. Clusters created with eksctl, or already set up with IRSA, commonly
+// have a provider. Bootstrapping in Go allows check-then-create.
+//
+// The provider is never deleted on uninstall because it may be shared with
+// other workloads in the cluster.
+func EnsureOIDCProvider(ctx context.Context, iamClient OIDCProviderAPI, issuerURL string) (string, error) {
+	targetURL := normalizeOIDCURL(issuerURL)
+
+	listOut, err := iamClient.ListOpenIDConnectProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list OIDC providers: %w", err)
+	}
+
+	for _, provider := range listOut.OpenIDConnectProviderList {
+		providerArn := aws.ToString(provider.Arn)
+		if providerArn == "" {
+			continue
+		}
+		getOut, getErr := iamClient.GetOpenIDConnectProvider(ctx, &iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(providerArn),
+		})
+		if getErr != nil {
+			return "", fmt.Errorf("failed to get OIDC provider %s: %w", providerArn, getErr)
+		}
+		if normalizeOIDCURL(aws.ToString(getOut.Url)) == targetURL {
+			return providerArn, nil
+		}
+	}
+
+	createOut, err := iamClient.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
+		Url:          aws.String(issuerURL),
+		ClientIDList: []string{"sts.amazonaws.com"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create OIDC provider for %s: %w", issuerURL, err)
+	}
+	arn := aws.ToString(createOut.OpenIDConnectProviderArn)
+
+	// IAM is eventually consistent: the CloudFormation stack created right
+	// after references this provider as the federated principal of the
+	// Karpenter IRSA role. Poll GetOpenIDConnectProvider until the provider
+	// is readable back, so the stack creation doesn't race with propagation.
+	if err := waitForOIDCProviderReadable(ctx, iamClient, arn); err != nil {
+		return "", err
+	}
+	return arn, nil
+}
+
+// waitForOIDCProviderReadable polls GetOpenIDConnectProvider until the given
+// provider ARN is readable, with a short bounded retry budget. IAM
+// CreateOpenIDConnectProvider is asynchronous from a read-consistency
+// standpoint; in practice the provider is readable within seconds.
+func waitForOIDCProviderReadable(ctx context.Context, iamClient OIDCProviderAPI, arn string) error {
+	const (
+		maxAttempts = 20
+		interval    = 500 * time.Millisecond
+	)
+	for range maxAttempts {
+		_, err := iamClient.GetOpenIDConnectProvider(ctx, &iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(arn),
+		})
+		if err == nil {
+			return nil
+		}
+		var notFound *iamtypes.NoSuchEntityException
+		if !errors.As(err, &notFound) {
+			return fmt.Errorf("failed to read back OIDC provider %s: %w", arn, err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+	return fmt.Errorf("OIDC provider %s not readable after %v", arn, maxAttempts*interval)
+}
+
+// normalizeOIDCURL strips the `https://` scheme and lowercases the host so
+// that the URL can be compared reliably with what IAM stores (no scheme).
+// The path segment is left case-sensitive because per RFC 3986 only the
+// scheme and host are case-insensitive — an OIDC provider URL with an
+// uppercase path ID must NOT collide with a different URL whose path only
+// differs by case.
+func normalizeOIDCURL(url string) string {
+	const httpsPrefix = "https://"
+	if len(url) >= len(httpsPrefix) && strings.EqualFold(url[:len(httpsPrefix)], httpsPrefix) {
+		url = url[len(httpsPrefix):]
+	}
+	slash := strings.Index(url, "/")
+	if slash < 0 {
+		return strings.ToLower(url)
+	}
+	return strings.ToLower(url[:slash]) + url[slash:]
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
@@ -17,7 +17,7 @@ type fakeIAM struct {
 	providers map[string]string // arn -> url (as stored by IAM, without https://)
 
 	createCalls int
-	createURL   string
+	createInput *iam.CreateOpenIDConnectProviderInput // captured on Create
 	createErr   error
 	listErr     error
 	getErr      error
@@ -47,136 +47,119 @@ func (f *fakeIAM) GetOpenIDConnectProvider(_ context.Context, params *iam.GetOpe
 
 func (f *fakeIAM) CreateOpenIDConnectProvider(_ context.Context, params *iam.CreateOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
 	f.createCalls++
-	f.createURL = aws.ToString(params.Url)
+	f.createInput = params
 	if f.createErr != nil {
 		return nil, f.createErr
 	}
-	arn := "arn:aws:iam::123456789012:oidc-provider/" + normalizeOIDCURL(f.createURL)
+	normalized := normalizeOIDCURL(aws.ToString(params.Url))
+	arn := "arn:aws:iam::123456789012:oidc-provider/" + normalized
 	if f.providers == nil {
 		f.providers = map[string]string{}
 	}
-	f.providers[arn] = normalizeOIDCURL(f.createURL)
+	f.providers[arn] = normalized
 	return &iam.CreateOpenIDConnectProviderOutput{OpenIDConnectProviderArn: aws.String(arn)}, nil
 }
 
-func TestEnsureOIDCProvider_AlreadyExists(t *testing.T) {
-	existingArn := "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF"
-	f := &fakeIAM{
-		providers: map[string]string{
-			existingArn: "oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF",
+func TestEnsureOIDCProvider(t *testing.T) {
+	const (
+		issuerURL   = "https://oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF"
+		issuerStore = "oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF"
+		issuerArn   = "arn:aws:iam::123456789012:oidc-provider/" + issuerStore
+	)
+
+	for _, tc := range []struct {
+		name          string
+		existing      map[string]string
+		listErr       error
+		createErr     error
+		issuerURL     string
+		expectError   bool
+		errorContains string
+		// When Create is NOT expected: expectArn is checked against the returned ARN.
+		// When Create IS expected: expectCreateURL holds the URL Create must receive.
+		expectArn       string
+		expectCreateURL string
+	}{
+		{
+			name:      "provider already exists",
+			existing:  map[string]string{issuerArn: issuerStore},
+			issuerURL: issuerURL,
+			expectArn: issuerArn,
 		},
-	}
-
-	arn, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF")
-
-	require.NoError(t, err)
-	assert.Equal(t, existingArn, arn)
-	assert.Equal(t, 0, f.createCalls, "should not create when provider already exists")
-}
-
-func TestEnsureOIDCProvider_CaseInsensitiveHostMatch(t *testing.T) {
-	existingArn := "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF"
-	f := &fakeIAM{
-		providers: map[string]string{
-			existingArn: "oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF",
+		{
+			name:      "host match is case-insensitive (RFC 3986)",
+			existing:  map[string]string{issuerArn: issuerStore},
+			issuerURL: "https://OIDC.EKS.EU-WEST-3.AMAZONAWS.COM/id/ABCDEF",
+			expectArn: issuerArn,
 		},
-	}
-
-	// Scheme and host are case-insensitive per RFC 3986.
-	arn, err := EnsureOIDCProvider(context.Background(), f, "HTTPS://OIDC.EKS.EU-WEST-3.AMAZONAWS.COM/id/ABCDEF")
-
-	require.NoError(t, err)
-	assert.Equal(t, existingArn, arn)
-	assert.Equal(t, 0, f.createCalls)
-}
-
-func TestEnsureOIDCProvider_PathIsCaseSensitive(t *testing.T) {
-	// Two providers whose URLs differ only by path case must not be treated as
-	// equal: the path is case-sensitive per RFC 3986.
-	existingArn := "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/abcdef"
-	f := &fakeIAM{
-		providers: map[string]string{
-			existingArn: "oidc.eks.eu-west-3.amazonaws.com/id/abcdef",
+		{
+			name: "path match is case-sensitive (RFC 3986)",
+			existing: map[string]string{
+				"arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/abcdef": "oidc.eks.eu-west-3.amazonaws.com/id/abcdef",
+			},
+			issuerURL:       issuerURL,
+			expectCreateURL: issuerURL,
 		},
+		{
+			name:            "creates when list is an empty map",
+			existing:        map[string]string{},
+			issuerURL:       "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW",
+			expectCreateURL: "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW",
+		},
+		{
+			name:            "creates when list is nil",
+			existing:        nil,
+			issuerURL:       "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ",
+			expectCreateURL: "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ",
+		},
+		{
+			name:          "list error propagates",
+			listErr:       errors.New("api throttled"),
+			issuerURL:     issuerURL,
+			expectError:   true,
+			errorContains: "failed to list OIDC providers",
+		},
+		{
+			name:          "create error propagates",
+			existing:      map[string]string{},
+			createErr:     errors.New("quota exceeded"),
+			issuerURL:     issuerURL,
+			expectError:   true,
+			errorContains: "failed to create OIDC provider",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeIAM{
+				providers: tc.existing,
+				listErr:   tc.listErr,
+				createErr: tc.createErr,
+			}
+
+			arn, err := EnsureOIDCProvider(t.Context(), f, tc.issuerURL)
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.expectCreateURL == "" {
+				assert.Equal(t, 0, f.createCalls, "Create must not be called when an existing provider matches")
+				assert.Equal(t, tc.expectArn, arn)
+				return
+			}
+
+			assert.Equal(t, 1, f.createCalls)
+			require.NotNil(t, f.createInput)
+			assert.Equal(t, tc.expectCreateURL, aws.ToString(f.createInput.Url))
+			assert.Equal(t, []string{"sts.amazonaws.com"}, f.createInput.ClientIDList)
+			assert.Nil(t, f.createInput.ThumbprintList, "ThumbprintList must be omitted so IAM auto-fetches it")
+			assert.Contains(t, arn, "oidc-provider/")
+		})
 	}
-
-	arn, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF")
-
-	require.NoError(t, err)
-	assert.NotEqual(t, existingArn, arn)
-	assert.Equal(t, 1, f.createCalls)
-}
-
-func TestEnsureOIDCProvider_CreatesWhenMissing(t *testing.T) {
-	f := &fakeIAM{providers: map[string]string{}}
-
-	arn, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW")
-
-	require.NoError(t, err)
-	assert.Equal(t, 1, f.createCalls)
-	assert.Equal(t, "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW", f.createURL)
-	assert.Contains(t, arn, "oidc-provider/")
-}
-
-func TestEnsureOIDCProvider_CreatesWhenListEmpty(t *testing.T) {
-	f := &fakeIAM{}
-
-	_, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
-
-	require.NoError(t, err)
-	assert.Equal(t, 1, f.createCalls)
-}
-
-func TestEnsureOIDCProvider_ListError(t *testing.T) {
-	f := &fakeIAM{listErr: errors.New("api throttled")}
-
-	_, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to list OIDC providers")
-}
-
-func TestEnsureOIDCProvider_CreateError(t *testing.T) {
-	f := &fakeIAM{
-		providers: map[string]string{},
-		createErr: errors.New("quota exceeded"),
-	}
-
-	_, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create OIDC provider")
-}
-
-func TestEnsureOIDCProvider_CreateRequestsSTSClientID(t *testing.T) {
-	var capturedInput *iam.CreateOpenIDConnectProviderInput
-	captureIAM := &captureCreateIAM{inner: &fakeIAM{}}
-	captureIAM.capture = &capturedInput
-
-	_, err := EnsureOIDCProvider(context.Background(), captureIAM, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
-	require.NoError(t, err)
-
-	require.NotNil(t, capturedInput)
-	assert.Equal(t, []string{"sts.amazonaws.com"}, capturedInput.ClientIDList)
-	assert.Nil(t, capturedInput.ThumbprintList, "ThumbprintList must be omitted so IAM auto-fetches it")
-}
-
-type captureCreateIAM struct {
-	inner   *fakeIAM
-	capture **iam.CreateOpenIDConnectProviderInput
-}
-
-func (c *captureCreateIAM) ListOpenIDConnectProviders(ctx context.Context, params *iam.ListOpenIDConnectProvidersInput, optFns ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error) {
-	return c.inner.ListOpenIDConnectProviders(ctx, params, optFns...)
-}
-
-func (c *captureCreateIAM) GetOpenIDConnectProvider(ctx context.Context, params *iam.GetOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error) {
-	return c.inner.GetOpenIDConnectProvider(ctx, params, optFns...)
-}
-
-func (c *captureCreateIAM) CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
-	*c.capture = params
-	return c.inner.CreateOpenIDConnectProvider(ctx, params, optFns...)
 }
 
 func TestGetClusterOIDCIssuerURL(t *testing.T) {

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
@@ -1,0 +1,228 @@
+package guess
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeIAM struct {
+	providers map[string]string // arn -> url (as stored by IAM, without https://)
+
+	createCalls int
+	createURL   string
+	createErr   error
+	listErr     error
+	getErr      error
+}
+
+func (f *fakeIAM) ListOpenIDConnectProviders(_ context.Context, _ *iam.ListOpenIDConnectProvidersInput, _ ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	entries := make([]iamtypes.OpenIDConnectProviderListEntry, 0, len(f.providers))
+	for arn := range f.providers {
+		entries = append(entries, iamtypes.OpenIDConnectProviderListEntry{Arn: aws.String(arn)})
+	}
+	return &iam.ListOpenIDConnectProvidersOutput{OpenIDConnectProviderList: entries}, nil
+}
+
+func (f *fakeIAM) GetOpenIDConnectProvider(_ context.Context, params *iam.GetOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	url, ok := f.providers[aws.ToString(params.OpenIDConnectProviderArn)]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return &iam.GetOpenIDConnectProviderOutput{Url: aws.String(url)}, nil
+}
+
+func (f *fakeIAM) CreateOpenIDConnectProvider(_ context.Context, params *iam.CreateOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	f.createCalls++
+	f.createURL = aws.ToString(params.Url)
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	arn := "arn:aws:iam::123456789012:oidc-provider/" + normalizeOIDCURL(f.createURL)
+	if f.providers == nil {
+		f.providers = map[string]string{}
+	}
+	f.providers[arn] = normalizeOIDCURL(f.createURL)
+	return &iam.CreateOpenIDConnectProviderOutput{OpenIDConnectProviderArn: aws.String(arn)}, nil
+}
+
+func TestEnsureOIDCProvider_AlreadyExists(t *testing.T) {
+	existingArn := "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF"
+	f := &fakeIAM{
+		providers: map[string]string{
+			existingArn: "oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF",
+		},
+	}
+
+	arn, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF")
+
+	require.NoError(t, err)
+	assert.Equal(t, existingArn, arn)
+	assert.Equal(t, 0, f.createCalls, "should not create when provider already exists")
+}
+
+func TestEnsureOIDCProvider_CaseInsensitiveHostMatch(t *testing.T) {
+	existingArn := "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF"
+	f := &fakeIAM{
+		providers: map[string]string{
+			existingArn: "oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF",
+		},
+	}
+
+	// Scheme and host are case-insensitive per RFC 3986.
+	arn, err := EnsureOIDCProvider(context.Background(), f, "HTTPS://OIDC.EKS.EU-WEST-3.AMAZONAWS.COM/id/ABCDEF")
+
+	require.NoError(t, err)
+	assert.Equal(t, existingArn, arn)
+	assert.Equal(t, 0, f.createCalls)
+}
+
+func TestEnsureOIDCProvider_PathIsCaseSensitive(t *testing.T) {
+	// Two providers whose URLs differ only by path case must not be treated as
+	// equal: the path is case-sensitive per RFC 3986.
+	existingArn := "arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/abcdef"
+	f := &fakeIAM{
+		providers: map[string]string{
+			existingArn: "oidc.eks.eu-west-3.amazonaws.com/id/abcdef",
+		},
+	}
+
+	arn, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF")
+
+	require.NoError(t, err)
+	assert.NotEqual(t, existingArn, arn)
+	assert.Equal(t, 1, f.createCalls)
+}
+
+func TestEnsureOIDCProvider_CreatesWhenMissing(t *testing.T) {
+	f := &fakeIAM{providers: map[string]string{}}
+
+	arn, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, f.createCalls)
+	assert.Equal(t, "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW", f.createURL)
+	assert.Contains(t, arn, "oidc-provider/")
+}
+
+func TestEnsureOIDCProvider_CreatesWhenListEmpty(t *testing.T) {
+	f := &fakeIAM{}
+
+	_, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, f.createCalls)
+}
+
+func TestEnsureOIDCProvider_ListError(t *testing.T) {
+	f := &fakeIAM{listErr: errors.New("api throttled")}
+
+	_, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list OIDC providers")
+}
+
+func TestEnsureOIDCProvider_CreateError(t *testing.T) {
+	f := &fakeIAM{
+		providers: map[string]string{},
+		createErr: errors.New("quota exceeded"),
+	}
+
+	_, err := EnsureOIDCProvider(context.Background(), f, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create OIDC provider")
+}
+
+func TestEnsureOIDCProvider_CreateRequestsSTSClientID(t *testing.T) {
+	var capturedInput *iam.CreateOpenIDConnectProviderInput
+	captureIAM := &captureCreateIAM{inner: &fakeIAM{}}
+	captureIAM.capture = &capturedInput
+
+	_, err := EnsureOIDCProvider(context.Background(), captureIAM, "https://oidc.eks.eu-west-3.amazonaws.com/id/XYZ")
+	require.NoError(t, err)
+
+	require.NotNil(t, capturedInput)
+	assert.Equal(t, []string{"sts.amazonaws.com"}, capturedInput.ClientIDList)
+	assert.Nil(t, capturedInput.ThumbprintList, "ThumbprintList must be omitted so IAM auto-fetches it")
+}
+
+type captureCreateIAM struct {
+	inner   *fakeIAM
+	capture **iam.CreateOpenIDConnectProviderInput
+}
+
+func (c *captureCreateIAM) ListOpenIDConnectProviders(ctx context.Context, params *iam.ListOpenIDConnectProvidersInput, optFns ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	return c.inner.ListOpenIDConnectProviders(ctx, params, optFns...)
+}
+
+func (c *captureCreateIAM) GetOpenIDConnectProvider(ctx context.Context, params *iam.GetOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.GetOpenIDConnectProviderOutput, error) {
+	return c.inner.GetOpenIDConnectProvider(ctx, params, optFns...)
+}
+
+func (c *captureCreateIAM) CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	*c.capture = params
+	return c.inner.CreateOpenIDConnectProvider(ctx, params, optFns...)
+}
+
+func TestGetClusterOIDCIssuerURL(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		cluster     *ekstypes.Cluster
+		expected    string
+		expectError bool
+	}{
+		{
+			name: "valid cluster with OIDC issuer",
+			cluster: &ekstypes.Cluster{
+				Identity: &ekstypes.Identity{
+					Oidc: &ekstypes.OIDC{
+						Issuer: aws.String("https://oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF"),
+					},
+				},
+			},
+			expected: "https://oidc.eks.eu-west-3.amazonaws.com/id/ABCDEF",
+		},
+		{
+			name:        "nil cluster",
+			cluster:     nil,
+			expectError: true,
+		},
+		{
+			name:        "cluster without identity",
+			cluster:     &ekstypes.Cluster{},
+			expectError: true,
+		},
+		{
+			name: "cluster with empty issuer URL",
+			cluster: &ekstypes.Cluster{
+				Identity: &ekstypes.Identity{Oidc: &ekstypes.OIDC{Issuer: aws.String("")}},
+			},
+			expectError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GetClusterOIDCIssuerURL(tc.cluster)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
@@ -96,9 +96,9 @@ func TestEnsureOIDCProvider(t *testing.T) {
 		errorContains string
 		// When Create is NOT expected: expectArn is checked against the returned ARN.
 		// When Create IS expected: expectCreateURL holds the URL Create must receive.
-		expectArn        string
-		expectCreateURL  string
-		expectAddClient  bool // true when the existing provider must be patched to add the STS audience
+		expectArn       string
+		expectCreateURL string
+		expectAddClient bool // true when the existing provider must be patched to add the STS audience
 	}{
 		{
 			name:      "provider already exists with STS audience",

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/oidcprovider_test.go
@@ -13,14 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type fakeIAM struct {
-	providers map[string]string // arn -> url (as stored by IAM, without https://)
+type fakeProvider struct {
+	url          string
+	clientIDList []string
+}
 
-	createCalls int
-	createInput *iam.CreateOpenIDConnectProviderInput // captured on Create
-	createErr   error
-	listErr     error
-	getErr      error
+type fakeIAM struct {
+	providers map[string]*fakeProvider // arn -> provider
+
+	createCalls       int
+	createInput       *iam.CreateOpenIDConnectProviderInput // captured on Create
+	createErr         error
+	listErr           error
+	getErr            error
+	addClientIDCalls  int
+	addClientIDInputs []*iam.AddClientIDToOpenIDConnectProviderInput
 }
 
 func (f *fakeIAM) ListOpenIDConnectProviders(_ context.Context, _ *iam.ListOpenIDConnectProvidersInput, _ ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error) {
@@ -38,11 +45,14 @@ func (f *fakeIAM) GetOpenIDConnectProvider(_ context.Context, params *iam.GetOpe
 	if f.getErr != nil {
 		return nil, f.getErr
 	}
-	url, ok := f.providers[aws.ToString(params.OpenIDConnectProviderArn)]
+	p, ok := f.providers[aws.ToString(params.OpenIDConnectProviderArn)]
 	if !ok {
 		return nil, errors.New("not found")
 	}
-	return &iam.GetOpenIDConnectProviderOutput{Url: aws.String(url)}, nil
+	return &iam.GetOpenIDConnectProviderOutput{
+		Url:          aws.String(p.url),
+		ClientIDList: p.clientIDList,
+	}, nil
 }
 
 func (f *fakeIAM) CreateOpenIDConnectProvider(_ context.Context, params *iam.CreateOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
@@ -54,10 +64,19 @@ func (f *fakeIAM) CreateOpenIDConnectProvider(_ context.Context, params *iam.Cre
 	normalized := normalizeOIDCURL(aws.ToString(params.Url))
 	arn := "arn:aws:iam::123456789012:oidc-provider/" + normalized
 	if f.providers == nil {
-		f.providers = map[string]string{}
+		f.providers = map[string]*fakeProvider{}
 	}
-	f.providers[arn] = normalized
+	f.providers[arn] = &fakeProvider{url: normalized, clientIDList: params.ClientIDList}
 	return &iam.CreateOpenIDConnectProviderOutput{OpenIDConnectProviderArn: aws.String(arn)}, nil
+}
+
+func (f *fakeIAM) AddClientIDToOpenIDConnectProvider(_ context.Context, params *iam.AddClientIDToOpenIDConnectProviderInput, _ ...func(*iam.Options)) (*iam.AddClientIDToOpenIDConnectProviderOutput, error) {
+	f.addClientIDCalls++
+	f.addClientIDInputs = append(f.addClientIDInputs, params)
+	if p, ok := f.providers[aws.ToString(params.OpenIDConnectProviderArn)]; ok {
+		p.clientIDList = append(p.clientIDList, aws.ToString(params.ClientID))
+	}
+	return &iam.AddClientIDToOpenIDConnectProviderOutput{}, nil
 }
 
 func TestEnsureOIDCProvider(t *testing.T) {
@@ -69,7 +88,7 @@ func TestEnsureOIDCProvider(t *testing.T) {
 
 	for _, tc := range []struct {
 		name          string
-		existing      map[string]string
+		existing      map[string]*fakeProvider
 		listErr       error
 		createErr     error
 		issuerURL     string
@@ -77,32 +96,43 @@ func TestEnsureOIDCProvider(t *testing.T) {
 		errorContains string
 		// When Create is NOT expected: expectArn is checked against the returned ARN.
 		// When Create IS expected: expectCreateURL holds the URL Create must receive.
-		expectArn       string
-		expectCreateURL string
+		expectArn        string
+		expectCreateURL  string
+		expectAddClient  bool // true when the existing provider must be patched to add the STS audience
 	}{
 		{
-			name:      "provider already exists",
-			existing:  map[string]string{issuerArn: issuerStore},
+			name:      "provider already exists with STS audience",
+			existing:  map[string]*fakeProvider{issuerArn: {url: issuerStore, clientIDList: []string{"sts.amazonaws.com"}}},
 			issuerURL: issuerURL,
 			expectArn: issuerArn,
 		},
 		{
+			name:            "provider exists without STS audience is patched in place",
+			existing:        map[string]*fakeProvider{issuerArn: {url: issuerStore, clientIDList: []string{"other.audience"}}},
+			issuerURL:       issuerURL,
+			expectArn:       issuerArn,
+			expectAddClient: true,
+		},
+		{
 			name:      "host match is case-insensitive (RFC 3986)",
-			existing:  map[string]string{issuerArn: issuerStore},
+			existing:  map[string]*fakeProvider{issuerArn: {url: issuerStore, clientIDList: []string{"sts.amazonaws.com"}}},
 			issuerURL: "https://OIDC.EKS.EU-WEST-3.AMAZONAWS.COM/id/ABCDEF",
 			expectArn: issuerArn,
 		},
 		{
 			name: "path match is case-sensitive (RFC 3986)",
-			existing: map[string]string{
-				"arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/abcdef": "oidc.eks.eu-west-3.amazonaws.com/id/abcdef",
+			existing: map[string]*fakeProvider{
+				"arn:aws:iam::123456789012:oidc-provider/oidc.eks.eu-west-3.amazonaws.com/id/abcdef": {
+					url:          "oidc.eks.eu-west-3.amazonaws.com/id/abcdef",
+					clientIDList: []string{"sts.amazonaws.com"},
+				},
 			},
 			issuerURL:       issuerURL,
 			expectCreateURL: issuerURL,
 		},
 		{
 			name:            "creates when list is an empty map",
-			existing:        map[string]string{},
+			existing:        map[string]*fakeProvider{},
 			issuerURL:       "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW",
 			expectCreateURL: "https://oidc.eks.eu-west-3.amazonaws.com/id/NEW",
 		},
@@ -121,7 +151,7 @@ func TestEnsureOIDCProvider(t *testing.T) {
 		},
 		{
 			name:          "create error propagates",
-			existing:      map[string]string{},
+			existing:      map[string]*fakeProvider{},
 			createErr:     errors.New("quota exceeded"),
 			issuerURL:     issuerURL,
 			expectError:   true,
@@ -149,6 +179,13 @@ func TestEnsureOIDCProvider(t *testing.T) {
 			if tc.expectCreateURL == "" {
 				assert.Equal(t, 0, f.createCalls, "Create must not be called when an existing provider matches")
 				assert.Equal(t, tc.expectArn, arn)
+				if tc.expectAddClient {
+					assert.Equal(t, 1, f.addClientIDCalls, "AddClientIDToOpenIDConnectProvider should have been called")
+					require.Len(t, f.addClientIDInputs, 1)
+					assert.Equal(t, "sts.amazonaws.com", aws.ToString(f.addClientIDInputs[0].ClientID))
+				} else {
+					assert.Equal(t, 0, f.addClientIDCalls, "AddClientIDToOpenIDConnectProvider must not be called when STS audience is already registered")
+				}
 				return
 			}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/privatesubnets.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/privatesubnets.go
@@ -1,0 +1,105 @@
+package guess
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+)
+
+// DescribeRouteTablesAPI is the subset of the EC2 client used by
+// GetClusterPrivateSubnets. Defined as an interface to allow mocking in tests.
+type DescribeRouteTablesAPI interface {
+	DescribeRouteTables(ctx context.Context, params *ec2.DescribeRouteTablesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error)
+}
+
+// GetClusterPrivateSubnets returns the subnets of the given EKS cluster that
+// do not have an active default route (0.0.0.0/0 or ::/0) going through an
+// Internet Gateway. Fargate profiles only accept private subnets.
+//
+// Subnets without an explicit route table association fall back to the VPC's
+// main route table. Routes going through NAT gateways, transit gateways,
+// egress-only internet gateways, VPC peerings, or VPC endpoints are not
+// considered public.
+func GetClusterPrivateSubnets(ctx context.Context, ec2Client DescribeRouteTablesAPI, cluster *ekstypes.Cluster) ([]string, error) {
+	if cluster == nil || cluster.ResourcesVpcConfig == nil {
+		return nil, fmt.Errorf("cluster has no VPC configuration")
+	}
+	subnetIDs := cluster.ResourcesVpcConfig.SubnetIds
+	vpcID := aws.ToString(cluster.ResourcesVpcConfig.VpcId)
+	if len(subnetIDs) == 0 || vpcID == "" {
+		return nil, fmt.Errorf("cluster has no subnets")
+	}
+
+	rtOut, err := ec2Client.DescribeRouteTables(ctx, &ec2.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe route tables for VPC %s: %w", vpcID, err)
+	}
+
+	explicitByAssoc := map[string]ec2types.RouteTable{}
+	var mainRT *ec2types.RouteTable
+	for _, rt := range rtOut.RouteTables {
+		for _, assoc := range rt.Associations {
+			// Skip associations that are not currently associated (e.g.
+			// disassociating, disassociated, failed).
+			if assoc.AssociationState != nil && assoc.AssociationState.State != ec2types.RouteTableAssociationStateCodeAssociated {
+				continue
+			}
+			if aws.ToBool(assoc.Main) {
+				rtCopy := rt
+				mainRT = &rtCopy
+			}
+			if assoc.SubnetId != nil {
+				explicitByAssoc[*assoc.SubnetId] = rt
+			}
+		}
+	}
+
+	var privateSubnets []string
+	for _, subnetID := range subnetIDs {
+		rt, ok := explicitByAssoc[subnetID]
+		if !ok {
+			if mainRT == nil {
+				return nil, fmt.Errorf("subnet %s has no explicit route table association and the VPC %s has no main route table", subnetID, vpcID)
+			}
+			rt = *mainRT
+		}
+		if !hasDefaultRouteThroughIGW(rt) {
+			privateSubnets = append(privateSubnets, subnetID)
+		}
+	}
+
+	if len(privateSubnets) == 0 {
+		return nil, fmt.Errorf("no private subnet found for cluster %s; pass --fargate-subnets to override auto-detection", aws.ToString(cluster.Name))
+	}
+
+	return privateSubnets, nil
+}
+
+// hasDefaultRouteThroughIGW returns true if the route table has an active
+// default route (0.0.0.0/0 or ::/0) going through an Internet Gateway.
+// EgressOnlyInternetGatewayId (prefix "eigw-") is intentionally excluded: EIGWs
+// only allow outbound IPv6 traffic and do not make a subnet publicly reachable.
+func hasDefaultRouteThroughIGW(rt ec2types.RouteTable) bool {
+	for _, route := range rt.Routes {
+		if route.State != ec2types.RouteStateActive {
+			continue
+		}
+		if route.GatewayId == nil || !strings.HasPrefix(*route.GatewayId, "igw-") {
+			continue
+		}
+		if aws.ToString(route.DestinationCidrBlock) == "0.0.0.0/0" ||
+			aws.ToString(route.DestinationIpv6CidrBlock) == "::/0" {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/privatesubnets_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/privatesubnets_test.go
@@ -54,8 +54,10 @@ func TestGetClusterPrivateSubnets(t *testing.T) {
 
 	for _, tc := range []struct {
 		name            string
+		cluster         *ekstypes.Cluster // overrides the default cluster built from clusterSubnets
 		clusterSubnets  []string
 		routeTables     []ec2types.RouteTable
+		ec2Err          error
 		expectedPrivate []string
 		expectError     bool
 		errorContains   string
@@ -189,18 +191,34 @@ func TestGetClusterPrivateSubnets(t *testing.T) {
 			},
 			expectedPrivate: []string{"subnet-tgw"},
 		},
+		{
+			name:          "cluster without VPC configuration",
+			cluster:       &ekstypes.Cluster{},
+			expectError:   true,
+			errorContains: "no VPC configuration",
+		},
+		{
+			name:           "DescribeRouteTables error propagates",
+			clusterSubnets: []string{"subnet-a"},
+			ec2Err:         errors.New("boom"),
+			expectError:    true,
+			errorContains:  "failed to describe route tables",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cluster := &ekstypes.Cluster{
-				Name: aws.String("my-cluster"),
-				ResourcesVpcConfig: &ekstypes.VpcConfigResponse{
-					VpcId:     aws.String(vpcID),
-					SubnetIds: tc.clusterSubnets,
-				},
+			cluster := tc.cluster
+			if cluster == nil {
+				cluster = &ekstypes.Cluster{
+					Name: aws.String("my-cluster"),
+					ResourcesVpcConfig: &ekstypes.VpcConfigResponse{
+						VpcId:     aws.String(vpcID),
+						SubnetIds: tc.clusterSubnets,
+					},
+				}
 			}
-			ec2Client := &fakeEC2DescribeRouteTables{routeTables: tc.routeTables}
+			ec2Client := &fakeEC2DescribeRouteTables{routeTables: tc.routeTables, err: tc.ec2Err}
 
-			subnets, err := GetClusterPrivateSubnets(context.Background(), ec2Client, cluster)
+			subnets, err := GetClusterPrivateSubnets(t.Context(), ec2Client, cluster)
 
 			if tc.expectError {
 				require.Error(t, err)
@@ -214,29 +232,4 @@ func TestGetClusterPrivateSubnets(t *testing.T) {
 			assert.Equal(t, tc.expectedPrivate, subnets)
 		})
 	}
-}
-
-func TestGetClusterPrivateSubnets_NoVPCConfig(t *testing.T) {
-	ec2Client := &fakeEC2DescribeRouteTables{}
-
-	_, err := GetClusterPrivateSubnets(context.Background(), ec2Client, &ekstypes.Cluster{})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no VPC configuration")
-}
-
-func TestGetClusterPrivateSubnets_DescribeRouteTablesError(t *testing.T) {
-	cluster := &ekstypes.Cluster{
-		Name: aws.String("my-cluster"),
-		ResourcesVpcConfig: &ekstypes.VpcConfigResponse{
-			VpcId:     aws.String("vpc-aaaa"),
-			SubnetIds: []string{"subnet-a"},
-		},
-	}
-	ec2Client := &fakeEC2DescribeRouteTables{err: errors.New("boom")}
-
-	_, err := GetClusterPrivateSubnets(context.Background(), ec2Client, cluster)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to describe route tables")
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/privatesubnets_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/privatesubnets_test.go
@@ -1,0 +1,242 @@
+package guess
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEC2DescribeRouteTables struct {
+	routeTables []ec2types.RouteTable
+	err         error
+}
+
+func (f *fakeEC2DescribeRouteTables) DescribeRouteTables(_ context.Context, _ *ec2.DescribeRouteTablesInput, _ ...func(*ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &ec2.DescribeRouteTablesOutput{RouteTables: f.routeTables}, nil
+}
+
+func association(subnetID string, main bool) ec2types.RouteTableAssociation {
+	a := ec2types.RouteTableAssociation{Main: aws.Bool(main)}
+	if subnetID != "" {
+		a.SubnetId = aws.String(subnetID)
+	}
+	return a
+}
+
+func igwRoute() ec2types.Route {
+	return ec2types.Route{
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		GatewayId:            aws.String("igw-0123456789abcdef0"),
+		State:                ec2types.RouteStateActive,
+	}
+}
+
+func natRoute() ec2types.Route {
+	return ec2types.Route{
+		DestinationCidrBlock: aws.String("0.0.0.0/0"),
+		NatGatewayId:         aws.String("nat-0123456789abcdef0"),
+		State:                ec2types.RouteStateActive,
+	}
+}
+
+func TestGetClusterPrivateSubnets(t *testing.T) {
+	const vpcID = "vpc-aaaa"
+
+	for _, tc := range []struct {
+		name            string
+		clusterSubnets  []string
+		routeTables     []ec2types.RouteTable
+		expectedPrivate []string
+		expectError     bool
+		errorContains   string
+	}{
+		{
+			name:           "mix of public and private with explicit associations",
+			clusterSubnets: []string{"subnet-pub-a", "subnet-pri-a"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-pub-a", false)},
+					Routes:       []ec2types.Route{igwRoute()},
+				},
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-pri-a", false)},
+					Routes:       []ec2types.Route{natRoute()},
+				},
+			},
+			expectedPrivate: []string{"subnet-pri-a"},
+		},
+		{
+			name:           "subnet without explicit association falls back to main RT (private)",
+			clusterSubnets: []string{"subnet-impl", "subnet-pub"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("", true)},
+					Routes:       []ec2types.Route{natRoute()},
+				},
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-pub", false)},
+					Routes:       []ec2types.Route{igwRoute()},
+				},
+			},
+			expectedPrivate: []string{"subnet-impl"},
+		},
+		{
+			name:           "subnet without explicit association falls back to main RT (public)",
+			clusterSubnets: []string{"subnet-impl", "subnet-pri"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("", true)},
+					Routes:       []ec2types.Route{igwRoute()},
+				},
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-pri", false)},
+					Routes:       []ec2types.Route{natRoute()},
+				},
+			},
+			expectedPrivate: []string{"subnet-pri"},
+		},
+		{
+			name:           "IPv6-only public default route",
+			clusterSubnets: []string{"subnet-v6pub", "subnet-v6pri"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-v6pub", false)},
+					Routes: []ec2types.Route{{
+						DestinationIpv6CidrBlock: aws.String("::/0"),
+						GatewayId:                aws.String("igw-0123456789abcdef0"),
+						State:                    ec2types.RouteStateActive,
+					}},
+				},
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-v6pri", false)},
+					Routes: []ec2types.Route{{
+						DestinationIpv6CidrBlock:    aws.String("::/0"),
+						EgressOnlyInternetGatewayId: aws.String("eigw-0123456789abcdef0"),
+						State:                       ec2types.RouteStateActive,
+					}},
+				},
+			},
+			expectedPrivate: []string{"subnet-v6pri"},
+		},
+		{
+			name:           "blackhole IGW route does not mark subnet public",
+			clusterSubnets: []string{"subnet-dead"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-dead", false)},
+					Routes: []ec2types.Route{{
+						DestinationCidrBlock: aws.String("0.0.0.0/0"),
+						GatewayId:            aws.String("igw-0123456789abcdef0"),
+						State:                ec2types.RouteStateBlackhole,
+					}},
+				},
+			},
+			expectedPrivate: []string{"subnet-dead"},
+		},
+		{
+			name:           "egress-only IGW is not treated as public",
+			clusterSubnets: []string{"subnet-eigw"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-eigw", false)},
+					Routes: []ec2types.Route{{
+						DestinationIpv6CidrBlock:    aws.String("::/0"),
+						EgressOnlyInternetGatewayId: aws.String("eigw-0123456789abcdef0"),
+						State:                       ec2types.RouteStateActive,
+					}},
+				},
+			},
+			expectedPrivate: []string{"subnet-eigw"},
+		},
+		{
+			name:           "no private subnet returns error",
+			clusterSubnets: []string{"subnet-pub-a", "subnet-pub-b"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-pub-a", false)},
+					Routes:       []ec2types.Route{igwRoute()},
+				},
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-pub-b", false)},
+					Routes:       []ec2types.Route{igwRoute()},
+				},
+			},
+			expectError:   true,
+			errorContains: "no private subnet found",
+		},
+		{
+			name:           "transit gateway route does not mark subnet public",
+			clusterSubnets: []string{"subnet-tgw"},
+			routeTables: []ec2types.RouteTable{
+				{
+					Associations: []ec2types.RouteTableAssociation{association("subnet-tgw", false)},
+					Routes: []ec2types.Route{{
+						DestinationCidrBlock: aws.String("0.0.0.0/0"),
+						TransitGatewayId:     aws.String("tgw-0123456789abcdef0"),
+						State:                ec2types.RouteStateActive,
+					}},
+				},
+			},
+			expectedPrivate: []string{"subnet-tgw"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster := &ekstypes.Cluster{
+				Name: aws.String("my-cluster"),
+				ResourcesVpcConfig: &ekstypes.VpcConfigResponse{
+					VpcId:     aws.String(vpcID),
+					SubnetIds: tc.clusterSubnets,
+				},
+			}
+			ec2Client := &fakeEC2DescribeRouteTables{routeTables: tc.routeTables}
+
+			subnets, err := GetClusterPrivateSubnets(context.Background(), ec2Client, cluster)
+
+			if tc.expectError {
+				require.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedPrivate, subnets)
+		})
+	}
+}
+
+func TestGetClusterPrivateSubnets_NoVPCConfig(t *testing.T) {
+	ec2Client := &fakeEC2DescribeRouteTables{}
+
+	_, err := GetClusterPrivateSubnets(context.Background(), ec2Client, &ekstypes.Cluster{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no VPC configuration")
+}
+
+func TestGetClusterPrivateSubnets_DescribeRouteTablesError(t *testing.T) {
+	cluster := &ekstypes.Cluster{
+		Name: aws.String("my-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigResponse{
+			VpcId:     aws.String("vpc-aaaa"),
+			SubnetIds: []string{"subnet-a"},
+		},
+	}
+	ec2Client := &fakeEC2DescribeRouteTables{err: errors.New("boom")}
+
+	_, err := GetClusterPrivateSubnets(context.Background(), ec2Client, cluster)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to describe route tables")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -12,8 +12,11 @@ import (
 	"os/signal"
 	"slices"
 	"strconv"
+	"strings"
 	"syscall"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/color"
 	"github.com/pkg/browser"
@@ -40,12 +43,54 @@ const (
 )
 
 var (
+	//go:embed assets/karpenter.yaml
+	KarpenterCfn string
+
 	//go:embed assets/dd-karpenter.yaml
 	DdKarpenterCfn string
 
-	//go:embed assets/karpenter.yaml
-	KarpenterCfn string
+	//go:embed assets/dd-karpenter-fargate.yaml
+	DdKarpenterFargateCfn string
 )
+
+// installModeTagKey is the CloudFormation stack tag tracking the deployment's
+// install-mode. Stacks created before this tag was introduced are treated as
+// install-mode=existing-nodes.
+const installModeTagKey = "install-mode"
+
+// InstallMode defines how to run the Karpenter controller.
+type InstallMode string
+
+const (
+	// InstallModeFargate runs the Karpenter controller on dedicated Fargate nodes.
+	InstallModeFargate InstallMode = "fargate"
+	// InstallModeExistingNodes runs the Karpenter controller on existing cluster nodes.
+	InstallModeExistingNodes InstallMode = "existing-nodes"
+)
+
+// String returns the string representation of the InstallMode.
+func (i *InstallMode) String() string {
+	return string(*i)
+}
+
+// Set sets the InstallMode value from a string.
+func (i *InstallMode) Set(s string) error {
+	switch s {
+	case "fargate":
+		*i = InstallModeFargate
+	case "existing-nodes":
+		*i = InstallModeExistingNodes
+	default:
+		return fmt.Errorf("install-mode must be one of fargate or existing-nodes")
+	}
+
+	return nil
+}
+
+// Type returns the type name for pflag.
+func (_ *InstallMode) Type() string {
+	return "InstallMode"
+}
 
 // CreateKarpenterResources defines which Karpenter resources to create
 type CreateKarpenterResources string
@@ -123,6 +168,8 @@ var (
 	clusterName              string
 	karpenterNamespace       string
 	karpenterVersion         string
+	installMode              = InstallModeFargate
+	fargateSubnets           []string
 	createKarpenterResources = CreateKarpenterResourcesAll
 	inferenceMethod          = InferenceMethodNodeGroups
 	debug                    bool
@@ -168,6 +215,8 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringVar(&clusterName, "cluster-name", "", "Name of the EKS cluster")
 	cmd.Flags().StringVar(&karpenterNamespace, "karpenter-namespace", "dd-karpenter", "Name of the Kubernetes namespace to deploy Karpenter into")
 	cmd.Flags().StringVar(&karpenterVersion, "karpenter-version", "", "Version of Karpenter to install (default to latest)")
+	cmd.Flags().Var(&installMode, "install-mode", "How to run the Karpenter controller: fargate (on dedicated Fargate nodes, default) or existing-nodes (on existing cluster nodes)")
+	cmd.Flags().StringSliceVar(&fargateSubnets, "fargate-subnets", nil, "Override auto-discovery of private subnets for the Fargate profile (comma-separated subnet IDs). Only used when --install-mode=fargate.")
 	cmd.Flags().Var(&createKarpenterResources, "create-karpenter-resources", "Which Karpenter resources to create: none, ec2nodeclass, all (default: all)")
 	cmd.Flags().Var(&inferenceMethod, "inference-method", "Method to infer EC2NodeClass and NodePool properties: nodes, nodegroups")
 	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug logs")
@@ -187,6 +236,14 @@ func (o *options) complete(cmd *cobra.Command, args []string) error {
 func (o *options) validate() error {
 	if len(o.args) > 0 {
 		return errors.New("no arguments are allowed")
+	}
+
+	if !slices.Contains([]InstallMode{InstallModeFargate, InstallModeExistingNodes}, installMode) {
+		return errors.New("install-mode must be one of fargate or existing-nodes")
+	}
+
+	if len(fargateSubnets) > 0 && installMode != InstallModeFargate {
+		return errors.New("--fargate-subnets can only be used with --install-mode=fargate")
 	}
 
 	if !slices.Contains([]CreateKarpenterResources{CreateKarpenterResourcesNone, CreateKarpenterResourcesEC2NodeClass, CreateKarpenterResourcesAll}, createKarpenterResources) {
@@ -234,7 +291,8 @@ func (o *options) run(cmd *cobra.Command) error {
 		return err
 	}
 
-	if err = createCloudFormationStacks(ctx, cli, clusterName, karpenterNamespace); err != nil {
+	irsaRoleArn, err := createCloudFormationStacks(ctx, cli, clusterName, karpenterNamespace, installMode, fargateSubnets)
+	if err != nil {
 		return err
 	}
 
@@ -242,7 +300,7 @@ func (o *options) run(cmd *cobra.Command) error {
 		return err
 	}
 
-	if err = o.installHelmChart(ctx, clusterName, karpenterNamespace, karpenterVersion, debug); err != nil {
+	if err = o.installHelmChart(ctx, clusterName, karpenterNamespace, karpenterVersion, debug, installMode, irsaRoleArn); err != nil {
 		return err
 	}
 
@@ -253,32 +311,144 @@ func (o *options) run(cmd *cobra.Command) error {
 	return displaySuccessMessage(cmd, clusterName, createKarpenterResources)
 }
 
-func createCloudFormationStacks(ctx context.Context, cli *clients.Clients, clusterName string, karpenterNamespace string) error {
-	if err := aws.CreateOrUpdateStack(ctx, cli.CloudFormation, "dd-karpenter-"+clusterName+"-karpenter", KarpenterCfn, map[string]string{
+// createCloudFormationStacks creates (or updates) the CFN stacks required for
+// the selected install mode. Returns the IRSA role ARN when the mode is
+// fargate; empty string otherwise.
+func createCloudFormationStacks(ctx context.Context, cli *clients.Clients, clusterName, karpenterNamespace string, mode InstallMode, fargateSubnetsOverride []string) (string, error) {
+	// The first stack (karpenter.yaml) is mode-independent — its resources
+	// (KarpenterNodeRole, KarpenterControllerPolicy, SQS, EventBridge) are
+	// identical in both modes, so no guardrail or install-mode tag is needed.
+	karpenterStackName := "dd-karpenter-" + clusterName + "-karpenter"
+	if err := aws.CreateOrUpdateStack(ctx, cli.CloudFormation, karpenterStackName, KarpenterCfn, map[string]string{
 		"ClusterName": clusterName,
-	}); err != nil {
-		return fmt.Errorf("failed to create or update Cloud Formation stack: %w", err)
+	}, nil); err != nil {
+		return "", fmt.Errorf("failed to create or update Cloud Formation stack: %w", err)
 	}
 
-	isUnmanagedEKSPIAInstalled, err := guess.IsThereUnmanagedEKSPodIdentityAgentInstalled(ctx, cli.EKS, clusterName)
+	describeOut, err := cli.EKS.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: awssdk.String(clusterName)})
 	if err != nil {
-		return fmt.Errorf("failed to check if EKS pod identity agent is installed: %w", err)
+		return "", fmt.Errorf("failed to describe cluster %s: %w", clusterName, err)
 	}
+	cluster := describeOut.Cluster
+	supportsAPIAuth := guess.SupportsAPIAuthenticationMode(cluster)
 
-	supportsAPIAuth, err := guess.SupportsAPIAuthenticationMode(ctx, cli.EKS, clusterName)
+	ddStackName := "dd-karpenter-" + clusterName + "-dd-karpenter"
+	ddStack, err := aws.GetStack(ctx, cli.CloudFormation, ddStackName)
 	if err != nil {
-		return fmt.Errorf("failed to check cluster authentication mode: %w", err)
+		return "", err
 	}
-
-	if err := aws.CreateOrUpdateStack(ctx, cli.CloudFormation, "dd-karpenter-"+clusterName+"-dd-karpenter", DdKarpenterCfn, map[string]string{
-		"ClusterName":            clusterName,
-		"KarpenterNamespace":     karpenterNamespace,
-		"DeployPodIdentityAddon": strconv.FormatBool(!isUnmanagedEKSPIAInstalled),
-		"DeployNodeAccessEntry":  strconv.FormatBool(supportsAPIAuth),
-	}); err != nil {
-		return fmt.Errorf("failed to create or update Cloud Formation stack: %w", err)
+	if err := checkInstallModeTag(ddStack, mode); err != nil {
+		return "", err
 	}
+	modeTags := map[string]string{installModeTagKey: string(mode)}
 
+	switch mode {
+	case InstallModeExistingNodes:
+		isUnmanagedEKSPIAInstalled, err := guess.IsThereUnmanagedEKSPodIdentityAgentInstalled(ctx, cli.EKS, clusterName)
+		if err != nil {
+			return "", fmt.Errorf("failed to check if EKS pod identity agent is installed: %w", err)
+		}
+		if err := aws.CreateOrUpdateStackWithExisting(ctx, cli.CloudFormation, ddStackName, DdKarpenterCfn, map[string]string{
+			"ClusterName":            clusterName,
+			"KarpenterNamespace":     karpenterNamespace,
+			"DeployPodIdentityAddon": strconv.FormatBool(!isUnmanagedEKSPIAInstalled),
+			"DeployNodeAccessEntry":  strconv.FormatBool(supportsAPIAuth),
+		}, modeTags, ddStack); err != nil {
+			return "", fmt.Errorf("failed to create or update Cloud Formation stack: %w", err)
+		}
+		return "", nil
+
+	case InstallModeFargate:
+		issuerURL, err := guess.GetClusterOIDCIssuerURL(cluster)
+		if err != nil {
+			return "", fmt.Errorf("failed to get cluster OIDC issuer URL: %w", err)
+		}
+		oidcArn, err := guess.EnsureOIDCProvider(ctx, cli.IAM, issuerURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to ensure OIDC provider: %w", err)
+		}
+
+		subnets := fargateSubnetsOverride
+		if len(subnets) == 0 {
+			subnets, err = guess.GetClusterPrivateSubnets(ctx, cli.EC2, cluster)
+			if err != nil {
+				return "", fmt.Errorf("failed to discover private subnets: %w", err)
+			}
+		}
+		// Sort so that different orderings of the same subnet set produce the
+		// same CloudFormation parameter value, making reruns idempotent and
+		// the immutability check order-independent.
+		slices.Sort(subnets)
+
+		if err = checkFargateStackImmutability(ddStack, karpenterNamespace, subnets); err != nil {
+			return "", err
+		}
+
+		if err = aws.CreateOrUpdateStackWithExisting(ctx, cli.CloudFormation, ddStackName, DdKarpenterFargateCfn, map[string]string{
+			"ClusterName":           clusterName,
+			"KarpenterNamespace":    karpenterNamespace,
+			"OIDCProviderArn":       oidcArn,
+			"OIDCProviderURL":       strings.TrimPrefix(issuerURL, "https://"),
+			"FargateSubnets":        strings.Join(subnets, ","),
+			"DeployNodeAccessEntry": strconv.FormatBool(supportsAPIAuth),
+		}, modeTags, ddStack); err != nil {
+			return "", fmt.Errorf("failed to create or update Cloud Formation stack: %w", err)
+		}
+
+		// Re-read the stack to pick up the outputs (not present pre-create).
+		updated, err := aws.GetStack(ctx, cli.CloudFormation, ddStackName)
+		if err != nil {
+			return "", fmt.Errorf("failed to read stack outputs: %w", err)
+		}
+		if updated == nil {
+			return "", fmt.Errorf("stack %s disappeared right after successful create/update", ddStackName)
+		}
+		irsaRoleArn := updated.OutputMap()["KarpenterRoleArn"]
+		if irsaRoleArn == "" {
+			return "", fmt.Errorf("stack %s did not produce a KarpenterRoleArn output", ddStackName)
+		}
+		return irsaRoleArn, nil
+
+	default:
+		return "", fmt.Errorf("unsupported install mode %q", mode)
+	}
+}
+
+// checkInstallModeTag verifies that an existing CFN stack's install-mode tag
+// matches the requested mode. Stacks created before this tag was introduced
+// have no tag and are treated as install-mode=existing-nodes.
+func checkInstallModeTag(stack *aws.Stack, expected InstallMode) error {
+	if stack == nil {
+		return nil // fresh install
+	}
+	existing := InstallModeExistingNodes
+	if tag, ok := stack.TagMap()[installModeTagKey]; ok && tag != "" {
+		existing = InstallMode(tag)
+	}
+	if existing != expected {
+		return fmt.Errorf("stack %s was created with --install-mode=%s; run 'kubectl datadog autoscaling cluster uninstall' first to switch to --install-mode=%s", awssdk.ToString(stack.StackName), existing, expected)
+	}
+	return nil
+}
+
+// checkFargateStackImmutability refuses to update an existing Fargate stack
+// when its KarpenterNamespace or FargateSubnets parameters differ from the
+// current ones. The underlying AWS::EKS::FargateProfile resource has a pinned
+// FargateProfileName and its Selectors/Subnets are CreateOnly properties; a
+// CloudFormation update with changed parameters would fail during replacement.
+func checkFargateStackImmutability(stack *aws.Stack, namespace string, subnets []string) error {
+	if stack == nil {
+		return nil // fresh install
+	}
+	stackName := awssdk.ToString(stack.StackName)
+	params := stack.ParameterMap()
+	if existing, ok := params["KarpenterNamespace"]; ok && existing != namespace {
+		return fmt.Errorf("stack %s was created with KarpenterNamespace=%s; run 'kubectl datadog autoscaling cluster uninstall' first to change it to %s", stackName, existing, namespace)
+	}
+	newSubnets := strings.Join(subnets, ",")
+	if existing, ok := params["FargateSubnets"]; ok && existing != newSubnets {
+		return fmt.Errorf("stack %s was created with FargateSubnets=%s; run 'kubectl datadog autoscaling cluster uninstall' first to change them to %s", stackName, existing, newSubnets)
+	}
 	return nil
 }
 
@@ -310,7 +480,7 @@ func updateAwsAuthConfigMap(ctx context.Context, cli *clients.Clients, clusterNa
 	return nil
 }
 
-func (o *options) installHelmChart(ctx context.Context, clusterName string, karpenterNamespace string, karpenterVersion string, debug bool) error {
+func (o *options) installHelmChart(ctx context.Context, clusterName, karpenterNamespace, karpenterVersion string, debug bool, mode InstallMode, irsaRoleArn string) error {
 	actionConfig, err := helm.NewActionConfig(o.ConfigFlags, karpenterNamespace)
 	if err != nil {
 		return err
@@ -324,6 +494,24 @@ func (o *options) installHelmChart(ctx context.Context, clusterName string, karp
 		return fmt.Errorf("failed to create registry client: %w", err)
 	}
 
+	if err = helm.CreateOrUpgrade(ctx, actionConfig, "karpenter", karpenterNamespace, karpenterOCIRegistry, karpenterVersion, karpenterHelmValues(clusterName, mode, irsaRoleArn)); err != nil {
+		return fmt.Errorf("failed to create or update Helm release: %w", err)
+	}
+
+	return nil
+}
+
+// karpenterHelmValues returns the Helm values for the Karpenter chart.
+//
+// resources are always set: the chart's default is {}, which in Fargate mode
+// falls back to Fargate's default (0.25 vCPU / 0.5 GiB) and OOMs the
+// controller, and in existing-nodes mode leaves the pod without any request.
+// 1 vCPU / 2 GiB is the smallest valid Fargate combination for 1 vCPU and
+// matches the chart's documented example for existing-nodes.
+//
+// In fargate mode, the service account is annotated with the IRSA role ARN so
+// the controller can assume the role via sts:AssumeRoleWithWebIdentity.
+func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn string) map[string]any {
 	values := map[string]any{
 		"additionalLabels": map[string]string{
 			"app.kubernetes.io/managed-by": "kubectl-datadog",
@@ -345,13 +533,21 @@ func (o *options) installHelmChart(ctx context.Context, clusterName string, karp
   }
 }`,
 		},
+		"resources": map[string]any{
+			"requests": map[string]string{"cpu": "1", "memory": "2Gi"},
+			"limits":   map[string]string{"cpu": "1", "memory": "2Gi"},
+		},
 	}
 
-	if err = helm.CreateOrUpgrade(ctx, actionConfig, "karpenter", karpenterNamespace, karpenterOCIRegistry, karpenterVersion, values); err != nil {
-		return fmt.Errorf("failed to create or update Helm release: %w", err)
+	if mode == InstallModeFargate {
+		values["serviceAccount"] = map[string]any{
+			"annotations": map[string]string{
+				"eks.amazonaws.com/role-arn": irsaRoleArn,
+			},
+		}
 	}
 
-	return nil
+	return values
 }
 
 func createNodePoolResources(ctx context.Context, cmd *cobra.Command, cli *clients.Clients, clusterName string, createResources CreateKarpenterResources, inferenceMethod InferenceMethod, debug bool) error {

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -533,9 +533,11 @@ func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn strin
   }
 }`,
 		},
-		"resources": map[string]any{
-			"requests": map[string]string{"cpu": "1", "memory": "2Gi"},
-			"limits":   map[string]string{"cpu": "1", "memory": "2Gi"},
+		"controller": map[string]any{
+			"resources": map[string]any{
+				"requests": map[string]string{"cpu": "1", "memory": "2Gi"},
+				"limits":   map[string]string{"cpu": "1", "memory": "2Gi"},
+			},
 		},
 	}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -513,7 +513,7 @@ func (o *options) installHelmChart(ctx context.Context, clusterName, karpenterNa
 // the controller can assume the role via sts:AssumeRoleWithWebIdentity.
 func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn string) map[string]any {
 	values := map[string]any{
-		"additionalLabels": map[string]string{
+		"additionalLabels": map[string]any{
 			"app.kubernetes.io/managed-by": "kubectl-datadog",
 			"app.kubernetes.io/version":    version.GetVersion(),
 		},
@@ -535,15 +535,15 @@ func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn strin
 		},
 		"controller": map[string]any{
 			"resources": map[string]any{
-				"requests": map[string]string{"cpu": "1", "memory": "2Gi"},
-				"limits":   map[string]string{"cpu": "1", "memory": "2Gi"},
+				"requests": map[string]any{"cpu": "1", "memory": "2Gi"},
+				"limits":   map[string]any{"cpu": "1", "memory": "2Gi"},
 			},
 		},
 	}
 
 	if mode == InstallModeFargate {
 		values["serviceAccount"] = map[string]any{
-			"annotations": map[string]string{
+			"annotations": map[string]any{
 				"eks.amazonaws.com/role-arn": irsaRoleArn,
 			},
 		}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install_test.go
@@ -6,6 +6,79 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestInstallMode_String(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mode     InstallMode
+		expected string
+	}{
+		{
+			name:     "Fargate mode",
+			mode:     InstallModeFargate,
+			expected: "fargate",
+		},
+		{
+			name:     "Existing-nodes mode",
+			mode:     InstallModeExistingNodes,
+			expected: "existing-nodes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.mode.String())
+		})
+	}
+}
+
+func TestInstallMode_Set(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		input       string
+		expected    InstallMode
+		expectError bool
+	}{
+		{
+			name:        "Set to fargate",
+			input:       "fargate",
+			expected:    InstallModeFargate,
+			expectError: false,
+		},
+		{
+			name:        "Set to existing-nodes",
+			input:       "existing-nodes",
+			expected:    InstallModeExistingNodes,
+			expectError: false,
+		},
+		{
+			name:        "Invalid value",
+			input:       "invalid",
+			expectError: true,
+		},
+		{
+			name:        "Empty value",
+			input:       "",
+			expectError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var mode InstallMode
+			err := mode.Set(tc.input)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "install-mode must be one of fargate or existing-nodes")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, mode)
+			}
+		})
+	}
+}
+
+func TestInstallMode_Type(t *testing.T) {
+	var mode InstallMode
+	assert.Equal(t, "InstallMode", mode.Type())
+}
+
 func TestCreateKarpenterResources_String(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -169,6 +242,8 @@ func TestValidate(t *testing.T) {
 	for _, tc := range []struct {
 		name                     string
 		args                     []string
+		installMode              InstallMode
+		fargateSubnets           []string
 		createKarpenterResources CreateKarpenterResources
 		inferenceMethod          InferenceMethod
 		expectError              bool
@@ -177,6 +252,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:                     "Valid with nodes inference method",
 			args:                     []string{},
+			installMode:              InstallModeFargate,
 			createKarpenterResources: CreateKarpenterResourcesEC2NodeClass,
 			inferenceMethod:          InferenceMethodNodes,
 			expectError:              false,
@@ -184,6 +260,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:                     "Valid with nodegroups inference method",
 			args:                     []string{},
+			installMode:              InstallModeFargate,
 			createKarpenterResources: CreateKarpenterResourcesEC2NodeClass,
 			inferenceMethod:          InferenceMethodNodeGroups,
 			expectError:              false,
@@ -191,6 +268,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:                     "Valid with create none",
 			args:                     []string{},
+			installMode:              InstallModeFargate,
 			createKarpenterResources: CreateKarpenterResourcesNone,
 			inferenceMethod:          InferenceMethodNodes,
 			expectError:              false,
@@ -198,6 +276,24 @@ func TestValidate(t *testing.T) {
 		{
 			name:                     "Valid with create all",
 			args:                     []string{},
+			installMode:              InstallModeFargate,
+			createKarpenterResources: CreateKarpenterResourcesAll,
+			inferenceMethod:          InferenceMethodNodes,
+			expectError:              false,
+		},
+		{
+			name:                     "Valid with existing-nodes mode",
+			args:                     []string{},
+			installMode:              InstallModeExistingNodes,
+			createKarpenterResources: CreateKarpenterResourcesAll,
+			inferenceMethod:          InferenceMethodNodes,
+			expectError:              false,
+		},
+		{
+			name:                     "Valid with fargate-subnets in fargate mode",
+			args:                     []string{},
+			installMode:              InstallModeFargate,
+			fargateSubnets:           []string{"subnet-abc", "subnet-def"},
 			createKarpenterResources: CreateKarpenterResourcesAll,
 			inferenceMethod:          InferenceMethodNodes,
 			expectError:              false,
@@ -205,6 +301,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:                     "Invalid with arguments",
 			args:                     []string{"arg1"},
+			installMode:              InstallModeFargate,
 			createKarpenterResources: CreateKarpenterResourcesEC2NodeClass,
 			inferenceMethod:          InferenceMethodNodes,
 			expectError:              true,
@@ -213,6 +310,7 @@ func TestValidate(t *testing.T) {
 		{
 			name:                     "Invalid with invalid inference method",
 			args:                     []string{},
+			installMode:              InstallModeFargate,
 			createKarpenterResources: CreateKarpenterResourcesEC2NodeClass,
 			inferenceMethod:          InferenceMethod("invalid"),
 			expectError:              true,
@@ -221,19 +319,45 @@ func TestValidate(t *testing.T) {
 		{
 			name:                     "Invalid with invalid create resources",
 			args:                     []string{},
+			installMode:              InstallModeFargate,
 			createKarpenterResources: CreateKarpenterResources("invalid"),
 			inferenceMethod:          InferenceMethodNodes,
 			expectError:              true,
 			errorContains:            "create-karpenter-resources must be one of none, ec2nodeclass or all",
 		},
+		{
+			name:                     "Invalid with invalid install mode",
+			args:                     []string{},
+			installMode:              InstallMode("invalid"),
+			createKarpenterResources: CreateKarpenterResourcesAll,
+			inferenceMethod:          InferenceMethodNodes,
+			expectError:              true,
+			errorContains:            "install-mode must be one of fargate or existing-nodes",
+		},
+		{
+			name:                     "Invalid fargate-subnets with existing-nodes mode",
+			args:                     []string{},
+			installMode:              InstallModeExistingNodes,
+			fargateSubnets:           []string{"subnet-abc"},
+			createKarpenterResources: CreateKarpenterResourcesAll,
+			inferenceMethod:          InferenceMethodNodes,
+			expectError:              true,
+			errorContains:            "--fargate-subnets can only be used with --install-mode=fargate",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Save and restore the global variables
+			oldMode := installMode
+			oldSubnets := fargateSubnets
 			oldCreate := createKarpenterResources
 			oldMethod := inferenceMethod
+			installMode = tc.installMode
+			fargateSubnets = tc.fargateSubnets
 			createKarpenterResources = tc.createKarpenterResources
 			inferenceMethod = tc.inferenceMethod
 			defer func() {
+				installMode = oldMode
+				fargateSubnets = oldSubnets
 				createKarpenterResources = oldCreate
 				inferenceMethod = oldMethod
 			}()

--- a/test/e2e/tests/autoscaling_suite/autoscaling_test.go
+++ b/test/e2e/tests/autoscaling_suite/autoscaling_test.go
@@ -20,6 +20,7 @@ import (
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -246,6 +247,36 @@ func (s *autoscalingSuite) TestAutoscalingDefault() {
 	})
 }
 
+func (s *autoscalingSuite) TestAutoscalingInstallModeFargate() {
+	ctx := s.T().Context()
+
+	s.Run("Install with install-mode=fargate", func() {
+		s.testInstall("--install-mode=fargate")
+		s.verifyKarpenterPodsComputeType(ctx, true)
+		s.waitForAllPodsRunning(ctx)
+	})
+
+	s.Run("Uninstall cleans up resources", func() {
+		s.testUninstall()
+		s.waitForPendingPods(ctx, 1)
+	})
+}
+
+func (s *autoscalingSuite) TestAutoscalingInstallModeExistingNodes() {
+	ctx := s.T().Context()
+
+	s.Run("Install with install-mode=existing-nodes", func() {
+		s.testInstall("--install-mode=existing-nodes")
+		s.verifyKarpenterPodsComputeType(ctx, false)
+		s.waitForAllPodsRunning(ctx)
+	})
+
+	s.Run("Uninstall cleans up resources", func() {
+		s.testUninstall()
+		s.waitForPendingPods(ctx, 1)
+	})
+}
+
 func (s *autoscalingSuite) TestAutoscalingNoNodePool() {
 	ctx := s.T().Context()
 
@@ -374,6 +405,39 @@ func (s *autoscalingSuite) verifyKarpenterInstalled(ctx context.Context) {
 	s.Assert().Truef(exists, "Karpenter Helm release not found")
 
 	t.Log("Karpenter installation verified successfully")
+}
+
+// verifyKarpenterPodsComputeType asserts that all Karpenter controller pods
+// run on a Fargate node (if wantFargate) or on a non-Fargate node (if not),
+// as reported by the `eks.amazonaws.com/compute-type` node label.
+func (s *autoscalingSuite) verifyKarpenterPodsComputeType(ctx context.Context, wantFargate bool) {
+	t := s.T()
+
+	const selector = "app.kubernetes.io/name=karpenter"
+	client := s.Env().KubernetesCluster.Client()
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		pods, err := client.CoreV1().Pods(karpenterNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: selector,
+		})
+		require.NoError(c, err, "listing Karpenter pods")
+		require.NotEmpty(c, pods.Items, "no Karpenter controller pod found")
+
+		for _, pod := range pods.Items {
+			require.Equalf(c, corev1.PodRunning, pod.Status.Phase, "pod %s is %s, want Running", pod.Name, pod.Status.Phase)
+			require.NotEmptyf(c, pod.Spec.NodeName, "pod %s has no node assigned", pod.Name)
+
+			node, err := client.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+			require.NoErrorf(c, err, "getting node %s hosting pod %s", pod.Spec.NodeName, pod.Name)
+
+			computeType := node.Labels["eks.amazonaws.com/compute-type"]
+			if wantFargate {
+				assert.Equalf(c, "fargate", computeType, "pod %s should run on Fargate; got node %s with compute-type=%q", pod.Name, node.Name, computeType)
+			} else {
+				assert.NotEqualf(c, "fargate", computeType, "pod %s should NOT run on Fargate; got node %s with compute-type=%q", pod.Name, node.Name, computeType)
+			}
+		}
+	}, 10*time.Minute, 10*time.Second)
 }
 
 // verifyCleanUninstall verifies that all Karpenter resources have been cleaned up

--- a/test/e2e/tests/autoscaling_suite/eks_test.go
+++ b/test/e2e/tests/autoscaling_suite/eks_test.go
@@ -16,7 +16,7 @@ import (
 func TestEKSAutoscalingSuite(t *testing.T) {
 	provisionerOptions := []provisioners.EKSProvisionerOption{
 		provisioners.WithEKSName("autoscaling-e2e"),
-		provisioners.WithEKSK8sVersion("1.32"),
+		provisioners.WithEKSK8sVersion("1.35"),
 		provisioners.WithEKSLinuxNodeGroup(),
 	}
 

--- a/test/e2e/tests/autoscaling_suite/eks_test.go
+++ b/test/e2e/tests/autoscaling_suite/eks_test.go
@@ -16,7 +16,7 @@ import (
 func TestEKSAutoscalingSuite(t *testing.T) {
 	provisionerOptions := []provisioners.EKSProvisionerOption{
 		provisioners.WithEKSName("autoscaling-e2e"),
-		provisioners.WithEKSK8sVersion("1.35"),
+		provisioners.WithEKSK8sVersion("1.34"),
 		provisioners.WithEKSLinuxNodeGroup(),
 	}
 

--- a/test/e2e/tests/autoscaling_suite/eks_test.go
+++ b/test/e2e/tests/autoscaling_suite/eks_test.go
@@ -18,6 +18,7 @@ func TestEKSAutoscalingSuite(t *testing.T) {
 		provisioners.WithEKSName("autoscaling-e2e"),
 		provisioners.WithEKSK8sVersion("1.34"),
 		provisioners.WithEKSLinuxNodeGroup(),
+		provisioners.WithEKSLinuxARMNodeGroup(),
 	}
 
 	e2eOpts := []e2e.SuiteOption{


### PR DESCRIPTION
### What does this PR do?

Adds a new `--install-mode` flag to `kubectl datadog autoscaling cluster install` with two values:
- `fargate` (**new default**) — deploys the Karpenter controller on dedicated Fargate nodes via IRSA.
- `existing-nodes` — previous behavior, uses EKS Pod Identity and schedules the controller on whatever nodes already exist in the cluster.

### Motivation

Karpenter's Helm chart enforces a hard `nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution` with `karpenter.sh/nodepool DoesNotExist`, so the controller pods can never be scheduled on the nodes Karpenter itself manages. With the previous default (controller on existing nodes), at least two non-Karpenter nodes had to remain in the cluster (2 replicas + `podAntiAffinity` on hostname for HA), blocking the removal of the last "legacy" nodes and potentially keeping user workload around.

Deploying the controller on dedicated Fargate nodes (invisible to Karpenter, no `karpenter.sh/nodepool` label) satisfies the constraint naturally and lets every user-workload node be drained and terminated once migration is complete.

Tracked in [CASCL-1292](https://datadoghq.atlassian.net/browse/CASCL-1292).

### Additional Notes

Key design points:

- **No EKS Pod Identity on Fargate.** Fargate pods are explicitly unsupported by EKS Pod Identity ([AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)), so Fargate mode uses IRSA (OIDC provider + federated IAM role) instead of `AWS::EKS::PodIdentityAssociation`.
- **OIDC provider bootstrapped in Go.** `AWS::IAM::OIDCProvider` is not idempotent against pre-existing providers (fails with `EntityAlreadyExists`). The install flow checks then creates via `iam.CreateOpenIDConnectProvider`, with a read-back poll to absorb IAM's eventual consistency. The provider is never deleted on uninstall since it may be shared with other workloads.
- **Private subnet auto-discovery.** EC2 `DescribeRouteTables` is used to identify subnets without a `0.0.0.0/0` or `::/0` route through an Internet Gateway. An optional `--fargate-subnets` flag overrides detection for shared-VPC or non-standard setups.
- **Guardrails.** A CFN stack tag `install-mode` refuses mode switches without uninstall first. A parameter-immutability check refuses `KarpenterNamespace` / `FargateSubnets` changes (since `AWS::EKS::FargateProfile` is immutable on those fields with a pinned profile name).
- **Helm resources always set.** The chart default is `{}`, which on Fargate falls back to 0.25 vCPU / 0.5 GiB and OOMs the controller. Explicit `1 vCPU / 2 GiB` (smallest valid Fargate combination for 1 vCPU) is now applied in both modes.

A new CFN template `cmd/kubectl-datadog/autoscaling/cluster/install/assets/dd-karpenter-fargate.yaml` is used in place of `dd-karpenter.yaml` when `--install-mode=fargate`. The stack name remains `dd-karpenter-<cluster>-dd-karpenter`; switching modes requires uninstall first (enforced by the install-mode tag guardrail).

### Minimum Agent Versions

No agent version dependency.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

**Unit tests** (\`go test ./cmd/kubectl-datadog/autoscaling/cluster/...\`):
- \`TestInstallMode_*\` — enum parsing/validation
- \`TestValidate\` — extended to cover install-mode + fargate-subnets constraints
- \`TestGetClusterPrivateSubnets\` — EC2 route-table mocks; covers explicit/main RT fallback, IPv6 IGW, blackhole routes, egress-only IGW, Transit Gateway, zero-private-subnet error
- \`TestEnsureOIDCProvider_*\` — provider lookup (case-insensitive host, case-sensitive path), create path, error paths
- \`TestGetClusterOIDCIssuerURL\` — cluster identity extraction

**Manual end-to-end on an EKS cluster** (EKS auto-mode disabled):

1. **Fresh Fargate install (new default):**
   \`\`\`
   kubectl datadog autoscaling cluster install --cluster-name=<cluster>
   \`\`\`
   - Both CFN stacks created; \`dd-karpenter-<cluster>-dd-karpenter\` has tag \`install-mode=fargate\`.
   - \`aws eks describe-fargate-profile --cluster-name <cluster> --fargate-profile-name dd-karpenter-<cluster>\` → \`ACTIVE\`.
   - \`kubectl -n dd-karpenter get pods -o wide\` → controller pods on \`fargate-ip-*\` nodes with label \`eks.amazonaws.com/compute-type=fargate\`.
   - Controller logs show no IRSA (\`AssumeRoleWithWebIdentity\`) errors.
2. **Idempotence:** rerun the same command → CloudFormation reports no updates, Helm up-to-date.
3. **Mode-switch guardrail:**
   \`\`\`
   kubectl datadog autoscaling cluster install --install-mode=existing-nodes --cluster-name=<cluster>
   \`\`\`
   → actionable error citing the existing \`install-mode=fargate\` and suggesting \`uninstall\` first.
4. **Karpenter provisioning end-to-end:** apply a Deployment requiring more capacity than existing nodes → Karpenter (running on Fargate) provisions EC2 nodes that join the cluster (validates \`NodeAccessEntry\` + \`aws-auth\` still works when the controller itself runs on Fargate).
5. **Uninstall:**
   \`\`\`
   kubectl datadog autoscaling cluster uninstall --cluster-name=<cluster>
   \`\`\`
   - Fargate profile deleted (3–5 min).
   - Both CFN stacks deleted.
   - OIDC provider retained in IAM (visible via \`aws iam list-open-id-connect-providers\`).
6. **Regression on existing-nodes mode:** rerun with \`--install-mode=existing-nodes\` explicit, verify Helm resource requests are applied (1 vCPU / 2 GiB) and no pods are OOM-killed or restarted.

### Checklist

- [x] PR has at least one valid label: \`bug\`, \`enhancement\`, \`refactoring\`, \`documentation\`, \`tooling\`, and/or \`dependencies\`
- [x] PR has a milestone or the \`qa/skip-qa\` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

[CASCL-1292]: https://datadoghq.atlassian.net/browse/CASCL-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ