### PR TITLE
[CASCL-1323] `kubectl-datadog`: delegate OCI image parsing to `go-containerregistry`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -115,6 +115,7 @@ core,github.com/golang/snappy,BSD-3-Clause
 core,github.com/google/btree,Apache-2.0
 core,github.com/google/cel-go,Apache-2.0
 core,github.com/google/gnostic-models,Apache-2.0
+core,github.com/google/go-containerregistry/pkg/name,Apache-2.0
 core,github.com/google/pprof/profile,Apache-2.0
 core,github.com/google/uuid,BSD-3-Clause
 core,github.com/gorilla/websocket,BSD-2-Clause

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	astypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -244,17 +245,22 @@ func extractClusterAutoscalerVersion(d appsv1.Deployment) string {
 	return d.Spec.Template.Labels["app.kubernetes.io/version"]
 }
 
-// imageTag extracts the tag portion of an OCI image reference, stripping
-// any `@sha256:...` digest. Returns empty when no tag is set (for instance,
-// digest-only references or bare image names).
+// imageTag extracts the tag portion of an OCI image reference. Returns empty
+// when no tag is set (digest-only references or bare image names).
 func imageTag(image string) string {
+	// pkg/name parses a combined `tag@digest` reference as a Digest, dropping
+	// the tag — strip the digest first so the tag is preserved.
 	if i := strings.Index(image, "@"); i >= 0 {
 		image = image[:i]
 	}
-	// The last colon is the tag separator only if it is not followed by a
-	// path component — otherwise it's a registry port (e.g. `localhost:5000/foo`).
-	if i := strings.LastIndex(image, ":"); i >= 0 && !strings.Contains(image[i+1:], "/") {
-		return image[i+1:]
+	// WithDefaultTag("") suppresses the implicit `latest` so a missing tag
+	// surfaces as an empty TagStr rather than the default.
+	ref, err := name.ParseReference(image, name.WeakValidation, name.WithDefaultTag(""))
+	if err != nil {
+		return ""
+	}
+	if t, ok := ref.(name.Tag); ok {
+		return t.TagStr()
 	}
 	return ""
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify_test.go
@@ -265,6 +265,11 @@ func TestClassify_ClusterAutoscalerVersion(t *testing.T) {
 			deploy: deploymentWith("kube-system", "cluster-autoscaler", nil, "registry.k8s.io/autoscaling/cluster-autoscaler@sha256:abcdef"),
 			want:   "",
 		},
+		{
+			name:   "malformed image falls back to label",
+			deploy: deploymentWith("kube-system", "cluster-autoscaler", map[string]string{"app.kubernetes.io/version": "v1.99.0"}, "cluster-autoscaler-:::"),
+			want:   "v1.99.0",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			clientset := fake.NewSimpleClientset(tc.deploy)

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/karpenter.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/karpenter.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,27 +99,28 @@ func FindKarpenterInstallation(ctx context.Context, clientset kubernetes.Interfa
 func hasKarpenterControllerContainer(containers []corev1.Container) bool {
 	return slices.ContainsFunc(containers, func(c corev1.Container) bool {
 		return slices.ContainsFunc(c.Env, func(e corev1.EnvVar) bool { return e.Name == karpenterServiceEnvName }) ||
-			imageRepoEndsWith(c.Image, karpenterControllerImageRepoSuffix)
+			imageRepoPathHasSuffix(c.Image, karpenterControllerImageRepoSuffix)
 	})
 }
 
-// imageRepoEndsWith reports whether `image`'s repository path (with tag and
-// digest stripped) ends with the slash-separated path components in `suffix`.
-//
-// Stripping order matters because of registries with ports
-// (`registry.local:5000/...`): digest comes off first (everything after `@`),
-// then a tag is recognised only when the last `:` lies after the last `/` —
-// otherwise the registry's port colon would be mistaken for a tag separator.
-func imageRepoEndsWith(image, suffix string) bool {
+// imageRepoPathHasSuffix reports whether `image`'s repository path (registry
+// stripped, tag and digest discarded) ends with the slash-separated path
+// components in `suffix`. Match is component-aware so
+// `team/karpenter/controllers` (plural) does not satisfy a
+// `karpenter/controller` suffix.
+func imageRepoPathHasSuffix(image, suffix string) bool {
+	// Strip a trailing `@digest` so we tolerate combined `tag@digest` forms
+	// (which pkg/name parses as a Digest, not a Tag) and malformed digest
+	// strings (which would otherwise make pkg/name reject the whole image).
 	if i := strings.Index(image, "@"); i >= 0 {
 		image = image[:i]
 	}
-	lastSlash := strings.LastIndex(image, "/")
-	if lastColon := strings.LastIndex(image, ":"); lastColon > lastSlash {
-		image = image[:lastColon]
+	ref, err := name.ParseReference(image, name.WeakValidation)
+	if err != nil {
+		return false
 	}
 	suffixParts := strings.Split(suffix, "/")
-	imageParts := strings.Split(image, "/")
+	imageParts := strings.Split(ref.Context().RepositoryStr(), "/")
 	if len(imageParts) < len(suffixParts) {
 		return false
 	}

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/karpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/karpenter_test.go
@@ -48,6 +48,8 @@ func TestImageRepoPathHasSuffix(t *testing.T) {
 		{"public.ecr.aws/karpenter/karpenter:1.0", "karpenter/controller", false},
 		{"cgr.dev/chainguard/karpenter:1.0", "karpenter/controller", false},
 		{"controller", "karpenter/controller", false},
+		{"", "karpenter/controller", false},
+		{"::malformed::reference::", "karpenter/controller", false},
 	} {
 		t.Run(tc.image, func(t *testing.T) {
 			assert.Equal(t, tc.expected, imageRepoPathHasSuffix(tc.image, tc.suffix))

--- a/cmd/kubectl-datadog/autoscaling/cluster/install/guess/karpenter_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/install/guess/karpenter_test.go
@@ -28,7 +28,7 @@ func TestKarpenterControllerFingerprintContract(t *testing.T) {
 	assert.Equal(t, "karpenter/controller", karpenterControllerImageRepoSuffix)
 }
 
-func TestImageRepoEndsWith(t *testing.T) {
+func TestImageRepoPathHasSuffix(t *testing.T) {
 	for _, tc := range []struct {
 		image    string
 		suffix   string
@@ -50,7 +50,7 @@ func TestImageRepoEndsWith(t *testing.T) {
 		{"controller", "karpenter/controller", false},
 	} {
 		t.Run(tc.image, func(t *testing.T) {
-			assert.Equal(t, tc.expected, imageRepoEndsWith(tc.image, tc.suffix))
+			assert.Equal(t, tc.expected, imageRepoPathHasSuffix(tc.image, tc.suffix))
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Replaces two hand-rolled OCI image-reference parsers under `cmd/kubectl-datadog/autoscaling/cluster/` with calls to `github.com/google/go-containerregistry/pkg/name` (already a direct dependency of the project).

- `imageRepoEndsWith` → renamed `imageRepoPathHasSuffix` to reflect component-aware suffix matching against the registry-stripped repository path.
- `imageTag` → returns the OCI tag, or empty for digest-only / tagless images.

Both helpers pre-strip a trailing `@digest` so combined `tag@digest` forms (which `pkg/name` parses as a `name.Digest`, dropping the tag) and malformed digests parse uniformly.

### Motivation

The two helpers re-implemented the subtle "`:` is a registry port vs. a tag separator" logic by hand. Delegating to the canonical `pkg/name` parser makes the intent clearer and removes a chunk of bespoke parsing.

### Additional Notes

No behavior change on the existing test corpus (combined `tag@digest`, registries with port, digest-only, single-component image names, plural-form false-positive guard).

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- `go test ./cmd/kubectl-datadog/autoscaling/cluster/install/guess/... ./cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/...` — passes
- `make lint` — passes
- `make kubectl-datadog` — builds

### Checklist

- [x] PR has at least one valid label: \`refactoring\`
- [x] PR has a milestone or the \`qa/skip-qa\` label
- [x] All commits are signed

/label refactoring
/label qa/skip-qa