### PR TITLE
chore: transfer dataplane feature ownership to agent-data-plane team

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -18,6 +18,14 @@ github_team = "agent-metric-pipelines"
 github_labels = ["team/agent-metric-pipelines"]
 exclude_members = [""]
 
+[teams."Agent Data Plane"]
+jira_project = "DADP"
+jira_issue_type = "Task"
+jira_statuses = ["To Do", "In Progress", "Done"]
+github_team = "agent-data-plane"
+github_labels = ["team/agent-data-plane"]
+exclude_members = [""]
+
 [teams."Agent Runtimes"]
 jira_project = "AGENTRUN"
 jira_issue_type = "QA"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@ README.md               @DataDog/documentation  @DataDog/container-platform
 /internal/controller/datadogagent/feature/controlplanemonitoring    @DataDog/container-integrations @DataDog/container-platform
 /internal/controller/datadogagent/feature/cspm                      @DataDog/agent-security         @DataDog/container-platform
 /internal/controller/datadogagent/feature/cws                       @DataDog/agent-security         @DataDog/container-platform
-/internal/controller/datadogagent/feature/dataplane                 @DataDog/agent-metric-pipelines @DataDog/container-platform
+/internal/controller/datadogagent/feature/dataplane                 @DataDog/agent-data-plane       @DataDog/container-platform
 /internal/controller/datadogagent/feature/dogstatsd                 @DataDog/agent-metric-pipelines @DataDog/container-platform
 /internal/controller/datadogagent/feature/dummy                     @DataDog/container-platform
 /internal/controller/datadogagent/feature/ebpfcheck                 @DataDog/ebpf-platform          @DataDog/container-platform


### PR DESCRIPTION
## Summary
- Transfer `/internal/controller/datadogagent/feature/dataplane` CODEOWNERS from `@DataDog/agent-metric-pipelines` to the new `@DataDog/agent-data-plane` team.
- The dogstatsd feature entry (`/internal/controller/datadogagent/feature/dogstatsd`) remains owned by `@DataDog/agent-metric-pipelines`.
- Register `[teams."Agent Data Plane"]` in `.ddqa/config.toml` (jira project `DADP`, label `team/agent-data-plane`).

## Test plan
- [x] CODEOWNERS syntax check passes
- [x] TOML syntax is valid
- [x] GitHub recognizes `@DataDog/agent-data-plane` as a reviewer for dataplane changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)