### PR TITLE
[CASCL-1305] No-op kubectl-datadog install on a foreign Karpenter

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log"
 	"slices"
+	"strings"
 
 	"github.com/samber/lo"
-	rbacv1 "k8s.io/api/rbac/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -22,80 +23,117 @@ const (
 	InstallerVersionLabel = "autoscaling.datadoghq.com/installer-version"
 )
 
-// karpenterAPIGroup is the API group the upstream v1 Karpenter chart's
-// controller ClusterRole references. Unlike the `app.kubernetes.io/name`
-// label this is not affected by the chart's `nameOverride`, raw kubectl
-// apply renames, or ArgoCD label rewrites.
-const karpenterAPIGroup = "karpenter.sh"
+// karpenterServiceEnvName is the env var name the upstream Karpenter chart's
+// controller deployment unconditionally sets (its value is the chart's
+// fullname, used by the controller to locate its own Service). Distinctive
+// enough that no other workload sets it, and robust to image-registry
+// rewrites — Docker Hardened Images, Chainguard, ECR pull-through caches
+// all swap the image but keep this env intact.
+const karpenterServiceEnvName = "KARPENTER_SERVICE"
 
-// karpenterControllerResources are resources the upstream v1 Karpenter
-// chart's clusterrole-core.yaml spells out explicitly. We require at least
-// one of them to be named in addition to the api group, because a wildcard
-// rule on `karpenter.sh/*` does not identify the controller — the Datadog
-// Operator's own ClusterRole carries such a wildcard to manage Karpenter
-// custom resources without being a Karpenter controller itself.
-var karpenterControllerResources = []string{"nodepools", "nodeclaims"}
+// karpenterControllerImageRepoSuffix is the trailing two path components of
+// the upstream chart's `controller.image.repository`. Used as a secondary
+// signal so chart forks that drop KARPENTER_SERVICE are still caught when
+// they keep the canonical `karpenter/controller` path. Match is
+// component-aware (not a substring) so `team/karpenter/controllers` or
+// `someone/karpenter/controller-something` do not false-positive.
+const karpenterControllerImageRepoSuffix = "karpenter/controller"
 
-// clusterRoleListChunkSize bounds the size of a single List response so we
-// don't pull thousands of ClusterRoles into memory at once on dense clusters.
+// deploymentListChunkSize bounds the size of a single List response so we
+// don't pull thousands of Deployments into memory at once on dense clusters.
 // Matches the chunk size used by GetNodesProperties.
-const clusterRoleListChunkSize = 100
+const deploymentListChunkSize = 100
 
-// IsForeignKarpenterInstalled reports whether a Karpenter installation that
-// was not produced by this plugin is running on the cluster. Detection lists
-// every ClusterRole and looks for rules that name both the `karpenter.sh`
-// API group AND at least one Karpenter controller resource (`nodepools` or
-// `nodeclaims`) — the structural fingerprint of a Karpenter controller's
-// ClusterRole, regardless of `nameOverride` or other metadata
-// customizations. ClusterRoles bearing our InstalledByLabel sentinel are
-// skipped. ClusterRoles are deleted by `helm uninstall`, unlike the CRDs in
-// `crds/`, so a leftover-only state returns false.
+// ForeignKarpenter is the location of a Karpenter controller Deployment that
+// was not produced by this plugin.
+type ForeignKarpenter struct {
+	Namespace string
+	Name      string
+}
+
+// FindForeignKarpenterInstallation returns the location of a Karpenter
+// controller Deployment running on the cluster that was not produced by
+// this plugin, or nil when none is found.
 //
-// The list is paginated with an early exit on the first foreign match: dense
-// clusters with thousands of ClusterRoles do not need to be fully materialised
-// in memory just to answer "is there at least one foreign Karpenter".
-func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
+// Detection scans every Deployment for a container that either sets the
+// chart-emitted `KARPENTER_SERVICE` env var or runs an image whose
+// repository ends with `karpenter/controller`. Looking at the running
+// controller is more robust than RBAC-based detection — monitoring or
+// management roles legitimately hold permissions on the `karpenter.sh` API
+// group without running a controller, and a Deployment that matches either
+// container signal is the only one that distinguishes "Karpenter is
+// actually running" from "something has read access to its CRs".
+//
+// Deployments bearing our InstalledByLabel sentinel are skipped. The list
+// is paginated with an early exit on the first foreign match: dense
+// clusters with thousands of Deployments do not need to be fully
+// materialised in memory just to answer "is there at least one foreign
+// Karpenter Deployment".
+func FindForeignKarpenterInstallation(ctx context.Context, clientset kubernetes.Interface) (*ForeignKarpenter, error) {
 	var cont string
 	for {
-		crs, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
-			Limit:    clusterRoleListChunkSize,
+		deps, err := clientset.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+			Limit:    deploymentListChunkSize,
 			Continue: cont,
 		})
 		if err != nil {
-			return false, fmt.Errorf("failed to list ClusterRoles: %w", err)
+			return nil, fmt.Errorf("failed to list Deployments: %w", err)
 		}
 
-		for _, cr := range crs.Items {
-			if !hasKarpenterControllerRule(cr.Rules) {
+		for _, dep := range deps.Items {
+			if !hasKarpenterControllerContainer(dep.Spec.Template.Spec.Containers) {
 				continue
 			}
-			if cr.Labels[InstalledByLabel] == InstalledByValue {
+			if dep.Labels[InstalledByLabel] == InstalledByValue {
 				continue
 			}
-			log.Printf("Detected foreign Karpenter ClusterRole")
-			return true, nil
+			log.Printf("Detected foreign Karpenter Deployment %s/%s", dep.Namespace, dep.Name)
+			return &ForeignKarpenter{Namespace: dep.Namespace, Name: dep.Name}, nil
 		}
 
-		cont = crs.Continue
+		cont = deps.Continue
 		if cont == "" {
-			return false, nil
+			return nil, nil
 		}
 	}
 }
 
-// hasKarpenterControllerRule reports whether any rule explicitly grants
-// permissions on a Karpenter controller resource (`nodepools` or
-// `nodeclaims`) under the `karpenter.sh` API group. A wildcard rule on
-// `karpenter.sh/*` (e.g. the Datadog Operator's own role for managing
-// Karpenter custom resources) does not match: the upstream v1 Karpenter
-// chart spells out specific resource names on its controller ClusterRole.
-func hasKarpenterControllerRule(rules []rbacv1.PolicyRule) bool {
-	return lo.ContainsBy(rules, func(rule rbacv1.PolicyRule) bool {
-		if !slices.Contains(rule.APIGroups, karpenterAPIGroup) {
-			return false
-		}
-		return lo.SomeBy(karpenterControllerResources, func(resource string) bool {
-			return slices.Contains(rule.Resources, resource)
-		})
-	})
+// hasKarpenterControllerContainer reports whether any container in the pod
+// spec is the Karpenter controller — primary signal is the
+// chart-unconditional KARPENTER_SERVICE env var; secondary is the canonical
+// `karpenter/controller` image repository tail.
+func hasKarpenterControllerContainer(containers []corev1.Container) bool {
+	return lo.ContainsBy(containers, isKarpenterControllerContainer)
+}
+
+func isKarpenterControllerContainer(c corev1.Container) bool {
+	if lo.ContainsBy(c.Env, func(e corev1.EnvVar) bool { return e.Name == karpenterServiceEnvName }) {
+		return true
+	}
+	return imageRepoEndsWith(c.Image, karpenterControllerImageRepoSuffix)
+}
+
+// imageRepoEndsWith reports whether `image`'s repository path (with tag and
+// digest stripped) ends with the slash-separated path components in `suffix`.
+// Used to avoid false positives from `team/karpenter/controllers` or
+// `someone/karpenter/controller-something`.
+//
+// Stripping order matters because of registries with ports
+// (`registry.local:5000/...`): digest comes off first (everything after `@`),
+// then a tag is recognised only when the last `:` lies after the last `/` —
+// otherwise the registry's port colon would be mistaken for a tag separator.
+func imageRepoEndsWith(image, suffix string) bool {
+	if i := strings.Index(image, "@"); i >= 0 {
+		image = image[:i]
+	}
+	lastSlash := strings.LastIndex(image, "/")
+	if lastColon := strings.LastIndex(image, ":"); lastColon > lastSlash {
+		image = image[:lastColon]
+	}
+	suffixParts := strings.Split(suffix, "/")
+	imageParts := strings.Split(image, "/")
+	if len(imageParts) < len(suffixParts) {
+		return false
+	}
+	return slices.Equal(imageParts[len(imageParts)-len(suffixParts):], suffixParts)
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
@@ -1,0 +1,52 @@
+package guess
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Datadog-namespaced labels written via the Karpenter chart's additionalLabels.
+// We avoid overriding standard app.kubernetes.io/* keys: the chart's
+// _helpers.tpl emits them before additionalLabels, producing duplicate YAML
+// keys whose deduplication at the API server is non-deterministic.
+const (
+	InstalledByLabel      = "autoscaling.datadoghq.com/installed-by"
+	InstalledByValue      = "kubectl-datadog"
+	InstallerVersionLabel = "autoscaling.datadoghq.com/installer-version"
+)
+
+// Standard chart-emitted label we use to recognize a Karpenter install,
+// regardless of whether it was deployed via Helm, raw kubectl apply or ArgoCD.
+const (
+	karpenterChartNameLabel      = "app.kubernetes.io/name"
+	karpenterChartNameValue      = "karpenter"
+	karpenterClusterRoleSelector = karpenterChartNameLabel + "=" + karpenterChartNameValue
+)
+
+// IsForeignKarpenterInstalled reports whether a Karpenter installation that
+// was not produced by this plugin is running on the cluster. Detection scans
+// ClusterRoles labeled `app.kubernetes.io/name=karpenter` for the absence of
+// our InstalledByLabel sentinel. ClusterRoles are deleted by `helm uninstall`,
+// unlike the CRDs in `crds/`, so a leftover-only state returns false.
+func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
+	crs, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
+		LabelSelector: karpenterClusterRoleSelector,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to list Karpenter ClusterRoles: %w", err)
+	}
+
+	for _, cr := range crs.Items {
+		if cr.Labels[InstalledByLabel] == InstalledByValue {
+			continue
+		}
+		log.Printf("Detected foreign Karpenter ClusterRole %q (instance=%q)", cr.Name, cr.Labels["app.kubernetes.io/instance"])
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
@@ -22,13 +22,19 @@ const (
 	InstallerVersionLabel = "autoscaling.datadoghq.com/installer-version"
 )
 
-// karpenterAPIGroup is the API group every Karpenter controller's ClusterRole
-// must reference: the chart's clusterrole.yaml and clusterrole-core.yaml
-// templates hard-code rules on `karpenter.sh` for nodepools/nodeclaims, which
-// is the structural fingerprint of a Karpenter install. Unlike the
-// `app.kubernetes.io/name` label this is not affected by the chart's
-// `nameOverride`, raw kubectl apply renames, or ArgoCD label rewrites.
+// karpenterAPIGroup is the API group the upstream v1 Karpenter chart's
+// controller ClusterRole references. Unlike the `app.kubernetes.io/name`
+// label this is not affected by the chart's `nameOverride`, raw kubectl
+// apply renames, or ArgoCD label rewrites.
 const karpenterAPIGroup = "karpenter.sh"
+
+// karpenterControllerResources are resources the upstream v1 Karpenter
+// chart's clusterrole-core.yaml spells out explicitly. We require at least
+// one of them to be named in addition to the api group, because a wildcard
+// rule on `karpenter.sh/*` does not identify the controller — the Datadog
+// Operator's own ClusterRole carries such a wildcard to manage Karpenter
+// custom resources without being a Karpenter controller itself.
+var karpenterControllerResources = []string{"nodepools", "nodeclaims"}
 
 // clusterRoleListChunkSize bounds the size of a single List response so we
 // don't pull thousands of ClusterRoles into memory at once on dense clusters.
@@ -37,12 +43,13 @@ const clusterRoleListChunkSize = 100
 
 // IsForeignKarpenterInstalled reports whether a Karpenter installation that
 // was not produced by this plugin is running on the cluster. Detection lists
-// every ClusterRole and looks for rules on the `karpenter.sh` API group,
-// which the chart hard-codes for nodepools/nodeclaims regardless of
-// `nameOverride` or other metadata customizations. ClusterRoles bearing our
-// InstalledByLabel sentinel are skipped. ClusterRoles are deleted by `helm
-// uninstall`, unlike the CRDs in `crds/`, so a leftover-only state returns
-// false.
+// every ClusterRole and looks for rules that name both the `karpenter.sh`
+// API group AND at least one Karpenter controller resource (`nodepools` or
+// `nodeclaims`) — the structural fingerprint of a Karpenter controller's
+// ClusterRole, regardless of `nameOverride` or other metadata
+// customizations. ClusterRoles bearing our InstalledByLabel sentinel are
+// skipped. ClusterRoles are deleted by `helm uninstall`, unlike the CRDs in
+// `crds/`, so a leftover-only state returns false.
 //
 // The list is paginated with an early exit on the first foreign match: dense
 // clusters with thousands of ClusterRoles do not need to be fully materialised
@@ -59,7 +66,7 @@ func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Inter
 		}
 
 		for _, cr := range crs.Items {
-			if !hasKarpenterAPIGroupRule(cr.Rules) {
+			if !hasKarpenterControllerRule(cr.Rules) {
 				continue
 			}
 			if cr.Labels[InstalledByLabel] == InstalledByValue {
@@ -76,12 +83,19 @@ func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Inter
 	}
 }
 
-// hasKarpenterAPIGroupRule reports whether any rule grants permissions on the
-// karpenter.sh API group. We don't constrain on resource names: any rule
-// touching the group is enough to identify a Karpenter ClusterRole, and a
-// looser check stays robust against upstream resource additions.
-func hasKarpenterAPIGroupRule(rules []rbacv1.PolicyRule) bool {
+// hasKarpenterControllerRule reports whether any rule explicitly grants
+// permissions on a Karpenter controller resource (`nodepools` or
+// `nodeclaims`) under the `karpenter.sh` API group. A wildcard rule on
+// `karpenter.sh/*` (e.g. the Datadog Operator's own role for managing
+// Karpenter custom resources) does not match: the upstream v1 Karpenter
+// chart spells out specific resource names on its controller ClusterRole.
+func hasKarpenterControllerRule(rules []rbacv1.PolicyRule) bool {
 	return lo.ContainsBy(rules, func(rule rbacv1.PolicyRule) bool {
-		return slices.Contains(rule.APIGroups, karpenterAPIGroup)
+		if !slices.Contains(rule.APIGroups, karpenterAPIGroup) {
+			return false
+		}
+		return lo.SomeBy(karpenterControllerResources, func(resource string) bool {
+			return slices.Contains(rule.Resources, resource)
+		})
 	})
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -19,28 +21,32 @@ const (
 	InstallerVersionLabel = "autoscaling.datadoghq.com/installer-version"
 )
 
-// Standard chart-emitted label we use to recognize a Karpenter install,
-// regardless of whether it was deployed via Helm, raw kubectl apply or ArgoCD.
-const (
-	karpenterChartNameLabel      = "app.kubernetes.io/name"
-	karpenterChartNameValue      = "karpenter"
-	karpenterClusterRoleSelector = karpenterChartNameLabel + "=" + karpenterChartNameValue
-)
+// karpenterAPIGroup is the API group every Karpenter controller's ClusterRole
+// must reference: the chart's clusterrole.yaml and clusterrole-core.yaml
+// templates hard-code rules on `karpenter.sh` for nodepools/nodeclaims, which
+// is the structural fingerprint of a Karpenter install. Unlike the
+// `app.kubernetes.io/name` label this is not affected by the chart's
+// `nameOverride`, raw kubectl apply renames, or ArgoCD label rewrites.
+const karpenterAPIGroup = "karpenter.sh"
 
 // IsForeignKarpenterInstalled reports whether a Karpenter installation that
-// was not produced by this plugin is running on the cluster. Detection scans
-// ClusterRoles labeled `app.kubernetes.io/name=karpenter` for the absence of
-// our InstalledByLabel sentinel. ClusterRoles are deleted by `helm uninstall`,
-// unlike the CRDs in `crds/`, so a leftover-only state returns false.
+// was not produced by this plugin is running on the cluster. Detection lists
+// every ClusterRole and looks for rules on the `karpenter.sh` API group,
+// which the chart hard-codes for nodepools/nodeclaims regardless of
+// `nameOverride` or other metadata customizations. ClusterRoles bearing our
+// InstalledByLabel sentinel are skipped. ClusterRoles are deleted by `helm
+// uninstall`, unlike the CRDs in `crds/`, so a leftover-only state returns
+// false.
 func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
-	crs, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
-		LabelSelector: karpenterClusterRoleSelector,
-	})
+	crs, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to list Karpenter ClusterRoles: %w", err)
+		return false, fmt.Errorf("failed to list ClusterRoles: %w", err)
 	}
 
 	for _, cr := range crs.Items {
+		if !hasKarpenterAPIGroupRule(cr.Rules) {
+			continue
+		}
 		if cr.Labels[InstalledByLabel] == InstalledByValue {
 			continue
 		}
@@ -49,4 +55,17 @@ func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Inter
 	}
 
 	return false, nil
+}
+
+// hasKarpenterAPIGroupRule reports whether any rule grants permissions on the
+// karpenter.sh API group. We don't constrain on resource names: any rule
+// touching the group is enough to identify a Karpenter ClusterRole, and a
+// looser check stays robust against upstream resource additions.
+func hasKarpenterAPIGroupRule(rules []rbacv1.PolicyRule) bool {
+	for _, rule := range rules {
+		if slices.Contains(rule.APIGroups, karpenterAPIGroup) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
@@ -65,7 +65,7 @@ func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Inter
 			if cr.Labels[InstalledByLabel] == InstalledByValue {
 				continue
 			}
-			log.Printf("Detected foreign Karpenter ClusterRole %q (instance=%q)", cr.Name, cr.Labels["app.kubernetes.io/instance"])
+			log.Printf("Detected foreign Karpenter ClusterRole")
 			return true, nil
 		}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"slices"
 
+	"github.com/samber/lo"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -29,6 +30,11 @@ const (
 // `nameOverride`, raw kubectl apply renames, or ArgoCD label rewrites.
 const karpenterAPIGroup = "karpenter.sh"
 
+// clusterRoleListChunkSize bounds the size of a single List response so we
+// don't pull thousands of ClusterRoles into memory at once on dense clusters.
+// Matches the chunk size used by GetNodesProperties.
+const clusterRoleListChunkSize = 100
+
 // IsForeignKarpenterInstalled reports whether a Karpenter installation that
 // was not produced by this plugin is running on the cluster. Detection lists
 // every ClusterRole and looks for rules on the `karpenter.sh` API group,
@@ -37,24 +43,37 @@ const karpenterAPIGroup = "karpenter.sh"
 // InstalledByLabel sentinel are skipped. ClusterRoles are deleted by `helm
 // uninstall`, unlike the CRDs in `crds/`, so a leftover-only state returns
 // false.
+//
+// The list is paginated with an early exit on the first foreign match: dense
+// clusters with thousands of ClusterRoles do not need to be fully materialised
+// in memory just to answer "is there at least one foreign Karpenter".
 func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Interface) (bool, error) {
-	crs, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return false, fmt.Errorf("failed to list ClusterRoles: %w", err)
-	}
-
-	for _, cr := range crs.Items {
-		if !hasKarpenterAPIGroupRule(cr.Rules) {
-			continue
+	var cont string
+	for {
+		crs, err := clientset.RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{
+			Limit:    clusterRoleListChunkSize,
+			Continue: cont,
+		})
+		if err != nil {
+			return false, fmt.Errorf("failed to list ClusterRoles: %w", err)
 		}
-		if cr.Labels[InstalledByLabel] == InstalledByValue {
-			continue
-		}
-		log.Printf("Detected foreign Karpenter ClusterRole %q (instance=%q)", cr.Name, cr.Labels["app.kubernetes.io/instance"])
-		return true, nil
-	}
 
-	return false, nil
+		for _, cr := range crs.Items {
+			if !hasKarpenterAPIGroupRule(cr.Rules) {
+				continue
+			}
+			if cr.Labels[InstalledByLabel] == InstalledByValue {
+				continue
+			}
+			log.Printf("Detected foreign Karpenter ClusterRole %q (instance=%q)", cr.Name, cr.Labels["app.kubernetes.io/instance"])
+			return true, nil
+		}
+
+		cont = crs.Continue
+		if cont == "" {
+			return false, nil
+		}
+	}
 }
 
 // hasKarpenterAPIGroupRule reports whether any rule grants permissions on the
@@ -62,10 +81,7 @@ func IsForeignKarpenterInstalled(ctx context.Context, clientset kubernetes.Inter
 // touching the group is enough to identify a Karpenter ClusterRole, and a
 // looser check stays robust against upstream resource additions.
 func hasKarpenterAPIGroupRule(rules []rbacv1.PolicyRule) bool {
-	for _, rule := range rules {
-		if slices.Contains(rule.APIGroups, karpenterAPIGroup) {
-			return true
-		}
-	}
-	return false
+	return lo.ContainsBy(rules, func(rule rbacv1.PolicyRule) bool {
+		return slices.Contains(rule.APIGroups, karpenterAPIGroup)
+	})
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter.go
@@ -44,16 +44,24 @@ const karpenterControllerImageRepoSuffix = "karpenter/controller"
 // Matches the chunk size used by GetNodesProperties.
 const deploymentListChunkSize = 100
 
-// ForeignKarpenter is the location of a Karpenter controller Deployment that
-// was not produced by this plugin.
+// ForeignKarpenter is the location of a Karpenter controller Deployment
+// that conflicts with the install we're about to perform — either a
+// third-party install or a previous kubectl-datadog install in a different
+// namespace, both of which would race the new controller on the
+// cluster-scoped Karpenter CRDs.
 type ForeignKarpenter struct {
 	Namespace string
 	Name      string
 }
 
 // FindForeignKarpenterInstallation returns the location of a Karpenter
-// controller Deployment running on the cluster that was not produced by
-// this plugin, or nil when none is found.
+// controller Deployment running on the cluster that this `install` run
+// would conflict with, or nil when none is found. `targetNamespace` is the
+// namespace the install would deploy into; only a kubectl-datadog
+// Deployment in that namespace is treated as ours and skipped — an
+// existing kubectl-datadog Deployment in a *different* namespace would
+// race the new one on the cluster-scoped Karpenter CRDs, so we surface
+// it too.
 //
 // Detection scans every Deployment for a container that either sets the
 // chart-emitted `KARPENTER_SERVICE` env var or runs an image whose
@@ -64,12 +72,11 @@ type ForeignKarpenter struct {
 // container signal is the only one that distinguishes "Karpenter is
 // actually running" from "something has read access to its CRs".
 //
-// Deployments bearing our InstalledByLabel sentinel are skipped. The list
-// is paginated with an early exit on the first foreign match: dense
-// clusters with thousands of Deployments do not need to be fully
+// The list is paginated with an early exit on the first foreign match:
+// dense clusters with thousands of Deployments do not need to be fully
 // materialised in memory just to answer "is there at least one foreign
 // Karpenter Deployment".
-func FindForeignKarpenterInstallation(ctx context.Context, clientset kubernetes.Interface) (*ForeignKarpenter, error) {
+func FindForeignKarpenterInstallation(ctx context.Context, clientset kubernetes.Interface, targetNamespace string) (*ForeignKarpenter, error) {
 	var cont string
 	for {
 		deps, err := clientset.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
@@ -84,7 +91,7 @@ func FindForeignKarpenterInstallation(ctx context.Context, clientset kubernetes.
 			if !hasKarpenterControllerContainer(dep.Spec.Template.Spec.Containers) {
 				continue
 			}
-			if dep.Labels[InstalledByLabel] == InstalledByValue {
+			if dep.Namespace == targetNamespace && dep.Labels[InstalledByLabel] == InstalledByValue {
 				continue
 			}
 			log.Printf("Detected foreign Karpenter Deployment %s/%s", dep.Namespace, dep.Name)

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
@@ -13,13 +13,25 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
-// TestKarpenterClusterRoleSelectorContract pins the exact label selector we
-// match against. Subsequent tests build fake objects via the same constants,
-// so a typo in the constants would silently make those tests pass while real
-// Karpenter installs stop matching — this assertion locks down the contract
-// against the chart's documented label.
-func TestKarpenterClusterRoleSelectorContract(t *testing.T) {
-	assert.Equal(t, "app.kubernetes.io/name=karpenter", karpenterClusterRoleSelector)
+// karpenterCoreRules is the minimal set of rules that uniquely identifies a
+// Karpenter ClusterRole: the chart's clusterrole-core.yaml hard-codes the
+// karpenter.sh API group with nodepools/nodeclaims, so any real Karpenter
+// install produces a ClusterRole containing them.
+var karpenterCoreRules = []rbacv1.PolicyRule{
+	{
+		APIGroups: []string{"karpenter.sh"},
+		Resources: []string{"nodepools", "nodeclaims"},
+		Verbs:     []string{"get", "list", "watch"},
+	},
+}
+
+// TestKarpenterAPIGroupContract pins the API group fingerprint we match
+// against. Subsequent tests build fake objects via the same constant, so a
+// typo here would silently make them pass while real Karpenter installs stop
+// matching — this assertion locks down the contract against the chart's
+// hard-coded apiGroup.
+func TestKarpenterAPIGroupContract(t *testing.T) {
+	assert.Equal(t, "karpenter.sh", karpenterAPIGroup)
 }
 
 func TestIsForeignKarpenterInstalled(t *testing.T) {
@@ -29,23 +41,32 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "no Karpenter ClusterRoles on the cluster",
+			name:     "no ClusterRoles on the cluster",
 			objects:  nil,
+			expected: false,
+		},
+		{
+			name: "no Karpenter ClusterRoles among unrelated ones",
+			objects: []runtime.Object{
+				clusterRole("system:auth-delegator", nil, []rbacv1.PolicyRule{
+					{APIGroups: []string{"authentication.k8s.io"}, Resources: []string{"tokenreviews"}, Verbs: []string{"create"}},
+				}),
+			},
 			expected: false,
 		},
 		{
 			name: "only kubectl-datadog ClusterRoles",
 			objects: []runtime.Object{
 				clusterRole("karpenter", map[string]string{
-					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/name":     "karpenter",
 					"app.kubernetes.io/instance": "karpenter",
 					InstalledByLabel:             InstalledByValue,
-				}),
+				}, karpenterCoreRules),
 				clusterRole("karpenter-core", map[string]string{
-					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/name":     "karpenter",
 					"app.kubernetes.io/instance": "karpenter",
 					InstalledByLabel:             InstalledByValue,
-				}),
+				}, karpenterCoreRules),
 			},
 			expected: false,
 		},
@@ -53,10 +74,24 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 			name: "foreign ClusterRole without our sentinel",
 			objects: []runtime.Object{
 				clusterRole("karpenter", map[string]string{
-					karpenterChartNameLabel:        karpenterChartNameValue,
+					"app.kubernetes.io/name":       "karpenter",
 					"app.kubernetes.io/instance":   "karpenter",
 					"app.kubernetes.io/managed-by": "Helm",
-				}),
+				}, karpenterCoreRules),
+			},
+			expected: true,
+		},
+		{
+			name: "foreign Karpenter installed with custom nameOverride",
+			// Helm chart with `nameOverride: my-karpenter` renames both the
+			// ClusterRole and its app.kubernetes.io/name label. The rules,
+			// however, still reference karpenter.sh — so we must detect it.
+			objects: []runtime.Object{
+				clusterRole("my-karpenter-core", map[string]string{
+					"app.kubernetes.io/name":       "my-karpenter",
+					"app.kubernetes.io/instance":   "my-karpenter",
+					"app.kubernetes.io/managed-by": "Helm",
+				}, karpenterCoreRules),
 			},
 			expected: true,
 		},
@@ -64,22 +99,27 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 			name: "mix of ours and foreign returns true",
 			objects: []runtime.Object{
 				clusterRole("karpenter-core", map[string]string{
-					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/name":     "karpenter",
 					"app.kubernetes.io/instance": "karpenter",
 					InstalledByLabel:             InstalledByValue,
-				}),
+				}, karpenterCoreRules),
 				clusterRole("karpenter", map[string]string{
-					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/name":     "karpenter",
 					"app.kubernetes.io/instance": "their-release",
-				}),
+				}, karpenterCoreRules),
 			},
 			expected: true,
 		},
 		{
-			name: "ClusterRole without the karpenter selector label is ignored",
+			name: "ClusterRole with karpenter-looking labels but no karpenter.sh rules is ignored",
+			// Defensive: a user-authored ClusterRole that happens to carry
+			// `app.kubernetes.io/name=karpenter` but no actual Karpenter
+			// rules must not trigger the guard.
 			objects: []runtime.Object{
-				clusterRole("unrelated", map[string]string{
-					karpenterChartNameLabel: "something-else",
+				clusterRole("fake-karpenter", map[string]string{
+					"app.kubernetes.io/name": "karpenter",
+				}, []rbacv1.PolicyRule{
+					{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get"}},
 				}),
 			},
 			expected: false,
@@ -88,9 +128,9 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 			name: "foreign sentinel value is treated as foreign",
 			objects: []runtime.Object{
 				clusterRole("karpenter", map[string]string{
-					karpenterChartNameLabel: karpenterChartNameValue,
-					InstalledByLabel:        "someone-else",
-				}),
+					"app.kubernetes.io/name": "karpenter",
+					InstalledByLabel:         "someone-else",
+				}, karpenterCoreRules),
 			},
 			expected: true,
 		},
@@ -114,15 +154,16 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 		_, err := IsForeignKarpenterInstalled(t.Context(), clientset)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to list Karpenter ClusterRoles")
+		assert.Contains(t, err.Error(), "failed to list ClusterRoles")
 	})
 }
 
-func clusterRole(name string, labels map[string]string) *rbacv1.ClusterRole {
+func clusterRole(name string, labels map[string]string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
 		},
+		Rules: rules,
 	}
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
@@ -1,0 +1,128 @@
+package guess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// TestKarpenterClusterRoleSelectorContract pins the exact label selector we
+// match against. Subsequent tests build fake objects via the same constants,
+// so a typo in the constants would silently make those tests pass while real
+// Karpenter installs stop matching — this assertion locks down the contract
+// against the chart's documented label.
+func TestKarpenterClusterRoleSelectorContract(t *testing.T) {
+	assert.Equal(t, "app.kubernetes.io/name=karpenter", karpenterClusterRoleSelector)
+}
+
+func TestIsForeignKarpenterInstalled(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		objects  []runtime.Object
+		expected bool
+	}{
+		{
+			name:     "no Karpenter ClusterRoles on the cluster",
+			objects:  nil,
+			expected: false,
+		},
+		{
+			name: "only kubectl-datadog ClusterRoles",
+			objects: []runtime.Object{
+				clusterRole("karpenter", map[string]string{
+					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/instance": "karpenter",
+					InstalledByLabel:             InstalledByValue,
+				}),
+				clusterRole("karpenter-core", map[string]string{
+					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/instance": "karpenter",
+					InstalledByLabel:             InstalledByValue,
+				}),
+			},
+			expected: false,
+		},
+		{
+			name: "foreign ClusterRole without our sentinel",
+			objects: []runtime.Object{
+				clusterRole("karpenter", map[string]string{
+					karpenterChartNameLabel:        karpenterChartNameValue,
+					"app.kubernetes.io/instance":   "karpenter",
+					"app.kubernetes.io/managed-by": "Helm",
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "mix of ours and foreign returns true",
+			objects: []runtime.Object{
+				clusterRole("karpenter-core", map[string]string{
+					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/instance": "karpenter",
+					InstalledByLabel:             InstalledByValue,
+				}),
+				clusterRole("karpenter", map[string]string{
+					karpenterChartNameLabel:      karpenterChartNameValue,
+					"app.kubernetes.io/instance": "their-release",
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "ClusterRole without the karpenter selector label is ignored",
+			objects: []runtime.Object{
+				clusterRole("unrelated", map[string]string{
+					karpenterChartNameLabel: "something-else",
+				}),
+			},
+			expected: false,
+		},
+		{
+			name: "foreign sentinel value is treated as foreign",
+			objects: []runtime.Object{
+				clusterRole("karpenter", map[string]string{
+					karpenterChartNameLabel: karpenterChartNameValue,
+					InstalledByLabel:        "someone-else",
+				}),
+			},
+			expected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tc.objects...)
+
+			result, err := IsForeignKarpenterInstalled(t.Context(), clientset)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+
+	t.Run("API list error propagates", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		clientset.PrependReactor("list", "clusterroles", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewServiceUnavailable("test failure")
+		})
+
+		_, err := IsForeignKarpenterInstalled(t.Context(), clientset)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list Karpenter ClusterRoles")
+	})
+}
+
+func clusterRole(name string, labels map[string]string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
@@ -156,6 +156,59 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to list ClusterRoles")
 	})
+
+	t.Run("pagination follows Continue token across pages and short-circuits on first foreign match", func(t *testing.T) {
+		// Three pages: an empty page with a non-empty Continue token
+		// (the API server may legitimately return one), a page with only
+		// our own ClusterRole, and a page where the foreign install lives.
+		// We expect the function to walk pages 1 and 2, find the foreign on
+		// page 3, and stop. Page 4 must never be requested.
+		pages := []*rbacv1.ClusterRoleList{
+			{
+				ListMeta: metav1.ListMeta{Continue: "page2"},
+				Items:    nil,
+			},
+			{
+				ListMeta: metav1.ListMeta{Continue: "page3"},
+				Items: []rbacv1.ClusterRole{
+					*clusterRole("karpenter", map[string]string{
+						InstalledByLabel: InstalledByValue,
+					}, karpenterCoreRules),
+				},
+			},
+			{
+				ListMeta: metav1.ListMeta{Continue: "page4"},
+				Items: []rbacv1.ClusterRole{
+					*clusterRole("their-karpenter", map[string]string{
+						"app.kubernetes.io/instance": "their-release",
+					}, karpenterCoreRules),
+				},
+			},
+			{
+				Items: []rbacv1.ClusterRole{
+					*clusterRole("never-fetched", nil, karpenterCoreRules),
+				},
+			},
+		}
+
+		clientset := fake.NewSimpleClientset()
+		var calls []string
+		clientset.PrependReactor("list", "clusterroles", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			opts := action.(k8stesting.ListActionImpl).GetListOptions()
+			calls = append(calls, opts.Continue)
+			assert.EqualValues(t, clusterRoleListChunkSize, opts.Limit, "Limit must be set so the API server can chunk")
+			require.Less(t, len(calls)-1, len(pages),
+				"reactor would over-fetch beyond the synthetic pages — early-exit broken")
+			return true, pages[len(calls)-1], nil
+		})
+
+		result, err := IsForeignKarpenterInstalled(t.Context(), clientset)
+
+		require.NoError(t, err)
+		assert.True(t, result)
+		assert.Equal(t, []string{"", "page2", "page3"}, calls,
+			"each call must forward the previous page's Continue token, and page 4 must never be requested")
+	})
 }
 
 func clusterRole(name string, labels map[string]string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
@@ -56,10 +56,13 @@ func TestImageRepoEndsWith(t *testing.T) {
 }
 
 func TestFindForeignKarpenterInstallation(t *testing.T) {
+	const ourNamespace = "dd-karpenter"
+
 	for _, tc := range []struct {
-		name     string
-		objects  []runtime.Object
-		expected *ForeignKarpenter
+		name            string
+		objects         []runtime.Object
+		targetNamespace string
+		expected        *ForeignKarpenter
 	}{
 		{
 			name:     "no Deployments on the cluster",
@@ -75,14 +78,46 @@ func TestFindForeignKarpenterInstallation(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "only kubectl-datadog Karpenter Deployment",
+			name: "only kubectl-datadog Karpenter Deployment in our target namespace",
 			objects: []runtime.Object{
-				deployment("dd-karpenter", "karpenter",
+				deployment(ourNamespace, "karpenter",
 					map[string]string{InstalledByLabel: InstalledByValue},
 					karpenterControllerImage,
 				),
 			},
-			expected: nil,
+			targetNamespace: ourNamespace,
+			expected:        nil,
+		},
+		{
+			name: "kubectl-datadog Deployment in another namespace is foreign when targeting a different namespace",
+			// User has an existing kubectl-datadog install in dd-karpenter and
+			// reruns `install --karpenter-namespace=other-ns`. The controller
+			// in dd-karpenter would race the new one we'd deploy in other-ns
+			// on the cluster-scoped CRDs, so it must surface as foreign even
+			// though it carries our sentinel.
+			objects: []runtime.Object{
+				deployment(ourNamespace, "karpenter",
+					map[string]string{InstalledByLabel: InstalledByValue},
+					karpenterControllerImage,
+				),
+			},
+			targetNamespace: "other-ns",
+			expected:        &ForeignKarpenter{Namespace: ourNamespace, Name: "karpenter"},
+		},
+		{
+			name: "empty targetNamespace surfaces every Karpenter controller, even sentinel-labeled",
+			// Defensive: an empty targetNamespace means no namespace
+			// qualifies as ours, so any matching controller surfaces as
+			// foreign. The CLI never sends an empty value (the flag has a
+			// default), but the detector should fail closed.
+			objects: []runtime.Object{
+				deployment(ourNamespace, "karpenter",
+					map[string]string{InstalledByLabel: InstalledByValue},
+					karpenterControllerImage,
+				),
+			},
+			targetNamespace: "",
+			expected:        &ForeignKarpenter{Namespace: ourNamespace, Name: "karpenter"},
 		},
 		{
 			name: "foreign Karpenter Deployment without our sentinel",
@@ -112,15 +147,16 @@ func TestFindForeignKarpenterInstallation(t *testing.T) {
 			expected: &ForeignKarpenter{Namespace: "autoscaling", Name: "my-karpenter"},
 		},
 		{
-			name: "mix of ours and foreign returns the foreign one",
+			name: "mix of ours-in-target-namespace and foreign returns the foreign one",
 			objects: []runtime.Object{
-				deployment("dd-karpenter", "karpenter",
+				deployment(ourNamespace, "karpenter",
 					map[string]string{InstalledByLabel: InstalledByValue},
 					karpenterControllerImage,
 				),
 				deployment("karpenter", "karpenter", nil, karpenterControllerImage),
 			},
-			expected: &ForeignKarpenter{Namespace: "karpenter", Name: "karpenter"},
+			targetNamespace: ourNamespace,
+			expected:        &ForeignKarpenter{Namespace: "karpenter", Name: "karpenter"},
 		},
 		{
 			name: "Datadog Cluster Agent Deployment with karpenter.sh RBAC is not the controller",
@@ -175,7 +211,7 @@ func TestFindForeignKarpenterInstallation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			clientset := fake.NewSimpleClientset(tc.objects...)
 
-			result, err := FindForeignKarpenterInstallation(t.Context(), clientset)
+			result, err := FindForeignKarpenterInstallation(t.Context(), clientset, tc.targetNamespace)
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
@@ -188,7 +224,7 @@ func TestFindForeignKarpenterInstallation(t *testing.T) {
 			return true, nil, apierrors.NewServiceUnavailable("test failure")
 		})
 
-		_, err := FindForeignKarpenterInstallation(t.Context(), clientset)
+		_, err := FindForeignKarpenterInstallation(t.Context(), clientset, ourNamespace)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to list Deployments")
@@ -236,7 +272,7 @@ func TestFindForeignKarpenterInstallation(t *testing.T) {
 			return true, pages[len(calls)-1], nil
 		})
 
-		result, err := FindForeignKarpenterInstallation(t.Context(), clientset)
+		result, err := FindForeignKarpenterInstallation(t.Context(), clientset, "dd-karpenter")
 
 		require.NoError(t, err)
 		assert.Equal(t, &ForeignKarpenter{Namespace: "their-ns", Name: "their-karpenter"}, result)

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
@@ -25,13 +25,14 @@ var karpenterCoreRules = []rbacv1.PolicyRule{
 	},
 }
 
-// TestKarpenterAPIGroupContract pins the API group fingerprint we match
-// against. Subsequent tests build fake objects via the same constant, so a
-// typo here would silently make them pass while real Karpenter installs stop
-// matching — this assertion locks down the contract against the chart's
-// hard-coded apiGroup.
-func TestKarpenterAPIGroupContract(t *testing.T) {
+// TestKarpenterControllerFingerprintContract pins the API group + resources
+// fingerprint we match against. Subsequent tests build fake objects via the
+// same constants, so a typo would silently make them pass while real
+// Karpenter installs stop matching — this assertion locks down the contract
+// against the chart's hard-coded clusterrole-core.yaml.
+func TestKarpenterControllerFingerprintContract(t *testing.T) {
 	assert.Equal(t, "karpenter.sh", karpenterAPIGroup)
+	assert.Equal(t, []string{"nodepools", "nodeclaims"}, karpenterControllerResources)
 }
 
 func TestIsForeignKarpenterInstalled(t *testing.T) {
@@ -133,6 +134,36 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 				}, karpenterCoreRules),
 			},
 			expected: true,
+		},
+		{
+			name: "split rules with only nodepools or only nodeclaims still match",
+			// The chart's clusterrole-core.yaml splits write permissions
+			// across separate rules — one per resource. Each rule on its
+			// own must carry the controller fingerprint.
+			objects: []runtime.Object{
+				clusterRole("their-karpenter", nil, []rbacv1.PolicyRule{
+					{APIGroups: []string{"karpenter.sh"}, Resources: []string{"nodeclaims", "nodeclaims/status"}, Verbs: []string{"create", "delete", "update", "patch"}},
+					{APIGroups: []string{"karpenter.sh"}, Resources: []string{"nodepools", "nodepools/status"}, Verbs: []string{"update", "patch"}},
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "Datadog Operator role with karpenter.sh wildcard is not a controller",
+			// The Datadog Operator's own ClusterRole grants `karpenter.sh/*`
+			// to manage Karpenter CRs as part of cluster autoscaling
+			// recommendations — but the operator is not a Karpenter
+			// controller. A wildcard-only rule must not trigger the guard.
+			objects: []runtime.Object{
+				clusterRole("datadog-operator-manager-role", nil, []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"karpenter.sh"},
+						Resources: []string{"*"},
+						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
+					},
+				}),
+			},
+			expected: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/foreignkarpenter_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	rbacv1 "k8s.io/api/rbac/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,163 +14,168 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
-// karpenterCoreRules is the minimal set of rules that uniquely identifies a
-// Karpenter ClusterRole: the chart's clusterrole-core.yaml hard-codes the
-// karpenter.sh API group with nodepools/nodeclaims, so any real Karpenter
-// install produces a ClusterRole containing them.
-var karpenterCoreRules = []rbacv1.PolicyRule{
-	{
-		APIGroups: []string{"karpenter.sh"},
-		Resources: []string{"nodepools", "nodeclaims"},
-		Verbs:     []string{"get", "list", "watch"},
-	},
-}
+// karpenterControllerImage is the upstream chart's default controller image,
+// constructed exactly as the `karpenter.controller.image` helper renders it.
+const karpenterControllerImage = "public.ecr.aws/karpenter/controller:1.12.0"
 
-// TestKarpenterControllerFingerprintContract pins the API group + resources
-// fingerprint we match against. Subsequent tests build fake objects via the
-// same constants, so a typo would silently make them pass while real
-// Karpenter installs stop matching — this assertion locks down the contract
-// against the chart's hard-coded clusterrole-core.yaml.
+// TestKarpenterControllerFingerprintContract pins the two signals we match
+// on. Subsequent tests build fake Deployments via these constants, so a
+// typo would silently let them pass while real Karpenter installs stop
+// matching — this assertion locks the contract against the chart's
+// deployment.yaml.
 func TestKarpenterControllerFingerprintContract(t *testing.T) {
-	assert.Equal(t, "karpenter.sh", karpenterAPIGroup)
-	assert.Equal(t, []string{"nodepools", "nodeclaims"}, karpenterControllerResources)
+	assert.Equal(t, "KARPENTER_SERVICE", karpenterServiceEnvName)
+	assert.Equal(t, "karpenter/controller", karpenterControllerImageRepoSuffix)
 }
 
-func TestIsForeignKarpenterInstalled(t *testing.T) {
+func TestImageRepoEndsWith(t *testing.T) {
+	for _, tc := range []struct {
+		image    string
+		suffix   string
+		expected bool
+	}{
+		{"public.ecr.aws/karpenter/controller:1.12.0", "karpenter/controller", true},
+		{"public.ecr.aws/karpenter/controller@sha256:abc", "karpenter/controller", true},
+		{"public.ecr.aws/karpenter/controller:1.12.0@sha256:abc", "karpenter/controller", true},
+		{"012345678901.dkr.ecr.us-west-2.amazonaws.com/karpenter/controller:1.10.0", "karpenter/controller", true},
+		{"registry.local:5000/karpenter/controller:1.12.0", "karpenter/controller", true},
+		{"registry.local:5000/karpenter/controller@sha256:abc", "karpenter/controller", true},
+		{"registry.local:5000/karpenter/controller:1.12.0@sha256:abc", "karpenter/controller", true},
+		{"karpenter/controller", "karpenter/controller", true},
+		{"team/karpenter/controllers:v1", "karpenter/controller", false},
+		{"team/karpenter/controller-something:v1", "karpenter/controller", false},
+		{"registry.local:5000/team/karpenter/controllers:v1", "karpenter/controller", false},
+		{"public.ecr.aws/karpenter/karpenter:1.0", "karpenter/controller", false},
+		{"cgr.dev/chainguard/karpenter:1.0", "karpenter/controller", false},
+		{"controller", "karpenter/controller", false},
+	} {
+		t.Run(tc.image, func(t *testing.T) {
+			assert.Equal(t, tc.expected, imageRepoEndsWith(tc.image, tc.suffix))
+		})
+	}
+}
+
+func TestFindForeignKarpenterInstallation(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		objects  []runtime.Object
-		expected bool
+		expected *ForeignKarpenter
 	}{
 		{
-			name:     "no ClusterRoles on the cluster",
+			name:     "no Deployments on the cluster",
 			objects:  nil,
-			expected: false,
+			expected: nil,
 		},
 		{
-			name: "no Karpenter ClusterRoles among unrelated ones",
+			name: "no Karpenter Deployment among unrelated ones",
 			objects: []runtime.Object{
-				clusterRole("system:auth-delegator", nil, []rbacv1.PolicyRule{
-					{APIGroups: []string{"authentication.k8s.io"}, Resources: []string{"tokenreviews"}, Verbs: []string{"create"}},
-				}),
+				deployment("kube-system", "coredns", nil, "registry.k8s.io/coredns/coredns:v1.10.1"),
+				deployment("default", "nginx", nil, "nginx:1.25"),
 			},
-			expected: false,
+			expected: nil,
 		},
 		{
-			name: "only kubectl-datadog ClusterRoles",
+			name: "only kubectl-datadog Karpenter Deployment",
 			objects: []runtime.Object{
-				clusterRole("karpenter", map[string]string{
-					"app.kubernetes.io/name":     "karpenter",
-					"app.kubernetes.io/instance": "karpenter",
-					InstalledByLabel:             InstalledByValue,
-				}, karpenterCoreRules),
-				clusterRole("karpenter-core", map[string]string{
-					"app.kubernetes.io/name":     "karpenter",
-					"app.kubernetes.io/instance": "karpenter",
-					InstalledByLabel:             InstalledByValue,
-				}, karpenterCoreRules),
+				deployment("dd-karpenter", "karpenter",
+					map[string]string{InstalledByLabel: InstalledByValue},
+					karpenterControllerImage,
+				),
 			},
-			expected: false,
+			expected: nil,
 		},
 		{
-			name: "foreign ClusterRole without our sentinel",
+			name: "foreign Karpenter Deployment without our sentinel",
 			objects: []runtime.Object{
-				clusterRole("karpenter", map[string]string{
-					"app.kubernetes.io/name":       "karpenter",
-					"app.kubernetes.io/instance":   "karpenter",
-					"app.kubernetes.io/managed-by": "Helm",
-				}, karpenterCoreRules),
+				deployment("karpenter", "karpenter", nil, karpenterControllerImage),
 			},
-			expected: true,
+			expected: &ForeignKarpenter{Namespace: "karpenter", Name: "karpenter"},
+		},
+		{
+			name: "foreign Karpenter installed via a private mirror still matches",
+			// Users behind a private registry rewrite the image but keep the
+			// `karpenter/controller` path so the marker still hits.
+			objects: []runtime.Object{
+				deployment("kube-system", "their-karpenter", nil,
+					"012345678901.dkr.ecr.us-west-2.amazonaws.com/karpenter/controller:1.10.0",
+				),
+			},
+			expected: &ForeignKarpenter{Namespace: "kube-system", Name: "their-karpenter"},
 		},
 		{
 			name: "foreign Karpenter installed with custom nameOverride",
-			// Helm chart with `nameOverride: my-karpenter` renames both the
-			// ClusterRole and its app.kubernetes.io/name label. The rules,
-			// however, still reference karpenter.sh — so we must detect it.
+			// nameOverride only renames the Deployment object itself; the
+			// controller still pulls public.ecr.aws/karpenter/controller.
 			objects: []runtime.Object{
-				clusterRole("my-karpenter-core", map[string]string{
-					"app.kubernetes.io/name":       "my-karpenter",
-					"app.kubernetes.io/instance":   "my-karpenter",
-					"app.kubernetes.io/managed-by": "Helm",
-				}, karpenterCoreRules),
+				deployment("autoscaling", "my-karpenter", nil, karpenterControllerImage),
 			},
-			expected: true,
+			expected: &ForeignKarpenter{Namespace: "autoscaling", Name: "my-karpenter"},
 		},
 		{
-			name: "mix of ours and foreign returns true",
+			name: "mix of ours and foreign returns the foreign one",
 			objects: []runtime.Object{
-				clusterRole("karpenter-core", map[string]string{
-					"app.kubernetes.io/name":     "karpenter",
-					"app.kubernetes.io/instance": "karpenter",
-					InstalledByLabel:             InstalledByValue,
-				}, karpenterCoreRules),
-				clusterRole("karpenter", map[string]string{
-					"app.kubernetes.io/name":     "karpenter",
-					"app.kubernetes.io/instance": "their-release",
-				}, karpenterCoreRules),
+				deployment("dd-karpenter", "karpenter",
+					map[string]string{InstalledByLabel: InstalledByValue},
+					karpenterControllerImage,
+				),
+				deployment("karpenter", "karpenter", nil, karpenterControllerImage),
 			},
-			expected: true,
+			expected: &ForeignKarpenter{Namespace: "karpenter", Name: "karpenter"},
 		},
 		{
-			name: "ClusterRole with karpenter-looking labels but no karpenter.sh rules is ignored",
-			// Defensive: a user-authored ClusterRole that happens to carry
-			// `app.kubernetes.io/name=karpenter` but no actual Karpenter
-			// rules must not trigger the guard.
+			name: "Datadog Cluster Agent Deployment with karpenter.sh RBAC is not the controller",
+			// The DD chart's cluster-agent grants karpenter.sh permissions to
+			// inspect Karpenter resources, but its Deployment runs the
+			// cluster-agent image and does not set KARPENTER_SERVICE. It
+			// must not trigger the guard.
 			objects: []runtime.Object{
-				clusterRole("fake-karpenter", map[string]string{
-					"app.kubernetes.io/name": "karpenter",
-				}, []rbacv1.PolicyRule{
-					{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get"}},
-				}),
+				deployment("datadog-agent", "datadog-cluster-agent", nil,
+					"gcr.io/datadoghq/cluster-agent:7.78.1",
+				),
 			},
-			expected: false,
+			expected: nil,
+		},
+		{
+			name: "hardened image without canonical path is matched via KARPENTER_SERVICE env",
+			// Docker Hardened Images / Chainguard ship Karpenter under
+			// repositories like `cgr.dev/chainguard/karpenter` whose path
+			// does not end in `karpenter/controller`. The chart still sets
+			// the KARPENTER_SERVICE env on the controller container; that
+			// env name is the more robust signal.
+			objects: []runtime.Object{
+				deploymentWithEnv("kube-system", "their-karpenter", nil,
+					"cgr.dev/chainguard/karpenter:1.0",
+					[]corev1.EnvVar{{Name: "KARPENTER_SERVICE", Value: "their-karpenter"}},
+				),
+			},
+			expected: &ForeignKarpenter{Namespace: "kube-system", Name: "their-karpenter"},
+		},
+		{
+			name: "image with `controllers` plural does not false-positive",
+			// Defensive: a workload named `team/karpenter/controllers`
+			// (note plural) must not match the canonical-suffix check.
+			objects: []runtime.Object{
+				deployment("team-ns", "controllers", nil,
+					"team/karpenter/controllers:v1",
+				),
+			},
+			expected: nil,
 		},
 		{
 			name: "foreign sentinel value is treated as foreign",
 			objects: []runtime.Object{
-				clusterRole("karpenter", map[string]string{
-					"app.kubernetes.io/name": "karpenter",
-					InstalledByLabel:         "someone-else",
-				}, karpenterCoreRules),
+				deployment("karpenter", "karpenter",
+					map[string]string{InstalledByLabel: "someone-else"},
+					karpenterControllerImage,
+				),
 			},
-			expected: true,
-		},
-		{
-			name: "split rules with only nodepools or only nodeclaims still match",
-			// The chart's clusterrole-core.yaml splits write permissions
-			// across separate rules — one per resource. Each rule on its
-			// own must carry the controller fingerprint.
-			objects: []runtime.Object{
-				clusterRole("their-karpenter", nil, []rbacv1.PolicyRule{
-					{APIGroups: []string{"karpenter.sh"}, Resources: []string{"nodeclaims", "nodeclaims/status"}, Verbs: []string{"create", "delete", "update", "patch"}},
-					{APIGroups: []string{"karpenter.sh"}, Resources: []string{"nodepools", "nodepools/status"}, Verbs: []string{"update", "patch"}},
-				}),
-			},
-			expected: true,
-		},
-		{
-			name: "Datadog Operator role with karpenter.sh wildcard is not a controller",
-			// The Datadog Operator's own ClusterRole grants `karpenter.sh/*`
-			// to manage Karpenter CRs as part of cluster autoscaling
-			// recommendations — but the operator is not a Karpenter
-			// controller. A wildcard-only rule must not trigger the guard.
-			objects: []runtime.Object{
-				clusterRole("datadog-operator-manager-role", nil, []rbacv1.PolicyRule{
-					{
-						APIGroups: []string{"karpenter.sh"},
-						Resources: []string{"*"},
-						Verbs:     []string{"create", "delete", "get", "list", "patch", "update", "watch"},
-					},
-				}),
-			},
-			expected: false,
+			expected: &ForeignKarpenter{Namespace: "karpenter", Name: "karpenter"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			clientset := fake.NewSimpleClientset(tc.objects...)
 
-			result, err := IsForeignKarpenterInstalled(t.Context(), clientset)
+			result, err := FindForeignKarpenterInstallation(t.Context(), clientset)
 
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result)
@@ -178,76 +184,86 @@ func TestIsForeignKarpenterInstalled(t *testing.T) {
 
 	t.Run("API list error propagates", func(t *testing.T) {
 		clientset := fake.NewSimpleClientset()
-		clientset.PrependReactor("list", "clusterroles", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		clientset.PrependReactor("list", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 			return true, nil, apierrors.NewServiceUnavailable("test failure")
 		})
 
-		_, err := IsForeignKarpenterInstalled(t.Context(), clientset)
+		_, err := FindForeignKarpenterInstallation(t.Context(), clientset)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to list ClusterRoles")
+		assert.Contains(t, err.Error(), "failed to list Deployments")
 	})
 
 	t.Run("pagination follows Continue token across pages and short-circuits on first foreign match", func(t *testing.T) {
-		// Three pages: an empty page with a non-empty Continue token
-		// (the API server may legitimately return one), a page with only
-		// our own ClusterRole, and a page where the foreign install lives.
-		// We expect the function to walk pages 1 and 2, find the foreign on
-		// page 3, and stop. Page 4 must never be requested.
-		pages := []*rbacv1.ClusterRoleList{
+		// Three pages: an empty page with a non-empty Continue token, a page
+		// with only our own Deployment, and a page where the foreign install
+		// lives. Page 4 must never be requested.
+		pages := []*appsv1.DeploymentList{
 			{
 				ListMeta: metav1.ListMeta{Continue: "page2"},
 				Items:    nil,
 			},
 			{
 				ListMeta: metav1.ListMeta{Continue: "page3"},
-				Items: []rbacv1.ClusterRole{
-					*clusterRole("karpenter", map[string]string{
-						InstalledByLabel: InstalledByValue,
-					}, karpenterCoreRules),
+				Items: []appsv1.Deployment{
+					*deployment("dd-karpenter", "karpenter",
+						map[string]string{InstalledByLabel: InstalledByValue},
+						karpenterControllerImage,
+					),
 				},
 			},
 			{
 				ListMeta: metav1.ListMeta{Continue: "page4"},
-				Items: []rbacv1.ClusterRole{
-					*clusterRole("their-karpenter", map[string]string{
-						"app.kubernetes.io/instance": "their-release",
-					}, karpenterCoreRules),
+				Items: []appsv1.Deployment{
+					*deployment("their-ns", "their-karpenter", nil, karpenterControllerImage),
 				},
 			},
 			{
-				Items: []rbacv1.ClusterRole{
-					*clusterRole("never-fetched", nil, karpenterCoreRules),
+				Items: []appsv1.Deployment{
+					*deployment("never", "fetched", nil, karpenterControllerImage),
 				},
 			},
 		}
 
 		clientset := fake.NewSimpleClientset()
 		var calls []string
-		clientset.PrependReactor("list", "clusterroles", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		clientset.PrependReactor("list", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
 			opts := action.(k8stesting.ListActionImpl).GetListOptions()
 			calls = append(calls, opts.Continue)
-			assert.EqualValues(t, clusterRoleListChunkSize, opts.Limit, "Limit must be set so the API server can chunk")
+			assert.EqualValues(t, deploymentListChunkSize, opts.Limit, "Limit must be set so the API server can chunk")
 			require.Less(t, len(calls)-1, len(pages),
 				"reactor would over-fetch beyond the synthetic pages — early-exit broken")
 			return true, pages[len(calls)-1], nil
 		})
 
-		result, err := IsForeignKarpenterInstalled(t.Context(), clientset)
+		result, err := FindForeignKarpenterInstallation(t.Context(), clientset)
 
 		require.NoError(t, err)
-		assert.True(t, result)
+		assert.Equal(t, &ForeignKarpenter{Namespace: "their-ns", Name: "their-karpenter"}, result)
 		assert.Equal(t, []string{"", "page2", "page3"}, calls,
 			"each call must forward the previous page's Continue token, and page 4 must never be requested")
 	})
 }
 
-func clusterRole(name string, labels map[string]string, rules []rbacv1.PolicyRule) *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
+func deployment(namespace, name string, labels map[string]string, image string) *appsv1.Deployment {
+	return deploymentWithEnv(namespace, name, labels, image, nil)
+}
+
+func deploymentWithEnv(namespace, name string, labels map[string]string, image string, env []corev1.EnvVar) *appsv1.Deployment {
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
+			Namespace: namespace,
+			Name:      name,
+			Labels:    labels,
 		},
-		Rules: rules,
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "controller", Image: image, Env: env},
+					},
+				},
+			},
+		},
 	}
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -280,7 +280,7 @@ func (o *options) run(cmd *cobra.Command) error {
 		return displayEKSAutoModeMessage(cmd, clusterName)
 	}
 
-	if foreign, err := guess.FindForeignKarpenterInstallation(ctx, o.Clientset); err != nil {
+	if foreign, err := guess.FindForeignKarpenterInstallation(ctx, o.Clientset, karpenterNamespace); err != nil {
 		return fmt.Errorf("failed to check for an existing Karpenter installation: %w", err)
 	} else if foreign != nil {
 		return displayForeignKarpenterMessage(cmd, clusterName, foreign)

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -280,10 +280,10 @@ func (o *options) run(cmd *cobra.Command) error {
 		return displayEKSAutoModeMessage(cmd, clusterName)
 	}
 
-	if foreign, err := guess.IsForeignKarpenterInstalled(ctx, o.Clientset); err != nil {
+	if foreign, err := guess.FindForeignKarpenterInstallation(ctx, o.Clientset); err != nil {
 		return fmt.Errorf("failed to check for an existing Karpenter installation: %w", err)
-	} else if foreign {
-		return displayForeignKarpenterMessage(cmd, clusterName)
+	} else if foreign != nil {
+		return displayForeignKarpenterMessage(cmd, clusterName, foreign)
 	}
 
 	display.PrintBox(cmd.OutOrStdout(), "Installing Karpenter on cluster "+clusterName+".")
@@ -638,11 +638,12 @@ func displayEKSAutoModeMessage(cmd *cobra.Command, clusterName string) error {
 	return nil
 }
 
-func displayForeignKarpenterMessage(cmd *cobra.Command, clusterName string) error {
+func displayForeignKarpenterMessage(cmd *cobra.Command, clusterName string, foreign *guess.ForeignKarpenter) error {
 	coloredURL := openAutoscalingSettingsURL(cmd, clusterName)
 
 	display.PrintBox(cmd.OutOrStdout(),
-		"Karpenter is already installed on cluster "+clusterName+".",
+		"Karpenter is already installed on cluster "+clusterName+":",
+		"Deployment "+foreign.Namespace+"/"+foreign.Name+".",
 		"",
 		"kubectl-datadog has nothing to install.",
 		"",

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install.go
@@ -280,6 +280,12 @@ func (o *options) run(cmd *cobra.Command) error {
 		return displayEKSAutoModeMessage(cmd, clusterName)
 	}
 
+	if foreign, err := guess.IsForeignKarpenterInstalled(ctx, o.Clientset); err != nil {
+		return fmt.Errorf("failed to check for an existing Karpenter installation: %w", err)
+	} else if foreign {
+		return displayForeignKarpenterMessage(cmd, clusterName)
+	}
+
 	display.PrintBox(cmd.OutOrStdout(), "Installing Karpenter on cluster "+clusterName+".")
 
 	cli, err := clients.Build(ctx, o.ConfigFlags, o.Clientset)
@@ -513,9 +519,10 @@ func (o *options) installHelmChart(ctx context.Context, clusterName, karpenterNa
 // the controller can assume the role via sts:AssumeRoleWithWebIdentity.
 func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn string) map[string]any {
 	values := map[string]any{
+		// See guess.InstalledByLabel for why these keys are Datadog-namespaced.
 		"additionalLabels": map[string]any{
-			"app.kubernetes.io/managed-by": "kubectl-datadog",
-			"app.kubernetes.io/version":    version.GetVersion(),
+			guess.InstalledByLabel:      guess.InstalledByValue,
+			guess.InstallerVersionLabel: version.GetVersion(),
 		},
 		"settings": map[string]any{
 			"clusterName":       clusterName,
@@ -622,6 +629,22 @@ func displayEKSAutoModeMessage(cmd *cobra.Command, clusterName string) error {
 		"",
 		"Karpenter is built into EKS auto-mode",
 		"and does not need to be installed separately.",
+		"",
+		"Navigate to the Autoscaling settings page",
+		"and select cluster to start generating recommendations:",
+		coloredURL,
+	)
+
+	return nil
+}
+
+func displayForeignKarpenterMessage(cmd *cobra.Command, clusterName string) error {
+	coloredURL := openAutoscalingSettingsURL(cmd, clusterName)
+
+	display.PrintBox(cmd.OutOrStdout(),
+		"Karpenter is already installed on cluster "+clusterName+".",
+		"",
+		"kubectl-datadog has nothing to install.",
 		"",
 		"Navigate to the Autoscaling settings page",
 		"and select cluster to start generating recommendations:",

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install_test.go
@@ -250,7 +250,7 @@ func TestKarpenterHelmValues(t *testing.T) {
 		labels, ok := values["additionalLabels"].(map[string]any)
 		require.True(t, ok, "additionalLabels must be a map")
 		assert.Equal(t, guess.InstalledByValue, labels[guess.InstalledByLabel],
-			"installed-by sentinel must match what IsForeignKarpenterInstalled looks for")
+			"installed-by sentinel must match what FindForeignKarpenterInstallation looks for")
 		assert.Contains(t, labels, guess.InstallerVersionLabel)
 
 		settings, ok := values["settings"].(map[string]any)
@@ -286,11 +286,14 @@ func TestDisplayForeignKarpenterMessage(t *testing.T) {
 	cmd.SetOut(out)
 	cmd.SetErr(&bytes.Buffer{})
 
-	err := displayForeignKarpenterMessage(cmd, "my-cluster")
+	foreign := &guess.ForeignKarpenter{Namespace: "karpenter", Name: "karpenter"}
+	err := displayForeignKarpenterMessage(cmd, "my-cluster", foreign)
 	require.NoError(t, err, "foreign Karpenter is a successful no-op, not an error")
 
 	rendered := out.String()
-	assert.Contains(t, rendered, "Karpenter is already installed on cluster my-cluster.")
+	assert.Contains(t, rendered, "Karpenter is already installed on cluster my-cluster")
+	assert.Contains(t, rendered, "Deployment karpenter/karpenter.",
+		"the message must surface the foreign install's namespace/name so the user can locate it")
 	assert.Contains(t, rendered, "kubectl-datadog has nothing to install.")
 	assert.Contains(t, rendered, "Autoscaling settings page")
 	assert.Contains(t, rendered, "kube_cluster_name%3Amy-cluster",

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/install_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/install_test.go
@@ -1,9 +1,14 @@
 package install
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/install/guess"
 )
 
 func TestInstallMode_String(t *testing.T) {
@@ -236,6 +241,60 @@ func TestInferenceMethod_Set(t *testing.T) {
 func TestInferenceMethod_Type(t *testing.T) {
 	var method InferenceMethod
 	assert.Equal(t, "InferenceMethod", method.Type())
+}
+
+func TestKarpenterHelmValues(t *testing.T) {
+	t.Run("existing-nodes mode carries Datadog ownership labels and no IRSA annotation", func(t *testing.T) {
+		values := karpenterHelmValues("my-cluster", InstallModeExistingNodes, "")
+
+		labels, ok := values["additionalLabels"].(map[string]any)
+		require.True(t, ok, "additionalLabels must be a map")
+		assert.Equal(t, guess.InstalledByValue, labels[guess.InstalledByLabel],
+			"installed-by sentinel must match what IsForeignKarpenterInstalled looks for")
+		assert.Contains(t, labels, guess.InstallerVersionLabel)
+
+		settings, ok := values["settings"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "my-cluster", settings["clusterName"])
+		assert.Equal(t, "my-cluster", settings["interruptionQueue"])
+
+		assert.NotContains(t, values, "serviceAccount",
+			"existing-nodes mode must not annotate the ServiceAccount with an IRSA role")
+	})
+
+	t.Run("fargate mode annotates the ServiceAccount with the IRSA role ARN", func(t *testing.T) {
+		const arn = "arn:aws:iam::123456789012:role/dd-karpenter"
+		values := karpenterHelmValues("my-cluster", InstallModeFargate, arn)
+
+		serviceAccount, ok := values["serviceAccount"].(map[string]any)
+		require.True(t, ok, "fargate mode must populate serviceAccount values")
+		annotations, ok := serviceAccount["annotations"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, arn, annotations["eks.amazonaws.com/role-arn"])
+	})
+}
+
+func TestDisplayForeignKarpenterMessage(t *testing.T) {
+	// browser.OpenURL spawns xdg-open with non-*os.File writers, which makes
+	// `cmd.Wait` hang on the pipe-copy goroutine until xdg-open's descendants
+	// all close the write side. Empty PATH makes the LookPath probe fail and
+	// browser.OpenURL returns ErrNotFound without spawning anything.
+	t.Setenv("PATH", "")
+
+	out := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := displayForeignKarpenterMessage(cmd, "my-cluster")
+	require.NoError(t, err, "foreign Karpenter is a successful no-op, not an error")
+
+	rendered := out.String()
+	assert.Contains(t, rendered, "Karpenter is already installed on cluster my-cluster.")
+	assert.Contains(t, rendered, "kubectl-datadog has nothing to install.")
+	assert.Contains(t, rendered, "Autoscaling settings page")
+	assert.Contains(t, rendered, "kube_cluster_name%3Amy-cluster",
+		"the linked URL must point at the cluster's autoscaling settings")
 }
 
 func TestValidate(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds a pre-flight guard to `kubectl datadog autoscaling cluster install` that recognises when Karpenter is already running on the cluster — be it a Helm install in another namespace, a raw `kubectl apply`, or anything in between — and short-circuits with a friendly success message and a link to the Datadog Autoscaling settings page, mirroring the existing EKS auto-mode handling (no error, exit 0). The message names the foreign install's `Deployment <namespace>/<name>` so the user can locate it.

Detection scans every Deployment cluster-wide and, for each container, looks for either:

* the `KARPENTER_SERVICE` env var name — the upstream chart's `templates/deployment.yaml` unconditionally sets this on the controller container, regardless of `controller.image.repository`; or
* an image whose repository ends with the path components `karpenter/controller`, parsed component-aware — strip digest first, then recognise a tag only when the last `:` lies after the last `/`, so ported registries (`registry.local:5000/...`) and digests are handled cleanly while neighbours like `team/karpenter/controllers` or `team/karpenter/controller-something` do not false-positive.

Deployments carrying our `autoscaling.datadoghq.com/installed-by=kubectl-datadog` sentinel are treated as ours and the install proceeds (Helm performs an upgrade). The list is paginated with `Limit: 100` + `Continue` and short-circuits on the first foreign match.

The PR also switches the chart's `additionalLabels` from overriding standard `app.kubernetes.io/managed-by` and `app.kubernetes.io/version` to Datadog-namespaced keys, exported as constants so the writer (`install.go`) and reader (`FindForeignKarpenterInstallation`) stay in sync.

### Motivation

PR #2717 (CASCL-1281) added a guard for EKS auto-mode clusters. We need a symmetric guard for any other cluster where Karpenter is already running, otherwise re-running `install` on such a cluster would deploy a second controller that would race with the first one on the same CRDs.

The first design tried RBAC — list ClusterRoles, look for `karpenter.sh` rules. That turned out fragile: monitoring and management workloads legitimately hold permissions on the `karpenter.sh` API group without running a controller. The Datadog Operator's own ClusterRole grants `karpenter.sh/*` (manager role generated from `internal/controller/datadogagent_controller.go`), and the Datadog Agent Helm chart's cluster-agent ClusterRole does the same to inspect Karpenter resources for autoscaling recommendations. Any tightening (require specific resources rather than `*`) is easy to defeat by a monitor that lists `nodepools` rather than `*`.

A Deployment running the Karpenter controller image — or setting the chart's `KARPENTER_SERVICE` env — is the only signal that distinguishes "Karpenter is actually running" from "something has read access to its CRs". It also carries the namespace/name we want to surface to the user.

The Datadog-namespaced label switch is required because the Karpenter chart's `_helpers.tpl` emits `app.kubernetes.io/managed-by: {{ .Release.Service }}` and `app.kubernetes.io/version: ...` *before* `additionalLabels`, producing duplicate YAML keys. Verified empirically on a real cluster: deduplication at the API server is non-deterministic across keys (`managed-by` resolves to the chart's `Helm` value while `version` resolves to ours, on the very same resource), so we cannot rely on those overrides as identity markers.

### Additional Notes

**Migration of existing kubectl-datadog installs.** Plugin installs deployed before this change carry the old `app.kubernetes.io/managed-by=kubectl-datadog` value (silently dropped by the chart) and lack the new sentinel on their Deployment metadata. The new code will detect them as foreign and no-op. To migrate, run once:

```
kubectl datadog autoscaling cluster uninstall
kubectl datadog autoscaling cluster install
```

Acceptable because the install command is recent and not yet broadly deployed.

**Out of scope.** Resources we apply directly (NodePool / EC2NodeClass via `cmd/kubectl-datadog/.../install/k8s/`) keep their existing `app.kubernetes.io/managed-by=kubectl-datadog` label — no chart helper to fight there, the label sticks, and `uninstall.go` continues to use it as a selector. Pre-v0.32 Karpenter (`provisioners`/`machines`) is also out of scope: the install command's chart reference is `karpenter-1.12.0` which targets v1+.

### Minimum Agent Versions

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

Unit tests:

* `go test ./cmd/kubectl-datadog/autoscaling/cluster/install/...` — covers
  * `TestFindForeignKarpenterInstallation`: no Deployments, ours-only, foreign without sentinel, foreign on a private mirror image, foreign with `nameOverride`, mix of ours and foreign, the Datadog Cluster Agent (cluster-agent image, no `KARPENTER_SERVICE` env — must NOT match), foreign with hardened image (`cgr.dev/chainguard/karpenter`) matched via the env signal, `controllers` plural not false-positiving, foreign sentinel value, API list error, pagination reactor that asserts the next page is never requested after the first foreign match;
  * `TestKarpenterControllerFingerprintContract` pins the literal `KARPENTER_SERVICE` and `karpenter/controller` so test fixtures using the constants cannot silently mask a typo;
  * `TestImageRepoEndsWith` covers default upstream, ECR mirror, digest, tag+digest, ported registry (with and without tag), bare `karpenter/controller`, `controllers` plural, `controller-something`, hardened-shape (`cgr.dev/chainguard/karpenter`), and single-component image;
  * `TestKarpenterHelmValues` pins the `additionalLabels` contract — both writer and reader go through the same exported constants — and covers both install modes (only Fargate annotates the ServiceAccount with the IRSA role ARN);
  * `TestDisplayForeignKarpenterMessage` renders the box into a buffered cobra `Command` and asserts the user-visible strings, including the `Deployment <namespace>/<name>` line and the URL-encoded `kube_cluster_name` query that points the user at their cluster's Datadog autoscaling settings page.

End-to-end on a real EKS test cluster (`AWS_PROFILE=exec-sso-container-integrations-account-admin AWS_REGION=eu-west-3`):

1. **No-op on a foreign Helm Karpenter** — `helm install karpenter oci://public.ecr.aws/karpenter/karpenter --namespace karpenter --create-namespace --set settings.clusterName=$CLUSTER`. Then `kubectl datadog autoscaling cluster install` → message names `Deployment karpenter/karpenter`, exit 0, no `dd-karpenter-…` CFN stacks created (`aws cloudformation list-stacks`).
2. **No-op on a foreign Helm Karpenter with `nameOverride`** — `helm install foo oci://... --set nameOverride=foo,settings.clusterName=$CLUSTER`. Then `kubectl datadog autoscaling cluster install` → still detected and no-op'd via the env var; namespace+Deployment name surfaced.
3. **Re-install after our uninstall (CRDs left over)** — `helm uninstall karpenter -n karpenter`, then `kubectl datadog autoscaling cluster install` → succeeds in spite of the four residual CRDs (Helm `crds/` is install-once).
4. **Auto-mode short-circuit unchanged** — on an auto-mode cluster, the auto-mode message is what shows up, not the new one.

### Checklist

- [x] PR has at least one valid label: `enhancement`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed