### PR TITLE
Update host profiler image

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -371,6 +371,10 @@ func ddotCollectorImage() string {
 	return images.GetLatestDdotCollectorImage()
 }
 
+func hostProfilerImage() string {
+	return images.GetLatestHostProfilerImage()
+}
+
 func initContainers(dda metav1.Object, requiredContainers []apicommon.AgentContainerName) []corev1.Container {
 	initContainers := []corev1.Container{
 		initVolumeContainer(),
@@ -529,8 +533,7 @@ func otelAgentContainer(dda metav1.Object) corev1.Container {
 func hostProfilerContainer(dda metav1.Object) corev1.Container {
 	return corev1.Container{
 		Name: string(apicommon.HostProfiler),
-		// Note: Need to override image via annotation
-		Image: agentImage(),
+		Image: hostProfilerImage(),
 		Command: []string{
 			"host-profiler",
 			"--core-config=" + agentCustomConfigVolumePath,

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -21,6 +21,9 @@ const (
 	ClusterAgentLatestVersion = "7.78.1"
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
 	DdotCollectorLatestVersion = "7.78.1"
+	// DdotCollectorLatestVersion corresponds to the latest stable host-profiler release
+	// todo: the host profiler will be first released in 7.80.0
+	HostProfilerLatestVersion = "n/a"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.23"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.
@@ -58,6 +61,7 @@ const (
 	DefaultAgentImageName         string = "agent"
 	DefaultClusterAgentImageName  string = "cluster-agent"
 	DefaultDdotCollectorImageName string = "ddot-collector"
+	DefaultHostProfilerImageName  string = "ddot-ebpf"
 )
 
 // imageHasTag identifies whether an image string contains a tag suffix
@@ -159,6 +163,12 @@ func GetLatestAgentImage() string {
 // GetLatestDdotCollectorImage returns the latest ddot collector image
 func GetLatestDdotCollectorImage() string {
 	image := newImage(DefaultImageRegistry, DefaultDdotCollectorImageName, DdotCollectorLatestVersion, false, false, false)
+	return image.ToString()
+}
+
+// GetLatestHostProfilerImage returns the latest ddot collector image
+func GetLatestHostProfilerImage() string {
+	image := newImage(DefaultImageRegistry, DefaultHostProfilerImageName, HostProfilerLatestVersion, false, false, false)
 	return image.ToString()
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR makes the operator set correct image for host profiler. Note the image will only be out in agent version 7.80.0.
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits