### PR TITLE
Update Chaingaurd for Release Worker

### DIFF
--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -7,5 +7,5 @@ claim_pattern:
   name: "rapid-agent-delivery.operatorrelease@kubernetes.us1.ddbuild.io"
 
 permissions:
-  contents: read
+  contents: write
   pull_requests: write

--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
 subject: "f012f0b0-d135-9dd7-7f53-44a4d5cb50ca"
 
 claim_pattern:
-  name: "rapid-agent-delivery-operatorrelease"
+  name: "rapid-agent-delivery.operatorrelease@kubernetes.us1.ddbuild.io"
 
 permissions:
   contents: read

--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
 subject: "f012f0b0-d135-9dd7-7f53-44a4d5cb50ca"
 
 claim_pattern:
-  name: "rapid-agent-delivery.operatorrelease@kubernetes.us1.ddbuild.io"
+  name: "rapid-agent-delivery\\.operatorrelease@kubernetes\\.us1\\.ddbuild\\.io"
 
 permissions:
   contents: write

--- a/.github/chainguard/self.operatorrelease-prod.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-prod.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
 subject: "f012f0b0-d135-9dd7-7f53-44a4d5cb50ca"
 
 claim_pattern:
-  name: "rapid-agent-delivery\\.operatorrelease@kubernetes\\.us1\\.ddbuild\\.io"
+  email: "rapid-agent-delivery\\.operatorrelease@kubernetes\\.us1\\.ddbuild\\.io"
 
 permissions:
   contents: write

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -7,5 +7,5 @@ claim_pattern:
   name: "rapid-agent-delivery.operatorrelease@kubernetes.us1.staging.dog"
 
 permissions:
-  contents: read
+  contents: write
   pull_requests: write

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.staging.dog/v1/identity/oidc
 subject: "1fed960d-1fe4-47de-ebb5-0992bfc0364e"
 
 claim_pattern:
-  name: "rapid-agent-delivery-operatorrelease"
+  name: "rapid-agent-delivery.operatorrelease@kubernetes.us1.staging.dog"
 
 permissions:
   contents: read

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.staging.dog/v1/identity/oidc
 subject: "1fed960d-1fe4-47de-ebb5-0992bfc0364e"
 
 claim_pattern:
-  name: "rapid-agent-delivery.operatorrelease@kubernetes.us1.staging.dog"
+  name: "rapid-agent-delivery\\.operatorrelease@kubernetes\\.us1\\.staging\\.dog"
 
 permissions:
   contents: write

--- a/.github/chainguard/self.operatorrelease-staging.sts.yaml
+++ b/.github/chainguard/self.operatorrelease-staging.sts.yaml
@@ -4,7 +4,7 @@ issuer: https://vault.us1.staging.dog/v1/identity/oidc
 subject: "1fed960d-1fe4-47de-ebb5-0992bfc0364e"
 
 claim_pattern:
-  name: "rapid-agent-delivery\\.operatorrelease@kubernetes\\.us1\\.staging\\.dog"
+  email: "rapid-agent-delivery\\.operatorrelease@kubernetes\\.us1\\.staging\\.dog"
 
 permissions:
   contents: write


### PR DESCRIPTION
### What does this PR do?

Atlas Domains recommend using the full email of the worker service rather than just the name (as used by the Agent Release worker using Atlas Classic)
