### PR TITLE
[FA] Serialize UPDATER_TASK execution and fix no-op config version clearing

### DIFF
--- a/pkg/fleet/daemon.go
+++ b/pkg/fleet/daemon.go
@@ -48,6 +48,7 @@ type Daemon struct {
 	mu               sync.RWMutex
 	configs          map[string]installerConfig // keyed by config ID; replaced on each RC update
 	experimentTarget types.NamespacedName       // DDA targeted by the current experiment; set on startExperiment
+	taskMu           sync.Mutex                 // serializes UPDATER_TASK execution
 }
 
 // NewDaemon creates a new Fleet Daemon. When revisionsEnabled is false, experiment
@@ -73,19 +74,7 @@ func (d *Daemon) Start(ctx context.Context) error {
 		return d.handleConfigs(ctx, configs)
 	}))
 	d.rcClient.Subscribe(state.ProductUpdaterTask, handleUpdaterTaskUpdate(ctx, func(req remoteAPIRequest) error {
-		d.setTaskState(req.Package, req.ID, pbgo.TaskState_RUNNING, nil)
-		err := d.handleRemoteAPIRequest(ctx, req)
-		if err != nil {
-			var stateErr *stateDoesntMatchError
-			if errors.As(err, &stateErr) {
-				d.setTaskState(req.Package, req.ID, pbgo.TaskState_INVALID_STATE, err)
-			} else {
-				d.setTaskState(req.Package, req.ID, pbgo.TaskState_ERROR, err)
-			}
-		} else {
-			d.setTaskState(req.Package, req.ID, pbgo.TaskState_DONE, nil)
-		}
-		return err
+		return d.handleTask(ctx, req)
 	}))
 
 	<-ctx.Done()
@@ -97,6 +86,26 @@ func (d *Daemon) Start(ctx context.Context) error {
 // The daemon only runs on the elected leader.
 func (d *Daemon) NeedLeaderElection() bool {
 	return true
+}
+
+// handleTask serializes UPDATER_TASK execution so at most one task runs at a time,
+// matching the datadog-agent's single-writer model and preventing races in setTaskState.
+func (d *Daemon) handleTask(ctx context.Context, req remoteAPIRequest) error {
+	d.taskMu.Lock()
+	defer d.taskMu.Unlock()
+	d.setTaskState(req.Package, req.ID, pbgo.TaskState_RUNNING, nil)
+	err := d.handleRemoteAPIRequest(ctx, req)
+	if err != nil {
+		var stateErr *stateDoesntMatchError
+		if errors.As(err, &stateErr) {
+			d.setTaskState(req.Package, req.ID, pbgo.TaskState_INVALID_STATE, err)
+		} else {
+			d.setTaskState(req.Package, req.ID, pbgo.TaskState_ERROR, err)
+		}
+	} else {
+		d.setTaskState(req.Package, req.ID, pbgo.TaskState_DONE, nil)
+	}
+	return err
 }
 
 // handleConfigs replaces the stored installer configs with the latest RC update.
@@ -291,6 +300,10 @@ func (d *Daemon) stopDatadogAgentExperiment(ctx context.Context, req remoteAPIRe
 	if isNoOp, err := canStop(ctx, getExperimentPhase(dda)); err != nil {
 		return fmt.Errorf("stop DatadogAgent experiment: %w", err)
 	} else if isNoOp {
+		// The spec rollback already happened (e.g. timeout), but the experiment
+		// config version still needs to be cleared so the backend can issue new tasks.
+		stable, _ := d.getPackageConfigVersions(req.Package)
+		d.setPackageConfigVersions(req.Package, stable, "")
 		return nil
 	}
 
@@ -340,6 +353,10 @@ func (d *Daemon) promoteDatadogAgentExperiment(ctx context.Context, req remoteAP
 	if isNoOp, err := canPromote(ctx, getExperimentPhase(dda)); err != nil {
 		return fmt.Errorf("promote DatadogAgent experiment: %w", err)
 	} else if isNoOp {
+		// The experiment is already in a terminal state. Clear the experiment
+		// config version so the backend can issue new tasks.
+		stable, _ := d.getPackageConfigVersions(req.Package)
+		d.setPackageConfigVersions(req.Package, stable, "")
 		return nil
 	}
 

--- a/pkg/fleet/daemon_test.go
+++ b/pkg/fleet/daemon_test.go
@@ -758,3 +758,46 @@ func TestSetTaskState_NilClient(t *testing.T) {
 		d.setTaskState("datadog-operator", "task-1", pbgo.TaskState_RUNNING, nil)
 	})
 }
+
+// --- handleTask state-transition tests ---
+
+func testDaemonFull(dda *v2alpha1.DatadogAgent, configs map[string]installerConfig, rcState []*pbgo.PackageState) (*Daemon, client.Client, *mockRCClient) {
+	d, c := testDaemon(dda, configs)
+	rc := &mockRCClient{state: rcState}
+	d.rcClient = rc
+	return d, c, rc
+}
+
+func TestHandleTask_Done(t *testing.T) {
+	rc := []*pbgo.PackageState{{Package: "datadog-operator", StableConfigVersion: "0.0.1"}}
+	d, _, m := testDaemonFull(testDDAObject(""), testInstallerConfigWithDDA(), rc)
+	req := testStartRequest()
+	req.ExpectedState = expectedState{StableConfig: "0.0.1"}
+	require.NoError(t, d.handleTask(context.Background(), req))
+	require.NotNil(t, m.state[0].Task)
+	assert.Equal(t, pbgo.TaskState_DONE, m.state[0].Task.State)
+}
+
+func TestHandleTask_Error(t *testing.T) {
+	rc := []*pbgo.PackageState{{Package: "datadog-operator", StableConfigVersion: "0.0.1"}}
+	d, _, m := testDaemonFull(testDDAObject(""), testInstallerConfigWithDDA(), rc)
+	req := testStartRequest()
+	req.Method = "unknown/method"
+	req.ExpectedState = expectedState{StableConfig: "0.0.1"}
+	err := d.handleTask(context.Background(), req)
+	require.Error(t, err)
+	require.NotNil(t, m.state[0].Task)
+	assert.Equal(t, pbgo.TaskState_ERROR, m.state[0].Task.State)
+	require.NotNil(t, m.state[0].Task.Error)
+}
+
+func TestHandleTask_InvalidState(t *testing.T) {
+	rc := []*pbgo.PackageState{{Package: "datadog-operator", StableConfigVersion: "0.0.1"}}
+	d, _, m := testDaemonFull(testDDAObject(""), testInstallerConfigWithDDA(), rc)
+	req := testStartRequest()
+	req.ExpectedState = expectedState{StableConfig: "wrong-version"}
+	err := d.handleTask(context.Background(), req)
+	require.Error(t, err)
+	require.NotNil(t, m.state[0].Task)
+	assert.Equal(t, pbgo.TaskState_INVALID_STATE, m.state[0].Task.State)
+}


### PR DESCRIPTION
## What does this PR do?

Ports three fixes from #2952 that are independent of the `parseTaskNSN` / namespace-from-task refactor.

### 1. Serialize UPDATER_TASK execution (`taskMu` + `handleTask`)

Adds a `taskMu sync.Mutex` to `Daemon` and extracts a `handleTask` method that holds the lock for the full lifecycle of one task (RUNNING → DONE/ERROR/INVALID_STATE). The inline block in `Start()` is replaced with `return d.handleTask(ctx, req)`.

**Why:** Multiple concurrent RC callbacks can race on `setTaskState`. This matches the datadog-agent's single-writer model.

### 2. No-op stop clears experiment config version

When `canStop` returns `isNoOp=true` (e.g. spec already rolled back due to timeout), the experiment config version is now cleared before returning.

**Why:** Without this, the backend could not issue new tasks after a timeout-triggered rollback.

### 3. No-op promote clears experiment config version

Same fix for `promoteDatadogAgentExperiment` when the experiment is already in a terminal state.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits