### PR TITLE
[FA] Read name from UPDATER_TASK

### DIFF
--- a/pkg/fleet/daemon.go
+++ b/pkg/fleet/daemon.go
@@ -47,7 +47,6 @@ type Daemon struct {
 	revisionsEnabled bool
 	mu               sync.RWMutex
 	configs          map[string]installerConfig // keyed by config ID; replaced on each RC update
-	experimentTarget types.NamespacedName       // DDA targeted by the current experiment; set on startExperiment
 }
 
 // NewDaemon creates a new Fleet Daemon. When revisionsEnabled is false, experiment
@@ -172,13 +171,12 @@ func (d *Daemon) handleRemoteAPIRequest(ctx context.Context, req remoteAPIReques
 
 // resolveOperation looks up the installer config for the request, validates its single
 // DatadogAgent operation, and fills in the canonical GVK. Returns the operation ready for use.
+// The target namespaced name is carried by the UPDATER_TASK itself (not the INSTALLER_CONFIG).
 func (d *Daemon) resolveOperation(req remoteAPIRequest, signal string) (fleetManagementOperation, error) {
-	// get params version from req
 	id := req.Params.Version
 	if id == "" {
 		return fleetManagementOperation{}, fmt.Errorf("%s: version is required", signal)
 	}
-	// match to d.configs[params.version] to get config
 	cfg, err := d.getConfig(id)
 	if err != nil {
 		return fleetManagementOperation{}, fmt.Errorf("%s: %w", signal, err)
@@ -204,16 +202,17 @@ func (d *Daemon) resolveOperation(req remoteAPIRequest, signal string) (fleetMan
 func (d *Daemon) startDatadogAgentExperiment(ctx context.Context, req remoteAPIRequest) error {
 	logger := ctrl.LoggerFrom(ctx).WithValues("id", req.ID)
 	logger.V(1).Info("Starting DatadogAgent experiment", "config", req.Params.Version)
+	nsn, err := parseTaskNSN(req, "start DatadogAgent experiment")
+	if err != nil {
+		return err
+	}
 	op, err := d.resolveOperation(req, "start DatadogAgent experiment")
 	if err != nil {
 		logger.Error(err, "Failed to resolve operation")
 		return err
 	}
 
-	// Store the target DDA for promote/stop signals (which don't carry a config).
-	d.experimentTarget = op.NamespacedName
-
-	logger = logger.WithValues("namespace", op.NamespacedName.Namespace, "name", op.NamespacedName.Name)
+	logger = logger.WithValues("namespace", nsn.Namespace, "name", nsn.Name)
 	ctx = ctrl.LoggerInto(ctx, logger)
 
 	// Check the operation
@@ -223,8 +222,8 @@ func (d *Daemon) startDatadogAgentExperiment(ctx context.Context, req remoteAPIR
 
 	// Fetch current DDA to check signal preconditions.
 	dda := &v2alpha1.DatadogAgent{}
-	if err := d.client.Get(ctx, op.NamespacedName, dda); err != nil {
-		return fmt.Errorf("start DatadogAgent experiment: failed to get DatadogAgent %s: %w", op.NamespacedName, err)
+	if err := d.client.Get(ctx, nsn, dda); err != nil {
+		return fmt.Errorf("start DatadogAgent experiment: failed to get DatadogAgent %s: %w", nsn, err)
 	}
 
 	if err := canStart(getExperimentPhase(dda)); err != nil {
@@ -253,7 +252,7 @@ func (d *Daemon) startDatadogAgentExperiment(ctx context.Context, req remoteAPIR
 	// Update status: phase=running, record experiment ID.
 	// Re-fetch inside the retry to get the latest ResourceVersion on conflict.
 	if err := retryWithBackoff(ctx, func() error {
-		if err := d.client.Get(ctx, op.NamespacedName, dda); err != nil {
+		if err := d.client.Get(ctx, nsn, dda); err != nil {
 			return err
 		}
 		dda.Status.Experiment = &v2alpha1.ExperimentStatus{
@@ -274,9 +273,9 @@ func (d *Daemon) startDatadogAgentExperiment(ctx context.Context, req remoteAPIR
 }
 
 func (d *Daemon) stopDatadogAgentExperiment(ctx context.Context, req remoteAPIRequest) error {
-	nsn := d.experimentTarget
-	if nsn.Name == "" {
-		return fmt.Errorf("stop DatadogAgent experiment: no experiment target set")
+	nsn, err := parseTaskNSN(req, "stop DatadogAgent experiment")
+	if err != nil {
+		return err
 	}
 
 	ctx = ctrl.LoggerInto(ctx, ctrl.LoggerFrom(ctx).WithValues("id", req.ID, "namespace", nsn.Namespace, "name", nsn.Name))
@@ -317,9 +316,9 @@ func (d *Daemon) stopDatadogAgentExperiment(ctx context.Context, req remoteAPIRe
 }
 
 func (d *Daemon) promoteDatadogAgentExperiment(ctx context.Context, req remoteAPIRequest) error {
-	nsn := d.experimentTarget
-	if nsn.Name == "" {
-		return fmt.Errorf("promote DatadogAgent experiment: no experiment target set")
+	nsn, err := parseTaskNSN(req, "promote DatadogAgent experiment")
+	if err != nil {
+		return err
 	}
 
 	ctx = ctrl.LoggerInto(ctx, ctrl.LoggerFrom(ctx).WithValues("id", req.ID, "namespace", nsn.Namespace, "name", nsn.Name))

--- a/pkg/fleet/daemon.go
+++ b/pkg/fleet/daemon.go
@@ -47,6 +47,7 @@ type Daemon struct {
 	revisionsEnabled bool
 	mu               sync.RWMutex
 	configs          map[string]installerConfig // keyed by config ID; replaced on each RC update
+	taskMu           sync.Mutex                 // serializes UPDATER_TASK execution
 }
 
 // NewDaemon creates a new Fleet Daemon. When revisionsEnabled is false, experiment
@@ -72,19 +73,7 @@ func (d *Daemon) Start(ctx context.Context) error {
 		return d.handleConfigs(ctx, configs)
 	}))
 	d.rcClient.Subscribe(state.ProductUpdaterTask, handleUpdaterTaskUpdate(ctx, func(req remoteAPIRequest) error {
-		d.setTaskState(req.Package, req.ID, pbgo.TaskState_RUNNING, nil)
-		err := d.handleRemoteAPIRequest(ctx, req)
-		if err != nil {
-			var stateErr *stateDoesntMatchError
-			if errors.As(err, &stateErr) {
-				d.setTaskState(req.Package, req.ID, pbgo.TaskState_INVALID_STATE, err)
-			} else {
-				d.setTaskState(req.Package, req.ID, pbgo.TaskState_ERROR, err)
-			}
-		} else {
-			d.setTaskState(req.Package, req.ID, pbgo.TaskState_DONE, nil)
-		}
-		return err
+		return d.handleTask(ctx, req)
 	}))
 
 	<-ctx.Done()
@@ -96,6 +85,26 @@ func (d *Daemon) Start(ctx context.Context) error {
 // The daemon only runs on the elected leader.
 func (d *Daemon) NeedLeaderElection() bool {
 	return true
+}
+
+// handleTask serializes UPDATER_TASK execution so at most one task runs at a time,
+// matching the datadog-agent's single-writer model and preventing races in setTaskState.
+func (d *Daemon) handleTask(ctx context.Context, req remoteAPIRequest) error {
+	d.taskMu.Lock()
+	defer d.taskMu.Unlock()
+	d.setTaskState(req.Package, req.ID, pbgo.TaskState_RUNNING, nil)
+	err := d.handleRemoteAPIRequest(ctx, req)
+	if err != nil {
+		var stateErr *stateDoesntMatchError
+		if errors.As(err, &stateErr) {
+			d.setTaskState(req.Package, req.ID, pbgo.TaskState_INVALID_STATE, err)
+		} else {
+			d.setTaskState(req.Package, req.ID, pbgo.TaskState_ERROR, err)
+		}
+	} else {
+		d.setTaskState(req.Package, req.ID, pbgo.TaskState_DONE, nil)
+	}
+	return err
 }
 
 // handleConfigs replaces the stored installer configs with the latest RC update.
@@ -290,6 +299,10 @@ func (d *Daemon) stopDatadogAgentExperiment(ctx context.Context, req remoteAPIRe
 	if isNoOp, err := canStop(ctx, getExperimentPhase(dda)); err != nil {
 		return fmt.Errorf("stop DatadogAgent experiment: %w", err)
 	} else if isNoOp {
+		// The spec rollback already happened (e.g. timeout), but the experiment
+		// config version still needs to be cleared so the backend can issue new tasks.
+		stable, _ := d.getPackageConfigVersions(req.Package)
+		d.setPackageConfigVersions(req.Package, stable, "")
 		return nil
 	}
 
@@ -339,6 +352,10 @@ func (d *Daemon) promoteDatadogAgentExperiment(ctx context.Context, req remoteAP
 	if isNoOp, err := canPromote(ctx, getExperimentPhase(dda)); err != nil {
 		return fmt.Errorf("promote DatadogAgent experiment: %w", err)
 	} else if isNoOp {
+		// The experiment is already in a terminal state. Clear the experiment
+		// config version so the backend can issue new tasks.
+		stable, _ := d.getPackageConfigVersions(req.Package)
+		d.setPackageConfigVersions(req.Package, stable, "")
 		return nil
 	}
 

--- a/pkg/fleet/daemon.go
+++ b/pkg/fleet/daemon.go
@@ -352,10 +352,18 @@ func (d *Daemon) promoteDatadogAgentExperiment(ctx context.Context, req remoteAP
 	if isNoOp, err := canPromote(ctx, getExperimentPhase(dda)); err != nil {
 		return fmt.Errorf("promote DatadogAgent experiment: %w", err)
 	} else if isNoOp {
-		// The experiment is already in a terminal state. Clear the experiment
-		// config version so the backend can issue new tasks.
-		stable, _ := d.getPackageConfigVersions(req.Package)
-		d.setPackageConfigVersions(req.Package, stable, "")
+		stable, exp := d.getPackageConfigVersions(req.Package)
+		if getExperimentPhase(dda) == v2alpha1.ExperimentPhasePromoted {
+			// The experiment was already promoted (e.g. daemon crashed between the
+			// status update and setPackageConfigVersions). Finish the promotion by
+			// moving the experiment version to stable so the backend gets the correct
+			// baseline for future expected_state checks.
+			d.setPackageConfigVersions(req.Package, exp, "")
+		} else {
+			// The experiment was rolled back (stopped/rollback/timeout). Just clear
+			// the experiment version so the backend can issue new tasks.
+			d.setPackageConfigVersions(req.Package, stable, "")
+		}
 		return nil
 	}
 

--- a/pkg/fleet/daemon_test.go
+++ b/pkg/fleet/daemon_test.go
@@ -44,7 +44,6 @@ func testDaemon(dda *v2alpha1.DatadogAgent, configs map[string]installerConfig) 
 		client:           c,
 		revisionsEnabled: true,
 		configs:          configs,
-		experimentTarget: testDDANSN,
 	}, c
 }
 
@@ -77,7 +76,6 @@ func testInstallerConfigWithDDA() map[string]installerConfig {
 				{
 					Operation:        OperationUpdate,
 					GroupVersionKind: testDDAGVK,
-					NamespacedName:   testDDANSN,
 					Config:           json.RawMessage(`{}`),
 				},
 			},
@@ -90,7 +88,7 @@ func testStartRequest() remoteAPIRequest {
 		ID:      "exp-abc",
 		Package: "datadog-operator",
 		Method:  methodStartDatadogAgentExperiment,
-		Params:  experimentParams{Version: "test-config"},
+		Params:  experimentParams{Version: "test-config", NamespacedName: testDDANSN},
 	}
 }
 
@@ -111,7 +109,6 @@ func TestStartDatadogAgentExperiment_NoDDAOperation(t *testing.T) {
 				{
 					Operation:        OperationUpdate,
 					GroupVersionKind: schema.GroupVersionKind{Group: "other.io", Version: "v1", Kind: "Other"},
-					NamespacedName:   testDDANSN,
 					Config:           json.RawMessage(`{}`),
 				},
 			},
@@ -221,7 +218,6 @@ func TestStartDatadogAgentExperiment_VersionMatchesInstallerConfig(t *testing.T)
 				{
 					Operation:        OperationUpdate,
 					GroupVersionKind: testDDAGVK,
-					NamespacedName:   testDDANSN,
 					Config:           json.RawMessage(`{"spec":{"features":{"apm":{"enabled":true}}}}`),
 				},
 			},
@@ -231,7 +227,7 @@ func TestStartDatadogAgentExperiment_VersionMatchesInstallerConfig(t *testing.T)
 	req := remoteAPIRequest{
 		ID:     "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
 		Method: methodStartDatadogAgentExperiment,
-		Params: experimentParams{Version: "aaaa-bbbb-cccc"},
+		Params: experimentParams{Version: "aaaa-bbbb-cccc", NamespacedName: testDDANSN},
 		ExpectedState: expectedState{
 			Stable:       "0.0.1",
 			StableConfig: "0.0.1",
@@ -271,7 +267,7 @@ func testStopRequest() remoteAPIRequest {
 		ID:      "exp-abc",
 		Package: "datadog-operator",
 		Method:  methodStopDatadogAgentExperiment,
-		Params:  experimentParams{Version: "test-config"},
+		Params:  experimentParams{Version: "test-config", NamespacedName: testDDANSN},
 	}
 }
 
@@ -337,7 +333,7 @@ func testPromoteRequest() remoteAPIRequest {
 		ID:      "exp-abc",
 		Package: "datadog-operator",
 		Method:  methodPromoteDatadogAgentExperiment,
-		Params:  experimentParams{Version: "test-config"},
+		Params:  experimentParams{Version: "test-config", NamespacedName: testDDANSN},
 	}
 }
 
@@ -497,33 +493,15 @@ func TestValidateOperation_Valid(t *testing.T) {
 	op := fleetManagementOperation{
 		Operation:        OperationUpdate,
 		GroupVersionKind: testDDAGVK,
-		NamespacedName:   testDDANSN,
 		Config:           json.RawMessage(`{}`),
 	}
 	assert.NoError(t, validateOperation(op))
-}
-
-func TestValidateOperation_EmptyName(t *testing.T) {
-	op := fleetManagementOperation{
-		GroupVersionKind: testDDAGVK,
-		NamespacedName:   types.NamespacedName{Namespace: "datadog", Name: ""},
-	}
-	assert.Error(t, validateOperation(op))
-}
-
-func TestValidateOperation_EmptyNamespace(t *testing.T) {
-	op := fleetManagementOperation{
-		GroupVersionKind: testDDAGVK,
-		NamespacedName:   types.NamespacedName{Namespace: "", Name: "datadog-agent"},
-	}
-	assert.Error(t, validateOperation(op))
 }
 
 func TestValidateOperation_EmptyGroup_Allowed(t *testing.T) {
 	// Group is auto-detected from the cluster; empty group is valid input.
 	op := fleetManagementOperation{
 		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "", Kind: "DatadogAgent"},
-		NamespacedName:   testDDANSN,
 	}
 	assert.NoError(t, validateOperation(op))
 }
@@ -531,9 +509,29 @@ func TestValidateOperation_EmptyGroup_Allowed(t *testing.T) {
 func TestValidateOperation_WrongKind(t *testing.T) {
 	op := fleetManagementOperation{
 		GroupVersionKind: schema.GroupVersionKind{Group: "datadoghq.com", Version: "v2alpha1", Kind: "DatadogMonitor"},
-		NamespacedName:   testDDANSN,
 	}
 	assert.Error(t, validateOperation(op))
+}
+
+// --- parseTaskNSN tests ---
+
+func TestParseTaskNSN_Valid(t *testing.T) {
+	req := remoteAPIRequest{Params: experimentParams{NamespacedName: testDDANSN}}
+	nsn, err := parseTaskNSN(req, "test")
+	require.NoError(t, err)
+	assert.Equal(t, testDDANSN, nsn)
+}
+
+func TestParseTaskNSN_MissingName(t *testing.T) {
+	req := remoteAPIRequest{Params: experimentParams{NamespacedName: types.NamespacedName{Namespace: "datadog"}}}
+	_, err := parseTaskNSN(req, "test")
+	assert.Error(t, err)
+}
+
+func TestParseTaskNSN_MissingNamespace(t *testing.T) {
+	req := remoteAPIRequest{Params: experimentParams{NamespacedName: types.NamespacedName{Name: "datadog-agent"}}}
+	_, err := parseTaskNSN(req, "test")
+	assert.Error(t, err)
 }
 
 // --- canStart tests ---

--- a/pkg/fleet/daemon_test.go
+++ b/pkg/fleet/daemon_test.go
@@ -361,39 +361,54 @@ func TestPromoteDatadogAgentExperiment_NoExperimentVersion(t *testing.T) {
 }
 
 func TestPromoteDatadogAgentExperiment_NoOp_Rollback(t *testing.T) {
-	d, c := testDaemon(testDDAObject(v2alpha1.ExperimentPhaseRollback), testInstallerConfigWithDDA())
-	d.rcClient = &mockRCClient{state: []*pbgo.PackageState{
+	rc := &mockRCClient{state: []*pbgo.PackageState{
 		{Package: "datadog-operator", StableConfigVersion: "stable-1", ExperimentConfigVersion: "exp-1"},
 	}}
+	d, c := testDaemon(testDDAObject(v2alpha1.ExperimentPhaseRollback), testInstallerConfigWithDDA())
+	d.rcClient = rc
 	require.NoError(t, d.promoteDatadogAgentExperiment(context.Background(), testPromoteRequest()))
 
 	dda := &v2alpha1.DatadogAgent{}
 	require.NoError(t, c.Get(context.Background(), testDDANSN, dda))
 	assert.Equal(t, v2alpha1.ExperimentPhaseRollback, dda.Status.Experiment.Phase)
+	// Rolled back: stable stays, experiment cleared.
+	assert.Equal(t, "stable-1", rc.state[0].StableConfigVersion)
+	assert.Equal(t, "", rc.state[0].ExperimentConfigVersion)
 }
 
 func TestPromoteDatadogAgentExperiment_NoOp_Timeout(t *testing.T) {
-	d, c := testDaemon(testDDAObject(v2alpha1.ExperimentPhaseTimeout), testInstallerConfigWithDDA())
-	d.rcClient = &mockRCClient{state: []*pbgo.PackageState{
+	rc := &mockRCClient{state: []*pbgo.PackageState{
 		{Package: "datadog-operator", StableConfigVersion: "stable-1", ExperimentConfigVersion: "exp-1"},
 	}}
+	d, c := testDaemon(testDDAObject(v2alpha1.ExperimentPhaseTimeout), testInstallerConfigWithDDA())
+	d.rcClient = rc
 	require.NoError(t, d.promoteDatadogAgentExperiment(context.Background(), testPromoteRequest()))
 
 	dda := &v2alpha1.DatadogAgent{}
 	require.NoError(t, c.Get(context.Background(), testDDANSN, dda))
 	assert.Equal(t, v2alpha1.ExperimentPhaseTimeout, dda.Status.Experiment.Phase)
+	// Timed out: stable stays, experiment cleared.
+	assert.Equal(t, "stable-1", rc.state[0].StableConfigVersion)
+	assert.Equal(t, "", rc.state[0].ExperimentConfigVersion)
 }
 
 func TestPromoteDatadogAgentExperiment_NoOp_Promoted(t *testing.T) {
-	d, c := testDaemon(testDDAObject(v2alpha1.ExperimentPhasePromoted), testInstallerConfigWithDDA())
-	d.rcClient = &mockRCClient{state: []*pbgo.PackageState{
+	// Simulates daemon crash between status update and setPackageConfigVersions:
+	// phase=Promoted but installer state still has the experiment version.
+	// The no-op path must complete the promotion by moving exp → stable.
+	rc := &mockRCClient{state: []*pbgo.PackageState{
 		{Package: "datadog-operator", StableConfigVersion: "stable-1", ExperimentConfigVersion: "exp-1"},
 	}}
+	d, c := testDaemon(testDDAObject(v2alpha1.ExperimentPhasePromoted), testInstallerConfigWithDDA())
+	d.rcClient = rc
 	require.NoError(t, d.promoteDatadogAgentExperiment(context.Background(), testPromoteRequest()))
 
 	dda := &v2alpha1.DatadogAgent{}
 	require.NoError(t, c.Get(context.Background(), testDDANSN, dda))
 	assert.Equal(t, v2alpha1.ExperimentPhasePromoted, dda.Status.Experiment.Phase)
+	// Promoted: experiment version moves to stable, experiment cleared.
+	assert.Equal(t, "exp-1", rc.state[0].StableConfigVersion)
+	assert.Equal(t, "", rc.state[0].ExperimentConfigVersion)
 }
 
 func TestPromoteDatadogAgentExperiment_Success_Running(t *testing.T) {

--- a/pkg/fleet/daemon_test.go
+++ b/pkg/fleet/daemon_test.go
@@ -756,3 +756,46 @@ func TestSetTaskState_NilClient(t *testing.T) {
 		d.setTaskState("datadog-operator", "task-1", pbgo.TaskState_RUNNING, nil)
 	})
 }
+
+// --- handleTask state-transition tests ---
+
+func testDaemonFull(dda *v2alpha1.DatadogAgent, configs map[string]installerConfig, rcState []*pbgo.PackageState) (*Daemon, client.Client, *mockRCClient) {
+	d, c := testDaemon(dda, configs)
+	rc := &mockRCClient{state: rcState}
+	d.rcClient = rc
+	return d, c, rc
+}
+
+func TestHandleTask_Done(t *testing.T) {
+	rc := []*pbgo.PackageState{{Package: "datadog-operator", StableConfigVersion: "0.0.1"}}
+	d, _, m := testDaemonFull(testDDAObject(""), testInstallerConfigWithDDA(), rc)
+	req := testStartRequest()
+	req.ExpectedState = expectedState{StableConfig: "0.0.1"}
+	require.NoError(t, d.handleTask(context.Background(), req))
+	require.NotNil(t, m.state[0].Task)
+	assert.Equal(t, pbgo.TaskState_DONE, m.state[0].Task.State)
+}
+
+func TestHandleTask_Error(t *testing.T) {
+	rc := []*pbgo.PackageState{{Package: "datadog-operator", StableConfigVersion: "0.0.1"}}
+	d, _, m := testDaemonFull(testDDAObject(""), testInstallerConfigWithDDA(), rc)
+	req := testStartRequest()
+	req.Method = "unknown/method"
+	req.ExpectedState = expectedState{StableConfig: "0.0.1"}
+	err := d.handleTask(context.Background(), req)
+	require.Error(t, err)
+	require.NotNil(t, m.state[0].Task)
+	assert.Equal(t, pbgo.TaskState_ERROR, m.state[0].Task.State)
+	require.NotNil(t, m.state[0].Task.Error)
+}
+
+func TestHandleTask_InvalidState(t *testing.T) {
+	rc := []*pbgo.PackageState{{Package: "datadog-operator", StableConfigVersion: "0.0.1"}}
+	d, _, m := testDaemonFull(testDDAObject(""), testInstallerConfigWithDDA(), rc)
+	req := testStartRequest()
+	req.ExpectedState = expectedState{StableConfig: "wrong-version"}
+	err := d.handleTask(context.Background(), req)
+	require.Error(t, err)
+	require.NotNil(t, m.state[0].Task)
+	assert.Equal(t, pbgo.TaskState_INVALID_STATE, m.state[0].Task.State)
+}

--- a/pkg/fleet/experiment.go
+++ b/pkg/fleet/experiment.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -19,19 +20,24 @@ import (
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 )
 
-// validateOperation checks that a fleetManagementOperation has the fields
-// required to locate and act on a DatadogAgent resource.
+// validateOperation checks that a fleetManagementOperation targets a DatadogAgent resource.
 func validateOperation(op fleetManagementOperation) error {
-	if op.NamespacedName.Name == "" {
-		return fmt.Errorf("operation namespaced name must have a non-empty name")
-	}
-	if op.NamespacedName.Namespace == "" {
-		return fmt.Errorf("operation namespaced name must have a non-empty namespace")
-	}
 	if op.GroupVersionKind.Kind != "DatadogAgent" {
 		return fmt.Errorf("operation kind must be DatadogAgent, got %q", op.GroupVersionKind.Kind)
 	}
 	return nil
+}
+
+// parseTaskNSN extracts and validates the target namespaced name from an UPDATER_TASK request.
+func parseTaskNSN(req remoteAPIRequest, signal string) (types.NamespacedName, error) {
+	nsn := req.Params.NamespacedName
+	if nsn.Name == "" {
+		return types.NamespacedName{}, fmt.Errorf("%s: params.namespaced_name.name is required", signal)
+	}
+	if nsn.Namespace == "" {
+		return types.NamespacedName{}, fmt.Errorf("%s: params.namespaced_name.namespace is required", signal)
+	}
+	return nsn, nil
 }
 
 // canStart returns whether a start signal is allowed given the current experiment phase.

--- a/pkg/fleet/remote_config.go
+++ b/pkg/fleet/remote_config.go
@@ -36,7 +36,6 @@ const (
 type fleetManagementOperation struct {
 	Operation        Operation               `json:"operation"`
 	GroupVersionKind schema.GroupVersionKind `json:"group_version_kind"`
-	NamespacedName   types.NamespacedName    `json:"namespaced_name"`
 	Config           json.RawMessage         `json:"config"`
 }
 
@@ -63,7 +62,8 @@ type expectedState struct {
 
 // experimentParams holds the parsed params for experiment methods.
 type experimentParams struct {
-	Version string `json:"version"`
+	Version        string               `json:"version"`
+	NamespacedName types.NamespacedName `json:"namespaced_name"`
 }
 
 // handleInstallerConfigUpdate returns an RC subscription callback that parses

--- a/pkg/fleet/remote_config_test.go
+++ b/pkg/fleet/remote_config_test.go
@@ -29,10 +29,6 @@ var testInstallerConfig = installerConfig{
 				Version: "v2alpha1",
 				Kind:    "DatadogAgent",
 			},
-			NamespacedName: types.NamespacedName{
-				Namespace: "datadog",
-				Name:      "datadog-agent",
-			},
 			Config: json.RawMessage(`{"spec":{"features":{"apm":{"enabled":true}}}}`),
 		},
 	},
@@ -41,7 +37,9 @@ var testInstallerConfig = installerConfig{
 var testRemoteAPIRequest = remoteAPIRequest{
 	ID:     "test",
 	Method: "some_method",
-	Params: experimentParams{},
+	Params: experimentParams{
+		NamespacedName: types.NamespacedName{Namespace: "datadog", Name: "datadog-agent"},
+	},
 }
 
 // callbackMock records calls made by the RC handler callbacks.


### PR DESCRIPTION
Re-do of #2913.

### What does this PR do?

Read the target `DatadogAgent` namespace/name from the `UPDATER_TASK` params directly (via a new `parseTaskNSN` helper) for start, stop, and promote operations, instead of storing it in a `experimentTarget` field on the daemon struct.

### Motivation

Previously, stop and promote operations relied on `d.experimentTarget` being set by a prior start call. This stateful approach was fragile — if the daemon restarted between start and stop/promote, the target was lost. Carrying the name in every task payload makes each operation self-contained and idempotent.

### Additional Notes

- Removes the `experimentTarget types.NamespacedName` field from the daemon struct.
- `NamespacedName` is now a field of `experimentParams` (carried in the task itself).
- `validateOperation` tests for empty name/namespace are replaced by `parseTaskNSN` tests.

### Minimum Agent Versions

No minimum version requirements.

### Describe your test plan

Unit tests in `pkg/fleet/daemon_test.go` and `pkg/fleet/remote_config_test.go` are updated to pass `NamespacedName` inside `experimentParams`. New `TestParseTaskNSN_*` tests cover the valid, missing-name, and missing-namespace cases.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits