### PR TITLE
Add KILL capability to CSPM container

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -288,11 +288,15 @@ func DefaultSyscallsForSystemProbe() []string {
 func syscallsForSystemProbe(ddaSpec *v2alpha1.DatadogAgentSpec) []string {
 	syscalls := DefaultSyscallsForSystemProbe()
 
-	if (ddaSpec.Features.CWS != nil && ddaSpec.Features.CWS.Enabled != nil && *ddaSpec.Features.CWS.Enabled &&
-		ddaSpec.Features.CWS.Enforcement != nil && ddaSpec.Features.CWS.Enforcement.Enabled != nil && *ddaSpec.Features.CWS.Enforcement.Enabled) ||
-		(ddaSpec.Features.CSPM != nil && ddaSpec.Features.CSPM.Enabled != nil && *ddaSpec.Features.CSPM.Enabled &&
-			ddaSpec.Features.CSPM.HostBenchmarks != nil && ddaSpec.Features.CSPM.HostBenchmarks.Enabled != nil && *ddaSpec.Features.CSPM.HostBenchmarks.Enabled &&
-			ddaSpec.Features.CSPM.RunInSystemProbe != nil && *ddaSpec.Features.CSPM.RunInSystemProbe) {
+	if (ddaSpec.Features.CWS != nil &&
+		ptr.Deref(ddaSpec.Features.CWS.Enabled, false) &&
+		ddaSpec.Features.CWS.Enforcement != nil &&
+		ptr.Deref(ddaSpec.Features.CWS.Enforcement.Enabled, false)) ||
+		(ddaSpec.Features.CSPM != nil &&
+			ptr.Deref(ddaSpec.Features.CSPM.Enabled, false) &&
+			ddaSpec.Features.CSPM.HostBenchmarks != nil &&
+			ptr.Deref(ddaSpec.Features.CSPM.HostBenchmarks.Enabled, false) &&
+			ptr.Deref(ddaSpec.Features.CSPM.RunInSystemProbe, false)) {
 		syscalls = append(syscalls, "kill")
 	}
 	return syscalls

--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -288,9 +288,11 @@ func DefaultSyscallsForSystemProbe() []string {
 func syscallsForSystemProbe(ddaSpec *v2alpha1.DatadogAgentSpec) []string {
 	syscalls := DefaultSyscallsForSystemProbe()
 
-	if ddaSpec.Features.CWS != nil &&
-		ddaSpec.Features.CWS.Enabled != nil && *ddaSpec.Features.CWS.Enabled &&
-		ddaSpec.Features.CWS.Enforcement != nil && *ddaSpec.Features.CWS.Enforcement.Enabled {
+	if (ddaSpec.Features.CWS != nil && ddaSpec.Features.CWS.Enabled != nil && *ddaSpec.Features.CWS.Enabled &&
+		ddaSpec.Features.CWS.Enforcement != nil && ddaSpec.Features.CWS.Enforcement.Enabled != nil && *ddaSpec.Features.CWS.Enforcement.Enabled) ||
+		(ddaSpec.Features.CSPM != nil && ddaSpec.Features.CSPM.Enabled != nil && *ddaSpec.Features.CSPM.Enabled &&
+			ddaSpec.Features.CSPM.HostBenchmarks != nil && ddaSpec.Features.CSPM.HostBenchmarks.Enabled != nil && *ddaSpec.Features.CSPM.HostBenchmarks.Enabled &&
+			ddaSpec.Features.CSPM.RunInSystemProbe != nil && *ddaSpec.Features.CSPM.RunInSystemProbe) {
 		syscalls = append(syscalls, "kill")
 	}
 	return syscalls

--- a/internal/controller/datadogagent/feature/cspm/feature.go
+++ b/internal/controller/datadogagent/feature/cspm/feature.go
@@ -252,6 +252,7 @@ func (f *cspmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, prov
 	capabilities := []corev1.Capability{
 		"AUDIT_CONTROL",
 		"AUDIT_READ",
+		"KILL",
 	}
 	managers.SecurityContext().AddCapabilitiesToContainer(capabilities, targetContainer)
 


### PR DESCRIPTION
### What does this PR do?

Add KILL capability to either the security-agent or system-probe container.

### Motivation

The OSCAP wrapper makes use of the kill signal, causing it not to be killed properly.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits