### PR TITLE
Add cache namespace options for DatadogCSIDriver controller

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -299,6 +299,7 @@ func run(opts *options) error {
 			IntrospectionEnabled:          opts.introspectionEnabled,
 			DatadogDashboardEnabled:       opts.datadogDashboardEnabled,
 			DatadogGenericResourceEnabled: opts.datadogGenericResourceEnabled,
+			DatadogCSIDriverEnabled:       opts.datadogCSIDriverEnabled,
 		}),
 		// UsePriorityQueue makes all controllers use the priority queue, which
 		// directly registers workqueue metrics into controller-runtime's metrics

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,8 @@ const (
 	profileWatchNamespaceEnvVar = "DD_AGENT_PROFILE_WATCH_NAMESPACE"
 	// SLOWatchNamespaceEnvVar is a comma-separated list of namespaces watched by the DatadogSLO controller.
 	sloWatchNamespaceEnvVar = "DD_SLO_WATCH_NAMESPACE"
+	// CSIDriverWatchNamespaceEnvVar is a comma-separated list of namespaces watched by the DatadogCSIDriver controller.
+	csiDriverWatchNamespaceEnvVar = "DD_CSIDRIVER_WATCH_NAMESPACE"
 )
 
 var (
@@ -55,6 +57,7 @@ var (
 	sloObj             = &datadoghqv1alpha1.DatadogSLO{}
 	profileObj         = &datadoghqv1alpha1.DatadogAgentProfile{}
 	agentInternalObj   = &datadoghqv1alpha1.DatadogAgentInternal{}
+	csiDriverObj       = &datadoghqv1alpha1.DatadogCSIDriver{}
 	podObj             = &corev1.Pod{}
 	nodeObj            = &corev1.Node{}
 )
@@ -68,6 +71,7 @@ type WatchOptions struct {
 	IntrospectionEnabled          bool
 	DatadogDashboardEnabled       bool
 	DatadogGenericResourceEnabled bool
+	DatadogCSIDriverEnabled       bool
 }
 
 // CacheOptions function configures Controller Runtime cache options on a resource level (supported in v0.16+).
@@ -185,6 +189,14 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 		logger.Info("DatadogAgentInternal Enabled", "watching namespaces", slices.Collect(maps.Keys(agentInternalNamespaces)))
 		byObject[agentInternalObj] = cache.ByObject{
 			Namespaces: agentInternalNamespaces,
+		}
+	}
+
+	if opts.DatadogCSIDriverEnabled {
+		csiDriverNamespaces := GetWatchNamespacesFromEnv(logger, csiDriverWatchNamespaceEnvVar)
+		logger.Info("DatadogCSIDriver Enabled", "watching namespaces", slices.Collect(maps.Keys(csiDriverNamespaces)))
+		byObject[csiDriverObj] = cache.ByObject{
+			Namespaces: csiDriverNamespaces,
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -58,6 +59,7 @@ var (
 	profileObj         = &datadoghqv1alpha1.DatadogAgentProfile{}
 	agentInternalObj   = &datadoghqv1alpha1.DatadogAgentInternal{}
 	csiDriverObj       = &datadoghqv1alpha1.DatadogCSIDriver{}
+	csiDaemonSetObj    = &appsv1.DaemonSet{}
 	podObj             = &corev1.Pod{}
 	nodeObj            = &corev1.Node{}
 )
@@ -197,6 +199,14 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 		logger.Info("DatadogCSIDriver Enabled", "watching namespaces", slices.Collect(maps.Keys(csiDriverNamespaces)))
 		byObject[csiDriverObj] = cache.ByObject{
 			Namespaces: csiDriverNamespaces,
+		}
+		// The DaemonSet owned by DatadogCSIDriver lives in the CSIDriver namespace, which may
+		// differ from the agent namespace covered by DefaultNamespaces. Explicitly add DaemonSet
+		// to ByObject merging both so neither controller loses its cache coverage.
+		daemonSetNamespaces := maps.Clone(GetWatchNamespacesFromEnv(logger, AgentWatchNamespaceEnvVar))
+		maps.Copy(daemonSetNamespaces, csiDriverNamespaces)
+		byObject[csiDaemonSetObj] = cache.ByObject{
+			Namespaces: daemonSetNamespaces,
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -64,6 +64,7 @@ func Test_CacheConfig(t *testing.T) {
 				podObj:             {configured: true, namespaces: []string{"agentNs"}},
 				nodeObj:            {configured: true, namespaces: nil},
 				csiDriverObj:       {configured: true, namespaces: []string{"csiDriverNs"}},
+				csiDaemonSetObj:    {configured: true, namespaces: []string{"csiDriverNs", "agentNs"}},
 			},
 		},
 		{
@@ -79,7 +80,8 @@ func Test_CacheConfig(t *testing.T) {
 			wantDefaultNamepsace: objectConfig{configured: true, namespaces: []string{"commonNs"}},
 
 			wantObjectConfig: map[client.Object]objectConfig{
-				csiDriverObj: {configured: true, namespaces: []string{"commonNs"}},
+				csiDriverObj:    {configured: true, namespaces: []string{"commonNs"}},
+				csiDaemonSetObj: {configured: true, namespaces: []string{"commonNs"}},
 			},
 		},
 		{
@@ -96,7 +98,28 @@ func Test_CacheConfig(t *testing.T) {
 			wantDefaultNamepsace: objectConfig{configured: true, namespaces: []string{"commonNs"}},
 
 			wantObjectConfig: map[client.Object]objectConfig{
-				csiDriverObj: {configured: true, namespaces: []string{"csiNs1", "csiNs2"}},
+				csiDriverObj:    {configured: true, namespaces: []string{"csiNs1", "csiNs2"}},
+				csiDaemonSetObj: {configured: true, namespaces: []string{"csiNs1", "csiNs2", "commonNs"}},
+			},
+		},
+		{
+			name: "CSIDriver in different namespace than Agent; DaemonSet cached in both",
+			watchOptions: WatchOptions{
+				DatadogAgentEnabled:     true,
+				DatadogCSIDriverEnabled: true,
+			},
+
+			envConfig: map[string]string{
+				AgentWatchNamespaceEnvVar:     "system",
+				csiDriverWatchNamespaceEnvVar: "default",
+			},
+
+			wantDefaultNamepsace: objectConfig{configured: true, namespaces: []string{"system"}},
+
+			wantObjectConfig: map[client.Object]objectConfig{
+				agentObj:        {configured: true, namespaces: []string{"system"}},
+				csiDriverObj:    {configured: true, namespaces: []string{"default"}},
+				csiDaemonSetObj: {configured: true, namespaces: []string{"system", "default"}},
 			},
 		},
 		{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -38,6 +38,7 @@ func Test_CacheConfig(t *testing.T) {
 				DatadogAgentProfileEnabled:    true,
 				DatadogDashboardEnabled:       true,
 				DatadogGenericResourceEnabled: true,
+				DatadogCSIDriverEnabled:       true,
 			},
 
 			envConfig: map[string]string{
@@ -48,6 +49,7 @@ func Test_CacheConfig(t *testing.T) {
 				profileWatchNamespaceEnvVar:         "profileNs",
 				dashboardWatchNamespaceEnvVar:       "dashboardNs",
 				genericResourceWatchNamespaceEnvVar: "genericNs",
+				csiDriverWatchNamespaceEnvVar:       "csiDriverNs",
 			},
 
 			wantDefaultNamepsace: objectConfig{configured: true, namespaces: []string{"agentNs"}},
@@ -61,6 +63,40 @@ func Test_CacheConfig(t *testing.T) {
 				profileObj:         {configured: true, namespaces: []string{"profileNs"}},
 				podObj:             {configured: true, namespaces: []string{"agentNs"}},
 				nodeObj:            {configured: true, namespaces: nil},
+				csiDriverObj:       {configured: true, namespaces: []string{"csiDriverNs"}},
+			},
+		},
+		{
+			name: "CSIDriver enabled; falls back to WATCH_NAMESPACE when DD_CSIDRIVER_WATCH_NAMESPACE not set",
+			watchOptions: WatchOptions{
+				DatadogCSIDriverEnabled: true,
+			},
+
+			envConfig: map[string]string{
+				WatchNamespaceEnvVar: "commonNs",
+			},
+
+			wantDefaultNamepsace: objectConfig{configured: true, namespaces: []string{"commonNs"}},
+
+			wantObjectConfig: map[client.Object]objectConfig{
+				csiDriverObj: {configured: true, namespaces: []string{"commonNs"}},
+			},
+		},
+		{
+			name: "CSIDriver enabled; uses DD_CSIDRIVER_WATCH_NAMESPACE when set",
+			watchOptions: WatchOptions{
+				DatadogCSIDriverEnabled: true,
+			},
+
+			envConfig: map[string]string{
+				WatchNamespaceEnvVar:          "commonNs",
+				csiDriverWatchNamespaceEnvVar: "csiNs1,csiNs2",
+			},
+
+			wantDefaultNamepsace: objectConfig{configured: true, namespaces: []string{"commonNs"}},
+
+			wantObjectConfig: map[client.Object]objectConfig{
+				csiDriverObj: {configured: true, namespaces: []string{"csiNs1", "csiNs2"}},
 			},
 		},
 		{
@@ -86,6 +122,7 @@ func Test_CacheConfig(t *testing.T) {
 				profileObj:         {configured: true, namespaces: []string{"profileNs"}},
 				podObj:             {configured: true, namespaces: []string{"datadog"}},
 				nodeObj:            {configured: true, namespaces: nil},
+				csiDriverObj:       {configured: false},
 			},
 		},
 
@@ -114,6 +151,7 @@ func Test_CacheConfig(t *testing.T) {
 				profileObj:         {configured: true, namespaces: []string{"profileNs"}},
 				podObj:             {configured: true, namespaces: []string{"agentNs1", "agentNs2"}},
 				nodeObj:            {configured: true, namespaces: nil},
+				csiDriverObj:       {configured: false},
 			},
 		},
 		{
@@ -141,6 +179,7 @@ func Test_CacheConfig(t *testing.T) {
 				profileObj:         {configured: false},
 				podObj:             {configured: false},
 				nodeObj:            {configured: false},
+				csiDriverObj:       {configured: false},
 			},
 		},
 		{
@@ -169,6 +208,7 @@ func Test_CacheConfig(t *testing.T) {
 				profileObj:         {configured: false},
 				podObj:             {configured: false},
 				nodeObj:            {configured: true, namespaces: nil},
+				csiDriverObj:       {configured: false},
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Adds cache namespace configuration for the `DatadogCSIDriver` controller, consistent with all other controllers.

Introduces `DD_CSIDRIVER_WATCH_NAMESPACE` env var (falls back to `WATCH_NAMESPACE`), wires `DatadogCSIDriverEnabled` into `config.CacheOptions()`, and adds test coverage.

### Motivation

The `DatadogCSIDriver` controller was the only controller missing its own cache namespace entry. Without it, the controller fell back to `DefaultNamespaces` (driven by `DD_AGENT_WATCH_NAMESPACE`/`WATCH_NAMESPACE`) instead of having its own `DD_CSIDRIVER_WATCH_NAMESPACE` override.

Additionally, `DatadogCSIDriver` is unique among controllers in that it creates and reconciles a native k8s `DaemonSet`, which must also be accessible from the cache. If the CSIDriver is deployed in a different namespace than the agent (e.g. `DD_CSIDRIVER_WATCH_NAMESPACE=default`, `DD_AGENT_WATCH_NAMESPACE=system`), the `DaemonSet` falls outside `DefaultNamespaces` and causes:

```
getting DaemonSet: unable to get: default/datadog-csi-driver-node-server because of unknown namespace for the cache
```

The fix explicitly adds `DaemonSet` to `ByObject` with the union of agent and CSIDriver namespaces. Using `DefaultNamespaces` instead would over-cache all other GVKs (Secrets, ConfigMaps, etc.) in the CSIDriver namespace unnecessarily.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits