### PR TITLE
[CONTP-1547] Push rc-latest mutable image tags from Operator GitLab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -610,22 +610,12 @@ trigger_internal_operator_image:
     RELEASE_PROD: "true"
 
 trigger_internal_operator_image_fips:
-  stage: release
-  rules:
-    - if: $CI_COMMIT_TAG
-    - when: never
-  trigger:
-    project: DataDog/images
-    branch: master
-    strategy: depend
+  extends: trigger_internal_operator_image
   variables:
     IMAGE_VERSION: tmpl-v2-fips
-    IMAGE_NAME: $PROJECTNAME
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-fips
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-fips
-    RELEASE_STAGING: "true"
-    RELEASE_PROD: "true"
 
 trigger_internal_operator_check_image:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -639,7 +639,6 @@ trigger_internal_operator_image_rc_latest:
   stage: release-latest
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
-      when: manual
     - when: never
   trigger:
     project: DataDog/images

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -645,6 +645,33 @@ trigger_internal_operator_check_image:
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
 
+trigger_internal_operator_image_rc_latest:
+  stage: release-latest
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
+      when: manual
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v2
+    IMAGE_NAME: $PROJECTNAME
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: rc-latest
+    BUILD_TAG: rc-latest
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"
+
+trigger_internal_operator_image_fips_rc_latest:
+  extends: trigger_internal_operator_image_rc_latest
+  variables:
+    IMAGE_VERSION: tmpl-v2-fips
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
+    RELEASE_TAG: rc-latest-fips
+    BUILD_TAG: rc-latest-fips
+
 trigger_internal_operator_nightly_image:
   stage: release
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -530,6 +530,9 @@ publish_redhat_public_tag:
 publish_public_latest:
   stage: release-latest
   rules:
+    # Skip latest jobs for vX.Y.Z-rc.W tags
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
+      when: never
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -552,6 +552,28 @@ publish_public_latest_fips:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
     IMG_DESTINATIONS: operator:latest-fips
 
+publish_public_rc_latest:
+  stage: release-latest
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
+      when: manual
+    - when: never
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
+    IMG_DESTINATIONS: operator:rc-latest
+    IMG_SIGNING: "false"
+    IMG_MERGE_STRATEGY: "index_oci"
+
+publish_public_rc_latest_fips:
+  extends: publish_public_rc_latest
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
+    IMG_DESTINATIONS: operator:rc-latest-fips
+
 publish_redhat_public_latest:
   stage: release-latest
   rules:


### PR DESCRIPTION
### What does this PR do?

Updates the GitLab CI pipeline to push `rc-latest` mutable image tags alongside each `vX.Y.Z-rc.W` RC release, and prevents RC tags from accidentally updating the `latest` mutable tag.

#### Commit breakdown

- 58be0e6d7 **Directly skip release-latest jobs for RC tags** — Adds a `when: never` guard as the first rule of `publish_public_latest` (inherited by `publish_public_latest_fips` via `extends`) so that RC tags (`vX.Y.Z-rc.W`) no longer trigger the `operator:latest` / `operator:latest-fips` publish jobs. Previously nothing prevented a manually triggered `publish_public_latest` from promoting an RC to `latest`.

- abbc2dcfb **Add public rc-latest tag for RCs** — Adds `publish_public_rc_latest` and `publish_public_rc_latest_fips` jobs in the `release-latest` stage. They trigger `DataDog/public-images` to push `operator:rc-latest` and `operator:rc-latest-fips` to DockerHub, activated only on RC tags, as manual jobs consistent with the other release publish jobs.

- c9ad0d68a **Add internal rc-latest tag for RCs** — Adds `trigger_internal_operator_image_rc_latest` and `trigger_internal_operator_image_fips_rc_latest` jobs in the `release-latest` stage. They trigger `DataDog/images` with `RELEASE_TAG: rc-latest` / `rc-latest-fips` so the internal registry also receives the mutable RC tag automatically (consistent with `trigger_internal_operator_image` which also runs automatically on tags). The FIPS variant uses `extends` following the established pattern.

- 6315c3243 **Extends FIPS internal job instead of fully re-defining it** — Refactors the pre-existing `trigger_internal_operator_image_fips` to use `extends: trigger_internal_operator_image`, overriding only the four FIPS-specific variables (`IMAGE_VERSION`, `TMPL_SRC_IMAGE`, `RELEASE_TAG`, `BUILD_TAG`). This is consistent with how all other FIPS variants (`publish_public_tag_fips`, `publish_public_latest_fips`, etc.) are defined.

- da6f83a25 **Make internal rc-latest image jobs automatic** — Removes the `when: manual` from `trigger_internal_operator_image_rc_latest` (inherited by its FIPS variant via `extends`) to match the behaviour of the existing internal image jobs, which run automatically on tags. Only the public publish jobs are manual.

### Motivation

Part of [CONTP-1547](https://datadoghq.atlassian.net/browse/CONTP-1547) — Phase 0 of the Operator Release Transfer to Agent Delivery initiative. Currently, each RC release requires a manual PR to `image-vuln-scans` to bump the scanned version. By pushing a mutable `rc-latest` tag, the vulnerability scanning pipeline can always read the latest RC image automatically.

### Additional Notes

Steps 3 and 4 of CONTP-1547 (updating `image-vuln-scans` and verifying the scan pipeline) will be handled separately.

### Minimum Agent Versions

N/A — pipeline-only change.

### Describe your test plan

Verify on the next RC release (`vX.Y.Z-rc.W` tag) that:
- `publish_public_rc_latest` and `publish_public_rc_latest_fips` appear as manual jobs in the `release-latest` stage
- `trigger_internal_operator_image_rc_latest` and `trigger_internal_operator_image_fips_rc_latest` run automatically in the `release-latest` stage
- `publish_public_latest` and `publish_public_latest_fips` do **not** appear (skipped by the new `when: never` rule)

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits