### PR TITLE
Update default Agent version to 7.78.1 and update CSI default tag to 1.2.2

### DIFF
--- a/api/datadoghq/v1alpha1/datadogcsidriver_types.go
+++ b/api/datadoghq/v1alpha1/datadogcsidriver_types.go
@@ -23,12 +23,10 @@ const (
 // +k8s:openapi-gen=true
 type DatadogCSIDriverSpec struct {
 	// CSIDriverImage is the image configuration for the main CSI node driver container.
-	// Default image: gcr.io/datadoghq/csi-driver:1.2.1
 	// +optional
 	CSIDriverImage *v2alpha1.AgentImageConfig `json:"csiDriverImage,omitempty"`
 
 	// RegistrarImage is the image configuration for the CSI node driver registrar sidecar.
-	// Default image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1
 	// +optional
 	RegistrarImage *v2alpha1.AgentImageConfig `json:"registrarImage,omitempty"`
 

--- a/api/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -721,13 +721,13 @@ func schema_datadog_operator_api_datadoghq_v1alpha1_DatadogCSIDriverSpec(ref com
 				Properties: map[string]spec.Schema{
 					"csiDriverImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CSIDriverImage is the image configuration for the main CSI node driver container. Default image: gcr.io/datadoghq/csi-driver:1.2.1",
+							Description: "CSIDriverImage is the image configuration for the main CSI node driver container.",
 							Ref:         ref("github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.AgentImageConfig"),
 						},
 					},
 					"registrarImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RegistrarImage is the image configuration for the CSI node driver registrar sidecar. Default image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1",
+							Description: "RegistrarImage is the image configuration for the CSI node driver registrar sidecar.",
 							Ref:         ref("github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.AgentImageConfig"),
 						},
 					},

--- a/config/crd/bases/v1/datadoghq.com_datadogcsidrivers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogcsidrivers.yaml
@@ -54,9 +54,7 @@ spec:
                     Default: /var/run/datadog/apm.socket
                   type: string
                 csiDriverImage:
-                  description: |-
-                    CSIDriverImage is the image configuration for the main CSI node driver container.
-                    Default image: gcr.io/datadoghq/csi-driver:1.2.1
+                  description: CSIDriverImage is the image configuration for the main CSI node driver container.
                   properties:
                     jmxEnabled:
                       description: |-
@@ -4325,9 +4323,7 @@ spec:
                       x-kubernetes-list-type: map
                   type: object
                 registrarImage:
-                  description: |-
-                    RegistrarImage is the image configuration for the CSI node driver registrar sidecar.
-                    Default image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1
+                  description: RegistrarImage is the image configuration for the CSI node driver registrar sidecar.
                   properties:
                     jmxEnabled:
                       description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogcsidrivers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogcsidrivers_v1alpha1.json
@@ -23,7 +23,7 @@
         },
         "csiDriverImage": {
           "additionalProperties": false,
-          "description": "CSIDriverImage is the image configuration for the main CSI node driver container.\nDefault image: gcr.io/datadoghq/csi-driver:1.2.1",
+          "description": "CSIDriverImage is the image configuration for the main CSI node driver container.",
           "properties": {
             "jmxEnabled": {
               "description": "Define whether the Agent image should support JMX.\nTo be used if the `Name` field does not correspond to a full image string.",
@@ -3855,7 +3855,7 @@
         },
         "registrarImage": {
           "additionalProperties": false,
-          "description": "RegistrarImage is the image configuration for the CSI node driver registrar sidecar.\nDefault image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1",
+          "description": "RegistrarImage is the image configuration for the CSI node driver registrar sidecar.",
           "properties": {
             "jmxEnabled": {
               "description": "Define whether the Agent image should support JMX.\nTo be used if the `Name` field does not correspond to a full image string.",

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.77.2"
+	AgentLatestVersion = "7.78.1"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.77.2"
+	ClusterAgentLatestVersion = "7.78.1"
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
-	DdotCollectorLatestVersion = "7.77.2"
+	DdotCollectorLatestVersion = "7.78.1"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.21"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.
@@ -28,7 +28,7 @@ const (
 	// Add "-0" so that pre-release versions are considered sufficient. https://github.com/Masterminds/semver#working-with-prerelease-versions
 	DDOTFIPSMinimumVersion = "7.78.0-0"
 	// CSILatestImageVersion corresponds to the latest stable Datadog CSIDriver release
-	CSILatestImageVersion = "1.2.1"
+	CSILatestImageVersion = "1.2.2"
 	// DefaultRegistrarImageVersion corresponds to the default CSI registrar image used
 	DefaultRegistrarImageVersion = "v2.0.1"
 	// Datadog container registry


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

What inspired you to submit this pull request?

### Additional Notes

It's not sustainable to update the CRD everytime we bump the image version for CSI, so removed from types.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits