### PR TITLE
enhancement: default dataPlane.dogstatsd.enabled to true

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -722,8 +722,8 @@ type DataPlaneFeatureConfig struct {
 // +k8s:openapi-gen=true
 type DataPlaneDogstatsdConfig struct {
 	// Enabled configures the Data Plane to handle DogStatsD traffic.
-	// When enabled, DogStatsD is disabled in the Core Agent.
-	// Default: false
+	// When set to false, DogStatsD is handled by the Core Agent instead.
+	// Default: true
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 }

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -300,7 +300,7 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_DataPlaneDogstatsdConfig(ref
 				Properties: map[string]spec.Schema{
 					"enabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enabled configures the Data Plane to handle DogStatsD traffic. When enabled, DogStatsD is disabled in the Core Agent. Default: false",
+							Description: "Enabled configures the Data Plane to handle DogStatsD traffic. When set to false, DogStatsD is handled by the Core Agent instead. Default: true",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/bundle/manifests/datadoghq.com_datadogagents.yaml
+++ b/bundle/manifests/datadoghq.com_datadogagents.yaml
@@ -1448,8 +1448,8 @@ spec:
                           enabled:
                             description: |-
                               Enabled configures the Data Plane to handle DogStatsD traffic.
-                              When enabled, DogStatsD is disabled in the Core Agent.
-                              Default: false
+                              When set to false, DogStatsD is handled by the Core Agent instead.
+                              Default: true
                             type: boolean
                         type: object
                       enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -1399,8 +1399,8 @@ spec:
                             enabled:
                               description: |-
                                 Enabled configures the Data Plane to handle DogStatsD traffic.
-                                When enabled, DogStatsD is disabled in the Core Agent.
-                                Default: false
+                                When set to false, DogStatsD is handled by the Core Agent instead.
+                                Default: true
                               type: boolean
                           type: object
                         enabled:
@@ -9845,8 +9845,8 @@ spec:
                                 enabled:
                                   description: |-
                                     Enabled configures the Data Plane to handle DogStatsD traffic.
-                                    When enabled, DogStatsD is disabled in the Core Agent.
-                                    Default: false
+                                    When set to false, DogStatsD is handled by the Core Agent instead.
+                                    Default: true
                                   type: boolean
                               type: object
                             enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -1395,7 +1395,7 @@
                   "description": "Dogstatsd configures DogStatsD handling by the Data Plane.",
                   "properties": {
                     "enabled": {
-                      "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen enabled, DogStatsD is disabled in the Core Agent.\nDefault: false",
+                      "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen set to false, DogStatsD is handled by the Core Agent instead.\nDefault: true",
                       "type": "boolean"
                     }
                   },
@@ -9582,7 +9582,7 @@
                       "description": "Dogstatsd configures DogStatsD handling by the Data Plane.",
                       "properties": {
                         "enabled": {
-                          "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen enabled, DogStatsD is disabled in the Core Agent.\nDefault: false",
+                          "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen set to false, DogStatsD is handled by the Core Agent instead.\nDefault: true",
                           "type": "boolean"
                         }
                       },

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -1399,8 +1399,8 @@ spec:
                                 enabled:
                                   description: |-
                                     Enabled configures the Data Plane to handle DogStatsD traffic.
-                                    When enabled, DogStatsD is disabled in the Core Agent.
-                                    Default: false
+                                    When set to false, DogStatsD is handled by the Core Agent instead.
+                                    Default: true
                                   type: boolean
                               type: object
                             enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -1399,7 +1399,7 @@
                       "description": "Dogstatsd configures DogStatsD handling by the Data Plane.",
                       "properties": {
                         "enabled": {
-                          "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen enabled, DogStatsD is disabled in the Core Agent.\nDefault: false",
+                          "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen set to false, DogStatsD is handled by the Core Agent instead.\nDefault: true",
                           "type": "boolean"
                         }
                       },

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -9916,8 +9916,8 @@ spec:
                                 enabled:
                                   description: |-
                                     Enabled configures the Data Plane to handle DogStatsD traffic.
-                                    When enabled, DogStatsD is disabled in the Core Agent.
-                                    Default: false
+                                    When set to false, DogStatsD is handled by the Core Agent instead.
+                                    Default: true
                                   type: boolean
                               type: object
                             enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1403,8 +1403,8 @@ spec:
                             enabled:
                               description: |-
                                 Enabled configures the Data Plane to handle DogStatsD traffic.
-                                When enabled, DogStatsD is disabled in the Core Agent.
-                                Default: false
+                                When set to false, DogStatsD is handled by the Core Agent instead.
+                                Default: true
                               type: boolean
                           type: object
                         enabled:

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1395,7 +1395,7 @@
                   "description": "Dogstatsd configures DogStatsD handling by the Data Plane.",
                   "properties": {
                     "enabled": {
-                      "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen enabled, DogStatsD is disabled in the Core Agent.\nDefault: false",
+                      "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen set to false, DogStatsD is handled by the Core Agent instead.\nDefault: true",
                       "type": "boolean"
                     }
                   },
@@ -9670,7 +9670,7 @@
                       "description": "Dogstatsd configures DogStatsD handling by the Data Plane.",
                       "properties": {
                         "enabled": {
-                          "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen enabled, DogStatsD is disabled in the Core Agent.\nDefault: false",
+                          "description": "Enabled configures the Data Plane to handle DogStatsD traffic.\nWhen set to false, DogStatsD is handled by the Core Agent instead.\nDefault: true",
                           "type": "boolean"
                         }
                       },

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -100,7 +100,7 @@ spec:
 | features.cws.remoteConfiguration.enabled | Enables Remote Configuration for Cloud Workload Security. Default: true |
 | features.cws.securityProfiles.enabled | Enables Security Profiles collection for Cloud Workload Security. Default: true |
 | features.cws.syscallMonitorEnabled | SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only). Default: false |
-| features.dataPlane.dogstatsd.enabled | Configures the Data Plane to handle DogStatsD traffic. When enabled, DogStatsD is disabled in the Core Agent. Default: false |
+| features.dataPlane.dogstatsd.enabled | Configures the Data Plane to handle DogStatsD traffic. When set to false, DogStatsD is handled by the Core Agent instead. Default: true |
 | features.dataPlane.enabled | Enables the Data Plane. Default: false |
 | features.dogstatsd.hostPortConfig.enabled | Enables host port configuration |
 | features.dogstatsd.hostPortConfig.hostPort | Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.) If HostNetwork is enabled, this value must match the ContainerPort. |

--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -166,7 +166,7 @@ spec:
 : SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only). Default: false
 
 `features.dataPlane.dogstatsd.enabled`
