### PR TITLE
[POC] GKE Autopilot POC for DDAI code path

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -7,7 +7,6 @@ package agent
 
 import (
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -692,10 +691,6 @@ func commonEnvVars(dda metav1.Object) []corev1.EnvVar {
 			Value: secrets.GetDefaultDCATokenSecretName(dda),
 		},
 		{
-			Name:  common.DDAuthTokenFilePath,
-			Value: filepath.Join(common.AuthVolumePath, "token"),
-		},
-		{
 			Name: common.DDKubeletHost,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -820,6 +815,7 @@ func volumeMountsForCoreAgent() []corev1.VolumeMount {
 		common.GetVolumeMountForAuth(false),
 		common.GetVolumeMountForInstallInfo(),
 		common.GetVolumeMountForConfig(),
+		common.GetVolumeMountForAuth(false),
 		common.GetVolumeMountForProc(),
 		common.GetVolumeMountForCgroups(),
 		common.GetVolumeMountForDogstatsdSocket(false),

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -178,6 +178,9 @@ func (f *dogstatsdFeature) ManageClusterAgent(managers feature.PodTemplateManage
 // It should do nothing if the feature doesn't need to configure it.
 func (f *dogstatsdFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers, provider string) error {
 	f.manageNodeAgent(apicommon.UnprivilegedSingleAgentContainerName, managers, provider)
+	// NodeAgentProviderCapabilities is not invoked for single-container strategy, so
+	// UDS socket volumes are wired up here directly.
+	f.manageUDSVolumes(apicommon.UnprivilegedSingleAgentContainerName, managers, provider)
 
 	// When the Data Plane feature is enabled, and handling DogStatsD, we have to disable DSD on the Core Agent by
 	// setting `DD_USE_DOGSTATSD` to `false`. For the non-single container strategy, we only set this on the Core Agent,
@@ -250,39 +253,9 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 	})
 	managers.Port().AddPortToContainer(agentContainerName, dogstatsdPort)
 
-	// uds
+	// uds — volumes are added via NodeAgentProviderCapabilities (or manageUDSVolumes for single-container)
 	if f.udsEnabled {
-		udsHostFolder := filepath.Dir(f.udsHostFilepath)
 		sockName := filepath.Base(f.udsHostFilepath)
-
-		var socketVol corev1.Volume
-		var socketVolMount corev1.VolumeMount
-		if provider == kubernetes.GKEAutopilotProvider {
-			// Autopilot nodes have no host socket directory; use emptyDir instead.
-			socketVol = corev1.Volume{
-				Name:         common.DogstatsdSocketVolumeName,
-				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-			}
-			socketVolMount = corev1.VolumeMount{
-				Name:      common.DogstatsdSocketVolumeName,
-				MountPath: common.DogstatsdSocketLocalPath,
-			}
-			// system-probe and process-agent only read from the emptyDir socket;
-			// Autopilot allowlist requires ReadOnly=true for non-owner containers.
-			readOnlySocketMount := corev1.VolumeMount{
-				Name:      common.DogstatsdSocketVolumeName,
-				MountPath: common.DogstatsdSocketLocalPath,
-				ReadOnly:  true,
-			}
-			managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&readOnlySocketMount, apicommon.SystemProbeContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
-			managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&readOnlySocketMount, apicommon.ProcessAgentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
-		} else {
-			socketVol, socketVolMount = volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
-			volType := corev1.HostPathDirectoryOrCreate
-			socketVol.VolumeSource.HostPath.Type = &volType
-		}
-		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
-		managers.Volume().AddVolume(&socketVol)
 		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
 			Name:  DDDogstatsdSocket,
 			Value: filepath.Join(common.DogstatsdSocketLocalPath, sockName),
@@ -346,4 +319,104 @@ func (f *dogstatsdFeature) ManageClusterChecksRunner(managers feature.PodTemplat
 
 func (f *dogstatsdFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers, provider string) error {
 	return nil
+}
+
+// manageUDSVolumes adds the UDS socket volume and mounts for the given agent container.
+// Called directly from ManageSingleContainerNodeAgent since NodeAgentProviderCapabilities is not
+// invoked for that path. The normal ManageNodeAgent path gets volumes from NodeAgentProviderCapabilities.
+func (f *dogstatsdFeature) manageUDSVolumes(agentContainerName apicommon.AgentContainerName, managers feature.PodTemplateManagers, provider string) {
+	if !f.udsEnabled {
+		return
+	}
+	udsHostFolder := filepath.Dir(f.udsHostFilepath)
+	var socketVol corev1.Volume
+	var socketVolMount corev1.VolumeMount
+	if provider == kubernetes.GKEAutopilotProvider {
+		socketVol = corev1.Volume{
+			Name:         common.DogstatsdSocketVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		}
+		socketVolMount = corev1.VolumeMount{
+			Name:      common.DogstatsdSocketVolumeName,
+			MountPath: common.DogstatsdSocketLocalPath,
+		}
+		readOnlySocketMount := corev1.VolumeMount{
+			Name:      common.DogstatsdSocketVolumeName,
+			MountPath: common.DogstatsdSocketLocalPath,
+			ReadOnly:  true,
+		}
+		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&readOnlySocketMount, apicommon.SystemProbeContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&readOnlySocketMount, apicommon.ProcessAgentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+	} else {
+		socketVol, socketVolMount = volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
+		volType := corev1.HostPathDirectoryOrCreate
+		socketVol.VolumeSource.HostPath.Type = &volType
+	}
+	managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+	managers.Volume().AddVolume(&socketVol)
+}
+
+// NodeAgentProviderCapabilities returns provider-conditional UDS socket volume rules.
+// On default providers a HostPath volume is used; on GKE Autopilot an EmptyDir replaces it
+// and system-probe / process-agent get read-only mounts (required by the Autopilot allowlist).
+func (f *dogstatsdFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
+	if !f.udsEnabled {
+		return feature.NodeAgentProviderCapabilities{}
+	}
+
+	udsHostFolder := filepath.Dir(f.udsHostFilepath)
+	agentContainerName := apicommon.CoreAgentContainerName
+	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled {
+		agentContainerName = apicommon.AgentDataPlaneContainerName
+	}
+
+	volType := corev1.HostPathDirectoryOrCreate
+	hostPathVol, hostPathMount := volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
+	hostPathVol.VolumeSource.HostPath.Type = &volType
+
+	emptyDirVol := corev1.Volume{
+		Name:         common.DogstatsdSocketVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+	emptyDirMount := corev1.VolumeMount{
+		Name:      common.DogstatsdSocketVolumeName,
+		MountPath: common.DogstatsdSocketLocalPath,
+	}
+	emptyDirMountReadOnly := corev1.VolumeMount{
+		Name:      common.DogstatsdSocketVolumeName,
+		MountPath: common.DogstatsdSocketLocalPath,
+		ReadOnly:  true,
+	}
+
+	return feature.NodeAgentProviderCapabilities{
+		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
+			// Default: HostPath socket directory.
+			{
+				Item: feature.VolumeAndMount{
+					Volume:     hostPathVol,
+					Mount:      hostPathMount,
+					Containers: []apicommon.AgentContainerName{agentContainerName},
+				},
+				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// Autopilot: EmptyDir socket (owner container, writable).
+			{
+				Item: feature.VolumeAndMount{
+					Volume:     emptyDirVol,
+					Mount:      emptyDirMount,
+					Containers: []apicommon.AgentContainerName{agentContainerName},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// Autopilot: same EmptyDir volume (deduped), read-only for system-probe and process-agent.
+			{
+				Item: feature.VolumeAndMount{
+					Volume:     emptyDirVol,
+					Mount:      emptyDirMountReadOnly,
+					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName, apicommon.ProcessAgentContainerName},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+	}
 }

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -178,8 +178,7 @@ func (f *dogstatsdFeature) ManageClusterAgent(managers feature.PodTemplateManage
 // It should do nothing if the feature doesn't need to configure it.
 func (f *dogstatsdFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers, provider string) error {
 	f.manageNodeAgent(apicommon.UnprivilegedSingleAgentContainerName, managers, provider)
-	// NodeAgentProviderCapabilities is not invoked for single-container strategy, so
-	// UDS socket volumes are wired up here directly.
+	// NodeAgentProviderCapabilities is not invoked for single-container, so handle UDS volumes here.
 	f.manageUDSVolumes(apicommon.UnprivilegedSingleAgentContainerName, managers, provider)
 
 	// When the Data Plane feature is enabled, and handling DogStatsD, we have to disable DSD on the Core Agent by
@@ -208,15 +207,27 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 	//
 	// While we _could_ leave the DSD-specific configuration set on the Core Agent -- it doesn't matter as long as DSD
 	// is disabled -- it's cleaner to remove it entirely to avoid confusion.
+	agentContainerName := apicommon.CoreAgentContainerName
 	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled {
-		f.manageNodeAgent(apicommon.AgentDataPlaneContainerName, managers, provider)
-
+		agentContainerName = apicommon.AgentDataPlaneContainerName
+		f.manageNodeAgent(agentContainerName, managers, provider)
 		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 			Name:  common.DDDogstatsdEnabled,
 			Value: "false",
 		})
 	} else {
-		f.manageNodeAgent(apicommon.CoreAgentContainerName, managers, provider)
+		f.manageNodeAgent(agentContainerName, managers, provider)
+	}
+
+	// UDS HostPath socket — added unconditionally here; NodeAgentProviderCapabilities removes
+	// and replaces it with EmptyDir on GKE Autopilot.
+	if f.udsEnabled {
+		udsHostFolder := filepath.Dir(f.udsHostFilepath)
+		socketVol, socketVolMount := volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
+		volType := corev1.HostPathDirectoryOrCreate
+		socketVol.VolumeSource.HostPath.Type = &volType
+		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+		managers.Volume().AddVolume(&socketVol)
 	}
 
 	return nil
@@ -253,7 +264,6 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 	})
 	managers.Port().AddPortToContainer(agentContainerName, dogstatsdPort)
 
-	// uds — volumes are added via NodeAgentProviderCapabilities (or manageUDSVolumes for single-container)
 	if f.udsEnabled {
 		sockName := filepath.Base(f.udsHostFilepath)
 		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
@@ -321,9 +331,54 @@ func (f *dogstatsdFeature) ManageOtelAgentGateway(managers feature.PodTemplateMa
 	return nil
 }
 
+// NodeAgentProviderCapabilities returns the Autopilot UDS override when UDS is enabled.
+// ManageNodeAgent adds a HostPath socket unconditionally; GKE Autopilot removes it and
+// substitutes an EmptyDir (HostPath volumes are not in the Autopilot Workload Allowlist).
+func (f *dogstatsdFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
+	if !f.udsEnabled {
+		return feature.NodeAgentProviderCapabilities{}
+	}
+
+	agentContainerName := apicommon.CoreAgentContainerName
+	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled {
+		agentContainerName = apicommon.AgentDataPlaneContainerName
+	}
+
+	emptyDirVol := corev1.Volume{
+		Name:         common.DogstatsdSocketVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+	emptyDirMount := corev1.VolumeMount{
+		Name:      common.DogstatsdSocketVolumeName,
+		MountPath: common.DogstatsdSocketLocalPath,
+	}
+	emptyDirMountReadOnly := corev1.VolumeMount{
+		Name:      common.DogstatsdSocketVolumeName,
+		MountPath: common.DogstatsdSocketLocalPath,
+		ReadOnly:  true,
+	}
+
+	return feature.NodeAgentProviderCapabilities{
+		kubernetes.GKEAutopilotProvider: {
+			// AddVolume with override-merge replaces the HostPath source with EmptyDir.
+			// Existing mounts on all containers (including trace-agent from default.go) stay intact.
+			Volumes: []feature.VolumeAndMount{
+				{
+					Volume:     emptyDirVol,
+					Mount:      emptyDirMount,
+					Containers: []apicommon.AgentContainerName{agentContainerName},
+				},
+				{
+					Volume:     emptyDirVol,
+					Mount:      emptyDirMountReadOnly,
+					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName, apicommon.ProcessAgentContainerName},
+				},
+			},
+		},
+	}
+}
+
 // manageUDSVolumes adds the UDS socket volume and mounts for the given agent container.
-// Called directly from ManageSingleContainerNodeAgent since NodeAgentProviderCapabilities is not
-// invoked for that path. The normal ManageNodeAgent path gets volumes from NodeAgentProviderCapabilities.
 func (f *dogstatsdFeature) manageUDSVolumes(agentContainerName apicommon.AgentContainerName, managers feature.PodTemplateManagers, provider string) {
 	if !f.udsEnabled {
 		return
@@ -356,67 +411,3 @@ func (f *dogstatsdFeature) manageUDSVolumes(agentContainerName apicommon.AgentCo
 	managers.Volume().AddVolume(&socketVol)
 }
 
-// NodeAgentProviderCapabilities returns provider-conditional UDS socket volume rules.
-// On default providers a HostPath volume is used; on GKE Autopilot an EmptyDir replaces it
-// and system-probe / process-agent get read-only mounts (required by the Autopilot allowlist).
-func (f *dogstatsdFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
-	if !f.udsEnabled {
-		return feature.NodeAgentProviderCapabilities{}
-	}
-
-	udsHostFolder := filepath.Dir(f.udsHostFilepath)
-	agentContainerName := apicommon.CoreAgentContainerName
-	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled {
-		agentContainerName = apicommon.AgentDataPlaneContainerName
-	}
-
-	volType := corev1.HostPathDirectoryOrCreate
-	hostPathVol, hostPathMount := volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
-	hostPathVol.VolumeSource.HostPath.Type = &volType
-
-	emptyDirVol := corev1.Volume{
-		Name:         common.DogstatsdSocketVolumeName,
-		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-	}
-	emptyDirMount := corev1.VolumeMount{
-		Name:      common.DogstatsdSocketVolumeName,
-		MountPath: common.DogstatsdSocketLocalPath,
-	}
-	emptyDirMountReadOnly := corev1.VolumeMount{
-		Name:      common.DogstatsdSocketVolumeName,
-		MountPath: common.DogstatsdSocketLocalPath,
-		ReadOnly:  true,
-	}
-
-	return feature.NodeAgentProviderCapabilities{
-		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
-			// Default: HostPath socket directory.
-			{
-				Item: feature.VolumeAndMount{
-					Volume:     hostPathVol,
-					Mount:      hostPathMount,
-					Containers: []apicommon.AgentContainerName{agentContainerName},
-				},
-				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// Autopilot: EmptyDir socket (owner container, writable).
-			{
-				Item: feature.VolumeAndMount{
-					Volume:     emptyDirVol,
-					Mount:      emptyDirMount,
-					Containers: []apicommon.AgentContainerName{agentContainerName},
-				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// Autopilot: same EmptyDir volume (deduped), read-only for system-probe and process-agent.
-			{
-				Item: feature.VolumeAndMount{
-					Volume:     emptyDirVol,
-					Mount:      emptyDirMountReadOnly,
-					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName, apicommon.ProcessAgentContainerName},
-				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-		},
-	}
-}

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 func init() {
@@ -253,10 +254,33 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 	if f.udsEnabled {
 		udsHostFolder := filepath.Dir(f.udsHostFilepath)
 		sockName := filepath.Base(f.udsHostFilepath)
-		socketVol, socketVolMount := volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
-		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
 
-		socketVol.VolumeSource.HostPath.Type = &volType
+		var socketVol corev1.Volume
+		var socketVolMount corev1.VolumeMount
+		if provider == kubernetes.GKEAutopilotProvider {
+			// Autopilot nodes have no host socket directory; use emptyDir instead.
+			socketVol = corev1.Volume{
+				Name:         common.DogstatsdSocketVolumeName,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			}
+			socketVolMount = corev1.VolumeMount{
+				Name:      common.DogstatsdSocketVolumeName,
+				MountPath: common.DogstatsdSocketLocalPath,
+			}
+			// system-probe and process-agent only read from the emptyDir socket;
+			// Autopilot allowlist requires ReadOnly=true for non-owner containers.
+			readOnlySocketMount := corev1.VolumeMount{
+				Name:      common.DogstatsdSocketVolumeName,
+				MountPath: common.DogstatsdSocketLocalPath,
+				ReadOnly:  true,
+			}
+			managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&readOnlySocketMount, apicommon.SystemProbeContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+			managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&readOnlySocketMount, apicommon.ProcessAgentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+		} else {
+			socketVol, socketVolMount = volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
+			volType := corev1.HostPathDirectoryOrCreate
+			socketVol.VolumeSource.HostPath.Type = &volType
+		}
 		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
 		managers.Volume().AddVolume(&socketVol)
 		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
@@ -274,7 +298,8 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 			Name:  DDDogstatsdOriginDetectionClient,
 			Value: "true",
 		})
-		if f.udsEnabled {
+		// hostPID is required for origin detection via UDS but is not supported on GKE Autopilot.
+		if f.udsEnabled && provider != kubernetes.GKEAutopilotProvider {
 			managers.PodTemplateSpec().Spec.HostPID = true
 		}
 		// Tag cardinality is only configured if origin detection is enabled.

--- a/internal/controller/datadogagent/feature/logcollection/feature.go
+++ b/internal/controller/datadogagent/feature/logcollection/feature.go
@@ -178,15 +178,23 @@ func (f *logCollectionFeature) ManageOtelAgentGateway(managers feature.PodTempla
 
 // NodeAgentProviderCapabilities returns provider-conditional volume removals.
 // Container log and symlink paths are not in the GKE Autopilot WorkloadAllowlist.
+// pointerdir is replaced with the Autopilot-specific host path (remove + re-add).
 func (f *logCollectionFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
-	autopilotPointerVol, _ := volume.GetVolumes(pointerVolumeName, autopilotPointerDirHostPath, pointerVolumePath, false)
+	autopilotPointerVol, autopilotPointerMount := volume.GetVolumes(pointerVolumeName, autopilotPointerDirHostPath, pointerVolumePath, false)
 	return feature.NodeAgentProviderCapabilities{
-		OverrideVolumes: []feature.ProviderRule[corev1.Volume]{
-			{Item: autopilotPointerVol, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
-		},
-		RemoveVolumes: []feature.ProviderRule[string]{
-			{Item: containerLogVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
-			{Item: symlinkContainerVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
+		kubernetes.GKEAutopilotProvider: {
+			RemoveVolumes: []string{
+				pointerVolumeName,
+				containerLogVolumeName,
+				symlinkContainerVolumeName,
+			},
+			Volumes: []feature.VolumeAndMount{
+				{
+					Volume:     autopilotPointerVol,
+					Mount:      autopilotPointerMount,
+					Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
+				},
+			},
 		},
 	}
 }

--- a/internal/controller/datadogagent/feature/logcollection/feature.go
+++ b/internal/controller/datadogagent/feature/logcollection/feature.go
@@ -19,7 +19,11 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
+
+// autopilotPointerDirHostPath is the fixed pointerdir host path on GKE Autopilot.
+const autopilotPointerDirHostPath = "/var/autopilot/addon/datadog/logs"
 
 func init() {
 	err := feature.Register(feature.LogCollectionIDType, buildLogCollectionFeature)
@@ -101,18 +105,18 @@ func (f *logCollectionFeature) ManageClusterAgent(managers feature.PodTemplateMa
 // if SingleContainerStrategy is enabled and can be used with the configured feature set.
 // It should do nothing if the feature doesn't need to configure it.
 func (f *logCollectionFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	f.manageNodeAgent(apicommon.UnprivilegedSingleAgentContainerName, managers, provider)
+	f.manageNodeAgent(apicommon.UnprivilegedSingleAgentContainerName, managers)
 	return nil
 }
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *logCollectionFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	f.manageNodeAgent(apicommon.CoreAgentContainerName, managers, provider)
+	f.manageNodeAgent(apicommon.CoreAgentContainerName, managers)
 	return nil
 }
 
-func (f *logCollectionFeature) manageNodeAgent(agentContainerName apicommon.AgentContainerName, managers feature.PodTemplateManagers, provider string) error {
+func (f *logCollectionFeature) manageNodeAgent(agentContainerName apicommon.AgentContainerName, managers feature.PodTemplateManagers) error {
 	// pointerdir volume mount (replace default empty dir volume)
 	pointerVol, pointerVolMount := volume.GetVolumes(pointerVolumeName, f.tempStoragePath, pointerVolumePath, false)
 	managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&pointerVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
@@ -170,4 +174,19 @@ func (f *logCollectionFeature) ManageClusterChecksRunner(managers feature.PodTem
 
 func (f *logCollectionFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers, provider string) error {
 	return nil
+}
+
+// NodeAgentProviderCapabilities returns provider-conditional volume removals.
+// Container log and symlink paths are not in the GKE Autopilot WorkloadAllowlist.
+func (f *logCollectionFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
+	autopilotPointerVol, _ := volume.GetVolumes(pointerVolumeName, autopilotPointerDirHostPath, pointerVolumePath, false)
+	return feature.NodeAgentProviderCapabilities{
+		OverrideVolumes: []feature.ProviderRule[corev1.Volume]{
+			{Item: autopilotPointerVol, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
+		},
+		RemoveVolumes: []feature.ProviderRule[string]{
+			{Item: containerLogVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
+			{Item: symlinkContainerVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
+		},
+	}
 }

--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 func init() {
@@ -95,8 +96,10 @@ func (f *npmFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplate
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	// enable HostPID for system-probe
-	managers.PodTemplateSpec().Spec.HostPID = true
+	// enable HostPID for system-probe (not supported on GKE Autopilot)
+	if provider != kubernetes.GKEAutopilotProvider {
+		managers.PodTemplateSpec().Spec.HostPID = true
+	}
 
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
@@ -197,4 +200,17 @@ func (f *npmFeature) ManageClusterChecksRunner(managers feature.PodTemplateManag
 
 func (f *npmFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers, provider string) error {
 	return nil
+}
+
+// NodeAgentProviderCapabilities returns provider-conditional volume removals.
+// debugfs is not in the GKE Autopilot WorkloadAllowlist for process-agent.
+func (f *npmFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
+	return feature.NodeAgentProviderCapabilities{
+		RemoveMounts: []feature.ProviderRule[feature.ContainerMountRef]{
+			{
+				Item:             feature.ContainerMountRef{VolumeName: common.DebugfsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName}},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+	}
 }

--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -206,10 +206,9 @@ func (f *npmFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers
 // debugfs is not in the GKE Autopilot WorkloadAllowlist for process-agent.
 func (f *npmFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
 	return feature.NodeAgentProviderCapabilities{
-		RemoveMounts: []feature.ProviderRule[feature.ContainerMountRef]{
-			{
-				Item:             feature.ContainerMountRef{VolumeName: common.DebugfsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName}},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+		kubernetes.GKEAutopilotProvider: {
+			RemoveMounts: []feature.ContainerMountRef{
+				{VolumeName: common.DebugfsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName}},
 			},
 		},
 	}

--- a/internal/controller/datadogagent/feature/oomkill/feature.go
+++ b/internal/controller/datadogagent/feature/oomkill/feature.go
@@ -35,6 +35,34 @@ func buildOOMKillFeature(options *feature.Options) feature.Feature {
 
 type oomKillFeature struct{}
 
+// NodeAgentProviderCapabilities returns provider-conditional volumes for oomkill.
+func (f *oomKillFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
+	srcVol, srcMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
+	modulesVol, modulesMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
+	return feature.NodeAgentProviderCapabilities{
+		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
+			{
+				// modules: excluded on GKE Autopilot (no host kernel modules)
+				Item: feature.VolumeAndMount{
+					Volume:     modulesVol,
+					Mount:      modulesMount,
+					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
+				},
+				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			{
+				// src: excluded on GKE COS and GKE Autopilot (no /usr/src on CO-RE nodes)
+				Item: feature.VolumeAndMount{
+					Volume:     srcVol,
+					Mount:      srcMount,
+					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
+				},
+				ExcludeProviders: []string{kubernetes.GKECosProvider, kubernetes.GKEAutopilotProvider},
+			},
+		},
+	}
+}
+
 // ID returns the ID of the Feature
 func (f *oomKillFeature) ID() feature.IDType {
 	return feature.OOMKillIDType
@@ -73,22 +101,10 @@ func (f *oomKillFeature) ManageSingleContainerNodeAgent(managers feature.PodTemp
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
+// Provider-conditional volumes (src, modules) are handled by NodeAgentProviderCapabilities.
 func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
 	// security context capabilities
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommon.SystemProbeContainerName)
-
-	// modules volume mount
-	modulesVol, modulesVolMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
-	managers.VolumeMount().AddVolumeMountToContainer(&modulesVolMount, apicommon.SystemProbeContainerName)
-	managers.Volume().AddVolume(&modulesVol)
-
-	// src volume mount
-	_, providerValue := kubernetes.GetProviderLabelKeyValue(provider)
-	if providerValue != kubernetes.GKECosType {
-		srcVol, srcVolMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
-		managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommon.SystemProbeContainerName)
-		managers.Volume().AddVolume(&srcVol)
-	}
 
 	// debugfs volume mount
 	debugfsVol, debugfsVolMount := volume.GetVolumes(common.DebugfsVolumeName, common.DebugfsPath, common.DebugfsPath, false)

--- a/internal/controller/datadogagent/feature/oomkill/feature.go
+++ b/internal/controller/datadogagent/feature/oomkill/feature.go
@@ -35,30 +35,16 @@ func buildOOMKillFeature(options *feature.Options) feature.Feature {
 
 type oomKillFeature struct{}
 
-// NodeAgentProviderCapabilities returns provider-conditional volumes for oomkill.
+// NodeAgentProviderCapabilities returns provider-conditional volume removals for oomkill.
+// modules and src are added unconditionally in ManageNodeAgent; GKE COS removes src
+// (no /usr/src on COS nodes); GKE Autopilot removes both (CO-RE, no host kernel modules).
 func (f *oomKillFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
-	srcVol, srcMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
-	modulesVol, modulesMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
 	return feature.NodeAgentProviderCapabilities{
-		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
-			{
-				// modules: excluded on GKE Autopilot (no host kernel modules)
-				Item: feature.VolumeAndMount{
-					Volume:     modulesVol,
-					Mount:      modulesMount,
-					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
-				},
-				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			{
-				// src: excluded on GKE COS and GKE Autopilot (no /usr/src on CO-RE nodes)
-				Item: feature.VolumeAndMount{
-					Volume:     srcVol,
-					Mount:      srcMount,
-					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
-				},
-				ExcludeProviders: []string{kubernetes.GKECosProvider, kubernetes.GKEAutopilotProvider},
-			},
+		kubernetes.GKECosProvider: {
+			RemoveVolumes: []string{common.SrcVolumeName},
+		},
+		kubernetes.GKEAutopilotProvider: {
+			RemoveVolumes: []string{common.SrcVolumeName, common.ModulesVolumeName},
 		},
 	}
 }
@@ -101,11 +87,17 @@ func (f *oomKillFeature) ManageSingleContainerNodeAgent(managers feature.PodTemp
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
-// Provider-conditional volumes (src, modules) are handled by NodeAgentProviderCapabilities.
 func (f *oomKillFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
 	// security context capabilities
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommon.SystemProbeContainerName)
 
+	// modules and src volumes — removed on GKE COS and/or Autopilot by NodeAgentProviderCapabilities
+	modulesVol, modulesVolMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&modulesVolMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&modulesVol)
+	srcVol, srcVolMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&srcVol)
 	// debugfs volume mount
 	debugfsVol, debugfsVolMount := volume.GetVolumes(common.DebugfsVolumeName, common.DebugfsPath, common.DebugfsPath, false)
 	managers.Volume().AddVolume(&debugfsVol)

--- a/internal/controller/datadogagent/feature/oomkill/feature_test.go
+++ b/internal/controller/datadogagent/feature/oomkill/feature_test.go
@@ -62,16 +62,6 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 
 		wantSystemProbeVolMounts := []corev1.VolumeMount{
 			{
-				Name:      common.ModulesVolumeName,
-				MountPath: common.ModulesVolumePath,
-				ReadOnly:  true,
-			},
-			{
-				Name:      common.SrcVolumeName,
-				MountPath: common.SrcVolumePath,
-				ReadOnly:  true,
-			},
-			{
 				Name:      common.DebugfsVolumeName,
 				MountPath: common.DebugfsPath,
 				ReadOnly:  false,
@@ -80,6 +70,16 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 				Name:      common.SystemProbeSocketVolumeName,
 				MountPath: common.SystemProbeSocketVolumePath,
 				ReadOnly:  false,
+			},
+			{
+				Name:      common.ModulesVolumeName,
+				MountPath: common.ModulesVolumePath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      common.SrcVolumeName,
+				MountPath: common.SrcVolumePath,
+				ReadOnly:  true,
 			},
 		}
 
@@ -91,6 +91,20 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 
 		// check volumes
 		wantVolumes := []corev1.Volume{
+			{
+				Name: common.DebugfsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: common.DebugfsPath,
+					},
+				},
+			},
+			{
+				Name: common.SystemProbeSocketVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
 			{
 				Name: common.ModulesVolumeName,
 				VolumeSource: corev1.VolumeSource{
@@ -105,20 +119,6 @@ func Test_oomKillFeature_Configure(t *testing.T) {
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: common.SrcVolumePath,
 					},
-				},
-			},
-			{
-				Name: common.DebugfsVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: common.DebugfsPath,
-					},
-				},
-			},
-			{
-				Name: common.SystemProbeSocketVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 		}

--- a/internal/controller/datadogagent/feature/provider_rule.go
+++ b/internal/controller/datadogagent/feature/provider_rule.go
@@ -1,0 +1,172 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package feature
+
+import (
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+)
+
+// ProviderRule wraps any config item with provider inclusion/exclusion lists.
+// Empty IncludeProviders means the rule applies to all providers.
+// ExcludeProviders takes priority over IncludeProviders.
+type ProviderRule[T any] struct {
+	Item             T
+	IncludeProviders []string
+	ExcludeProviders []string
+}
+
+// VolumeAndMount groups a pod-level volume with a container volume mount.
+// Volume is added to the pod spec; Mount is added to each listed container.
+type VolumeAndMount struct {
+	Volume     corev1.Volume
+	Mount      corev1.VolumeMount
+	Containers []apicommon.AgentContainerName
+}
+
+// EnvVarSet groups an env var with its target containers.
+// Empty Containers means the env var is added to all agent containers.
+type EnvVarSet struct {
+	EnvVar     corev1.EnvVar
+	Containers []apicommon.AgentContainerName
+}
+
+// ContainerMountRef identifies a volume mount by volume name and the containers
+// it should be stripped from. Empty Containers means strip from all containers.
+type ContainerMountRef struct {
+	VolumeName string
+	Containers []apicommon.AgentContainerName
+}
+
+// NodeAgentProviderCapabilities holds provider-conditional volumes and env vars
+// that a feature contributes to the node agent pod template.
+type NodeAgentProviderCapabilities struct {
+	Volumes []ProviderRule[VolumeAndMount]
+	EnvVars []ProviderRule[EnvVarSet]
+	// RemoveVolumes lists volume names to remove entirely (volume + all mounts).
+	RemoveVolumes []ProviderRule[string]
+	// RemoveMounts lists specific container-volume mount pairs to strip.
+	RemoveMounts []ProviderRule[ContainerMountRef]
+	// OverrideVolumes replaces named volumes in the pod spec post-feature.
+	// Only the volume source is swapped; existing mounts are unaffected since
+	// they reference volumes by name.
+	OverrideVolumes []ProviderRule[corev1.Volume]
+}
+
+// ProviderAwareFeature is an optional interface for features that vary behaviour
+// by provider. Features that have no provider-specific variation do not need
+// to implement it.
+type ProviderAwareFeature interface {
+	Feature
+	NodeAgentProviderCapabilities() NodeAgentProviderCapabilities
+}
+
+// ShouldApply returns true when the rule should be applied for the given provider.
+func ShouldApply(provider string, include, exclude []string) bool {
+	if slices.Contains(exclude, provider) {
+		return false
+	}
+	if len(include) == 0 {
+		return true
+	}
+	return slices.Contains(include, provider)
+}
+
+// ApplyNodeAgentProviderCapabilities applies all provider-conditional mutations
+// from a NodeAgentProviderCapabilities in order: additions, then removals, then
+// volume source overrides. Call this after ManageNodeAgent so that volumes added
+// by the feature are in scope for removal and override.
+func ApplyNodeAgentProviderCapabilities(mgr PodTemplateManagers, provider string, caps NodeAgentProviderCapabilities) {
+	addedVolumes := make(map[string]bool)
+	for _, rule := range caps.Volumes {
+		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			if !addedVolumes[rule.Item.Volume.Name] {
+				mgr.Volume().AddVolume(&rule.Item.Volume)
+				addedVolumes[rule.Item.Volume.Name] = true
+			}
+			mgr.VolumeMount().AddVolumeMountToContainers(&rule.Item.Mount, rule.Item.Containers)
+		}
+	}
+	for _, rule := range caps.EnvVars {
+		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			if len(rule.Item.Containers) == 0 {
+				mgr.EnvVar().AddEnvVar(&rule.Item.EnvVar)
+			} else {
+				mgr.EnvVar().AddEnvVarToContainers(rule.Item.Containers, &rule.Item.EnvVar)
+			}
+		}
+	}
+	tmpl := mgr.PodTemplateSpec()
+	for _, rule := range caps.RemoveVolumes {
+		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			stripVolume(tmpl, rule.Item)
+		}
+	}
+	for _, rule := range caps.RemoveMounts {
+		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			stripMounts(tmpl, rule.Item.VolumeName, rule.Item.Containers)
+		}
+	}
+	for _, rule := range caps.OverrideVolumes {
+		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			for i := range tmpl.Spec.Volumes {
+				if tmpl.Spec.Volumes[i].Name == rule.Item.Name {
+					tmpl.Spec.Volumes[i] = rule.Item
+					break
+				}
+			}
+		}
+	}
+}
+
+// stripVolume removes a named volume from the pod spec and all its mounts
+// from every container and init container.
+func stripVolume(tmpl *corev1.PodTemplateSpec, volumeName string) {
+	filtered := tmpl.Spec.Volumes[:0]
+	for _, v := range tmpl.Spec.Volumes {
+		if v.Name != volumeName {
+			filtered = append(filtered, v)
+		}
+	}
+	tmpl.Spec.Volumes = filtered
+	// nil means all containers
+	stripMounts(tmpl, volumeName, nil)
+}
+
+// stripMounts removes the mount for volumeName from the specified containers.
+// If containers is nil or empty, the mount is stripped from every container
+// and init container.
+func stripMounts(tmpl *corev1.PodTemplateSpec, volumeName string, containers []apicommon.AgentContainerName) {
+	targetAll := len(containers) == 0
+	targetSet := make(map[string]bool, len(containers))
+	for _, c := range containers {
+		targetSet[string(c)] = true
+	}
+
+	for i := range tmpl.Spec.Containers {
+		if targetAll || targetSet[tmpl.Spec.Containers[i].Name] {
+			tmpl.Spec.Containers[i].VolumeMounts = removeMountByName(tmpl.Spec.Containers[i].VolumeMounts, volumeName)
+		}
+	}
+	for i := range tmpl.Spec.InitContainers {
+		if targetAll || targetSet[tmpl.Spec.InitContainers[i].Name] {
+			tmpl.Spec.InitContainers[i].VolumeMounts = removeMountByName(tmpl.Spec.InitContainers[i].VolumeMounts, volumeName)
+		}
+	}
+}
+
+func removeMountByName(mounts []corev1.VolumeMount, name string) []corev1.VolumeMount {
+	out := mounts[:0]
+	for _, m := range mounts {
+		if m.Name != name {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/internal/controller/datadogagent/feature/provider_rule.go
+++ b/internal/controller/datadogagent/feature/provider_rule.go
@@ -6,21 +6,10 @@
 package feature
 
 import (
-	"slices"
-
 	corev1 "k8s.io/api/core/v1"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 )
-
-// ProviderRule wraps any config item with provider inclusion/exclusion lists.
-// Empty IncludeProviders means the rule applies to all providers.
-// ExcludeProviders takes priority over IncludeProviders.
-type ProviderRule[T any] struct {
-	Item             T
-	IncludeProviders []string
-	ExcludeProviders []string
-}
 
 // VolumeAndMount groups a pod-level volume with a container volume mount.
 // Volume is added to the pod spec; Mount is added to each listed container.
@@ -44,20 +33,23 @@ type ContainerMountRef struct {
 	Containers []apicommon.AgentContainerName
 }
 
-// NodeAgentProviderCapabilities holds provider-conditional volumes and env vars
-// that a feature contributes to the node agent pod template.
-type NodeAgentProviderCapabilities struct {
-	Volumes []ProviderRule[VolumeAndMount]
-	EnvVars []ProviderRule[EnvVarSet]
-	// RemoveVolumes lists volume names to remove entirely (volume + all mounts).
-	RemoveVolumes []ProviderRule[string]
-	// RemoveMounts lists specific container-volume mount pairs to strip.
-	RemoveMounts []ProviderRule[ContainerMountRef]
-	// OverrideVolumes replaces named volumes in the pod spec post-feature.
-	// Only the volume source is swapped; existing mounts are unaffected since
-	// they reference volumes by name.
-	OverrideVolumes []ProviderRule[corev1.Volume]
+// ProviderCapabilities holds the volumes, env vars, and removals for a
+// specific provider entry in a NodeAgentProviderCapabilities map.
+type ProviderCapabilities struct {
+	Volumes       []VolumeAndMount
+	EnvVars       []EnvVarSet
+	// RemoveVolumes strips named volumes (vol + all mounts) before provider additions run.
+	RemoveVolumes []string
+	// RemoveMounts strips specific container-volume mount pairs before provider additions run.
+	RemoveMounts  []ContainerMountRef
+	// RemoveEnvVars strips env vars by name before provider additions run.
+	RemoveEnvVars []string
 }
+
+// NodeAgentProviderCapabilities maps a provider string to its capabilities.
+// The empty string key "" is the baseline applied to all providers first.
+// Provider-specific entries are then applied on top: removals first, additions second.
+type NodeAgentProviderCapabilities = map[string]ProviderCapabilities
 
 // ProviderAwareFeature is an optional interface for features that vary behaviour
 // by provider. Features that have no provider-specific variation do not need
@@ -67,60 +59,53 @@ type ProviderAwareFeature interface {
 	NodeAgentProviderCapabilities() NodeAgentProviderCapabilities
 }
 
-// ShouldApply returns true when the rule should be applied for the given provider.
-func ShouldApply(provider string, include, exclude []string) bool {
-	if slices.Contains(exclude, provider) {
-		return false
-	}
-	if len(include) == 0 {
-		return true
-	}
-	return slices.Contains(include, provider)
-}
-
-// ApplyNodeAgentProviderCapabilities applies all provider-conditional mutations
-// from a NodeAgentProviderCapabilities in order: additions, then removals, then
-// volume source overrides. Call this after ManageNodeAgent so that volumes added
-// by the feature are in scope for removal and override.
+// ApplyNodeAgentProviderCapabilities applies all provider-conditional mutations.
+// The baseline ("") entry is applied first. The provider-specific entry is then
+// applied: removals run before additions so a provider can replace a baseline item
+// by removing it and re-adding a modified version.
 func ApplyNodeAgentProviderCapabilities(mgr PodTemplateManagers, provider string, caps NodeAgentProviderCapabilities) {
-	addedVolumes := make(map[string]bool)
-	for _, rule := range caps.Volumes {
-		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			if !addedVolumes[rule.Item.Volume.Name] {
-				mgr.Volume().AddVolume(&rule.Item.Volume)
-				addedVolumes[rule.Item.Volume.Name] = true
-			}
-			mgr.VolumeMount().AddVolumeMountToContainers(&rule.Item.Mount, rule.Item.Containers)
-		}
+	if len(caps) == 0 {
+		return
 	}
-	for _, rule := range caps.EnvVars {
-		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			if len(rule.Item.Containers) == 0 {
-				mgr.EnvVar().AddEnvVar(&rule.Item.EnvVar)
+
+	applyAdditions := func(c ProviderCapabilities) {
+		addedVolumes := make(map[string]bool)
+		for _, vm := range c.Volumes {
+			if !addedVolumes[vm.Volume.Name] {
+				mgr.Volume().AddVolume(&vm.Volume)
+				addedVolumes[vm.Volume.Name] = true
+			}
+			mgr.VolumeMount().AddVolumeMountToContainers(&vm.Mount, vm.Containers)
+		}
+		for _, ev := range c.EnvVars {
+			if len(ev.Containers) == 0 {
+				mgr.EnvVar().AddEnvVar(&ev.EnvVar)
 			} else {
-				mgr.EnvVar().AddEnvVarToContainers(rule.Item.Containers, &rule.Item.EnvVar)
+				mgr.EnvVar().AddEnvVarToContainers(ev.Containers, &ev.EnvVar)
 			}
 		}
 	}
-	tmpl := mgr.PodTemplateSpec()
-	for _, rule := range caps.RemoveVolumes {
-		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			stripVolume(tmpl, rule.Item)
+
+	applyRemovals := func(c ProviderCapabilities) {
+		tmpl := mgr.PodTemplateSpec()
+		for _, name := range c.RemoveVolumes {
+			stripVolume(tmpl, name)
+		}
+		for _, ref := range c.RemoveMounts {
+			stripMounts(tmpl, ref.VolumeName, ref.Containers)
+		}
+		for _, name := range c.RemoveEnvVars {
+			stripEnvVar(tmpl, name)
 		}
 	}
-	for _, rule := range caps.RemoveMounts {
-		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			stripMounts(tmpl, rule.Item.VolumeName, rule.Item.Containers)
-		}
+
+	if baseline, ok := caps[""]; ok {
+		applyAdditions(baseline)
 	}
-	for _, rule := range caps.OverrideVolumes {
-		if ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			for i := range tmpl.Spec.Volumes {
-				if tmpl.Spec.Volumes[i].Name == rule.Item.Name {
-					tmpl.Spec.Volumes[i] = rule.Item
-					break
-				}
-			}
+	if provider != "" {
+		if providerCaps, ok := caps[provider]; ok {
+			applyRemovals(providerCaps)
+			applyAdditions(providerCaps)
 		}
 	}
 }
@@ -161,11 +146,31 @@ func stripMounts(tmpl *corev1.PodTemplateSpec, volumeName string, containers []a
 	}
 }
 
+// stripEnvVar removes an env var by name from every container and init container.
+func stripEnvVar(tmpl *corev1.PodTemplateSpec, name string) {
+	for i := range tmpl.Spec.Containers {
+		tmpl.Spec.Containers[i].Env = removeEnvVarByName(tmpl.Spec.Containers[i].Env, name)
+	}
+	for i := range tmpl.Spec.InitContainers {
+		tmpl.Spec.InitContainers[i].Env = removeEnvVarByName(tmpl.Spec.InitContainers[i].Env, name)
+	}
+}
+
 func removeMountByName(mounts []corev1.VolumeMount, name string) []corev1.VolumeMount {
 	out := mounts[:0]
 	for _, m := range mounts {
 		if m.Name != name {
 			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func removeEnvVarByName(envs []corev1.EnvVar, name string) []corev1.EnvVar {
+	out := envs[:0]
+	for _, e := range envs {
+		if e.Name != name {
+			out = append(out, e)
 		}
 	}
 	return out

--- a/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
+++ b/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
@@ -35,30 +35,16 @@ func buildTCPQueueLengthFeature(options *feature.Options) feature.Feature {
 
 type tcpQueueLengthFeature struct{}
 
-// NodeAgentProviderCapabilities returns provider-conditional volumes for tcpqueuelength.
+// NodeAgentProviderCapabilities returns provider-conditional volume removals for tcpqueuelength.
+// modules and src are added unconditionally in ManageNodeAgent; GKE COS removes src
+// (no /usr/src on COS nodes); GKE Autopilot removes both (CO-RE, no host kernel modules).
 func (f *tcpQueueLengthFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
-	srcVol, srcMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
-	modulesVol, modulesMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
 	return feature.NodeAgentProviderCapabilities{
-		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
-			{
-				// modules: excluded on GKE Autopilot (no host kernel modules)
-				Item: feature.VolumeAndMount{
-					Volume:     modulesVol,
-					Mount:      modulesMount,
-					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
-				},
-				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			{
-				// src: excluded on GKE COS and GKE Autopilot (no /usr/src on CO-RE nodes)
-				Item: feature.VolumeAndMount{
-					Volume:     srcVol,
-					Mount:      srcMount,
-					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
-				},
-				ExcludeProviders: []string{kubernetes.GKECosProvider, kubernetes.GKEAutopilotProvider},
-			},
+		kubernetes.GKECosProvider: {
+			RemoveVolumes: []string{common.SrcVolumeName},
+		},
+		kubernetes.GKEAutopilotProvider: {
+			RemoveVolumes: []string{common.SrcVolumeName, common.ModulesVolumeName},
 		},
 	}
 }
@@ -104,10 +90,17 @@ func (f *tcpQueueLengthFeature) ManageSingleContainerNodeAgent(managers feature.
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
-// Provider-conditional volumes (src, modules) are handled by NodeAgentProviderCapabilities.
 func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
 	// security context capabilities
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommon.SystemProbeContainerName)
+
+	// modules and src volumes — removed on GKE COS and/or Autopilot by NodeAgentProviderCapabilities
+	modulesVol, modulesVolMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&modulesVolMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&modulesVol)
+	srcVol, srcVolMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&srcVol)
 
 	// debugfs volume mount
 	debugfsVol, debugfsVolMount := volume.GetVolumes(common.DebugfsVolumeName, common.DebugfsPath, common.DebugfsPath, false)

--- a/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
+++ b/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
@@ -35,6 +35,34 @@ func buildTCPQueueLengthFeature(options *feature.Options) feature.Feature {
 
 type tcpQueueLengthFeature struct{}
 
+// NodeAgentProviderCapabilities returns provider-conditional volumes for tcpqueuelength.
+func (f *tcpQueueLengthFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
+	srcVol, srcMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
+	modulesVol, modulesMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
+	return feature.NodeAgentProviderCapabilities{
+		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
+			{
+				// modules: excluded on GKE Autopilot (no host kernel modules)
+				Item: feature.VolumeAndMount{
+					Volume:     modulesVol,
+					Mount:      modulesMount,
+					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
+				},
+				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			{
+				// src: excluded on GKE COS and GKE Autopilot (no /usr/src on CO-RE nodes)
+				Item: feature.VolumeAndMount{
+					Volume:     srcVol,
+					Mount:      srcMount,
+					Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
+				},
+				ExcludeProviders: []string{kubernetes.GKECosProvider, kubernetes.GKEAutopilotProvider},
+			},
+		},
+	}
+}
+
 // ID returns the ID of the Feature
 func (f *tcpQueueLengthFeature) ID() feature.IDType {
 	return feature.TCPQueueLengthIDType
@@ -76,22 +104,10 @@ func (f *tcpQueueLengthFeature) ManageSingleContainerNodeAgent(managers feature.
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
+// Provider-conditional volumes (src, modules) are handled by NodeAgentProviderCapabilities.
 func (f *tcpQueueLengthFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
 	// security context capabilities
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommon.SystemProbeContainerName)
-
-	// modules volume mount
-	modulesVol, modulesVolMount := volume.GetVolumes(common.ModulesVolumeName, common.ModulesVolumePath, common.ModulesVolumePath, true)
-	managers.VolumeMount().AddVolumeMountToContainer(&modulesVolMount, apicommon.SystemProbeContainerName)
-	managers.Volume().AddVolume(&modulesVol)
-
-	// src volume mount
-	_, providerValue := kubernetes.GetProviderLabelKeyValue(provider)
-	if providerValue != kubernetes.GKECosType {
-		srcVol, srcVolMount := volume.GetVolumes(common.SrcVolumeName, common.SrcVolumePath, common.SrcVolumePath, true)
-		managers.VolumeMount().AddVolumeMountToContainer(&srcVolMount, apicommon.SystemProbeContainerName)
-		managers.Volume().AddVolume(&srcVol)
-	}
 
 	// debugfs volume mount
 	debugfsVol, debugfsVolMount := volume.GetVolumes(common.DebugfsVolumeName, common.DebugfsPath, common.DebugfsPath, false)

--- a/internal/controller/datadogagent/feature/tcpqueuelength/feature_test.go
+++ b/internal/controller/datadogagent/feature/tcpqueuelength/feature_test.go
@@ -63,16 +63,6 @@ func Test_tcpQueueLengthFeature_Configure(t *testing.T) {
 
 		wantSystemProbeVolMounts := []corev1.VolumeMount{
 			{
-				Name:      common.ModulesVolumeName,
-				MountPath: common.ModulesVolumePath,
-				ReadOnly:  true,
-			},
-			{
-				Name:      common.SrcVolumeName,
-				MountPath: common.SrcVolumePath,
-				ReadOnly:  true,
-			},
-			{
 				Name:      common.DebugfsVolumeName,
 				MountPath: common.DebugfsPath,
 				ReadOnly:  false,
@@ -81,6 +71,16 @@ func Test_tcpQueueLengthFeature_Configure(t *testing.T) {
 				Name:      common.SystemProbeSocketVolumeName,
 				MountPath: common.SystemProbeSocketVolumePath,
 				ReadOnly:  false,
+			},
+			{
+				Name:      common.ModulesVolumeName,
+				MountPath: common.ModulesVolumePath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      common.SrcVolumeName,
+				MountPath: common.SrcVolumePath,
+				ReadOnly:  true,
 			},
 		}
 
@@ -92,6 +92,20 @@ func Test_tcpQueueLengthFeature_Configure(t *testing.T) {
 
 		// check volumes
 		wantVolumes := []corev1.Volume{
+			{
+				Name: common.DebugfsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: common.DebugfsPath,
+					},
+				},
+			},
+			{
+				Name: common.SystemProbeSocketVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
 			{
 				Name: common.ModulesVolumeName,
 				VolumeSource: corev1.VolumeSource{
@@ -106,20 +120,6 @@ func Test_tcpQueueLengthFeature_Configure(t *testing.T) {
 					HostPath: &corev1.HostPathVolumeSource{
 						Path: common.SrcVolumePath,
 					},
-				},
-			},
-			{
-				Name: common.DebugfsVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: common.DebugfsPath,
-					},
-				},
-			},
-			{
-				Name: common.SystemProbeSocketVolumeName,
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			},
 		}

--- a/internal/controller/datadogagent/feature/test/testsuite.go
+++ b/internal/controller/datadogagent/feature/test/testsuite.go
@@ -161,6 +161,9 @@ func runTest(t *testing.T, tt FeatureTest) {
 				_ = feat.ManageSingleContainerNodeAgent(tplManager, provider)
 			} else {
 				_ = feat.ManageNodeAgent(tplManager, provider)
+				if paf, ok := feat.(feature.ProviderAwareFeature); ok {
+					feature.ApplyNodeAgentProviderCapabilities(tplManager, provider, paf.NodeAgentProviderCapabilities())
+				}
 			}
 
 			tt.Agent.WantFunc(t, tplManager)

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -208,10 +208,9 @@ func (f *usmFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers
 // debugfs is not in the GKE Autopilot WorkloadAllowlist for process-agent.
 func (f *usmFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
 	return feature.NodeAgentProviderCapabilities{
-		RemoveMounts: []feature.ProviderRule[feature.ContainerMountRef]{
-			{
-				Item:             feature.ContainerMountRef{VolumeName: common.DebugfsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName}},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+		kubernetes.GKEAutopilotProvider: {
+			RemoveMounts: []feature.ContainerMountRef{
+				{VolumeName: common.DebugfsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName}},
 			},
 		},
 	}

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 func init() {
@@ -112,8 +113,10 @@ func (f *usmFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplate
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	// enable HostPID for system-probe
-	managers.PodTemplateSpec().Spec.HostPID = true
+	// enable HostPID for system-probe (not supported on GKE Autopilot)
+	if provider != kubernetes.GKEAutopilotProvider {
+		managers.PodTemplateSpec().Spec.HostPID = true
+	}
 
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
@@ -199,4 +202,17 @@ func (f *usmFeature) ManageClusterChecksRunner(managers feature.PodTemplateManag
 
 func (f *usmFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers, provider string) error {
 	return nil
+}
+
+// NodeAgentProviderCapabilities returns provider-conditional mount removals.
+// debugfs is not in the GKE Autopilot WorkloadAllowlist for process-agent.
+func (f *usmFeature) NodeAgentProviderCapabilities() feature.NodeAgentProviderCapabilities {
+	return feature.NodeAgentProviderCapabilities{
+		RemoveMounts: []feature.ProviderRule[feature.ContainerMountRef]{
+			{
+				Item:             feature.ContainerMountRef{VolumeName: common.DebugfsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName}},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+	}
 }

--- a/internal/controller/datadogagent/global/provider_spec.go
+++ b/internal/controller/datadogagent/global/provider_spec.go
@@ -1,0 +1,287 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package global
+
+import (
+	"maps"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	objvolume "github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/images"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+// ProviderAnnotationKey is the annotation on a DDAI that declares the provider string.
+// The POC drives provider detection from this annotation rather than node labels.
+const ProviderAnnotationKey = "datadoghq.com/provider"
+
+// globalNodeAgentSpec holds all provider-conditional mutations for the node
+// agent pod template.
+type globalNodeAgentSpec struct {
+	Volumes        []feature.ProviderRule[feature.VolumeAndMount]
+	EnvVars        []feature.ProviderRule[feature.EnvVarSet]
+	ImageRegistry  []feature.ProviderRule[string]
+	PodLabels      []feature.ProviderRule[map[string]string]
+	PodAnnotations []feature.ProviderRule[map[string]string]
+	// RemoveVolumes lists volume names to strip entirely (volume + all mounts) for a provider.
+	// Applied inside ApplyGlobalNodeAgentSpec, before features run.
+	RemoveVolumes []feature.ProviderRule[string]
+	// RemoveMounts lists specific container-volume mount pairs to strip for a provider.
+	// Applied inside ApplyGlobalNodeAgentSpec, before features run.
+	RemoveMounts []feature.ProviderRule[feature.ContainerMountRef]
+	// CRISocketRoot is the host CRI socket directory; used to fix the init-config mount path.
+	CRISocketRoot string
+}
+
+// nodeAgentGlobalSpec builds the globalNodeAgentSpec for the given provider.
+func nodeAgentGlobalSpec(provider string) globalNodeAgentSpec {
+	criSocketRoot := common.RuntimeDirVolumePath
+	hostDataRoot := "/var/lib/datadog-agent"
+	if provider == kubernetes.GKEAutopilotProvider {
+		criSocketRoot = "/var/run/containerd"
+		hostDataRoot = "/var/autopilot/addon/datadog"
+	}
+
+	// CRI socket: HostPath replaces the default /var/run volume on Autopilot
+	criSocketVol, criSocketMount := objvolume.GetVolumes(
+		common.CriSocketVolumeName,
+		criSocketRoot,
+		common.HostCriSocketPathPrefix+criSocketRoot,
+		true,
+	)
+
+	// pointerdir: on Autopilot replace the default EmptyDir with a HostPath
+	pointerdirVol, pointerdirMount := objvolume.GetVolumes(
+		common.RunPathVolumeName,
+		hostDataRoot,
+		common.RunPathVolumeMount,
+		false,
+	)
+
+	spec := globalNodeAgentSpec{
+		CRISocketRoot: criSocketRoot,
+		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
+			// pointerdir: override EmptyDir with HostPath on Autopilot
+			{
+				Item: feature.VolumeAndMount{
+					Volume:     pointerdirVol,
+					Mount:      pointerdirMount,
+					Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// CRI socket: override default /var/run path on Autopilot
+			{
+				Item: feature.VolumeAndMount{
+					Volume: criSocketVol,
+					Mount:  criSocketMount,
+					Containers: []apicommon.AgentContainerName{
+						apicommon.CoreAgentContainerName,
+						apicommon.ProcessAgentContainerName,
+						apicommon.TraceAgentContainerName,
+						apicommon.SecurityAgentContainerName,
+						apicommon.AgentDataPlaneContainerName,
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+		EnvVars: []feature.ProviderRule[feature.EnvVarSet]{
+			// DD_AUTH_TOKEN_FILE_PATH: all containers except Autopilot
+			{
+				Item: feature.EnvVarSet{
+					EnvVar: corev1.EnvVar{
+						Name:  common.DDAuthTokenFilePath,
+						Value: filepath.Join(common.AuthVolumePath, "token"),
+					},
+				},
+				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// GKE Autopilot: cloud provider metadata env var
+			{
+				Item: feature.EnvVarSet{
+					EnvVar: corev1.EnvVar{
+						Name:  "DD_CLOUD_PROVIDER_METADATA",
+						Value: `["gcp"]`,
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// GKE Autopilot: disable HTTPS kubelet port (Autopilot uses HTTP)
+			{
+				Item: feature.EnvVarSet{
+					EnvVar: corev1.EnvVar{
+						Name:  "DD_KUBERNETES_HTTPS_KUBELET_PORT",
+						Value: "0",
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// GKE Autopilot: provider kind tag consumed by the agent
+			{
+				Item: feature.EnvVarSet{
+					EnvVar: corev1.EnvVar{
+						Name:  "DD_PROVIDER_KIND",
+						Value: kubernetes.GKEAutopilotProvider,
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+		ImageRegistry: []feature.ProviderRule[string]{
+			{
+				Item:             "gcr.io/datadoghq",
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+		PodLabels: []feature.ProviderRule[map[string]string]{
+			{
+				Item:             map[string]string{"env.datadoghq.com/kind": kubernetes.GKEAutopilotProvider},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+		PodAnnotations: []feature.ProviderRule[map[string]string]{
+			{
+				Item:             map[string]string{"autopilot.gke.io/no-connect": "true"},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+		// RemoveVolumes and RemoveMounts strip base-template volumes before features run.
+		RemoveVolumes: []feature.ProviderRule[string]{
+			// auth-token volume is absent on GKE Autopilot (not in the Workload Allowlist).
+			{Item: common.AuthVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
+			// tmp EmptyDir is not permitted on GKE Autopilot (not in the Workload Allowlist).
+			{Item: common.TmpVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
+		},
+		RemoveMounts: []feature.ProviderRule[feature.ContainerMountRef]{
+			// procdir is not permitted on trace-agent in the Autopilot Workload Allowlist.
+			{
+				Item:             feature.ContainerMountRef{VolumeName: common.ProcdirVolumeName, Containers: []apicommon.AgentContainerName{apicommon.TraceAgentContainerName}},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// cgroups is not permitted on trace-agent in the Autopilot Workload Allowlist.
+			{
+				Item:             feature.ContainerMountRef{VolumeName: common.CgroupsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.TraceAgentContainerName}},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			// system-probe does not mount pointerdir on GKE Autopilot.
+			{
+				Item:             feature.ContainerMountRef{VolumeName: common.RunPathVolumeName, Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName}},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
+	}
+
+	return spec
+}
+
+// ApplyGlobalNodeAgentSpec applies all provider-conditional mutations for the
+// node agent pod template. Call this once, before features run.
+func ApplyGlobalNodeAgentSpec(mgr feature.PodTemplateManagers, provider string) {
+	spec := nodeAgentGlobalSpec(provider)
+	feature.ApplyNodeAgentProviderCapabilities(mgr, provider, feature.NodeAgentProviderCapabilities{
+		Volumes:       spec.Volumes,
+		EnvVars:       spec.EnvVars,
+		RemoveVolumes: spec.RemoveVolumes,
+		RemoveMounts:  spec.RemoveMounts,
+	})
+
+	for _, rule := range spec.ImageRegistry {
+		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			overrideImageRegistry(mgr, rule.Item)
+		}
+	}
+
+	for _, rule := range spec.PodLabels {
+		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			if mgr.PodTemplateSpec().Labels == nil {
+				mgr.PodTemplateSpec().Labels = map[string]string{}
+			}
+			maps.Copy(mgr.PodTemplateSpec().Labels, rule.Item)
+		}
+	}
+
+	for _, rule := range spec.PodAnnotations {
+		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			if mgr.PodTemplateSpec().Annotations == nil {
+				mgr.PodTemplateSpec().Annotations = map[string]string{}
+			}
+			maps.Copy(mgr.PodTemplateSpec().Annotations, rule.Item)
+		}
+	}
+
+	// Autopilot imperative overrides that cannot be expressed as ProviderRules.
+	if provider == kubernetes.GKEAutopilotProvider {
+		applyAutopilotInitContainerOverrides(mgr, spec.CRISocketRoot)
+		applyAutopilotContainerCommandOverrides(mgr)
+	}
+}
+
+// applyAutopilotInitContainerOverrides fixes init-volume args and the init-config
+// CRI socket mount path for GKE Autopilot.
+func applyAutopilotInitContainerOverrides(mgr feature.PodTemplateManagers, criSocketRoot string) {
+	criMountPath := common.HostCriSocketPathPrefix + criSocketRoot
+	for i := range mgr.PodTemplateSpec().Spec.InitContainers {
+		switch mgr.PodTemplateSpec().Spec.InitContainers[i].Name {
+		case "init-volume":
+			// Autopilot allowlist requires no -vn flags.
+			mgr.PodTemplateSpec().Spec.InitContainers[i].Args = []string{"cp -r /etc/datadog-agent /opt"}
+		case string(apicommon.InitConfigContainerName):
+			// Remap the CRI socket mount to the Autopilot-specific path.
+			for j := range mgr.PodTemplateSpec().Spec.InitContainers[i].VolumeMounts {
+				if mgr.PodTemplateSpec().Spec.InitContainers[i].VolumeMounts[j].Name == common.CriSocketVolumeName {
+					mgr.PodTemplateSpec().Spec.InitContainers[i].VolumeMounts[j].MountPath = criMountPath
+				}
+			}
+		case "seccomp-setup":
+			// Autopilot allowlist requires the seccomp-security ConfigMap mount to be read-only.
+			for j := range mgr.PodTemplateSpec().Spec.InitContainers[i].VolumeMounts {
+				if mgr.PodTemplateSpec().Spec.InitContainers[i].VolumeMounts[j].Name == common.SeccompSecurityVolumeName {
+					mgr.PodTemplateSpec().Spec.InitContainers[i].VolumeMounts[j].ReadOnly = true
+				}
+			}
+		}
+	}
+}
+
+// applyAutopilotContainerCommandOverrides sets the Autopilot-allowlisted commands
+// for trace-agent and process-agent, and removes the startup probe from core-agent
+// (startup probes are unsupported on Autopilot).
+func applyAutopilotContainerCommandOverrides(mgr feature.PodTemplateManagers) {
+	for i := range mgr.PodTemplateSpec().Spec.Containers {
+		switch mgr.PodTemplateSpec().Spec.Containers[i].Name {
+		case string(apicommon.CoreAgentContainerName):
+			mgr.PodTemplateSpec().Spec.Containers[i].StartupProbe = nil
+		case string(apicommon.TraceAgentContainerName):
+			mgr.PodTemplateSpec().Spec.Containers[i].Command = []string{"trace-agent", "-config=/etc/datadog-agent/datadog.yaml"}
+		case string(apicommon.ProcessAgentContainerName):
+			mgr.PodTemplateSpec().Spec.Containers[i].Command = []string{"process-agent", "-config=/etc/datadog-agent/datadog.yaml"}
+		}
+	}
+}
+
+func overrideImageRegistry(mgr feature.PodTemplateManagers, registry string) {
+	if registry == "" {
+		return
+	}
+	for i, c := range mgr.PodTemplateSpec().Spec.Containers {
+		if c.Image == "" {
+			continue
+		}
+		mgr.PodTemplateSpec().Spec.Containers[i].Image = images.FromString(c.Image).WithRegistry(registry).ToString()
+	}
+	for i, c := range mgr.PodTemplateSpec().Spec.InitContainers {
+		if c.Image == "" {
+			continue
+		}
+		mgr.PodTemplateSpec().Spec.InitContainers[i].Image = images.FromString(c.Image).WithRegistry(registry).ToString()
+	}
+}

--- a/internal/controller/datadogagent/global/provider_spec.go
+++ b/internal/controller/datadogagent/global/provider_spec.go
@@ -31,167 +31,49 @@ type containerResourceDefault struct {
 // The POC drives provider detection from this annotation rather than node labels.
 const ProviderAnnotationKey = "datadoghq.com/provider"
 
-// globalNodeAgentSpec holds all provider-conditional mutations for the node
-// agent pod template.
-type globalNodeAgentSpec struct {
-	Volumes        []feature.ProviderRule[feature.VolumeAndMount]
-	EnvVars        []feature.ProviderRule[feature.EnvVarSet]
-	ImageRegistry  []feature.ProviderRule[string]
-	PodLabels      []feature.ProviderRule[map[string]string]
-	PodAnnotations []feature.ProviderRule[map[string]string]
-	// RemoveVolumes lists volume names to strip entirely (volume + all mounts) for a provider.
-	// Applied inside ApplyGlobalNodeAgentSpec, before features run.
-	RemoveVolumes []feature.ProviderRule[string]
-	// RemoveMounts lists specific container-volume mount pairs to strip for a provider.
-	// Applied inside ApplyGlobalNodeAgentSpec, before features run.
-	RemoveMounts []feature.ProviderRule[feature.ContainerMountRef]
-	// ContainerResources sets default resource requests/limits per container.
-	// Applied with "fill if zero" semantics after DDA override runs, so explicit DDA values always win.
-	ContainerResources []feature.ProviderRule[containerResourceDefault]
-	// CRISocketRoot is the host CRI socket directory; used to fix the init-config mount path.
-	CRISocketRoot string
+// globalProviderCapabilities extends ProviderCapabilities with fields that are
+// global-spec-specific (not available in the feature-level ProviderCapabilities).
+type globalProviderCapabilities struct {
+	feature.ProviderCapabilities
+	ImageRegistry      string
+	PodLabels          map[string]string
+	PodAnnotations     map[string]string
+	ContainerResources []containerResourceDefault
 }
 
-// nodeAgentGlobalSpec builds the globalNodeAgentSpec for the given provider.
-func nodeAgentGlobalSpec(provider string) globalNodeAgentSpec {
-	criSocketRoot := common.RuntimeDirVolumePath
-	hostDataRoot := "/var/lib/datadog-agent"
-	if provider == kubernetes.GKEAutopilotProvider {
-		criSocketRoot = "/var/run/containerd"
-		hostDataRoot = "/var/autopilot/addon/datadog"
-	}
-
-	// CRI socket: HostPath replaces the default /var/run volume on Autopilot
+// nodeAgentGlobalSpec builds the full provider registry for the node agent pod
+// template. The "" key is the baseline applied to all providers; provider-keyed
+// entries are applied on top (removals first, then additions).
+func nodeAgentGlobalSpec() map[string]globalProviderCapabilities {
 	criSocketVol, criSocketMount := objvolume.GetVolumes(
 		common.CriSocketVolumeName,
-		criSocketRoot,
-		common.HostCriSocketPathPrefix+criSocketRoot,
+		"/var/run/containerd",
+		common.HostCriSocketPathPrefix+"/var/run/containerd",
 		true,
 	)
-
-	// pointerdir: on Autopilot replace the default EmptyDir with a HostPath
 	pointerdirVol, pointerdirMount := objvolume.GetVolumes(
 		common.RunPathVolumeName,
-		hostDataRoot,
+		"/var/autopilot/addon/datadog",
 		common.RunPathVolumeMount,
 		false,
 	)
 
-	spec := globalNodeAgentSpec{
-		CRISocketRoot: criSocketRoot,
-		Volumes: []feature.ProviderRule[feature.VolumeAndMount]{
-			// pointerdir: override EmptyDir with HostPath on Autopilot
-			{
-				Item: feature.VolumeAndMount{
-					Volume:     pointerdirVol,
-					Mount:      pointerdirMount,
-					Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
-				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// CRI socket: override default /var/run path on Autopilot
-			{
-				Item: feature.VolumeAndMount{
-					Volume: criSocketVol,
-					Mount:  criSocketMount,
-					Containers: []apicommon.AgentContainerName{
-						apicommon.CoreAgentContainerName,
-						apicommon.ProcessAgentContainerName,
-						apicommon.TraceAgentContainerName,
-						apicommon.SecurityAgentContainerName,
-						apicommon.AgentDataPlaneContainerName,
+	return map[string]globalProviderCapabilities{
+		"": {
+			ProviderCapabilities: feature.ProviderCapabilities{
+				EnvVars: []feature.EnvVarSet{
+					{
+						EnvVar: corev1.EnvVar{
+							Name:  common.DDAuthTokenFilePath,
+							Value: filepath.Join(common.AuthVolumePath, "token"),
+						},
 					},
 				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
 			},
 		},
-		EnvVars: []feature.ProviderRule[feature.EnvVarSet]{
-			// DD_AUTH_TOKEN_FILE_PATH: all containers except Autopilot
-			{
-				Item: feature.EnvVarSet{
-					EnvVar: corev1.EnvVar{
-						Name:  common.DDAuthTokenFilePath,
-						Value: filepath.Join(common.AuthVolumePath, "token"),
-					},
-				},
-				ExcludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// GKE Autopilot: cloud provider metadata env var
-			{
-				Item: feature.EnvVarSet{
-					EnvVar: corev1.EnvVar{
-						Name:  "DD_CLOUD_PROVIDER_METADATA",
-						Value: `["gcp"]`,
-					},
-				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// GKE Autopilot: disable HTTPS kubelet port (Autopilot uses HTTP)
-			{
-				Item: feature.EnvVarSet{
-					EnvVar: corev1.EnvVar{
-						Name:  "DD_KUBERNETES_HTTPS_KUBELET_PORT",
-						Value: "0",
-					},
-				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// GKE Autopilot: provider kind tag consumed by the agent
-			{
-				Item: feature.EnvVarSet{
-					EnvVar: corev1.EnvVar{
-						Name:  "DD_PROVIDER_KIND",
-						Value: kubernetes.GKEAutopilotProvider,
-					},
-				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-		},
-		ImageRegistry: []feature.ProviderRule[string]{
-			{
-				Item:             "gcr.io/datadoghq",
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-		},
-		PodLabels: []feature.ProviderRule[map[string]string]{
-			{
-				Item:             map[string]string{"env.datadoghq.com/kind": kubernetes.GKEAutopilotProvider},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-		},
-		PodAnnotations: []feature.ProviderRule[map[string]string]{
-			{
-				Item:             map[string]string{"autopilot.gke.io/no-connect": "true"},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-		},
-		// RemoveVolumes and RemoveMounts strip base-template volumes before features run.
-		RemoveVolumes: []feature.ProviderRule[string]{
-			// auth-token volume is absent on GKE Autopilot (not in the Workload Allowlist).
-			{Item: common.AuthVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
-			// tmp EmptyDir is not permitted on GKE Autopilot (not in the Workload Allowlist).
-			{Item: common.TmpVolumeName, IncludeProviders: []string{kubernetes.GKEAutopilotProvider}},
-		},
-		RemoveMounts: []feature.ProviderRule[feature.ContainerMountRef]{
-			// procdir is not permitted on trace-agent in the Autopilot Workload Allowlist.
-			{
-				Item:             feature.ContainerMountRef{VolumeName: common.ProcdirVolumeName, Containers: []apicommon.AgentContainerName{apicommon.TraceAgentContainerName}},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// cgroups is not permitted on trace-agent in the Autopilot Workload Allowlist.
-			{
-				Item:             feature.ContainerMountRef{VolumeName: common.CgroupsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.TraceAgentContainerName}},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			// system-probe does not mount pointerdir on GKE Autopilot.
-			{
-				Item:             feature.ContainerMountRef{VolumeName: common.RunPathVolumeName, Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName}},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-		},
-		ContainerResources: []feature.ProviderRule[containerResourceDefault]{
-			{
-				Item: containerResourceDefault{
+		kubernetes.GKEAutopilotProvider: {
+			ContainerResources: []containerResourceDefault{
+				{
 					ContainerName: apicommon.CoreAgentContainerName,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -200,10 +82,7 @@ func nodeAgentGlobalSpec(provider string) globalNodeAgentSpec {
 						},
 					},
 				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			{
-				Item: containerResourceDefault{
+				{
 					ContainerName: apicommon.TraceAgentContainerName,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -212,10 +91,7 @@ func nodeAgentGlobalSpec(provider string) globalNodeAgentSpec {
 						},
 					},
 				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			{
-				Item: containerResourceDefault{
+				{
 					ContainerName: apicommon.ProcessAgentContainerName,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -224,10 +100,7 @@ func nodeAgentGlobalSpec(provider string) globalNodeAgentSpec {
 						},
 					},
 				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
-			},
-			{
-				Item: containerResourceDefault{
+				{
 					ContainerName: apicommon.SystemProbeContainerName,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -236,58 +109,114 @@ func nodeAgentGlobalSpec(provider string) globalNodeAgentSpec {
 						},
 					},
 				},
-				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
 			},
+			ProviderCapabilities: feature.ProviderCapabilities{
+				Volumes: []feature.VolumeAndMount{
+					// pointerdir: replace default EmptyDir with Autopilot HostPath
+					{
+						Volume:     pointerdirVol,
+						Mount:      pointerdirMount,
+						Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
+					},
+					// CRI socket: override /var/run with Autopilot containerd path
+					{
+						Volume: criSocketVol,
+						Mount:  criSocketMount,
+						Containers: []apicommon.AgentContainerName{
+							apicommon.CoreAgentContainerName,
+							apicommon.ProcessAgentContainerName,
+							apicommon.TraceAgentContainerName,
+							apicommon.SecurityAgentContainerName,
+							apicommon.AgentDataPlaneContainerName,
+						},
+					},
+				},
+				EnvVars: []feature.EnvVarSet{
+					{
+						EnvVar: corev1.EnvVar{
+							Name:  "DD_CLOUD_PROVIDER_METADATA",
+							Value: `["gcp"]`,
+						},
+					},
+					{
+						EnvVar: corev1.EnvVar{
+							Name:  "DD_KUBERNETES_HTTPS_KUBELET_PORT",
+							Value: "0",
+						},
+					},
+					{
+						EnvVar: corev1.EnvVar{
+							Name:  "DD_PROVIDER_KIND",
+							Value: kubernetes.GKEAutopilotProvider,
+						},
+					},
+				},
+				RemoveVolumes: []string{
+					// auth-token is absent on GKE Autopilot (not in the Workload Allowlist).
+					common.AuthVolumeName,
+					// tmp EmptyDir is not permitted on GKE Autopilot.
+					common.TmpVolumeName,
+				},
+				RemoveMounts: []feature.ContainerMountRef{
+					// procdir is not permitted on trace-agent in the Autopilot Workload Allowlist.
+					{VolumeName: common.ProcdirVolumeName, Containers: []apicommon.AgentContainerName{apicommon.TraceAgentContainerName}},
+					// cgroups is not permitted on trace-agent in the Autopilot Workload Allowlist.
+					{VolumeName: common.CgroupsVolumeName, Containers: []apicommon.AgentContainerName{apicommon.TraceAgentContainerName}},
+					// system-probe does not mount pointerdir on GKE Autopilot.
+					{VolumeName: common.RunPathVolumeName, Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName}},
+				},
+				RemoveEnvVars: []string{
+					// auth-token env var is absent on Autopilot (volume removed above).
+					common.DDAuthTokenFilePath,
+				},
+			},
+			ImageRegistry:  "gcr.io/datadoghq",
+			PodLabels:      map[string]string{"env.datadoghq.com/kind": kubernetes.GKEAutopilotProvider},
+			PodAnnotations: map[string]string{"autopilot.gke.io/no-connect": "true"},
 		},
 	}
-
-	return spec
 }
 
 // ApplyGlobalNodeAgentSpec applies all provider-conditional mutations for the
 // node agent pod template. Call this once, before features run.
 func ApplyGlobalNodeAgentSpec(mgr feature.PodTemplateManagers, provider string) {
-	spec := nodeAgentGlobalSpec(provider)
-	feature.ApplyNodeAgentProviderCapabilities(mgr, provider, feature.NodeAgentProviderCapabilities{
-		Volumes:       spec.Volumes,
-		EnvVars:       spec.EnvVars,
-		RemoveVolumes: spec.RemoveVolumes,
-		RemoveMounts:  spec.RemoveMounts,
-	})
+	spec := nodeAgentGlobalSpec()
 
-	for _, rule := range spec.ImageRegistry {
-		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			overrideImageRegistry(mgr, rule.Item)
-		}
+	// Extract the common ProviderCapabilities for each entry and delegate to
+	// the feature-level applier (handles baseline + provider removals/additions).
+	featureCaps := make(feature.NodeAgentProviderCapabilities, len(spec))
+	for k, v := range spec {
+		featureCaps[k] = v.ProviderCapabilities
 	}
+	feature.ApplyNodeAgentProviderCapabilities(mgr, provider, featureCaps)
 
-	for _, rule := range spec.PodLabels {
-		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			if mgr.PodTemplateSpec().Labels == nil {
-				mgr.PodTemplateSpec().Labels = map[string]string{}
+	// Apply provider-specific global fields.
+	if provider != "" {
+		if providerCaps, ok := spec[provider]; ok {
+			for _, r := range providerCaps.ContainerResources {
+				applyDefaultContainerResources(mgr.PodTemplateSpec(), r)
 			}
-			maps.Copy(mgr.PodTemplateSpec().Labels, rule.Item)
-		}
-	}
-
-	for _, rule := range spec.PodAnnotations {
-		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			if mgr.PodTemplateSpec().Annotations == nil {
-				mgr.PodTemplateSpec().Annotations = map[string]string{}
+			if providerCaps.ImageRegistry != "" {
+				overrideImageRegistry(mgr, providerCaps.ImageRegistry)
 			}
-			maps.Copy(mgr.PodTemplateSpec().Annotations, rule.Item)
+			if providerCaps.PodLabels != nil {
+				if mgr.PodTemplateSpec().Labels == nil {
+					mgr.PodTemplateSpec().Labels = map[string]string{}
+				}
+				maps.Copy(mgr.PodTemplateSpec().Labels, providerCaps.PodLabels)
+			}
+			if providerCaps.PodAnnotations != nil {
+				if mgr.PodTemplateSpec().Annotations == nil {
+					mgr.PodTemplateSpec().Annotations = map[string]string{}
+				}
+				maps.Copy(mgr.PodTemplateSpec().Annotations, providerCaps.PodAnnotations)
+			}
 		}
 	}
 
-	for _, rule := range spec.ContainerResources {
-		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
-			applyDefaultContainerResources(mgr.PodTemplateSpec(), rule.Item)
-		}
-	}
-
-	// Autopilot imperative overrides that cannot be expressed as ProviderRules.
+	// Imperative overrides that cannot be expressed as ProviderCapabilities entries.
 	if provider == kubernetes.GKEAutopilotProvider {
-		applyAutopilotInitContainerOverrides(mgr, spec.CRISocketRoot)
+		applyAutopilotInitContainerOverrides(mgr, "/var/run/containerd")
 		applyAutopilotContainerCommandOverrides(mgr)
 	}
 }

--- a/internal/controller/datadogagent/global/provider_spec.go
+++ b/internal/controller/datadogagent/global/provider_spec.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
@@ -18,6 +19,13 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
+
+// containerResourceDefault specifies default resource requests/limits for a named container.
+// Applied with "fill if zero" semantics — only written when the container has no existing requests/limits.
+type containerResourceDefault struct {
+	ContainerName apicommon.AgentContainerName
+	Resources     corev1.ResourceRequirements
+}
 
 // ProviderAnnotationKey is the annotation on a DDAI that declares the provider string.
 // The POC drives provider detection from this annotation rather than node labels.
@@ -37,6 +45,9 @@ type globalNodeAgentSpec struct {
 	// RemoveMounts lists specific container-volume mount pairs to strip for a provider.
 	// Applied inside ApplyGlobalNodeAgentSpec, before features run.
 	RemoveMounts []feature.ProviderRule[feature.ContainerMountRef]
+	// ContainerResources sets default resource requests/limits per container.
+	// Applied with "fill if zero" semantics after DDA override runs, so explicit DDA values always win.
+	ContainerResources []feature.ProviderRule[containerResourceDefault]
 	// CRISocketRoot is the host CRI socket directory; used to fix the init-config mount path.
 	CRISocketRoot string
 }
@@ -178,6 +189,56 @@ func nodeAgentGlobalSpec(provider string) globalNodeAgentSpec {
 				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
 			},
 		},
+		ContainerResources: []feature.ProviderRule[containerResourceDefault]{
+			{
+				Item: containerResourceDefault{
+					ContainerName: apicommon.CoreAgentContainerName,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			{
+				Item: containerResourceDefault{
+					ContainerName: apicommon.TraceAgentContainerName,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			{
+				Item: containerResourceDefault{
+					ContainerName: apicommon.ProcessAgentContainerName,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+			{
+				Item: containerResourceDefault{
+					ContainerName: apicommon.SystemProbeContainerName,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("400Mi"),
+						},
+					},
+				},
+				IncludeProviders: []string{kubernetes.GKEAutopilotProvider},
+			},
+		},
 	}
 
 	return spec
@@ -218,10 +279,34 @@ func ApplyGlobalNodeAgentSpec(mgr feature.PodTemplateManagers, provider string) 
 		}
 	}
 
+	for _, rule := range spec.ContainerResources {
+		if feature.ShouldApply(provider, rule.IncludeProviders, rule.ExcludeProviders) {
+			applyDefaultContainerResources(mgr.PodTemplateSpec(), rule.Item)
+		}
+	}
+
 	// Autopilot imperative overrides that cannot be expressed as ProviderRules.
 	if provider == kubernetes.GKEAutopilotProvider {
 		applyAutopilotInitContainerOverrides(mgr, spec.CRISocketRoot)
 		applyAutopilotContainerCommandOverrides(mgr)
+	}
+}
+
+// applyDefaultContainerResources sets resource requests/limits on a container only when
+// the container is present and has no existing requests or limits set.
+func applyDefaultContainerResources(tmpl *corev1.PodTemplateSpec, d containerResourceDefault) {
+	for i := range tmpl.Spec.Containers {
+		if tmpl.Spec.Containers[i].Name != string(d.ContainerName) {
+			continue
+		}
+		c := &tmpl.Spec.Containers[i]
+		if c.Resources.Requests == nil && d.Resources.Requests != nil {
+			c.Resources.Requests = d.Resources.Requests.DeepCopy()
+		}
+		if c.Resources.Limits == nil && d.Resources.Limits != nil {
+			c.Resources.Limits = d.Resources.Limits.DeepCopy()
+		}
+		return
 	}
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -33,7 +33,7 @@ import (
 )
 
 func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents feature.RequiredComponents, features []feature.Feature,
-	ddai *datadoghqv1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) (reconcile.Result, error) {
+	ddai *datadoghqv1alpha1.DatadogAgentInternal, resourcesManager feature.ResourceManagers, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus, provider string) (reconcile.Result, error) {
 	var result reconcile.Result
 	var eds *edsv1alpha1.ExtendedDaemonSet
 	var daemonset *appsv1.DaemonSet
@@ -60,13 +60,21 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 		objLogger := daemonsetLogger.WithValues("object.kind", "ExtendedDaemonSet", "object.namespace", eds.Namespace, "object.name", eds.Name)
 		podManagers = feature.NewPodTemplateManagers(&eds.Spec.Template)
 
+		// Apply provider-aware global settings (volumes, env vars, labels, registry) — pre-feature.
+		global.ApplyGlobalNodeAgentSpec(podManagers, provider)
+
 		// Set Global setting on the default extendeddaemonset
 		global.ApplyGlobalSettingsNodeAgent(objLogger, podManagers, ddai.GetObjectMeta(), &ddai.Spec, resourcesManager, singleContainerStrategyEnabled, requiredComponents)
 
-		// Apply features changes on the Deployment.Spec.Template
+		// Apply features changes on the Deployment.Spec.Template.
+		// Provider capabilities are applied immediately after each feature's ManageNodeAgent
+		// so that each feature owns its provider correctness independently.
 		for _, feat := range features {
-			if errFeat := feat.ManageNodeAgent(podManagers, ""); errFeat != nil {
+			if errFeat := feat.ManageNodeAgent(podManagers, provider); errFeat != nil {
 				return result, errFeat
+			}
+			if paf, ok := feat.(feature.ProviderAwareFeature); ok {
+				feature.ApplyNodeAgentProviderCapabilities(podManagers, provider, paf.NodeAgentProviderCapabilities())
 			}
 		}
 
@@ -112,18 +120,27 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 	daemonset = componentagent.NewDefaultAgentDaemonset(ddai, &r.options.ExtendedDaemonsetOptions, requiredComponents.Agent, component.GetAgentName(ddai))
 	objLogger := daemonsetLogger.WithValues("object.kind", "DaemonSet", "object.namespace", daemonset.Namespace, "object.name", daemonset.Name)
 	podManagers = feature.NewPodTemplateManagers(&daemonset.Spec.Template)
+
+	// Apply provider-aware global settings (volumes, env vars, labels, registry) — pre-feature.
+	global.ApplyGlobalNodeAgentSpec(podManagers, provider)
+
 	// Set Global setting on the default daemonset
 	global.ApplyGlobalSettingsNodeAgent(objLogger, podManagers, ddai.GetObjectMeta(), &ddai.Spec, resourcesManager, singleContainerStrategyEnabled, requiredComponents)
 
-	// Apply features changes on the Deployment.Spec.Template
+	// Apply features changes on the Deployment.Spec.Template.
+	// Provider capabilities are applied immediately after each feature's ManageNodeAgent
+	// so that each feature owns its provider correctness independently.
 	for _, feat := range features {
 		if singleContainerStrategyEnabled {
-			if errFeat := feat.ManageSingleContainerNodeAgent(podManagers, ""); errFeat != nil {
+			if errFeat := feat.ManageSingleContainerNodeAgent(podManagers, provider); errFeat != nil {
 				return result, errFeat
 			}
 		} else {
-			if errFeat := feat.ManageNodeAgent(podManagers, ""); errFeat != nil {
+			if errFeat := feat.ManageNodeAgent(podManagers, provider); errFeat != nil {
 				return result, errFeat
+			}
+			if paf, ok := feat.(feature.ProviderAwareFeature); ok {
+				feature.ApplyNodeAgentProviderCapabilities(podManagers, provider, paf.NodeAgentProviderCapabilities())
 			}
 		}
 	}

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/defaults"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
 	"github.com/DataDog/datadog-operator/internal/controller/finalizer"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -100,7 +101,8 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	}
 
 	// 2.b. Node Agent
-	result, err = r.reconcileV2Agent(ctx, requiredComponents, append(configuredFeatures, enabledFeatures...), instance, resourceManagers, newStatus)
+	provider := instance.GetAnnotations()[global.ProviderAnnotationKey]
+	result, err = r.reconcileV2Agent(ctx, requiredComponents, append(configuredFeatures, enabledFeatures...), instance, resourceManagers, newStatus, provider)
 	if utils.ShouldReturn(result, err) {
 		return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
 	}

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -47,6 +47,13 @@ const (
 	// EKS label prefixes for provider detection
 	eksLabelPrefix    = "eks.amazonaws.com/"
 	eksctlLabelPrefix = "alpha.eksctl.io/"
+
+	// GKEAutopilotProvider is the provider string for GKE Autopilot clusters.
+	// Driven by annotation in POC; node-label-based detection is a production concern.
+	GKEAutopilotProvider = "gke-autopilot"
+
+	// GKECosProvider is the full provider string for GKE Container-Optimized OS nodes.
+	GKECosProvider = "gke-cos"
 )
 
 // ProviderValue allowlist


### PR DESCRIPTION
### What does this PR do?

POC for handling provider specific variations in DDAI code path for GKE autopilot provider. Tested with four container enabled.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  annotations:
    # POC: declare provider so the DDAI reconciler applies GKE Autopilot-specific config
    datadoghq.com/provider: gke-autopilot
spec:
  global:
    kubelet:
      tlsVerify: false
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
  features:
    logCollection:
      enabled: true
      containerCollectAll: true
    liveProcessCollection:
      enabled: true
    usm:
      enabled: true
    npm:
      enabled: true
    apm:
      enabled: true
      hostPortConfig:
        enabled: true
      unixDomainSocketConfig:
        enabled: false
      instrumentation:
        enabled: true
        targets:
          - name: default-target
            ddTraceVersions:
              java: "1"
              python: "4"
              js: "5"
              php: "1"
              dotnet: "3"
              ruby: "2"
            ddTraceConfigs:
              - name: DD_PROFILING_ENABLED
                value: "auto"
  override:
    nodeAgent:
      labels:
        # Required by GKE Autopilot WorkloadAllowlist to exempt the DaemonSet
        cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.3
      priorityClassName: datadog
      containers:
        agent:
          resources:
            requests:
              cpu: "200m"
              memory: "256Mi"
        trace-agent:
          resources:
            requests:
              cpu: "100m"
              memory: "200Mi"
        process-agent:
          resources:
            requests:
              cpu: "100m"
              memory: "200Mi"
        system-probe:
          resources:
            requests:
              cpu: "100m"
              memory: "400Mi"
---
apiVersion: scheduling.k8s.io/v1
description: Used for Datadog Agent Components to be scheduled with higher priority.
kind: PriorityClass
metadata:
  name: datadog
preemptionPolicy: PreemptLowerPriority
value: 1e+09
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits