### PR TITLE
fix(experiment): propagate fresh ResourceVersion after spec rollback

### DIFF
--- a/internal/controller/datadogagent/controller_experiment_integration_test.go
+++ b/internal/controller/datadogagent/controller_experiment_integration_test.go
@@ -182,6 +182,16 @@ func Test_Experiment_RollbackDoesNotClobberConcurrentPhaseWrite(t *testing.T) {
 	concurrent.Status.Experiment.Phase = v2alpha1.ExperimentPhasePromoted
 	assert.NoError(t, r.client.Status().Update(context.TODO(), concurrent))
 
+	// Identify the experiment revision for later annotation assertions.
+	var experimentRevName string
+	maxRev := int64(0)
+	for _, rev := range listOwnedRevisions(t, r.client, ns, uid) {
+		if rev.Revision > maxRev {
+			maxRev = rev.Revision
+			experimentRevName = rev.Name
+		}
+	}
+
 	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: snapshot.Status.Experiment.DeepCopy()}
 	revisions := mustListRevisions(t, r, snapshot)
 	assert.NoError(t, r.restorePreviousSpec(context.TODO(), snapshot, newStatus, revisions, v2alpha1.ExperimentPhaseRollback))
@@ -192,6 +202,20 @@ func Test_Experiment_RollbackDoesNotClobberConcurrentPhaseWrite(t *testing.T) {
 	assert.NoError(t, r.client.Get(context.TODO(), nsName, after))
 	assert.Equal(t, v2alpha1.ExperimentPhasePromoted, after.Status.Experiment.Phase,
 		"concurrent phase write must not be overwritten by a stale targeted patch")
+
+	// The rollback annotation must still have landed on the experiment
+	// revision. Annotation is unconditional — it is NOT gated on the phase
+	// patch succeeding — so even when the test op rejects our stale phase
+	// decision, the annotation protects a future re-apply of the same spec
+	// from the stale CreationTimestamp path.
+	var annotated bool
+	for _, rev := range listOwnedRevisions(t, r.client, ns, uid) {
+		if rev.Name == experimentRevName && rev.Annotations[annotationExperimentRollback] == "true" {
+			annotated = true
+		}
+	}
+	assert.True(t, annotated,
+		"experiment revision must be annotated regardless of phase-patch outcome")
 }
 
 // Test_Experiment_StoppedRollback verifies that when RC writes phase=stopped,

--- a/internal/controller/datadogagent/controller_experiment_integration_test.go
+++ b/internal/controller/datadogagent/controller_experiment_integration_test.go
@@ -56,6 +56,46 @@ func reconcileN(t *testing.T, r *Reconciler, ns, name string, n int) {
 	}
 }
 
+// Test_Experiment_RollbackPersistsInSingleReconcile verifies that the spec
+// rollback and the terminal phase write both land in the same reconcile —
+// i.e. the status update uses the post-rollback ResourceVersion rather than
+// 409'ing and deferring the phase write. Regression guard: without
+// ResourceVersion propagation, reconcile 2 could observe a post-rollback spec
+// matching an annotated, freshly-timestamped revision and skip the timeout
+// check, leaving phase=running.
+func Test_Experiment_RollbackPersistsInSingleReconcile(t *testing.T) {
+	const ns, name = "default", "test-dda"
+	const uid = types.UID("uid-1")
+	const timeout = 50 * time.Millisecond
+	nsName := types.NamespacedName{Namespace: ns, Name: name}
+
+	r := newExperimentIntegrationReconciler(t, timeout)
+
+	dda := baseDDA(ns, name, uid)
+	createAndReconcile(t, r, dda)
+
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
+	dda.Spec.Global.Site = ptr.To("datadoghq.eu")
+	assert.NoError(t, r.client.Update(context.TODO(), dda))
+	reconcileN(t, r, ns, name, 1)
+
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
+	dda.Status.Experiment = &v2alpha1.ExperimentStatus{
+		Phase: v2alpha1.ExperimentPhaseRunning,
+		ID:    "exp-1",
+	}
+	assert.NoError(t, r.client.Status().Update(context.TODO(), dda))
+	time.Sleep(2 * timeout)
+
+	// Exactly one reconcile — both spec rollback and phase=timeout must persist.
+	reconcileN(t, r, ns, name, 1)
+
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
+	assert.Equal(t, "datadoghq.com", *dda.Spec.Global.Site, "spec must be rolled back in the same reconcile")
+	assert.NotNil(t, dda.Status.Experiment)
+	assert.Equal(t, v2alpha1.ExperimentPhaseTimeout, dda.Status.Experiment.Phase, "phase=timeout must persist in the same reconcile as the rollback")
+}
+
 // Test_Experiment_StoppedRollback verifies that when RC writes phase=stopped,
 // the operator restores the previous spec and sets phase=rollback.
 func Test_Experiment_StoppedRollback(t *testing.T) {

--- a/internal/controller/datadogagent/controller_experiment_integration_test.go
+++ b/internal/controller/datadogagent/controller_experiment_integration_test.go
@@ -146,6 +146,54 @@ func Test_Experiment_RollbackPreservesConcurrentStatusWrite(t *testing.T) {
 	assert.Equal(t, v2alpha1.ExperimentPhaseRollback, after.Status.Experiment.Phase)
 }
 
+// Test_Experiment_RollbackDoesNotClobberConcurrentPhaseWrite verifies that
+// when a concurrent writer (e.g. the RC daemon accepting a promotion) has
+// moved `status.experiment.phase` between the reconcile's initial fetch and
+// the restorePreviousSpec patch, the targeted JSON patch's `test` op fails
+// and the concurrent phase is left intact — rather than silently overwritten
+// by our stale terminal-phase decision.
+func Test_Experiment_RollbackDoesNotClobberConcurrentPhaseWrite(t *testing.T) {
+	const ns, name = "default", "test-dda"
+	const uid = types.UID("uid-1")
+	nsName := types.NamespacedName{Namespace: ns, Name: name}
+
+	r := newExperimentIntegrationReconciler(t, 0)
+
+	dda := baseDDA(ns, name, uid)
+	createAndReconcile(t, r, dda)
+
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
+	dda.Spec.Global.Site = ptr.To("datadoghq.eu")
+	assert.NoError(t, r.client.Update(context.TODO(), dda))
+	reconcileN(t, r, ns, name, 1)
+
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
+	dda.Status.Experiment = &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseStopped, ID: "exp-1"}
+	assert.NoError(t, r.client.Status().Update(context.TODO(), dda))
+
+	// Snapshot the observed state — as if a reconcile had just fetched.
+	snapshot := &v2alpha1.DatadogAgent{}
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, snapshot))
+
+	// Simulate a concurrent writer moving the phase to promoted *after* the
+	// operator fetched its view but *before* restorePreviousSpec runs.
+	concurrent := &v2alpha1.DatadogAgent{}
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, concurrent))
+	concurrent.Status.Experiment.Phase = v2alpha1.ExperimentPhasePromoted
+	assert.NoError(t, r.client.Status().Update(context.TODO(), concurrent))
+
+	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: snapshot.Status.Experiment.DeepCopy()}
+	revisions := mustListRevisions(t, r, snapshot)
+	assert.NoError(t, r.restorePreviousSpec(context.TODO(), snapshot, newStatus, revisions, v2alpha1.ExperimentPhaseRollback))
+
+	// The targeted patch's test op must have rejected our stale decision —
+	// the concurrent writer's promoted phase survives.
+	after := &v2alpha1.DatadogAgent{}
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, after))
+	assert.Equal(t, v2alpha1.ExperimentPhasePromoted, after.Status.Experiment.Phase,
+		"concurrent phase write must not be overwritten by a stale targeted patch")
+}
+
 // Test_Experiment_StoppedRollback verifies that when RC writes phase=stopped,
 // the operator restores the previous spec and sets phase=rollback.
 func Test_Experiment_StoppedRollback(t *testing.T) {

--- a/internal/controller/datadogagent/controller_experiment_integration_test.go
+++ b/internal/controller/datadogagent/controller_experiment_integration_test.go
@@ -96,6 +96,56 @@ func Test_Experiment_RollbackPersistsInSingleReconcile(t *testing.T) {
 	assert.Equal(t, v2alpha1.ExperimentPhaseTimeout, dda.Status.Experiment.Phase, "phase=timeout must persist in the same reconcile as the rollback")
 }
 
+// Test_Experiment_RollbackPreservesConcurrentStatusWrite verifies that the
+// targeted phase patch in restorePreviousSpec does not mutate the caller's
+// instance.ResourceVersion. A downstream writer (simulated by mutating the
+// stored status after the rollback has run but before updateStatusIfNeededV2
+// would fire) must retain 409 protection on the full-status replace.
+// Regression guard: if patchExperimentPhase were to patch the caller's
+// instance in-place, the client would decode the server response onto it and
+// advance ResourceVersion, causing the downstream full-status update to use a
+// fresh RV and silently overwrite any concurrent status write.
+func Test_Experiment_RollbackPreservesConcurrentStatusWrite(t *testing.T) {
+	const ns, name = "default", "test-dda"
+	const uid = types.UID("uid-1")
+	nsName := types.NamespacedName{Namespace: ns, Name: name}
+
+	r := newExperimentIntegrationReconciler(t, 0)
+
+	// Fetch the instance as the reconcile would, and capture its RV.
+	dda := baseDDA(ns, name, uid)
+	createAndReconcile(t, r, dda)
+
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
+	dda.Spec.Global.Site = ptr.To("datadoghq.eu")
+	assert.NoError(t, r.client.Update(context.TODO(), dda))
+	reconcileN(t, r, ns, name, 1)
+
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
+	dda.Status.Experiment = &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseStopped, ID: "exp-1"}
+	assert.NoError(t, r.client.Status().Update(context.TODO(), dda))
+
+	// Snapshot what a reconcile loop would hold in memory at this point:
+	// the RV prior to invoking restorePreviousSpec.
+	snapshot := &v2alpha1.DatadogAgent{}
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, snapshot))
+	rvBefore := snapshot.ResourceVersion
+
+	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: snapshot.Status.Experiment.DeepCopy()}
+	revisions := mustListRevisions(t, r, snapshot)
+	assert.NoError(t, r.restorePreviousSpec(context.TODO(), snapshot, newStatus, revisions, v2alpha1.ExperimentPhaseRollback))
+
+	// The caller's in-memory instance RV must not have been advanced by the
+	// targeted status patch — otherwise a subsequent full-status write would
+	// skip its 409 protection.
+	assert.Equal(t, rvBefore, snapshot.ResourceVersion, "restorePreviousSpec must not mutate caller's ResourceVersion")
+
+	// Phase must still have landed on the server via the targeted patch.
+	after := &v2alpha1.DatadogAgent{}
+	assert.NoError(t, r.client.Get(context.TODO(), nsName, after))
+	assert.Equal(t, v2alpha1.ExperimentPhaseRollback, after.Status.Experiment.Phase)
+}
+
 // Test_Experiment_StoppedRollback verifies that when RC writes phase=stopped,
 // the operator restores the previous spec and sets phase=rollback.
 func Test_Experiment_StoppedRollback(t *testing.T) {

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -180,7 +180,7 @@ func (r *Reconciler) restorePreviousSpec(
 	terminalPhase v2alpha1.ExperimentPhase,
 ) error {
 	rollbackTarget := findRollbackTarget(revisions)
-	if err := r.rollback(ctx, instance, rollbackTarget); err != nil {
+	if err := r.rollback(ctx, instance.ObjectMeta, rollbackTarget); err != nil {
 		return err
 	}
 	newStatus.Experiment.Phase = terminalPhase
@@ -214,7 +214,7 @@ func (r *Reconciler) patchExperimentPhase(ctx context.Context, instance *v2alpha
 // rollback restores the DDA spec from the named ControllerRevision.
 func (r *Reconciler) rollback(
 	ctx context.Context,
-	instance *v2alpha1.DatadogAgent,
+	instanceMeta metav1.ObjectMeta,
 	rollbackTarget string,
 ) error {
 	if rollbackTarget == "" {
@@ -223,7 +223,7 @@ func (r *Reconciler) rollback(
 	}
 
 	cr := &appsv1.ControllerRevision{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: rollbackTarget}, cr); err != nil {
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instanceMeta.Namespace, Name: rollbackTarget}, cr); err != nil {
 		return fmt.Errorf("failed to get previous ControllerRevision %s: %w", rollbackTarget, err)
 	}
 
@@ -235,7 +235,7 @@ func (r *Reconciler) rollback(
 	// Re-fetch for the latest ResourceVersion and to check whether the spec is
 	// rolled back already. If it is, skip the update.
 	current := &v2alpha1.DatadogAgent{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, current); err != nil {
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instanceMeta.Namespace, Name: instanceMeta.Name}, current); err != nil {
 		return fmt.Errorf("failed to get current DDA for rollback: %w", err)
 	}
 	currentSnap, err := json.Marshal(revisionSnapshot{Spec: current.Spec, Annotations: datadogAnnotations(current.GetAnnotations())})

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -204,9 +204,17 @@ func (r *Reconciler) restorePreviousSpec(
 // the terminal phase is guaranteed to land in the same reconcile as the
 // rollback. Best-effort: a transient failure here just means the next
 // reconcile will re-compute and retry.
+//
+// The patch is applied to a DeepCopy so the client's response decoding does
+// not advance instance.ResourceVersion. Keeping the caller's RV stale
+// preserves the 409 protection on the subsequent full-status write — any
+// concurrent writer that touched status between our initial fetch and this
+// patch will still cause that write to conflict and retry, rather than being
+// silently overwritten with our stale newStatus.
 func (r *Reconciler) patchExperimentPhase(ctx context.Context, instance *v2alpha1.DatadogAgent, phase v2alpha1.ExperimentPhase) {
 	patch := fmt.Appendf(nil, `{"status":{"experiment":{"phase":%q}}}`, phase)
-	if err := r.client.Status().Patch(ctx, instance, client.RawPatch(types.MergePatchType, patch)); err != nil {
+	scratch := instance.DeepCopy()
+	if err := r.client.Status().Patch(ctx, scratch, client.RawPatch(types.MergePatchType, patch)); err != nil {
 		ctrl.LoggerFrom(ctx).Error(err, "Failed to patch experiment phase, will retry on next reconcile", "phase", phase)
 	}
 }

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -188,9 +188,16 @@ func (r *Reconciler) restorePreviousSpec(
 		return err
 	}
 	newStatus.Experiment.Phase = terminalPhase
-	r.patchExperimentPhase(ctx, instance, observedPhase, terminalPhase)
-	// Mark the experiment revision (highest-numbered) so its stale timestamp
-	// doesn't cause an immediate timeout if the same spec is re-applied.
+	// Order matters: annotate the experiment revision BEFORE persisting the
+	// terminal phase. If the operator crashes between these two writes, the
+	// phase is still non-terminal on restart, handleRollback re-fires, and
+	// annotateRevision is idempotent — eventually both writes succeed. If the
+	// order were reversed, a crash between them would leave a terminal phase
+	// without the rollback annotation, and since handleRollback ignores
+	// terminal phases the revision would never get annotated, causing a
+	// future re-apply of the same spec to fire an immediate false timeout on
+	// the stale CreationTimestamp.
+	//
 	// Only annotate the highest revision rather than all non-rollback-target
 	// revisions: if GC failed on a prior reconcile there may be 3+ revisions,
 	// and annotating old baselines would cause needless delete+recreate in
@@ -198,6 +205,7 @@ func (r *Reconciler) restorePreviousSpec(
 	if rev := highestRevision(revisions); rev != nil && rev.Name != rollbackTarget {
 		r.annotateRevision(ctx, rev, annotationExperimentRollback)
 	}
+	r.patchExperimentPhase(ctx, instance, observedPhase, terminalPhase)
 	return nil
 }
 

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -166,6 +166,12 @@ func (r *Reconciler) handleRollback(
 // experiment revision (the highest-numbered, non-rollback-target revision) with
 // the rollback annotation so its stale CreationTimestamp doesn't cause an
 // immediate timeout if the same spec is re-applied later.
+//
+// The terminal phase is also persisted via a targeted status subresource patch
+// so the phase transition lands in the same reconcile as the spec rollback,
+// without racing the full-status write in updateStatusIfNeededV2 (which could
+// otherwise 409 on the ResourceVersion bumped by the spec Update, deferring
+// the phase write to the next reconcile).
 func (r *Reconciler) restorePreviousSpec(
 	ctx context.Context,
 	instance *v2alpha1.DatadogAgent,
@@ -178,6 +184,7 @@ func (r *Reconciler) restorePreviousSpec(
 		return err
 	}
 	newStatus.Experiment.Phase = terminalPhase
+	r.patchExperimentPhase(ctx, instance, terminalPhase)
 	// Mark the experiment revision (highest-numbered) so its stale timestamp
 	// doesn't cause an immediate timeout if the same spec is re-applied.
 	// Only annotate the highest revision rather than all non-rollback-target
@@ -190,10 +197,21 @@ func (r *Reconciler) restorePreviousSpec(
 	return nil
 }
 
+// patchExperimentPhase writes the terminal experiment phase via a targeted
+// status subresource merge patch. This is narrower than updateStatusIfNeededV2's
+// full-status replace: concurrent writes to other status fields (e.g. by the
+// RC daemon) retain their own 409 protection on the full-status write, while
+// the terminal phase is guaranteed to land in the same reconcile as the
+// rollback. Best-effort: a transient failure here just means the next
+// reconcile will re-compute and retry.
+func (r *Reconciler) patchExperimentPhase(ctx context.Context, instance *v2alpha1.DatadogAgent, phase v2alpha1.ExperimentPhase) {
+	patch := fmt.Appendf(nil, `{"status":{"experiment":{"phase":%q}}}`, phase)
+	if err := r.client.Status().Patch(ctx, instance, client.RawPatch(types.MergePatchType, patch)); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "Failed to patch experiment phase, will retry on next reconcile", "phase", phase)
+	}
+}
+
 // rollback restores the DDA spec from the named ControllerRevision.
-// On success, instance.ResourceVersion is updated to the post-Update value so
-// the caller's in-flight status write uses a fresh ResourceVersion and avoids a
-// 409 that would defer the terminal phase write to the next reconcile.
 func (r *Reconciler) rollback(
 	ctx context.Context,
 	instance *v2alpha1.DatadogAgent,
@@ -226,9 +244,6 @@ func (r *Reconciler) rollback(
 	}
 	if bytes.Equal(currentSnap, cr.Data.Raw) {
 		ctrl.LoggerFrom(ctx).Info("Rollback spec already matches target, skipping update", "rollbackTarget", rollbackTarget)
-		// Sync the caller's ResourceVersion to the latest observed value so a
-		// concurrent-update status write doesn't 409.
-		instance.ResourceVersion = current.ResourceVersion
 		return nil
 	}
 
@@ -245,14 +260,7 @@ func (r *Reconciler) rollback(
 		Spec:       snapshot.Spec,
 	}
 	toUpdate.Annotations = merged
-	if err := r.client.Update(ctx, toUpdate); err != nil {
-		return err
-	}
-	// Propagate the post-Update ResourceVersion so the downstream status write
-	// in the same reconcile uses the fresh RV and the terminal phase is
-	// persisted without requiring a follow-up reconcile.
-	instance.ResourceVersion = toUpdate.ResourceVersion
-	return nil
+	return r.client.Update(ctx, toUpdate)
 }
 
 // findRollbackTarget returns the name of the previous ControllerRevision to restore.

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -180,11 +180,15 @@ func (r *Reconciler) restorePreviousSpec(
 	terminalPhase v2alpha1.ExperimentPhase,
 ) error {
 	rollbackTarget := findRollbackTarget(revisions)
+	// Capture the observed phase before mutating newStatus. This is the phase
+	// our rollback decision is based on; if a concurrent writer has since
+	// changed it, our decision is outdated and the patch must not apply.
+	observedPhase := instance.Status.Experiment.Phase
 	if err := r.rollback(ctx, instance.ObjectMeta, rollbackTarget); err != nil {
 		return err
 	}
 	newStatus.Experiment.Phase = terminalPhase
-	r.patchExperimentPhase(ctx, instance, terminalPhase)
+	r.patchExperimentPhase(ctx, instance, observedPhase, terminalPhase)
 	// Mark the experiment revision (highest-numbered) so its stale timestamp
 	// doesn't cause an immediate timeout if the same spec is re-applied.
 	// Only annotate the highest revision rather than all non-rollback-target
@@ -198,24 +202,30 @@ func (r *Reconciler) restorePreviousSpec(
 }
 
 // patchExperimentPhase writes the terminal experiment phase via a targeted
-// status subresource merge patch. This is narrower than updateStatusIfNeededV2's
+// status subresource JSON patch. This is narrower than updateStatusIfNeededV2's
 // full-status replace: concurrent writes to other status fields (e.g. by the
 // RC daemon) retain their own 409 protection on the full-status write, while
 // the terminal phase is guaranteed to land in the same reconcile as the
-// rollback. Best-effort: a transient failure here just means the next
-// reconcile will re-compute and retry.
+// rollback.
+//
+// A `test` op guards the `replace`: the patch only applies if the server's
+// current phase still matches the phase the rollback decision was based on.
+// If another writer (e.g. the RC daemon promoting the experiment) has moved
+// the phase in between, the test op fails, the patch is rejected, and we
+// leave their decision untouched — mirroring the 409-and-retry semantics of
+// a full-status Update without the RV plumbing.
 //
 // The patch is applied to a DeepCopy so the client's response decoding does
-// not advance instance.ResourceVersion. Keeping the caller's RV stale
-// preserves the 409 protection on the subsequent full-status write — any
-// concurrent writer that touched status between our initial fetch and this
-// patch will still cause that write to conflict and retry, rather than being
-// silently overwritten with our stale newStatus.
-func (r *Reconciler) patchExperimentPhase(ctx context.Context, instance *v2alpha1.DatadogAgent, phase v2alpha1.ExperimentPhase) {
-	patch := fmt.Appendf(nil, `{"status":{"experiment":{"phase":%q}}}`, phase)
+// not advance instance.ResourceVersion; the subsequent full-status write
+// retains its own 409 protection for every other status field.
+//
+// Best-effort: any error here (test failure or transient) is logged at V(1)
+// and the next reconcile will re-compute and retry.
+func (r *Reconciler) patchExperimentPhase(ctx context.Context, instance *v2alpha1.DatadogAgent, expectedCurrent, newPhase v2alpha1.ExperimentPhase) {
+	patch := fmt.Appendf(nil, `[{"op":"test","path":"/status/experiment/phase","value":%q},{"op":"replace","path":"/status/experiment/phase","value":%q}]`, expectedCurrent, newPhase)
 	scratch := instance.DeepCopy()
-	if err := r.client.Status().Patch(ctx, scratch, client.RawPatch(types.MergePatchType, patch)); err != nil {
-		ctrl.LoggerFrom(ctx).Error(err, "Failed to patch experiment phase, will retry on next reconcile", "phase", phase)
+	if err := r.client.Status().Patch(ctx, scratch, client.RawPatch(types.JSONPatchType, patch)); err != nil {
+		ctrl.LoggerFrom(ctx).V(1).Info("Experiment phase patch skipped (concurrent write or transient error), will retry on next reconcile", "error", err.Error(), "expectedCurrent", expectedCurrent, "new", newPhase)
 	}
 }
 

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -133,7 +133,7 @@ func (r *Reconciler) handleRollback(
 	// stopped signal from RC: restore DDA spec and ack by setting phase to rollback.
 	case phase == v2alpha1.ExperimentPhaseStopped:
 		logger.Info("Experiment stopped, rolling back")
-		return r.restorePreviousSpec(ctx, instance.ObjectMeta, newStatus, revisions, v2alpha1.ExperimentPhaseRollback)
+		return r.restorePreviousSpec(ctx, instance, newStatus, revisions, v2alpha1.ExperimentPhaseRollback)
 	case phase == v2alpha1.ExperimentPhaseRunning:
 		rev := findMostRecentMatchingRevision(revisions, instance)
 		if rev == nil && len(revisions) >= 2 {
@@ -153,7 +153,7 @@ func (r *Reconciler) handleRollback(
 			elapsed := now.Sub(rev.CreationTimestamp.Time)
 			if elapsed >= getExperimentTimeout(r.options.ExperimentTimeout) {
 				logger.Info("Experiment timed out, rolling back", "elapsed", elapsed.String())
-				return r.restorePreviousSpec(ctx, instance.ObjectMeta, newStatus, revisions, v2alpha1.ExperimentPhaseTimeout)
+				return r.restorePreviousSpec(ctx, instance, newStatus, revisions, v2alpha1.ExperimentPhaseTimeout)
 			}
 		}
 	}
@@ -168,13 +168,13 @@ func (r *Reconciler) handleRollback(
 // immediate timeout if the same spec is re-applied later.
 func (r *Reconciler) restorePreviousSpec(
 	ctx context.Context,
-	instanceMeta metav1.ObjectMeta,
+	instance *v2alpha1.DatadogAgent,
 	newStatus *v2alpha1.DatadogAgentStatus,
 	revisions []appsv1.ControllerRevision,
 	terminalPhase v2alpha1.ExperimentPhase,
 ) error {
 	rollbackTarget := findRollbackTarget(revisions)
-	if err := r.rollback(ctx, instanceMeta, rollbackTarget); err != nil {
+	if err := r.rollback(ctx, instance, rollbackTarget); err != nil {
 		return err
 	}
 	newStatus.Experiment.Phase = terminalPhase
@@ -191,9 +191,12 @@ func (r *Reconciler) restorePreviousSpec(
 }
 
 // rollback restores the DDA spec from the named ControllerRevision.
+// On success, instance.ResourceVersion is updated to the post-Update value so
+// the caller's in-flight status write uses a fresh ResourceVersion and avoids a
+// 409 that would defer the terminal phase write to the next reconcile.
 func (r *Reconciler) rollback(
 	ctx context.Context,
-	instanceMeta metav1.ObjectMeta,
+	instance *v2alpha1.DatadogAgent,
 	rollbackTarget string,
 ) error {
 	if rollbackTarget == "" {
@@ -202,7 +205,7 @@ func (r *Reconciler) rollback(
 	}
 
 	cr := &appsv1.ControllerRevision{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instanceMeta.Namespace, Name: rollbackTarget}, cr); err != nil {
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: rollbackTarget}, cr); err != nil {
 		return fmt.Errorf("failed to get previous ControllerRevision %s: %w", rollbackTarget, err)
 	}
 
@@ -214,7 +217,7 @@ func (r *Reconciler) rollback(
 	// Re-fetch for the latest ResourceVersion and to check whether the spec is
 	// rolled back already. If it is, skip the update.
 	current := &v2alpha1.DatadogAgent{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instanceMeta.Namespace, Name: instanceMeta.Name}, current); err != nil {
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}, current); err != nil {
 		return fmt.Errorf("failed to get current DDA for rollback: %w", err)
 	}
 	currentSnap, err := json.Marshal(revisionSnapshot{Spec: current.Spec, Annotations: datadogAnnotations(current.GetAnnotations())})
@@ -223,6 +226,9 @@ func (r *Reconciler) rollback(
 	}
 	if bytes.Equal(currentSnap, cr.Data.Raw) {
 		ctrl.LoggerFrom(ctx).Info("Rollback spec already matches target, skipping update", "rollbackTarget", rollbackTarget)
+		// Sync the caller's ResourceVersion to the latest observed value so a
+		// concurrent-update status write doesn't 409.
+		instance.ResourceVersion = current.ResourceVersion
 		return nil
 	}
 
@@ -239,7 +245,14 @@ func (r *Reconciler) rollback(
 		Spec:       snapshot.Spec,
 	}
 	toUpdate.Annotations = merged
-	return r.client.Update(ctx, toUpdate)
+	if err := r.client.Update(ctx, toUpdate); err != nil {
+		return err
+	}
+	// Propagate the post-Update ResourceVersion so the downstream status write
+	// in the same reconcile uses the fresh RV and the terminal phase is
+	// persisted without requiring a follow-up reconcile.
+	instance.ResourceVersion = toUpdate.ResourceVersion
+	return nil
 }
 
 // findRollbackTarget returns the name of the previous ControllerRevision to restore.

--- a/internal/controller/datadogagent/experiment_test.go
+++ b/internal/controller/datadogagent/experiment_test.go
@@ -196,6 +196,7 @@ func TestRestorePreviousSpec_PhaseSetOnlyOnSuccess(t *testing.T) {
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
+	instanceB.Status.Experiment = &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseStopped}
 	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
 
 	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseStopped}}

--- a/internal/controller/datadogagent/experiment_test.go
+++ b/internal/controller/datadogagent/experiment_test.go
@@ -115,14 +115,14 @@ func TestRollback_RestoresSpec(t *testing.T) {
 	require.NoError(t, c.Create(context.Background(), instanceB))
 
 	// Rollback from instanceB to prevRevision (specA).
-	require.NoError(t, r.rollback(context.Background(), instanceB.ObjectMeta, prevRevision))
+	require.NoError(t, r.rollback(context.Background(), instanceB, prevRevision))
 }
 
 func TestRollback_NoPreviousRevision(t *testing.T) {
 	r, _ := newRevisionTestReconciler(t)
 	instance := newRevisionTestOwner("test-dda", "default")
 
-	err := r.rollback(context.Background(), instance.ObjectMeta, "")
+	err := r.rollback(context.Background(), instance, "")
 	require.NoError(t, err)
 }
 
@@ -176,7 +176,7 @@ func TestRollback_PreservesNonDatadogAnnotations(t *testing.T) {
 	}
 	require.NoError(t, c.Create(context.Background(), instanceB))
 
-	require.NoError(t, r.rollback(context.Background(), instanceB.ObjectMeta, prevRevision))
+	require.NoError(t, r.rollback(context.Background(), instanceB, prevRevision))
 
 	updated := &v2alpha1.DatadogAgent{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-dda"}, updated))
@@ -201,14 +201,14 @@ func TestRestorePreviousSpec_PhaseSetOnlyOnSuccess(t *testing.T) {
 	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseStopped}}
 
 	// rollback requires the DDA to exist in the fake client; don't create it so it errors.
-	err := r.restorePreviousSpec(context.Background(), instanceB.ObjectMeta, newStatus, mustListRevisions(t, r, instanceB), v2alpha1.ExperimentPhaseRollback)
+	err := r.restorePreviousSpec(context.Background(), instanceB, newStatus, mustListRevisions(t, r, instanceB), v2alpha1.ExperimentPhaseRollback)
 	require.Error(t, err)
 	// Phase must NOT have been set since rollback failed.
 	assert.Equal(t, v2alpha1.ExperimentPhaseStopped, newStatus.Experiment.Phase)
 
 	// Now create the DDA so rollback can succeed.
 	require.NoError(t, c.Create(context.Background(), instanceB))
-	err = r.restorePreviousSpec(context.Background(), instanceB.ObjectMeta, newStatus, mustListRevisions(t, r, instanceB), v2alpha1.ExperimentPhaseRollback)
+	err = r.restorePreviousSpec(context.Background(), instanceB, newStatus, mustListRevisions(t, r, instanceB), v2alpha1.ExperimentPhaseRollback)
 	require.NoError(t, err)
 	assert.Equal(t, v2alpha1.ExperimentPhaseRollback, newStatus.Experiment.Phase)
 }
@@ -421,7 +421,7 @@ func TestRestorePreviousSpec_ThreeRevisions_AnnotatesOnlyHighest(t *testing.T) {
 	// Trigger rollback via phase=stopped.
 	instanceC.Status.Experiment = &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseStopped}
 	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: instanceC.Status.Experiment.DeepCopy()}
-	require.NoError(t, r.restorePreviousSpec(context.Background(), instanceC.ObjectMeta, newStatus, revList, v2alpha1.ExperimentPhaseRollback))
+	require.NoError(t, r.restorePreviousSpec(context.Background(), instanceC, newStatus, revList, v2alpha1.ExperimentPhaseRollback))
 	assert.Equal(t, v2alpha1.ExperimentPhaseRollback, newStatus.Experiment.Phase)
 
 	// Verify: only rev3 (experiment, highest) is annotated.

--- a/internal/controller/datadogagent/experiment_test.go
+++ b/internal/controller/datadogagent/experiment_test.go
@@ -115,14 +115,14 @@ func TestRollback_RestoresSpec(t *testing.T) {
 	require.NoError(t, c.Create(context.Background(), instanceB))
 
 	// Rollback from instanceB to prevRevision (specA).
-	require.NoError(t, r.rollback(context.Background(), instanceB, prevRevision))
+	require.NoError(t, r.rollback(context.Background(), instanceB.ObjectMeta, prevRevision))
 }
 
 func TestRollback_NoPreviousRevision(t *testing.T) {
 	r, _ := newRevisionTestReconciler(t)
 	instance := newRevisionTestOwner("test-dda", "default")
 
-	err := r.rollback(context.Background(), instance, "")
+	err := r.rollback(context.Background(), instance.ObjectMeta, "")
 	require.NoError(t, err)
 }
 
@@ -176,7 +176,7 @@ func TestRollback_PreservesNonDatadogAnnotations(t *testing.T) {
 	}
 	require.NoError(t, c.Create(context.Background(), instanceB))
 
-	require.NoError(t, r.rollback(context.Background(), instanceB, prevRevision))
+	require.NoError(t, r.rollback(context.Background(), instanceB.ObjectMeta, prevRevision))
 
 	updated := &v2alpha1.DatadogAgent{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-dda"}, updated))


### PR DESCRIPTION
### What does this PR do?

Persists the terminal experiment phase (`timeout`/`rollback`) in the same reconcile as the spec rollback, via a targeted `Status().Patch()` guarded by a JSON patch `test` op on `status.experiment.phase`. This eliminates a cross-reconcile race where the terminal phase could be silently dropped, without compromising concurrent-write safety or crash-recovery of the rollback annotation.

### Motivation

`Test_Experiment_StateTransitions` subtests (`rollback_then_timeout`, `promoted_then_timeout`, with/without `stale_old_revision`) were flaking on CI — failing with `expected=timeout, actual=running` at `controller_experiment_integration_test.go:947`. Reproduced locally (5+ failures in 20 runs).

Root cause: reconcile 1 of the timeout path updated spec (bumping `ResourceVersion`) but the full-status write used the stale RV → 409 → `phase=running` persisted. On reconcile 2, the refetched spec already matched a freshly-timestamped, rollback-annotated revision, so `findMostRecentMatchingRevision` returned it, `elapsed < timeout`, and the terminal phase was never written.

### Fix

`restorePreviousSpec` now writes the terminal phase via a targeted status subresource JSON patch (`patchExperimentPhase`) after the spec rollback. The patch is narrow (only `status.experiment.phase`) and carries a `test` op that asserts the server's phase still matches the phase the rollback decision was based on. Four safety properties are preserved:

1. **Lands in the same reconcile**: the targeted patch bypasses the RV bump from the spec Update, so `phase=timeout`/`phase=rollback` persists without waiting for a follow-up reconcile.
2. **Concurrent phase writes survive**: if the RC daemon (e.g. `pkg/fleet/daemon.go:354` writing `phase=promoted`) moves the phase between our reconcile fetch and our patch, the `test` op fails and the patch is rejected — our stale decision does not clobber their accepted state. Mirrors the 409-and-retry semantics of a full-status Update.
3. **Concurrent writes to other status fields survive**: the patch is applied to an `instance.DeepCopy()` scratch so the client's response decoding does not advance the caller's `instance.ResourceVersion`. The downstream full-status write in `updateStatusIfNeededV2` therefore retains its own 409 protection for every other status field.
4. **Crash-safe annotation ordering**: `annotateRevision` runs BEFORE `patchExperimentPhase`. If the operator exits between the two writes, the phase is still non-terminal on restart, `handleRollback` re-fires, `annotateRevision` is idempotent, and both writes eventually succeed. Reversing this order would leave a terminal phase without the rollback annotation — and since `handleRollback` ignores terminal phases, the annotation would never be applied, causing a later re-apply of the same spec to fire an immediate false timeout on the stale `CreationTimestamp`.

The patch is best-effort — any error (test op failure or transient) is logged at V(1) and the next reconcile re-computes and retries.

### Additional Notes

- `restorePreviousSpec` signature change: now takes `*v2alpha1.DatadogAgent` instead of `metav1.ObjectMeta` (needed for `Status().Patch()`).
- `rollback` signature unchanged (`metav1.ObjectMeta`).
- `TestRestorePreviousSpec_PhaseSetOnlyOnSuccess` was updated to populate `instance.Status.Experiment` (the new observed-phase capture in `restorePreviousSpec` dereferences it — safe in production because `handleRollback` guards against nil before delegating, but needed for this direct unit-test call).
- Regression guards added:
  - `Test_Experiment_RollbackPersistsInSingleReconcile` — asserts spec rollback and `phase=timeout` both persist in a single reconcile.
  - `Test_Experiment_RollbackPreservesConcurrentStatusWrite` — asserts `restorePreviousSpec` does not mutate the caller's `ResourceVersion` (bisected: reverting the scratch-copy fails this test).
  - `Test_Experiment_RollbackDoesNotClobberConcurrentPhaseWrite` — asserts a concurrent `phase=promoted` write survives a stale `phase=rollback` decision, AND that the rollback annotation still lands even when the phase patch is rejected (bisected: reverting to an unconditional merge patch fails the first assertion).

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

- Reproduced the flake: `go test ./internal/controller/datadogagent/ -run Test_Experiment_StateTransitions -count=20` — multiple subtest failures before fix.
- Validated after fix: `Test_Experiment_StateTransitions + Test_Experiment_RollbackPersistsInSingleReconcile + Test_Experiment_RollbackPreservesConcurrentStatusWrite + Test_Experiment_RollbackDoesNotClobberConcurrentPhaseWrite` `-count=20` — all green.
- Full experiment suite (`Test_Experiment_|TestManageExperiment|TestHandleRollback|TestRollback|TestRestorePreviousSpec|TestReapplySameSpecAfterRollback`) `-count=10` — clean.
- Full `internal/controller/datadogagent` package — clean.

### Checklist

- [x] PR has at least one valid label: `bug`
- [x] PR has a milestone: `v1.26.0` (also `qa/skip-qa` — test-infrastructure stability, no user-facing change)
- [x] All commits are signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)