### PR TITLE
Add SBOMEnabled field to CWSFeatureConfig for "package in use" feature

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -509,6 +509,13 @@ type CWSFeatureConfig struct {
 	// +optional
 	DirectSendFromSystemProbe *bool `json:"directSendFromSystemProbe,omitempty"`
 
+	// Enables the SBOM resolver to track runtime package usage.
+	// When enabled, system-probe maps file accesses to packages and enriches
+	// SBOMs with LastSeenRunning timestamps ("package in use" feature).
+	// Default: false
+	// +optional
+	SBOMEnabled *bool `json:"sbomEnabled,omitempty"`
+
 	Enforcement         *CWSEnforcementConfig         `json:"enforcement,omitempty"`
 	Network             *CWSNetworkConfig             `json:"network,omitempty"`
 	SecurityProfiles    *CWSSecurityProfilesConfig    `json:"securityProfiles,omitempty"`

--- a/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
+++ b/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
@@ -560,6 +560,11 @@ func (in *CWSFeatureConfig) DeepCopyInto(out *CWSFeatureConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SBOMEnabled != nil {
+		in, out := &in.SBOMEnabled, &out.SBOMEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Enforcement != nil {
 		in, out := &in.Enforcement, &out.Enforcement
 		*out = new(CWSEnforcementConfig)

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -1374,6 +1374,13 @@ spec:
                                 Default: true
                               type: boolean
                           type: object
+                        sbomEnabled:
+                          description: |-
+                            Enables the SBOM resolver to track runtime package usage.
+                            When enabled, system-probe maps file accesses to packages and enriches
+                            SBOMs with LastSeenRunning timestamps ("package in use" feature).
+                            Default: false
+                          type: boolean
                         securityProfiles:
                           properties:
                             enabled:
@@ -9806,6 +9813,13 @@ spec:
                                     Default: true
                                   type: boolean
                               type: object
+                            sbomEnabled:
+                              description: |-
+                                Enables the SBOM resolver to track runtime package usage.
+                                When enabled, system-probe maps file accesses to packages and enriches
+                                SBOMs with LastSeenRunning timestamps ("package in use" feature).
+                                Default: false
+                              type: boolean
                             securityProfiles:
                               properties:
                                 enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -1369,6 +1369,10 @@
                   },
                   "type": "object"
                 },
+                "sbomEnabled": {
+                  "description": "Enables the SBOM resolver to track runtime package usage.\nWhen enabled, system-probe maps file accesses to packages and enriches\nSBOMs with LastSeenRunning timestamps (\"package in use\" feature).\nDefault: false",
+                  "type": "boolean"
+                },
                 "securityProfiles": {
                   "additionalProperties": false,
                   "properties": {
@@ -9537,6 +9541,10 @@
                         }
                       },
                       "type": "object"
+                    },
+                    "sbomEnabled": {
+                      "description": "Enables the SBOM resolver to track runtime package usage.\nWhen enabled, system-probe maps file accesses to packages and enriches\nSBOMs with LastSeenRunning timestamps (\"package in use\" feature).\nDefault: false",
+                      "type": "boolean"
                     },
                     "securityProfiles": {
                       "additionalProperties": false,

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -1374,6 +1374,13 @@ spec:
                                     Default: true
                                   type: boolean
                               type: object
+                            sbomEnabled:
+                              description: |-
+                                Enables the SBOM resolver to track runtime package usage.
+                                When enabled, system-probe maps file accesses to packages and enriches
+                                SBOMs with LastSeenRunning timestamps ("package in use" feature).
+                                Default: false
+                              type: boolean
                             securityProfiles:
                               properties:
                                 enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -1373,6 +1373,10 @@
                       },
                       "type": "object"
                     },
+                    "sbomEnabled": {
+                      "description": "Enables the SBOM resolver to track runtime package usage.\nWhen enabled, system-probe maps file accesses to packages and enriches\nSBOMs with LastSeenRunning timestamps (\"package in use\" feature).\nDefault: false",
+                      "type": "boolean"
+                    },
                     "securityProfiles": {
                       "additionalProperties": false,
                       "properties": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1378,6 +1378,13 @@ spec:
                                 Default: true
                               type: boolean
                           type: object
+                        sbomEnabled:
+                          description: |-
+                            Enables the SBOM resolver to track runtime package usage.
+                            When enabled, system-probe maps file accesses to packages and enriches
+                            SBOMs with LastSeenRunning timestamps ("package in use" feature).
+                            Default: false
+                          type: boolean
                         securityProfiles:
                           properties:
                             enabled:
@@ -9886,6 +9893,13 @@ spec:
                                     Default: true
                                   type: boolean
                               type: object
+                            sbomEnabled:
+                              description: |-
+                                Enables the SBOM resolver to track runtime package usage.
+                                When enabled, system-probe maps file accesses to packages and enriches
+                                SBOMs with LastSeenRunning timestamps ("package in use" feature).
+                                Default: false
+                              type: boolean
                             securityProfiles:
                               properties:
                                 enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1369,6 +1369,10 @@
                   },
                   "type": "object"
                 },
+                "sbomEnabled": {
+                  "description": "Enables the SBOM resolver to track runtime package usage.\nWhen enabled, system-probe maps file accesses to packages and enriches\nSBOMs with LastSeenRunning timestamps (\"package in use\" feature).\nDefault: false",
+                  "type": "boolean"
+                },
                 "securityProfiles": {
                   "additionalProperties": false,
                   "properties": {
@@ -9630,6 +9634,10 @@
                         }
                       },
                       "type": "object"
+                    },
+                    "sbomEnabled": {
+                      "description": "Enables the SBOM resolver to track runtime package usage.\nWhen enabled, system-probe maps file accesses to packages and enriches\nSBOMs with LastSeenRunning timestamps (\"package in use\" feature).\nDefault: false",
+                      "type": "boolean"
                     },
                     "securityProfiles": {
                       "additionalProperties": false,

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -98,6 +98,7 @@ spec:
 | features.cws.enforcement.enabled | Enables Enforcement for Cloud Workload Security. Default: true |
 | features.cws.network.enabled | Enables Cloud Workload Security Network detections. Default: true |
 | features.cws.remoteConfiguration.enabled | Enables Remote Configuration for Cloud Workload Security. Default: true |
+| features.cws.sbomEnabled | Enables the SBOM resolver to track runtime package usage. When enabled, system-probe maps file accesses to packages and enriches SBOMs with LastSeenRunning timestamps ("package in use" feature). Default: false |
 | features.cws.securityProfiles.enabled | Enables Security Profiles collection for Cloud Workload Security. Default: true |
 | features.cws.syscallMonitorEnabled | SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only). Default: false |
 | features.dataPlane.dogstatsd.enabled | Configures the Data Plane to handle DogStatsD traffic. When enabled, DogStatsD is disabled in the Core Agent. Default: false |

--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -159,6 +159,9 @@ spec:
 `features.cws.remoteConfiguration.enabled`
 : Enables Remote Configuration for Cloud Workload Security. Default: true
 
+`features.cws.sbomEnabled`
+: Enables the SBOM resolver to track runtime package usage. When enabled, system-probe maps file accesses to packages and enriches SBOMs with LastSeenRunning timestamps ("package in use" feature). Default: false
+
 `features.cws.securityProfiles.enabled`
 : Enables Security Profiles collection for Cloud Workload Security. Default: true
 

--- a/internal/controller/datadogagent/feature/cws/envvar.go
+++ b/internal/controller/datadogagent/feature/cws/envvar.go
@@ -16,4 +16,5 @@ const (
 	DDRuntimeSecurityConfigRemoteConfigurationEnabled = "DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED"
 	DDRuntimeSecurityConfigDirectSendFromSystemProbe  = "DD_RUNTIME_SECURITY_CONFIG_DIRECT_SEND_FROM_SYSTEM_PROBE"
 	DDRuntimeSecurityConfigEventGRPCServer            = "DD_RUNTIME_SECURITY_CONFIG_EVENT_GRPC_SERVER"
+	DDRuntimeSecurityConfigSBOMEnabled                = "DD_RUNTIME_SECURITY_CONFIG_SBOM_ENABLED"
 )

--- a/internal/controller/datadogagent/feature/cws/feature.go
+++ b/internal/controller/datadogagent/feature/cws/feature.go
@@ -51,6 +51,7 @@ type cwsFeature struct {
 	remoteConfigurationEnabled bool
 	directSendFromSystemProbe  bool
 	enforcementEnabled         bool
+	sbomEnabled                bool
 	useVSock                   bool
 
 	owner  metav1.Object
@@ -92,6 +93,8 @@ func (f *cwsFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.CWSIDType)
 		}
 		f.configMapName = constants.GetConfName(dda, f.customConfig, defaultCWSConf)
+
+		f.sbomEnabled = apiutils.BoolValue(cwsConfig.SBOMEnabled)
 
 		if cwsConfig.Enforcement != nil {
 			f.enforcementEnabled = apiutils.BoolValue(cwsConfig.Enforcement.Enabled)
@@ -276,6 +279,20 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 			Value: "true",
 		}
 		managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, rcEnvVar)
+	}
+
+	if f.sbomEnabled {
+		sbomEnvVar := &corev1.EnvVar{
+			Name:  DDRuntimeSecurityConfigSBOMEnabled,
+			Value: "true",
+		}
+		managers.EnvVar().AddEnvVarToContainers(
+			[]apicommon.AgentContainerName{
+				apicommon.SystemProbeContainerName,
+				apicommon.CoreAgentContainerName,
+			},
+			sbomEnvVar,
+		)
 	}
 
 	policiesDirEnvVar := &corev1.EnvVar{

--- a/internal/controller/datadogagent/feature/cws/feature_test.go
+++ b/internal/controller/datadogagent/feature/cws/feature_test.go
@@ -93,6 +93,11 @@ func Test_cwsFeature_Configure(t *testing.T) {
 		ddaCWSLiteEnforcementEnabled.Spec.Features.CWS.Enforcement.Enabled = ptr.To(true)
 	}
 
+	ddaCWSSBOMEnabled := ddaCWSLiteEnabled.DeepCopy()
+	{
+		ddaCWSSBOMEnabled.Spec.Features.CWS.SBOMEnabled = ptr.To(true)
+	}
+
 	tests := test.FeatureTestSuite{
 		{
 			Name:          "v2alpha1 CWS not enabled",
@@ -103,32 +108,38 @@ func Test_cwsFeature_Configure(t *testing.T) {
 			Name:          "v2alpha1 CWS enabled",
 			DDA:           ddaCWSLiteEnabled,
 			WantConfigure: true,
-			Agent:         cwsAgentNodeWantFunc(false, false, false),
+			Agent:         cwsAgentNodeWantFunc(false, false, false, false),
 		},
 		{
 			Name:          "v2alpha1 CWS enabled (with network, security profiles and remote configuration)",
 			DDA:           ddaCWSFullEnabled,
 			WantConfigure: true,
-			Agent:         cwsAgentNodeWantFunc(true, false, false),
+			Agent:         cwsAgentNodeWantFunc(true, false, false, false),
 		},
 		{
 			Name:          "v2alpha1 CWS enabled in direct sender mode",
 			DDA:           ddaCWSLiteDirectSendEnabled,
 			WantConfigure: true,
-			Agent:         cwsAgentNodeWantFunc(false, true, false),
+			Agent:         cwsAgentNodeWantFunc(false, true, false, false),
 		},
 		{
 			Name:          "v2alpha1 CWS enabled with enforcement",
 			DDA:           ddaCWSLiteEnforcementEnabled,
 			WantConfigure: true,
-			Agent:         cwsAgentNodeWantFunc(false, false, true),
+			Agent:         cwsAgentNodeWantFunc(false, false, true, false),
+		},
+		{
+			Name:          "v2alpha1 CWS enabled with SBOM",
+			DDA:           ddaCWSSBOMEnabled,
+			WantConfigure: true,
+			Agent:         cwsAgentNodeWantFunc(false, false, false, true),
 		},
 	}
 
 	tests.Run(t, buildCWSFeature)
 }
 
-func cwsAgentNodeWantFunc(withSubFeatures bool, directSendFromSysProbe bool, enforcementEnabled bool) *test.ComponentTest {
+func cwsAgentNodeWantFunc(withSubFeatures bool, directSendFromSysProbe bool, enforcementEnabled bool, sbomEnabled bool) *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -196,6 +207,15 @@ func cwsAgentNodeWantFunc(withSubFeatures bool, directSendFromSysProbe bool, enf
 					},
 				)
 			}
+			if sbomEnabled {
+				sysProbeWant = append(
+					sysProbeWant,
+					&corev1.EnvVar{
+						Name:  DDRuntimeSecurityConfigSBOMEnabled,
+						Value: "true",
+					},
+				)
+			}
 			sysProbeWant = append(
 				sysProbeWant,
 				&corev1.EnvVar{
@@ -212,6 +232,29 @@ func cwsAgentNodeWantFunc(withSubFeatures bool, directSendFromSysProbe bool, enf
 			}
 			sysProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
 			assert.True(t, apiutils.IsEqualStruct(sysProbeEnvVars, sysProbeWant), "System probe envvars \ndiff = %s", cmp.Diff(sysProbeEnvVars, sysProbeWant))
+
+			coreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+			if sbomEnabled {
+				coreAgentSBOMWant := []*corev1.EnvVar{
+					{
+						Name:  DDRuntimeSecurityConfigEnabled,
+						Value: "true",
+					},
+					{
+						Name:  DDRuntimeSecurityConfigSocket,
+						Value: "/var/run/sysprobe/runtime-security.sock",
+					},
+					{
+						Name:  DDRuntimeSecurityConfigSyscallMonitorEnabled,
+						Value: "true",
+					},
+					{
+						Name:  DDRuntimeSecurityConfigSBOMEnabled,
+						Value: "true",
+					},
+				}
+				assert.True(t, apiutils.IsEqualStruct(coreAgentEnvVars, coreAgentSBOMWant), "Core agent envvars \ndiff = %s", cmp.Diff(coreAgentEnvVars, coreAgentSBOMWant))
+			}
 
 			// check volume mounts
 			securityWantVolumeMount := []corev1.VolumeMount{


### PR DESCRIPTION
### What does this PR do?

Adds spec.features.cws.sbomEnabled to the DatadogAgent CRD, enabling the CWS SBOM resolver to track runtime package usage. When enabled, system-probe maps file accesses to packages and enriches SBOMs with LastSeenRunning timestamps. The env var DD_RUNTIME_SECURITY_CONFIG_SBOM_ENABLED is set on both system-probe and core agent containers.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.78.0

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits