### PR TITLE
chore: OperatorRelease worker permissions

### DIFF
--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://vault.us1.staging.dog/v1/identity/oidc
+
+subject: "f012f0b0-d135-9dd7-7f53-44a4d5cb50ca"
+
+claim_pattern:
+  email: "rapid-agent-delivery.operatorrelease@kubernetes.us1.ddbuild.io"
+
+permissions:
+  contents: read
+  pull_requests: write

--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
 subject: "f012f0b0-d135-9dd7-7f53-44a4d5cb50ca"
 
 claim_pattern:
-  email: "rapid-agent-delivery.operatorrelease@kubernetes.us1.ddbuild.io"
+  name: "rapid-agent-delivery-operatorrelease"
 
 permissions:
   contents: read

--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -1,5 +1,6 @@
-issuer: https://vault.us1.staging.dog/v1/identity/oidc
+issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
 
+# ddtool auth whois --datacenter us1.ddbuild.io rapid-agent-delivery-operatorrelease --format json | jq -r .id
 subject: "f012f0b0-d135-9dd7-7f53-44a4d5cb50ca"
 
 claim_pattern:

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -1,5 +1,6 @@
 issuer: https://vault.us1.staging.dog/v1/identity/oidc
 
+# ddtool auth whois --datacenter us1.staging.dog rapid-agent-delivery-operatorrelease --format json | jq -r .id
 subject: "1fed960d-1fe4-47de-ebb5-0992bfc0364e"
 
 claim_pattern:

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://vault.us1.staging.dog/v1/identity/oidc
+
+subject: "1fed960d-1fe4-47de-ebb5-0992bfc0364e"
+
+claim_pattern:
+  email: "rapid-agent-delivery.operatorrelease@kubernetes.us1.staging.dog"
+
+permissions:
+  contents: read
+  pull_requests: write

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.staging.dog/v1/identity/oidc
 subject: "1fed960d-1fe4-47de-ebb5-0992bfc0364e"
 
 claim_pattern:
-  email: "rapid-agent-delivery.operatorrelease@kubernetes.us1.staging.dog"
+  name: "rapid-agent-delivery-operatorrelease"
 
 permissions:
   contents: read


### PR DESCRIPTION
### What does this PR do?

Permissions for Operator Release Atlas Worker

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits