### PR TITLE
[CONTP-1656] Add datadog instrumentation crd rbac perms

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -296,6 +296,23 @@ rules:
 - apiGroups:
   - datadoghq.com
   resources:
+  - datadoginstrumentations
+  - extendeddaemonsetreplicasets
+  - watermarkpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - datadoginstrumentations/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - datadoghq.com
+  resources:
   - datadogmetrics
   verbs:
   - create
@@ -312,15 +329,6 @@ rules:
   - datadogpodautoscalers/status
   verbs:
   - '*'
-- apiGroups:
-  - datadoghq.com
-  resources:
-  - extendeddaemonsetreplicasets
-  - watermarkpodautoscalers
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - datadoghq.com
   - karpenter.azure.com

--- a/internal/controller/datadogagent/component/clusteragent/rbac.go
+++ b/internal/controller/datadogagent/component/clusteragent/rbac.go
@@ -117,15 +117,12 @@ func GetDefaultClusterAgentClusterRolePolicyRules(_ metav1.Object) []rbacv1.Poli
 				rbac.GetVerb,
 				rbac.ListVerb,
 				rbac.WatchVerb,
-				rbac.PatchVerb,
-				rbac.UpdateVerb,
 			},
 		},
 		{
 			APIGroups: []string{rbac.DatadogAPIGroup},
 			Resources: []string{rbac.DatadogInstrumentationsStatusResource},
 			Verbs: []string{
-				rbac.GetVerb,
 				rbac.PatchVerb,
 				rbac.UpdateVerb,
 			},

--- a/internal/controller/datadogagent/component/clusteragent/rbac.go
+++ b/internal/controller/datadogagent/component/clusteragent/rbac.go
@@ -111,6 +111,26 @@ func GetDefaultClusterAgentClusterRolePolicyRules(_ metav1.Object) []rbacv1.Poli
 			Verbs:     []string{rbac.GetVerb, rbac.ListVerb},
 		},
 		{
+			APIGroups: []string{rbac.DatadogAPIGroup},
+			Resources: []string{rbac.DatadogInstrumentationsResource},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.ListVerb,
+				rbac.WatchVerb,
+				rbac.PatchVerb,
+				rbac.UpdateVerb,
+			},
+		},
+		{
+			APIGroups: []string{rbac.DatadogAPIGroup},
+			Resources: []string{rbac.DatadogInstrumentationsStatusResource},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.PatchVerb,
+				rbac.UpdateVerb,
+			},
+		},
+		{
 			NonResourceURLs: []string{rbac.VersionURL, rbac.HealthzURL, rbac.MetricsURL},
 			Verbs:           []string{rbac.GetVerb},
 		},

--- a/internal/controller/datadogagent/component/clusteragent/rbac_test.go
+++ b/internal/controller/datadogagent/component/clusteragent/rbac_test.go
@@ -8,11 +8,11 @@ package clusteragent
 import (
 	"testing"
 
+	assert "github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
-	assert "github.com/stretchr/testify/require"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 func TestGetDefaultClusterAgentClusterRolePolicyRulesDatadogInstrumentation(t *testing.T) {
@@ -24,15 +24,12 @@ func TestGetDefaultClusterAgentClusterRolePolicyRulesDatadogInstrumentation(t *t
 				rbac.GetVerb,
 				rbac.ListVerb,
 				rbac.WatchVerb,
-				rbac.PatchVerb,
-				rbac.UpdateVerb,
 			},
 		},
 		{
 			APIGroups: []string{rbac.DatadogAPIGroup},
 			Resources: []string{rbac.DatadogInstrumentationsStatusResource},
 			Verbs: []string{
-				rbac.GetVerb,
 				rbac.PatchVerb,
 				rbac.UpdateVerb,
 			},

--- a/internal/controller/datadogagent/component/clusteragent/rbac_test.go
+++ b/internal/controller/datadogagent/component/clusteragent/rbac_test.go
@@ -8,10 +8,43 @@ package clusteragent
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
 	assert "github.com/stretchr/testify/require"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
+
+func TestGetDefaultClusterAgentClusterRolePolicyRulesDatadogInstrumentation(t *testing.T) {
+	expectedRules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{rbac.DatadogAPIGroup},
+			Resources: []string{rbac.DatadogInstrumentationsResource},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.ListVerb,
+				rbac.WatchVerb,
+				rbac.PatchVerb,
+				rbac.UpdateVerb,
+			},
+		},
+		{
+			APIGroups: []string{rbac.DatadogAPIGroup},
+			Resources: []string{rbac.DatadogInstrumentationsStatusResource},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.PatchVerb,
+				rbac.UpdateVerb,
+			},
+		},
+	}
+
+	rules := GetDefaultClusterAgentClusterRolePolicyRules(&metav1.ObjectMeta{})
+
+	for _, expectedRule := range expectedRules {
+		assert.Contains(t, rules, expectedRule)
+	}
+}
 
 func TestGetKubernetesResourceMetadataAsTagsPolicyRules(t *testing.T) {
 	labelsAsTags := map[string]map[string]string{

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -104,6 +104,10 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=karpenter.k8s.aws,resources=*,verbs=get;list;watch
 // +kubebuilder:rbac:groups=eks.amazonaws.com,resources=*,verbs=get;list;watch
 
+// Configure Datadog Intrumentation
+// +kubebuilder:rbac:groups=datadoghq.com,resources=datadoginstrumentations,verbs=get;list;watch
+// +kubebuilder:rbac:groups=datadoghq.com,resources=datadoginstrumentations/status,verbs=patch;update
+
 // Use ExtendedDaemonSet
 // +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsetreplicasets,verbs=get;list;watch

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -57,6 +57,8 @@ const (
 	DaemonsetsResource                                = "daemonsets"
 	DatadogAgentsResource                             = "datadogagents"
 	DatadogAgentInternalsResource                     = "datadogagentinternals"
+	DatadogInstrumentationsResource                   = "datadoginstrumentations"
+	DatadogInstrumentationsStatusResource             = "datadoginstrumentations/status"
 	DatadogMetricsResource                            = "datadogmetrics"
 	DatadogMetricsStatusResource                      = "datadogmetrics/status"
 	DatadogPodAutoscalersResource                     = "datadogpodautoscalers"


### PR DESCRIPTION
### What does this PR do?

Gives the cluster agent necessary RBAC permissions to `get/list/watch` the `DatadogInstrumentation` CRD and `update/patch` the status section of the CRD.

### Motivation

Follow up https://github.com/DataDog/datadog-operator/pull/2962

### Describe your test plan

* Added RBAC unit tests

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
