### PR TITLE
[FA] feat: read group_version_kind from UPDATER_TASK.params

### DIFF
--- a/pkg/fleet/daemon.go
+++ b/pkg/fleet/daemon.go
@@ -196,11 +196,15 @@ func (d *Daemon) resolveOperation(req remoteAPIRequest, signal string) (fleetMan
 	}
 	op := cfg.Operations[0]
 
+	gvk := req.Params.GroupVersionKind
+	if gvk.Kind == "" {
+		gvk = v2alpha1.GroupVersion.WithKind("DatadogAgent")
+	}
+	op.GroupVersionKind = gvk
+
 	if err := validateOperation(op); err != nil {
 		return fleetManagementOperation{}, fmt.Errorf("%s: invalid operation: %w", signal, err)
 	}
-
-	op.GroupVersionKind = v2alpha1.GroupVersion.WithKind("DatadogAgent")
 
 	return op, nil
 }

--- a/pkg/fleet/daemon_test.go
+++ b/pkg/fleet/daemon_test.go
@@ -102,21 +102,9 @@ func TestStartDatadogAgentExperiment_ConfigNotFound(t *testing.T) {
 }
 
 func TestStartDatadogAgentExperiment_NoDDAOperation(t *testing.T) {
-	configs := map[string]installerConfig{
-		"no-dda-config": {
-			ID: "no-dda-config",
-			Operations: []fleetManagementOperation{
-				{
-					Operation:        OperationUpdate,
-					GroupVersionKind: schema.GroupVersionKind{Group: "other.io", Version: "v1", Kind: "Other"},
-					Config:           json.RawMessage(`{}`),
-				},
-			},
-		},
-	}
-	d, _ := testDaemon(testDDAObject(""), configs)
+	d, _ := testDaemon(testDDAObject(""), testInstallerConfigWithDDA())
 	req := testStartRequest()
-	req.Params.Version = "no-dda-config"
+	req.Params.GroupVersionKind = schema.GroupVersionKind{Group: "other.io", Version: "v1", Kind: "Other"}
 	assert.Error(t, d.startDatadogAgentExperiment(context.Background(), req))
 }
 
@@ -203,6 +191,26 @@ func TestStartDatadogAgentExperiment_Success_OverwritesPreviousExperiment(t *tes
 	assert.Equal(t, v2alpha1.ExperimentPhaseRunning, dda.Status.Experiment.Phase)
 	assert.Equal(t, req.ID, dda.Status.Experiment.ID)
 	assert.NotEqual(t, "old-exp", dda.Status.Experiment.ID)
+}
+
+// --- resolveOperation: GVK source tests ---
+
+func TestResolveOperation_GVKFromTaskParams(t *testing.T) {
+	d, _ := testDaemon(testDDAObject(""), testInstallerConfigWithDDA())
+	req := testStartRequest()
+	req.Params.GroupVersionKind = schema.GroupVersionKind{Group: "datadoghq.com", Version: "v2alpha1", Kind: "DatadogAgent"}
+	op, err := d.resolveOperation(req, "test")
+	require.NoError(t, err)
+	assert.Equal(t, req.Params.GroupVersionKind, op.GroupVersionKind)
+}
+
+func TestResolveOperation_GVKFallback(t *testing.T) {
+	d, _ := testDaemon(testDDAObject(""), testInstallerConfigWithDDA())
+	req := testStartRequest()
+	// No GVK in task params — should fall back to the canonical default.
+	op, err := d.resolveOperation(req, "test")
+	require.NoError(t, err)
+	assert.Equal(t, v2alpha1.GroupVersion.WithKind("DatadogAgent"), op.GroupVersionKind)
 }
 
 // --- resolveOperation: params.version matching tests ---

--- a/pkg/fleet/remote_config.go
+++ b/pkg/fleet/remote_config.go
@@ -62,8 +62,9 @@ type expectedState struct {
 
 // experimentParams holds the parsed params for experiment methods.
 type experimentParams struct {
-	Version        string               `json:"version"`
-	NamespacedName types.NamespacedName `json:"namespaced_name"`
+	Version          string                  `json:"version"`
+	NamespacedName   types.NamespacedName    `json:"namespaced_name"`
+	GroupVersionKind schema.GroupVersionKind `json:"group_version_kind"`
 }
 
 // handleInstallerConfigUpdate returns an RC subscription callback that parses


### PR DESCRIPTION
Stacked on #2952.

## Summary
- Added `group_version_kind` field to `experimentParams` (parsed from `UPDATER_TASK.params`)
- `resolveOperation` now reads GVK from task params instead of hardcoding `datadoghq.com/v2alpha1/DatadogAgent`
- Falls back to the hardcoded default when the field is absent (backward compat for old tasks)
- Updated `TestStartDatadogAgentExperiment_NoDDAOperation` to assert on task params GVK (since that's now the authoritative source)
- Added `TestResolveOperation_GVKFromTaskParams` and `TestResolveOperation_GVKFallback`

## Test plan
- [ ] `go test ./pkg/fleet/... -run TestResolveOperation`
- [ ] `go test ./pkg/fleet/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)