-: Configures the Data Plane to handle DogStatsD traffic. When enabled, DogStatsD is disabled in the Core Agent. Default: false
+: Configures the Data Plane to handle DogStatsD traffic. When set to false, DogStatsD is handled by the Core Agent instead. Default: true
 
 `features.dataPlane.enabled`
 : Enables the Data Plane. Default: false

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1753,7 +1753,7 @@ func Test_DDAI_ReconcileV3(t *testing.T) {
 			wantFunc: func(t *testing.T, c client.Client) {
 				expectedDDAI := getBaseDDAI(dda)
 				expectedDDAI.Annotations = map[string]string{
-					constants.MD5DDAIDeploymentAnnotationKey: "ccac39a3a007bad81d7baf8febc6445f",
+					constants.MD5DDAIDeploymentAnnotationKey: "a43eaa4f5f2fb5c4ed48df37f6922e57",
 				}
 
 				verifyDDAI(t, c, []v1alpha1.DatadogAgentInternal{expectedDDAI})
@@ -1785,7 +1785,7 @@ func Test_DDAI_ReconcileV3(t *testing.T) {
 				baseDDAI := getBaseDDAI(dda)
 				expectedDDAI := baseDDAI.DeepCopy()
 				expectedDDAI.Annotations = map[string]string{
-					constants.MD5DDAIDeploymentAnnotationKey: "f2aa21d0ecced63c091ca2df3d31e451",
+					constants.MD5DDAIDeploymentAnnotationKey: "8299f1d26607c80df5978be6bb192ac3",
 				}
 				expectedDDAI.Spec.Features.ClusterChecks.UseClusterChecksRunners = ptr.To(true)
 				expectedDDAI.Spec.Global.Credentials = &v2alpha1.DatadogCredentials{
@@ -1861,7 +1861,7 @@ func Test_DDAI_ReconcileV3(t *testing.T) {
 				profileDDAI := getBaseDDAI(dda)
 				profileDDAI.Name = "foo-profile"
 				profileDDAI.Annotations = map[string]string{
-					constants.MD5DDAIDeploymentAnnotationKey: "73e0cc1e445001e326507ac23654104e",
+					constants.MD5DDAIDeploymentAnnotationKey: "eeea7d553308e497de6f78247cc3a59e",
 				}
 				profileDDAI.Labels[constants.ProfileLabelKey] = "foo-profile"
 				profileDDAI.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
@@ -2095,7 +2095,7 @@ func getBaseDDAI(dda *v2alpha1.DatadogAgent) v1alpha1.DatadogAgentInternal {
 func getDefaultDDAI(dda *v2alpha1.DatadogAgent) v1alpha1.DatadogAgentInternal {
 	expectedDDAI := getBaseDDAI(dda)
 	expectedDDAI.Annotations = map[string]string{
-		constants.MD5DDAIDeploymentAnnotationKey: "f98c0497c66e2747f6d116970ab8f0b1",
+		constants.MD5DDAIDeploymentAnnotationKey: "c7bdc6ac8d1d1cd85c8c09a666227dd7",
 	}
 	expectedDDAI.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 		v2alpha1.NodeAgentComponentName: {

--- a/internal/controller/datadogagent/defaults/datadogagent_default.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default.go
@@ -141,7 +141,7 @@ const (
 
 	defaultControlPlaneMonitoringEnabled bool = true
 
-	defaultDataPlaneDogstatsdEnabled bool = false
+	defaultDataPlaneDogstatsdEnabled bool = true
 )
 
 // DefaultDatadogAgentSpec defaults the DatadogAgentSpec GlobalConfig and Features.

--- a/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
@@ -406,6 +406,29 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 			),
 		},
 		{
+			Name: "data plane enabled without explicit dogstatsd config - DSD routes to ADP by default",
+			DDA: testutils.NewDefaultDatadogAgentBuilder().
+				WithDataPlaneEnabled(true).
+				BuildWithDefaults(),
+			WantConfigure: true,
+			Agent: test.NewDefaultComponentTest().WithWantFunc(
+				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+					dsdDisabledEnvVar := &corev1.EnvVar{
+						Name:  common.DDDogstatsdEnabled,
+						Value: "false",
+					}
+
+					mgr := mgrInterface.(*fake.PodTemplateManagers)
+					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+					assert.Contains(t, agentEnvVars, dsdDisabledEnvVar, "DD_USE_DOGSTATSD should be set to false when Data Plane is enabled (dogstatsd defaults to true)")
+
+					// Verify DogStatsD config is applied to ADP container
+					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AgentDataPlaneContainerName]
+					assert.NotEmpty(t, adpEnvVars, "ADP container should have DogStatsD env vars when dogstatsd defaults to enabled")
+				},
+			),
+		},
+		{
 			Name: "data plane enabled via CRD with dogstatsd routed to ADP",
 			DDA: testutils.NewDefaultDatadogAgentBuilder().
 				WithDataPlaneEnabled(true).

--- a/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
@@ -406,7 +406,7 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 			),
 		},
 		{
-			Name: "data plane enabled without explicit dogstatsd config - DSD routes to ADP by default",
+			Name: "data plane enabled without explicit dogstatsd config with dogstatsd routed to ADP by default",
 			DDA: testutils.NewDefaultDatadogAgentBuilder().
 				WithDataPlaneEnabled(true).
 				BuildWithDefaults(),

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -78,10 +78,11 @@ func IsDataPlaneEnabled(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec) b
 }
 
 // IsDataPlaneDogstatsdEnabled returns true if the Data Plane should handle DogStatsD.
+// Defaults to true: when data_plane.enabled=true, ADP handles DogStatsD unless explicitly disabled.
 func IsDataPlaneDogstatsdEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 	if ddaSpec.Features != nil && ddaSpec.Features.DataPlane != nil &&
 		ddaSpec.Features.DataPlane.Dogstatsd != nil && ddaSpec.Features.DataPlane.Dogstatsd.Enabled != nil {
 		return *ddaSpec.Features.DataPlane.Dogstatsd.Enabled
 	}
-	return false
+	return true
 }


### PR DESCRIPTION
## Summary

When `dataPlane.enabled: true` is set, ADP now handles DogStatsD by default. Previously, users also had to set `dataPlane.dogstatsd.enabled: true` explicitly; this change removes that requirement by flipping the default to `true` so that only one configuration option has to be set.

This is part of a series implementing the DogStatsD routing truth table described in DataDog/saluki#1334.

## Test plan

- [x] New unit test: `data plane enabled without explicit dogstatsd config - DSD routes to ADP by default`
- [x] All existing dogstatsd feature tests pass
- [x] DDAI reconcile tests updated with new spec hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Tracked by [DADP-38]

[DADP-38]: https://datadoghq.atlassian.net/browse/DADP-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