### PR TITLE
Add writev and shutdown to system-probe seccomp profile

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -259,6 +259,7 @@ func DefaultSyscallsForSystemProbe() []string {
 		"setsockopt",
 		"setuid",
 		"setuid32",
+		"shutdown",
 		"sigaltstack",
 		"socket",
 		"socketcall",
@@ -282,6 +283,7 @@ func DefaultSyscallsForSystemProbe() []string {
 		"waitid",
 		"waitpid",
 		"write",
+		"writev",
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds `writev` and `shutdown` to the default `system-probe` seccomp profile (`SCMP_ACT_ERRNO` default), in `DefaultSyscallsForSystemProbe()`.

### Motivation

Required by `system-probe-lite` (Rust/hyper-based) which uses vectored writes (`writev`) for HTTP responses and `shutdown(2)` to close the write half of connections. The Go-based `system-probe` didn't surface these as a problem because `net/http` buffers responses through `bufio.Writer` and writes them via plain `write(2)`, and the HTTP/1 keep-alive happy path used by the agent's checks never triggers a `shutdown(2)` (Go only calls `CloseWrite` in edge cases like 431 oversized headers or partially-consumed request bodies).

Hyper, by contrast, calls `shutdown(SHUT_WR)` at the end of every served connection (`proto/h1/dispatch.rs` — `Future::poll` passes `should_shutdown=true` and the dispatcher invokes `poll_shutdown` once `is_done()`), and uses tokio's `AsyncWrite::poll_write_vectored` which translates to `writev(2)` — both of which the existing profile's `SCMP_ACT_ERRNO` default rejected with `EPERM`.

When the operator deploys an agent with `serviceDiscovery.enabled: true` and a node Agent image >= 7.78.0, the operator sets `DD_DISCOVERY_USE_SYSTEM_PROBE_LITE=true`, the `system-probe` binary execs into `system-probe-lite`, and hyper's first `writev` returns `EPERM`. The agent's `pkg/system-probe/api/client/check.go:ensureStarted()` retries `GET /debug/stats` every 5s and only ever sees `EOF`, blocking the discovery check from starting at all:

```
SYS-PROBE-LITE | ERROR | Error serving connection: error writing a body to connection
                                                  ^-- BodyWrite, EPERM (Operation not permitted)

CORE | WARN | system-probe not started yet: Get "http://sysprobe/debug/stats": EOF
```

After adding the two syscalls, both endpoints respond correctly and the discovery check runs cleanly.

### Additional Notes

- Mirrors the equivalent fix in [helm-charts#2634](https://github.com/DataDog/helm-charts/pull/2634) (which also adds `chown` — already allowed in the operator's profile, so not needed here).
- `writev` and `shutdown` are not security-sensitive (basic socket I/O primitives); they are already in the upstream Docker default seccomp profile.
- `TestDefaultSyscallsForSystemProbe` references `DefaultSyscallsForSystemProbe()` directly, so it picks up the additions automatically — no test update required.

### Minimum Agent Versions

* Agent: 7.78.0+ (only when `serviceDiscovery.enabled: true` causes the operator to set `DD_DISCOVERY_USE_SYSTEM_PROBE_LITE=true`)

### Describe your test plan

Verified end-to-end on a kind cluster (aarch64): built the operator from this branch, deployed a `DatadogAgent` with `features.serviceDiscovery.enabled: true` and an agent image execing into `system-probe-lite`. With the fix:

- `kubectl exec ... -c system-probe -- curl --unix-socket /var/run/sysprobe/sysprobe.sock http://sysprobe/debug/stats` returns `{}` (was empty reply).
- 0 `Error serving connection` log lines in `system-probe-lite`.
- 0 `EOF` warnings on the agent's `ensureStarted()` probe.
- The seccomp configmap (`datadog-system-probe-seccomp`) generated by the operator includes both `writev` and `shutdown` (191 syscalls total).

### Checklist

- [x] PR has at least one valid label: `bug`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed