### PR TITLE
Fix AppArmor annotations for absent containers in annotation overrides

### DIFF
--- a/internal/controller/datadogagent/override/container.go
+++ b/internal/controller/datadogagent/override/container.go
@@ -242,15 +242,7 @@ func overrideAppArmorProfile(containerName apicommon.AgentContainerName, manager
 		// Only add the AppArmor annotation if the container actually exists in the pod spec.
 		// This avoids invalid DaemonSet configurations when a container is not present
 		// (e.g. security-agent is absent when directSendFromSystemProbe is enabled).
-		containerExists := false
-		allContainers := append(manager.PodTemplateSpec().Spec.Containers, manager.PodTemplateSpec().Spec.InitContainers...)
-		for _, c := range allContainers {
-			if c.Name == effectiveName {
-				containerExists = true
-				break
-			}
-		}
-		if !containerExists {
+		if !podSpecHasContainer(&manager.PodTemplateSpec().Spec, effectiveName) {
 			return
 		}
 

--- a/internal/controller/datadogagent/override/podtemplatespec.go
+++ b/internal/controller/datadogagent/override/podtemplatespec.go
@@ -193,6 +193,22 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 	manager.PodTemplateSpec().Spec.Tolerations = append(manager.PodTemplateSpec().Spec.Tolerations, override.Tolerations...)
 
 	for annotationName, annotationVal := range override.Annotations {
+		// For AppArmor annotations, skip if the referenced container doesn't exist.
+		// This mirrors the check in overrideAppArmorProfile() and prevents invalid DaemonSet
+		// configurations when a container is absent (e.g. security-agent with directSendFromSystemProbe).
+		if containerName, ok := strings.CutPrefix(annotationName, common.AppArmorAnnotationKey+"/"); ok {
+			allContainers := append(manager.PodTemplateSpec().Spec.Containers, manager.PodTemplateSpec().Spec.InitContainers...)
+			containerExists := false
+			for _, c := range allContainers {
+				if c.Name == containerName {
+					containerExists = true
+					break
+				}
+			}
+			if !containerExists {
+				continue
+			}
+		}
 		manager.Annotation().AddAnnotation(annotationName, annotationVal)
 	}
 

--- a/internal/controller/datadogagent/override/podtemplatespec.go
+++ b/internal/controller/datadogagent/override/podtemplatespec.go
@@ -197,15 +197,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		// This mirrors the check in overrideAppArmorProfile() and prevents invalid DaemonSet
 		// configurations when a container is absent (e.g. security-agent with directSendFromSystemProbe).
 		if containerName, ok := strings.CutPrefix(annotationName, common.AppArmorAnnotationKey+"/"); ok {
-			allContainers := append(manager.PodTemplateSpec().Spec.Containers, manager.PodTemplateSpec().Spec.InitContainers...)
-			containerExists := false
-			for _, c := range allContainers {
-				if c.Name == containerName {
-					containerExists = true
-					break
-				}
-			}
-			if !containerExists {
+			if !podSpecHasContainer(&manager.PodTemplateSpec().Spec, containerName) {
 				continue
 			}
 		}
@@ -276,6 +268,14 @@ func overrideCustomConfigVolumes(logger logr.Logger, manager feature.PodTemplate
 		annotationKey := object.GetChecksumAnnotationKey(string(fileName))
 		manager.Annotation().AddAnnotation(annotationKey, hash)
 	}
+}
+
+// podSpecHasContainer reports whether the pod spec contains a (init)container with the given name.
+func podSpecHasContainer(podSpec *corev1.PodSpec, name string) bool {
+	allContainers := append(podSpec.Containers, podSpec.InitContainers...)
+	return slices.ContainsFunc(allContainers, func(c corev1.Container) bool {
+		return c.Name == name
+	})
 }
 
 func sortKeys(keysMap map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig) []v2alpha1.AgentConfigFileName {

--- a/internal/controller/datadogagent/override/podtemplatespec_test.go
+++ b/internal/controller/datadogagent/override/podtemplatespec_test.go
@@ -1037,6 +1037,59 @@ func TestPodTemplateSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "AppArmor annotation in override.Annotations for existing container is added",
+			existingManager: func() *fake.PodTemplateManagers {
+				manager := fake.NewPodTemplateManagers(t, v1.PodTemplateSpec{})
+				manager.PodTemplateSpec().Spec.Containers = []v1.Container{
+					{Name: string(apicommon.CoreAgentContainerName)},
+				}
+				return manager
+			},
+			override: v2alpha1.DatadogAgentComponentOverride{
+				Annotations: map[string]string{
+					fmt.Sprintf("%s/%s", common.AppArmorAnnotationKey, apicommon.CoreAgentContainerName): "runtime/default",
+				},
+			},
+			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers) {
+				annotation := fmt.Sprintf("%s/%s", common.AppArmorAnnotationKey, apicommon.CoreAgentContainerName)
+				assert.Equal(t, "runtime/default", manager.AnnotationMgr.Annotations[annotation])
+			},
+		},
+		{
+			name: "AppArmor annotation in override.Annotations for absent container is skipped",
+			existingManager: func() *fake.PodTemplateManagers {
+				manager := fake.NewPodTemplateManagers(t, v1.PodTemplateSpec{})
+				manager.PodTemplateSpec().Spec.Containers = []v1.Container{
+					{Name: string(apicommon.CoreAgentContainerName)},
+				}
+				return manager
+			},
+			override: v2alpha1.DatadogAgentComponentOverride{
+				Annotations: map[string]string{
+					fmt.Sprintf("%s/%s", common.AppArmorAnnotationKey, apicommon.SecurityAgentContainerName): "runtime/default",
+				},
+			},
+			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers) {
+				annotation := fmt.Sprintf("%s/%s", common.AppArmorAnnotationKey, apicommon.SecurityAgentContainerName)
+				_, found := manager.AnnotationMgr.Annotations[annotation]
+				assert.False(t, found, "AppArmor annotation for absent container should not be added")
+			},
+		},
+		{
+			name: "non-AppArmor annotation in override.Annotations is always added",
+			existingManager: func() *fake.PodTemplateManagers {
+				return fake.NewPodTemplateManagers(t, v1.PodTemplateSpec{})
+			},
+			override: v2alpha1.DatadogAgentComponentOverride{
+				Annotations: map[string]string{
+					"some-other-annotation": "value",
+				},
+			},
+			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers) {
+				assert.Equal(t, "value", manager.AnnotationMgr.Annotations["some-other-annotation"])
+			},
+		},
+		{
 			name: "Add CEL Workload Exclude",
 			existingManager: func() *fake.PodTemplateManagers {
 				manager := fake.NewPodTemplateManagers(t, v1.PodTemplateSpec{})


### PR DESCRIPTION
…verrides

The fix in a0dc8c07 added a container existence check to overrideAppArmorProfile(), preventing invalid AppArmor annotations when a container (e.g. security-agent with directSendFromSystemProbe=true) is absent from the pod spec.

However, the same guard was missing from the direct annotation loop in PodTemplateSpec(), which blindly copies spec.override.nodeAgent.annotations to the pod template. Any AppArmor annotation set via that path would bypass the existing fix and still produce an invalid DaemonSet.

Apply the same container existence check when iterating override.Annotations: skip AppArmor annotations (container.apparmor.security.beta.kubernetes.io/<name>) if <name> does not match any container in the pod spec.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits