### PR TITLE
Remove datadog code coverage pr gate

### DIFF
--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -2,10 +2,6 @@ schema-version: v1
 ignore:
   - "test/"
   - "**/zz_generated.*.go"
-gates:
-  - type: patch_coverage_percentage
-    config:
-      threshold: 80
 flags:
   unittests:
     carryforward: false


### PR DESCRIPTION
### What does this PR do?

Remove datadog code coverage pr gate. It shows up as a check for prs and while it's not required to merge, it still looks concerning

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits