### PR TITLE
Validate AWS account consistency before Karpenter operations

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -128,33 +129,36 @@ func resolveKubeContext(configFlags *genericclioptions.ConfigFlags) (api.Config,
 }
 
 // GetClusterNameFromKubeconfig extracts the EKS cluster name from the current kubeconfig context.
-func GetClusterNameFromKubeconfig(ctx context.Context, configFlags *genericclioptions.ConfigFlags) (string, error) {
+func GetClusterNameFromKubeconfig(configFlags *genericclioptions.ConfigFlags) (string, error) {
 	kubeRawConfig, kubeContext, err := resolveKubeContext(configFlags)
 	if err != nil {
 		return "", err
 	}
 
-	return guess.GetClusterNameFromKubeconfig(ctx, kubeRawConfig, kubeContext), nil
+	return guess.GetClusterNameFromKubeconfig(kubeRawConfig, kubeContext), nil
 }
 
 // getAccountIDFromKubeconfig attempts to extract the AWS account ID from the
 // kubeconfig context. Returns an empty string if the context is not an EKS ARN.
-func getAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) string {
+func getAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) (string, error) {
 	kubeRawConfig, kubeContext, err := resolveKubeContext(configFlags)
 	if err != nil || kubeContext == "" {
-		return ""
+		return "", err
 	}
 
 	kubeCtx, exists := kubeRawConfig.Contexts[kubeContext]
 	if !exists {
-		return ""
+		return "", fmt.Errorf("kube context %q doesn’t exist", kubeContext)
 	}
 
-	if parsed, err := arn.Parse(kubeCtx.Cluster); err == nil {
-		return parsed.AccountID
+	parsed, err := arn.Parse(kubeCtx.Cluster)
+	if err != nil {
+		// The kubeconfig cluster field is not an ARN (e.g. plain name,
+		// eksctl FQDN). This is a normal fallback case, not an error.
+		return "", nil
 	}
 
-	return ""
+	return parsed.AccountID, nil
 }
 
 // GetAWSAccountID returns the AWS account ID from the current credentials.
@@ -183,7 +187,10 @@ func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterNam
 		return err
 	}
 
-	clusterAccountID := getAccountIDFromKubeconfig(configFlags)
+	clusterAccountID, err := getAccountIDFromKubeconfig(configFlags)
+	if err != nil {
+		log.Printf("Warning: failed to get AWS account ID from kubeconfig: %v", err)
+	}
 	if clusterAccountID == "" {
 		cluster, err := cli.EKS.DescribeCluster(ctx, &eks.DescribeClusterInput{
 			Name: awssdk.String(clusterName),

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	karpawsv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
@@ -200,7 +201,12 @@ func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterNam
 			Name: awssdk.String(clusterName),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to describe EKS cluster %s: %w", clusterName, err)
+			wrapped := fmt.Errorf("failed to describe EKS cluster %s: %w", clusterName, err)
+			var notFound *ekstypes.ResourceNotFoundException
+			if errors.As(err, &notFound) {
+				return &ClusterLookupUnavailableError{Err: wrapped}
+			}
+			return wrapped
 		}
 		if cluster.Cluster == nil || cluster.Cluster.Arn == nil {
 			return fmt.Errorf("EKS cluster %s has no ARN", clusterName)
@@ -240,3 +246,17 @@ func (e *AccountMismatchError) Error() string {
 		e.CredentialsAccountID, e.ClusterName, e.ClusterAccountID,
 	)
 }
+
+// ClusterLookupUnavailableError wraps EKS.DescribeCluster failures with a
+// ResourceNotFoundException — the cluster does not exist (e.g. already
+// deleted). Callers such as uninstall may choose to proceed on this error.
+//
+// Other DescribeCluster failures (AccessDenied, throttling, wrong region,
+// transient API errors) and malformed responses (nil cluster, nil ARN,
+// unparseable ARN) are not wrapped and surface as hard errors.
+type ClusterLookupUnavailableError struct {
+	Err error
+}
+
+func (e *ClusterLookupUnavailableError) Error() string { return e.Err.Error() }
+func (e *ClusterLookupUnavailableError) Unwrap() error { return e.Err }

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -137,9 +137,9 @@ func GetClusterNameFromKubeconfig(ctx context.Context, configFlags *genericcliop
 	return guess.GetClusterNameFromKubeconfig(ctx, kubeRawConfig, kubeContext), nil
 }
 
-// GetAccountIDFromKubeconfig attempts to extract the AWS account ID from the
+// getAccountIDFromKubeconfig attempts to extract the AWS account ID from the
 // kubeconfig context. Returns an empty string if the context is not an EKS ARN.
-func GetAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) string {
+func getAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) string {
 	kubeRawConfig, kubeContext, err := resolveKubeContext(configFlags)
 	if err != nil || kubeContext == "" {
 		return ""
@@ -173,42 +173,44 @@ func GetAWSAccountID(ctx context.Context, cli *Clients) (string, error) {
 // deployment by verifying that the current AWS credentials and the target
 // EKS cluster belong to the same AWS account.
 //
-// kubeconfigAccountID should be the account ID extracted from the kubeconfig
-// context ARN (via GetAccountIDFromKubeconfig). When non-empty, it is used
-// directly — this avoids relying on DescribeCluster with the credentials
-// being validated, which would give a false positive if both accounts
-// happen to have a cluster with the same name.
-//
-// When kubeconfigAccountID is empty (kubeconfig context is not an ARN),
-// falls back to DescribeCluster.
-func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterName string, kubeconfigAccountID string) error {
+// The cluster's account ID is derived from the kubeconfig context ARN when
+// available. This is independent of the AWS credentials and cannot be fooled
+// by same-named clusters in different accounts. When the kubeconfig context
+// is not an ARN, falls back to DescribeCluster.
+func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterName string, configFlags *genericclioptions.ConfigFlags) error {
 	credentialsAccountID, err := GetAWSAccountID(ctx, cli)
 	if err != nil {
 		return err
 	}
 
-	if kubeconfigAccountID != "" {
-		if credentialsAccountID != kubeconfigAccountID {
-			return &AccountMismatchError{
-				CredentialsAccountID: credentialsAccountID,
-				ClusterAccountID:     kubeconfigAccountID,
-				ClusterName:          clusterName,
-			}
+	clusterAccountID := getAccountIDFromKubeconfig(configFlags)
+	if clusterAccountID == "" {
+		cluster, err := cli.EKS.DescribeCluster(ctx, &eks.DescribeClusterInput{
+			Name: awssdk.String(clusterName),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to describe EKS cluster %s: %w", clusterName, err)
 		}
-		return nil
+		if cluster.Cluster == nil || cluster.Cluster.Arn == nil {
+			return fmt.Errorf("EKS cluster %s has no ARN", clusterName)
+		}
+
+		clusterArn, err := arn.Parse(*cluster.Cluster.Arn)
+		if err != nil {
+			return fmt.Errorf("failed to parse EKS cluster ARN %q: %w", *cluster.Cluster.Arn, err)
+		}
+		clusterAccountID = clusterArn.AccountID
 	}
 
-	cluster, err := cli.EKS.DescribeCluster(ctx, &eks.DescribeClusterInput{
-		Name: awssdk.String(clusterName),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to describe EKS cluster %s: %w", clusterName, err)
-	}
-	if cluster.Cluster == nil || cluster.Cluster.Arn == nil {
-		return fmt.Errorf("EKS cluster %s has no ARN", clusterName)
+	if credentialsAccountID != clusterAccountID {
+		return &AccountMismatchError{
+			CredentialsAccountID: credentialsAccountID,
+			ClusterAccountID:     clusterAccountID,
+			ClusterName:          clusterName,
+		}
 	}
 
-	return validateAccountIDs(credentialsAccountID, *cluster.Cluster.Arn, clusterName)
+	return nil
 }
 
 // AccountMismatchError indicates that the AWS credentials and the EKS cluster
@@ -226,23 +228,4 @@ func (e *AccountMismatchError) Error() string {
 			"ensure your AWS credentials and kubeconfig target the same AWS account",
 		e.CredentialsAccountID, e.ClusterName, e.ClusterAccountID,
 	)
-}
-
-// validateAccountIDs checks that the credentials account ID matches the
-// account ID extracted from the cluster ARN.
-func validateAccountIDs(credentialsAccountID string, clusterARN string, clusterName string) error {
-	clusterArn, err := arn.Parse(clusterARN)
-	if err != nil {
-		return fmt.Errorf("failed to parse EKS cluster ARN %q: %w", clusterARN, err)
-	}
-
-	if credentialsAccountID != clusterArn.AccountID {
-		return &AccountMismatchError{
-			CredentialsAccountID: credentialsAccountID,
-			ClusterAccountID:     clusterArn.AccountID,
-			ClusterName:          clusterName,
-		}
-	}
-
-	return nil
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -4,9 +4,11 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -119,4 +121,74 @@ func GetClusterNameFromKubeconfig(ctx context.Context, configFlags *genericcliop
 	}
 
 	return guess.GetClusterNameFromKubeconfig(ctx, kubeRawConfig, kubeContext), nil
+}
+
+// GetAWSAccountID returns the AWS account ID from the current credentials.
+func GetAWSAccountID(ctx context.Context, cli *Clients) (string, error) {
+	callerIdentity, err := cli.STS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get AWS caller identity: %w", err)
+	}
+	if callerIdentity.Account == nil {
+		return "", errors.New("unable to determine AWS account ID from STS GetCallerIdentity")
+	}
+	return *callerIdentity.Account, nil
+}
+
+// ValidateAWSAccountConsistency prevents accidental cross-account resource
+// deployment by verifying that the current AWS credentials and the target
+// EKS cluster belong to the same AWS account.
+func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterName string) error {
+	credentialsAccountID, err := GetAWSAccountID(ctx, cli)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := cli.EKS.DescribeCluster(ctx, &eks.DescribeClusterInput{
+		Name: awssdk.String(clusterName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to describe EKS cluster %s: %w", clusterName, err)
+	}
+	if cluster.Cluster == nil || cluster.Cluster.Arn == nil {
+		return fmt.Errorf("EKS cluster %s has no ARN", clusterName)
+	}
+
+	return validateAccountIDs(credentialsAccountID, *cluster.Cluster.Arn, clusterName)
+}
+
+// AccountMismatchError indicates that the AWS credentials and the EKS cluster
+// belong to different AWS accounts.
+type AccountMismatchError struct {
+	CredentialsAccountID string
+	ClusterAccountID     string
+	ClusterName          string
+}
+
+func (e *AccountMismatchError) Error() string {
+	return fmt.Sprintf(
+		"AWS account mismatch: current credentials belong to account %s, "+
+			"but EKS cluster %q belongs to account %s; "+
+			"ensure your AWS credentials and kubeconfig target the same AWS account",
+		e.CredentialsAccountID, e.ClusterName, e.ClusterAccountID,
+	)
+}
+
+// validateAccountIDs checks that the credentials account ID matches the
+// account ID extracted from the cluster ARN.
+func validateAccountIDs(credentialsAccountID string, clusterARN string, clusterName string) error {
+	clusterArn, err := arn.Parse(clusterARN)
+	if err != nil {
+		return fmt.Errorf("failed to parse EKS cluster ARN %q: %w", clusterARN, err)
+	}
+
+	if credentialsAccountID != clusterArn.AccountID {
+		return &AccountMismatchError{
+			CredentialsAccountID: credentialsAccountID,
+			ClusterAccountID:     clusterArn.AccountID,
+			ClusterName:          clusterName,
+		}
+	}
+
+	return nil
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -151,11 +151,15 @@ func getAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) (str
 		return "", fmt.Errorf("kube context %q doesn’t exist", kubeContext)
 	}
 
+	// The kubeconfig cluster field may not be an ARN (e.g. plain name,
+	// eksctl FQDN). Treat that as a normal fallback, not an error.
+	if !arn.IsARN(kubeCtx.Cluster) {
+		return "", nil
+	}
+
 	parsed, err := arn.Parse(kubeCtx.Cluster)
 	if err != nil {
-		// The kubeconfig cluster field is not an ARN (e.g. plain name,
-		// eksctl FQDN). This is a normal fallback case, not an error.
-		return "", nil
+		return "", fmt.Errorf("failed to parse EKS cluster ARN %q: %w", kubeCtx.Cluster, err)
 	}
 
 	return parsed.AccountID, nil

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -108,27 +109,11 @@ func Build(ctx context.Context, configFlags *genericclioptions.ConfigFlags, k8sC
 	}, nil
 }
 
-// GetClusterNameFromKubeconfig extracts the EKS cluster name from the current kubeconfig context.
-func GetClusterNameFromKubeconfig(ctx context.Context, configFlags *genericclioptions.ConfigFlags) (string, error) {
+// resolveKubeContext loads the kubeconfig and resolves the active context name.
+func resolveKubeContext(configFlags *genericclioptions.ConfigFlags) (api.Config, string, error) {
 	kubeRawConfig, err := configFlags.ToRawKubeConfigLoader().RawConfig()
 	if err != nil {
-		return "", fmt.Errorf("failed to get raw kubeconfig: %w", err)
-	}
-
-	kubeContext := ""
-	if configFlags.Context != nil {
-		kubeContext = *configFlags.Context
-	}
-
-	return guess.GetClusterNameFromKubeconfig(ctx, kubeRawConfig, kubeContext), nil
-}
-
-// GetAccountIDFromKubeconfig attempts to extract the AWS account ID from the
-// kubeconfig context. Returns an empty string if the context is not an EKS ARN.
-func GetAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) string {
-	kubeRawConfig, err := configFlags.ToRawKubeConfigLoader().RawConfig()
-	if err != nil {
-		return ""
+		return api.Config{}, "", fmt.Errorf("failed to get raw kubeconfig: %w", err)
 	}
 
 	kubeContext := ""
@@ -138,16 +123,34 @@ func GetAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) stri
 	if kubeContext == "" {
 		kubeContext = kubeRawConfig.CurrentContext
 	}
-	if kubeContext == "" {
+
+	return kubeRawConfig, kubeContext, nil
+}
+
+// GetClusterNameFromKubeconfig extracts the EKS cluster name from the current kubeconfig context.
+func GetClusterNameFromKubeconfig(ctx context.Context, configFlags *genericclioptions.ConfigFlags) (string, error) {
+	kubeRawConfig, kubeContext, err := resolveKubeContext(configFlags)
+	if err != nil {
+		return "", err
+	}
+
+	return guess.GetClusterNameFromKubeconfig(ctx, kubeRawConfig, kubeContext), nil
+}
+
+// GetAccountIDFromKubeconfig attempts to extract the AWS account ID from the
+// kubeconfig context. Returns an empty string if the context is not an EKS ARN.
+func GetAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) string {
+	kubeRawConfig, kubeContext, err := resolveKubeContext(configFlags)
+	if err != nil || kubeContext == "" {
 		return ""
 	}
 
-	ctx, exists := kubeRawConfig.Contexts[kubeContext]
+	kubeCtx, exists := kubeRawConfig.Contexts[kubeContext]
 	if !exists {
 		return ""
 	}
 
-	if parsed, err := arn.Parse(ctx.Cluster); err == nil {
+	if parsed, err := arn.Parse(kubeCtx.Cluster); err == nil {
 		return parsed.AccountID
 	}
 
@@ -184,8 +187,6 @@ func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterNam
 		return err
 	}
 
-	// Prefer the kubeconfig-derived account ID: it is independent of the
-	// AWS credentials and cannot be fooled by same-named clusters.
 	if kubeconfigAccountID != "" {
 		if credentialsAccountID != kubeconfigAccountID {
 			return &AccountMismatchError{
@@ -197,9 +198,6 @@ func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterNam
 		return nil
 	}
 
-	// Fallback: resolve the cluster account via DescribeCluster. This uses
-	// the same credentials being validated, so it cannot detect a mismatch
-	// when both accounts have a cluster with the same name.
 	cluster, err := cli.EKS.DescribeCluster(ctx, &eks.DescribeClusterInput{
 		Name: awssdk.String(clusterName),
 	})

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -123,6 +123,37 @@ func GetClusterNameFromKubeconfig(ctx context.Context, configFlags *genericcliop
 	return guess.GetClusterNameFromKubeconfig(ctx, kubeRawConfig, kubeContext), nil
 }
 
+// GetAccountIDFromKubeconfig attempts to extract the AWS account ID from the
+// kubeconfig context. Returns an empty string if the context is not an EKS ARN.
+func GetAccountIDFromKubeconfig(configFlags *genericclioptions.ConfigFlags) string {
+	kubeRawConfig, err := configFlags.ToRawKubeConfigLoader().RawConfig()
+	if err != nil {
+		return ""
+	}
+
+	kubeContext := ""
+	if configFlags.Context != nil {
+		kubeContext = *configFlags.Context
+	}
+	if kubeContext == "" {
+		kubeContext = kubeRawConfig.CurrentContext
+	}
+	if kubeContext == "" {
+		return ""
+	}
+
+	ctx, exists := kubeRawConfig.Contexts[kubeContext]
+	if !exists {
+		return ""
+	}
+
+	if parsed, err := arn.Parse(ctx.Cluster); err == nil {
+		return parsed.AccountID
+	}
+
+	return ""
+}
+
 // GetAWSAccountID returns the AWS account ID from the current credentials.
 func GetAWSAccountID(ctx context.Context, cli *Clients) (string, error) {
 	callerIdentity, err := cli.STS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
@@ -138,12 +169,37 @@ func GetAWSAccountID(ctx context.Context, cli *Clients) (string, error) {
 // ValidateAWSAccountConsistency prevents accidental cross-account resource
 // deployment by verifying that the current AWS credentials and the target
 // EKS cluster belong to the same AWS account.
-func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterName string) error {
+//
+// kubeconfigAccountID should be the account ID extracted from the kubeconfig
+// context ARN (via GetAccountIDFromKubeconfig). When non-empty, it is used
+// directly — this avoids relying on DescribeCluster with the credentials
+// being validated, which would give a false positive if both accounts
+// happen to have a cluster with the same name.
+//
+// When kubeconfigAccountID is empty (kubeconfig context is not an ARN),
+// falls back to DescribeCluster.
+func ValidateAWSAccountConsistency(ctx context.Context, cli *Clients, clusterName string, kubeconfigAccountID string) error {
 	credentialsAccountID, err := GetAWSAccountID(ctx, cli)
 	if err != nil {
 		return err
 	}
 
+	// Prefer the kubeconfig-derived account ID: it is independent of the
+	// AWS credentials and cannot be fooled by same-named clusters.
+	if kubeconfigAccountID != "" {
+		if credentialsAccountID != kubeconfigAccountID {
+			return &AccountMismatchError{
+				CredentialsAccountID: credentialsAccountID,
+				ClusterAccountID:     kubeconfigAccountID,
+				ClusterName:          clusterName,
+			}
+		}
+		return nil
+	}
+
+	// Fallback: resolve the cluster account via DescribeCluster. This uses
+	// the same credentials being validated, so it cannot detect a mismatch
+	// when both accounts have a cluster with the same name.
 	cluster, err := cli.EKS.DescribeCluster(ctx, &eks.DescribeClusterInput{
 		Name: awssdk.String(clusterName),
 	})

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
@@ -89,10 +89,10 @@ func TestValidateAccountIDs(t *testing.T) {
 
 func TestGetAccountIDFromKubeconfig(t *testing.T) {
 	tests := []struct {
-		name            string
-		kubeconfig      string
-		context         string
-		wantAccountID   string
+		name          string
+		kubeconfig    string
+		context       string
+		wantAccountID string
 	}{
 		{
 			name: "EKS ARN context extracts account ID",

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
@@ -1,0 +1,85 @@
+package clients
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAccountIDs(t *testing.T) {
+	tests := []struct {
+		name                 string
+		credentialsAccountID string
+		clusterARN           string
+		clusterName          string
+		wantErr              bool
+		wantMismatch         bool
+		errContains          string
+	}{
+		{
+			name:                 "matching accounts",
+			credentialsAccountID: "123456789012",
+			clusterARN:           "arn:aws:eks:us-east-1:123456789012:cluster/my-cluster",
+			clusterName:          "my-cluster",
+		},
+		{
+			name:                 "mismatched accounts",
+			credentialsAccountID: "111111111111",
+			clusterARN:           "arn:aws:eks:us-east-1:222222222222:cluster/my-cluster",
+			clusterName:          "my-cluster",
+			wantErr:              true,
+			wantMismatch:         true,
+			errContains:          "AWS account mismatch",
+		},
+		{
+			name:                 "matching accounts in GovCloud partition",
+			credentialsAccountID: "123456789012",
+			clusterARN:           "arn:aws-us-gov:eks:us-gov-west-1:123456789012:cluster/my-cluster",
+			clusterName:          "my-cluster",
+		},
+		{
+			name:                 "matching accounts in China partition",
+			credentialsAccountID: "123456789012",
+			clusterARN:           "arn:aws-cn:eks:cn-north-1:123456789012:cluster/my-cluster",
+			clusterName:          "my-cluster",
+		},
+		{
+			name:                 "invalid ARN format",
+			credentialsAccountID: "123456789012",
+			clusterARN:           "not-an-arn",
+			clusterName:          "my-cluster",
+			wantErr:              true,
+			errContains:          "failed to parse EKS cluster ARN",
+		},
+		{
+			name:                 "error message contains both account IDs",
+			credentialsAccountID: "111111111111",
+			clusterARN:           "arn:aws:eks:eu-west-1:999999999999:cluster/prod-cluster",
+			clusterName:          "prod-cluster",
+			wantErr:              true,
+			wantMismatch:         true,
+			errContains:          "999999999999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAccountIDs(tt.credentialsAccountID, tt.clusterARN, tt.clusterName)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+
+				var mismatch *AccountMismatchError
+				if tt.wantMismatch {
+					assert.True(t, errors.As(err, &mismatch))
+				} else {
+					assert.False(t, errors.As(err, &mismatch))
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
@@ -2,10 +2,13 @@ package clients
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func TestValidateAccountIDs(t *testing.T) {
@@ -80,6 +83,149 @@ func TestValidateAccountIDs(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestGetAccountIDFromKubeconfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		kubeconfig      string
+		context         string
+		wantAccountID   string
+	}{
+		{
+			name: "EKS ARN context extracts account ID",
+			kubeconfig: `
+apiVersion: v1
+kind: Config
+current-context: eks-context
+contexts:
+- name: eks-context
+  context:
+    cluster: arn:aws:eks:us-east-1:123456789012:cluster/my-cluster
+    user: eks-user
+clusters:
+- name: arn:aws:eks:us-east-1:123456789012:cluster/my-cluster
+  cluster:
+    server: https://example.eks.amazonaws.com
+users:
+- name: eks-user
+  user: {}
+`,
+			wantAccountID: "123456789012",
+		},
+		{
+			name: "GovCloud ARN context extracts account ID",
+			kubeconfig: `
+apiVersion: v1
+kind: Config
+current-context: gov-context
+contexts:
+- name: gov-context
+  context:
+    cluster: arn:aws-us-gov:eks:us-gov-west-1:987654321098:cluster/gov-cluster
+    user: gov-user
+clusters:
+- name: arn:aws-us-gov:eks:us-gov-west-1:987654321098:cluster/gov-cluster
+  cluster:
+    server: https://example.eks.amazonaws.com
+users:
+- name: gov-user
+  user: {}
+`,
+			wantAccountID: "987654321098",
+		},
+		{
+			name: "plain cluster name returns empty",
+			kubeconfig: `
+apiVersion: v1
+kind: Config
+current-context: plain-context
+contexts:
+- name: plain-context
+  context:
+    cluster: my-cluster
+    user: my-user
+clusters:
+- name: my-cluster
+  cluster:
+    server: https://example.eks.amazonaws.com
+users:
+- name: my-user
+  user: {}
+`,
+			wantAccountID: "",
+		},
+		{
+			name: "eksctl format returns empty",
+			kubeconfig: `
+apiVersion: v1
+kind: Config
+current-context: eksctl-context
+contexts:
+- name: eksctl-context
+  context:
+    cluster: my-cluster.us-east-1.eksctl.io
+    user: eksctl-user
+clusters:
+- name: my-cluster.us-east-1.eksctl.io
+  cluster:
+    server: https://example.eks.amazonaws.com
+users:
+- name: eksctl-user
+  user: {}
+`,
+			wantAccountID: "",
+		},
+		{
+			name: "explicit context override",
+			kubeconfig: `
+apiVersion: v1
+kind: Config
+current-context: default-context
+contexts:
+- name: default-context
+  context:
+    cluster: plain-cluster
+    user: user1
+- name: eks-context
+  context:
+    cluster: arn:aws:eks:eu-west-1:111222333444:cluster/prod
+    user: user2
+clusters:
+- name: plain-cluster
+  cluster:
+    server: https://example1.eks.amazonaws.com
+- name: arn:aws:eks:eu-west-1:111222333444:cluster/prod
+  cluster:
+    server: https://example2.eks.amazonaws.com
+users:
+- name: user1
+  user: {}
+- name: user2
+  user: {}
+`,
+			context:       "eks-context",
+			wantAccountID: "111222333444",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Write kubeconfig to a temp file
+			dir := t.TempDir()
+			kubeconfigPath := filepath.Join(dir, "kubeconfig")
+			require.NoError(t, os.WriteFile(kubeconfigPath, []byte(tt.kubeconfig), 0600))
+
+			flags := genericclioptions.NewConfigFlags(false)
+			flags.KubeConfig = &kubeconfigPath
+			if tt.context != "" {
+				flags.Context = &tt.context
+			}
+
+			got := GetAccountIDFromKubeconfig(flags)
+			assert.Equal(t, tt.wantAccountID, got)
 		})
 	}
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
@@ -78,7 +78,6 @@ users:
 - name: my-user
   user: {}
 `,
-			wantAccountID: "",
 		},
 		{
 			name: "eksctl format returns empty",
@@ -99,7 +98,6 @@ users:
 - name: eksctl-user
   user: {}
 `,
-			wantAccountID: "",
 		},
 		{
 			name: "explicit context override",
@@ -145,7 +143,8 @@ users:
 				flags.Context = &tt.context
 			}
 
-			got := getAccountIDFromKubeconfig(flags)
+			got, err := getAccountIDFromKubeconfig(flags)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.wantAccountID, got)
 		})
 	}

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients_test.go
@@ -1,7 +1,6 @@
 package clients
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,84 +10,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func TestValidateAccountIDs(t *testing.T) {
-	tests := []struct {
-		name                 string
-		credentialsAccountID string
-		clusterARN           string
-		clusterName          string
-		wantErr              bool
-		wantMismatch         bool
-		errContains          string
-	}{
-		{
-			name:                 "matching accounts",
-			credentialsAccountID: "123456789012",
-			clusterARN:           "arn:aws:eks:us-east-1:123456789012:cluster/my-cluster",
-			clusterName:          "my-cluster",
-		},
-		{
-			name:                 "mismatched accounts",
-			credentialsAccountID: "111111111111",
-			clusterARN:           "arn:aws:eks:us-east-1:222222222222:cluster/my-cluster",
-			clusterName:          "my-cluster",
-			wantErr:              true,
-			wantMismatch:         true,
-			errContains:          "AWS account mismatch",
-		},
-		{
-			name:                 "matching accounts in GovCloud partition",
-			credentialsAccountID: "123456789012",
-			clusterARN:           "arn:aws-us-gov:eks:us-gov-west-1:123456789012:cluster/my-cluster",
-			clusterName:          "my-cluster",
-		},
-		{
-			name:                 "matching accounts in China partition",
-			credentialsAccountID: "123456789012",
-			clusterARN:           "arn:aws-cn:eks:cn-north-1:123456789012:cluster/my-cluster",
-			clusterName:          "my-cluster",
-		},
-		{
-			name:                 "invalid ARN format",
-			credentialsAccountID: "123456789012",
-			clusterARN:           "not-an-arn",
-			clusterName:          "my-cluster",
-			wantErr:              true,
-			errContains:          "failed to parse EKS cluster ARN",
-		},
-		{
-			name:                 "error message contains both account IDs",
-			credentialsAccountID: "111111111111",
-			clusterARN:           "arn:aws:eks:eu-west-1:999999999999:cluster/prod-cluster",
-			clusterName:          "prod-cluster",
-			wantErr:              true,
-			wantMismatch:         true,
-			errContains:          "999999999999",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateAccountIDs(tt.credentialsAccountID, tt.clusterARN, tt.clusterName)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errContains)
-
-				var mismatch *AccountMismatchError
-				if tt.wantMismatch {
-					assert.True(t, errors.As(err, &mismatch))
-				} else {
-					assert.False(t, errors.As(err, &mismatch))
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestGetAccountIDFromKubeconfig(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		name          string
 		kubeconfig    string
 		context       string
@@ -209,9 +132,7 @@ users:
 			context:       "eks-context",
 			wantAccountID: "111222333444",
 		},
-	}
-
-	for _, tt := range tests {
+	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// Write kubeconfig to a temp file
 			dir := t.TempDir()
@@ -224,7 +145,7 @@ users:
 				flags.Context = &tt.context
 			}
 
-			got := GetAccountIDFromKubeconfig(flags)
+			got := getAccountIDFromKubeconfig(flags)
 			assert.Equal(t, tt.wantAccountID, got)
 		})
 	}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/clustername.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/clustername.go
@@ -1,14 +1,13 @@
 package guess
 
 import (
-	"context"
 	"strings"
 
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 // GetClusterNameFromKubeconfig attempts to extract the EKS cluster name from the current kubectl context
-func GetClusterNameFromKubeconfig(ctx context.Context, rawConfig api.Config, kubeContext string) (clusterName string) {
+func GetClusterNameFromKubeconfig(rawConfig api.Config, kubeContext string) (clusterName string) {
 	if kubeContext == "" {
 		kubeContext = rawConfig.CurrentContext
 	}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/clustername_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/clustername_test.go
@@ -37,7 +37,7 @@ func TestGetClusterNameFromKubeConfig(t *testing.T) {
 			)
 			rawConfig, err := clientConfig.RawConfig()
 			require.NoError(t, err)
-			assert.Equal(t, tc.clusterName, GetClusterNameFromKubeconfig(t.Context(), rawConfig, tc.kubeContext))
+			assert.Equal(t, tc.clusterName, GetClusterNameFromKubeconfig(rawConfig, tc.kubeContext))
 		})
 	}
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -208,7 +208,7 @@ func (o *options) run(cmd *cobra.Command) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(false), zap.WriteTo(cmd.ErrOrStderr())))
 
 	if clusterName == "" {
-		if name, err := clients.GetClusterNameFromKubeconfig(ctx, o.ConfigFlags); err != nil {
+		if name, err := clients.GetClusterNameFromKubeconfig(o.ConfigFlags); err != nil {
 			return err
 		} else if name != "" {
 			clusterName = name

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/color"
 	"github.com/pkg/browser"
@@ -231,6 +230,10 @@ func (o *options) run(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to build clients: %w", err)
 	}
 
+	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName); err != nil {
+		return err
+	}
+
 	if err = createCloudFormationStacks(ctx, cli, clusterName, karpenterNamespace); err != nil {
 		return err
 	}
@@ -290,15 +293,10 @@ func updateAwsAuthConfigMap(ctx context.Context, cli *clients.Clients, clusterNa
 		return nil
 	}
 
-	// Get AWS account ID
-	callerIdentity, err := cli.STS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	accountID, err := clients.GetAWSAccountID(ctx, cli)
 	if err != nil {
-		return fmt.Errorf("failed to get identity caller: %w", err)
+		return err
 	}
-	if callerIdentity.Account == nil {
-		return errors.New("unable to determine AWS account ID from STS GetCallerIdentity")
-	}
-	accountID := *callerIdentity.Account
 
 	// Add role mapping in the `aws-auth` ConfigMap
 	if err = aws.EnsureAwsAuthRole(ctx, cli.K8sClientset, aws.RoleMapping{

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -230,7 +230,8 @@ func (o *options) run(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to build clients: %w", err)
 	}
 
-	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName); err != nil {
+	kubeconfigAccountID := clients.GetAccountIDFromKubeconfig(o.ConfigFlags)
+	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName, kubeconfigAccountID); err != nil {
 		return err
 	}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -230,8 +230,7 @@ func (o *options) run(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to build clients: %w", err)
 	}
 
-	kubeconfigAccountID := clients.GetAccountIDFromKubeconfig(o.ConfigFlags)
-	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName, kubeconfigAccountID); err != nil {
+	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName, o.ConfigFlags); err != nil {
 		return err
 	}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
@@ -120,7 +120,7 @@ func (o *options) run(cmd *cobra.Command) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(false), zap.WriteTo(cmd.ErrOrStderr())))
 
 	if clusterName == "" {
-		if name, err := clients.GetClusterNameFromKubeconfig(ctx, o.ConfigFlags); err != nil {
+		if name, err := clients.GetClusterNameFromKubeconfig(o.ConfigFlags); err != nil {
 			return err
 		} else if name != "" {
 			clusterName = name

--- a/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
@@ -137,13 +137,12 @@ func (o *options) run(cmd *cobra.Command) error {
 	}
 
 	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName, o.ConfigFlags); err != nil {
-		var mismatch *clients.AccountMismatchError
-		if errors.As(err, &mismatch) {
+		var lookupUnavailable *clients.ClusterLookupUnavailableError
+		if !errors.As(err, &lookupUnavailable) {
 			return err
 		}
-		// The cluster may already be deleted or DescribeCluster may be
-		// unavailable; warn but proceed with cleanup.
-		log.Printf("Warning: AWS account consistency check failed: %v", err)
+		// The cluster may already be deleted; warn but proceed with cleanup.
+		log.Printf("Warning: AWS account consistency check skipped: %v", err)
 	}
 
 	nodePoolNames, nodes := displayResourceSummary(ctx, cmd, cli, clusterName)

--- a/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
@@ -136,7 +136,8 @@ func (o *options) run(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to build clients: %w", err)
 	}
 
-	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName); err != nil {
+	kubeconfigAccountID := clients.GetAccountIDFromKubeconfig(o.ConfigFlags)
+	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName, kubeconfigAccountID); err != nil {
 		var mismatch *clients.AccountMismatchError
 		if errors.As(err, &mismatch) {
 			return err

--- a/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
@@ -18,7 +18,6 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	karpawsv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/fatih/color"
 	"github.com/samber/lo"
@@ -135,6 +134,16 @@ func (o *options) run(cmd *cobra.Command) error {
 	cli, err := clients.Build(ctx, o.ConfigFlags, o.Clientset)
 	if err != nil {
 		return fmt.Errorf("failed to build clients: %w", err)
+	}
+
+	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName); err != nil {
+		var mismatch *clients.AccountMismatchError
+		if errors.As(err, &mismatch) {
+			return err
+		}
+		// The cluster may already be deleted or DescribeCluster may be
+		// unavailable; warn but proceed with cleanup.
+		log.Printf("Warning: AWS account consistency check failed: %v", err)
 	}
 
 	nodePoolNames, nodes := displayResourceSummary(ctx, cmd, cli, clusterName)
@@ -490,15 +499,10 @@ func removeAwsAuthConfigMapRole(ctx context.Context, cli *clients.Clients, clust
 		return nil
 	}
 
-	// Get AWS account ID
-	callerIdentity, err := cli.STS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	accountID, err := clients.GetAWSAccountID(ctx, cli)
 	if err != nil {
-		return fmt.Errorf("failed to get identity caller: %w", err)
+		return err
 	}
-	if callerIdentity.Account == nil {
-		return errors.New("unable to determine AWS account ID from STS GetCallerIdentity")
-	}
-	accountID := *callerIdentity.Account
 
 	roleArn := "arn:aws:iam::" + accountID + ":role/KarpenterNodeRole-" + clusterName
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/uninstall/uninstall.go
@@ -136,8 +136,7 @@ func (o *options) run(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to build clients: %w", err)
 	}
 
-	kubeconfigAccountID := clients.GetAccountIDFromKubeconfig(o.ConfigFlags)
-	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName, kubeconfigAccountID); err != nil {
+	if err = clients.ValidateAWSAccountConsistency(ctx, cli, clusterName, o.ConfigFlags); err != nil {
 		var mismatch *clients.AccountMismatchError
 		if errors.As(err, &mismatch) {
 			return err


### PR DESCRIPTION
### What does this PR do?

Adds a guard to verify that the AWS credentials being used belong to the same AWS account as the target EKS cluster before any `kubectl datadog autoscaling cluster` operations (install/uninstall). This prevents accidentally creating CloudFormation stacks in one AWS account while deploying Helm charts to an EKS cluster in another.

### Motivation

The install and uninstall commands create both AWS resources (CloudFormation stacks, IAM roles) and Kubernetes resources (Helm chart, Karpenter CRDs). The AWS clients are configured from the default AWS credential chain, while the Kubernetes clients come from kubeconfig. Without validation, a misconfigured environment could silently target different AWS accounts for each.

### Additional Notes

- **Install path**: Validation is a hard error — the cluster must exist and accounts must match.
- **Uninstall path**: A confirmed mismatch is a hard error, but if the cluster cannot be described (e.g. already deleted), it logs a warning and proceeds with cleanup.
- Also extracts a shared `GetAWSAccountID` helper to deduplicate the `STS.GetCallerIdentity` boilerplate that was repeated in install and uninstall.
- Introduces `AccountMismatchError` typed error so the uninstall flow can distinguish "confirmed mismatch" from "cannot verify".

### Minimum Agent Versions

N/A — this is a `kubectl-datadog` plugin change, not an agent change.

### Describe your test plan

- Unit tests added for the `validateAccountIDs` pure logic covering: matching accounts, mismatched accounts, GovCloud/China partitions, and invalid ARN format.
- `go build ./cmd/kubectl-datadog/...` passes.
- `go test ./cmd/kubectl-datadog/autoscaling/cluster/common/clients/...` passes.
- `go vet ./cmd/kubectl-datadog/...` passes.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)