### PR TITLE
Mount only registry.json via HostPath for log collection

### DIFF
--- a/internal/controller/datadogagent/common/const.go
+++ b/internal/controller/datadogagent/common/const.go
@@ -158,8 +158,9 @@ const (
 	HostRunPath       = "/run"
 	HostRunMountPath  = "/host/run"
 
-	RunPathVolumeName  = "pointerdir"
-	RunPathVolumeMount = "/opt/datadog-agent/run"
+	RunPathVolumeName    = "pointerdir"
+	RunPathVolumeMount   = "/opt/datadog-agent/run"
+	LogRegistryVolumeName = "logregistry"
 
 	FlightRecorderSocketVolumeName = "flightrecorder-socket"
 	FlightRecorderSocketPath       = "/var/run/datadog/flightrecorder"

--- a/internal/controller/datadogagent/feature/logcollection/const.go
+++ b/internal/controller/datadogagent/feature/logcollection/const.go
@@ -5,9 +5,12 @@
 
 package logcollection
 
+import "github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+
 const (
-	pointerVolumeName          = "pointerdir"
-	pointerVolumePath          = "/opt/datadog-agent/run"
+	registryVolumeName         = common.LogRegistryVolumeName
+	registryVolumePath         = common.RunPathVolumeMount + "/registry.json"
+	registrySubPath            = "registry.json"
 	podLogVolumeName           = "logpodpath"
 	podLogVolumePath           = "/var/log/pods"
 	containerLogVolumeName     = "logcontainerpath"

--- a/internal/controller/datadogagent/feature/logcollection/feature.go
+++ b/internal/controller/datadogagent/feature/logcollection/feature.go
@@ -17,7 +17,6 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 )
 
@@ -113,10 +112,24 @@ func (f *logCollectionFeature) ManageNodeAgent(managers feature.PodTemplateManag
 }
 
 func (f *logCollectionFeature) manageNodeAgent(agentContainerName apicommon.AgentContainerName, managers feature.PodTemplateManagers, provider string) error {
-	// pointerdir volume mount (replace default empty dir volume)
-	pointerVol, pointerVolMount := volume.GetVolumes(pointerVolumeName, f.tempStoragePath, pointerVolumePath, false)
-	managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&pointerVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
-	managers.Volume().AddVolumeWithMergeFunc(&pointerVol, merger.OverrideCurrentVolumeMergeFunction)
+	// registry.json volume: FileOrCreate hostPath so Kubernetes creates a file (not a directory)
+	// when registry.json doesn't yet exist on the node, mounted directly — no SubPath needed.
+	hostPathFileOrCreate := corev1.HostPathFileOrCreate
+	registryVol := corev1.Volume{
+		Name: registryVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: f.tempStoragePath + "/" + registrySubPath,
+				Type: &hostPathFileOrCreate,
+			},
+		},
+	}
+	registryVolMount := corev1.VolumeMount{
+		Name:      registryVolumeName,
+		MountPath: registryVolumePath,
+	}
+	managers.VolumeMount().AddVolumeMountToContainer(&registryVolMount, agentContainerName)
+	managers.Volume().AddVolume(&registryVol)
 
 	// pod logs volume mount
 	podLogVol, podLogVolMount := volume.GetVolumes(podLogVolumeName, f.podLogsPath, podLogVolumePath, true)

--- a/internal/controller/datadogagent/feature/logcollection/feature_test.go
+++ b/internal/controller/datadogagent/feature/logcollection/feature_test.go
@@ -149,11 +149,11 @@ func Test_LogCollectionFeature_Configure(t *testing.T) {
 			WantConfigure: true,
 			Agent: test.NewDefaultComponentTest().WithWantFunc(
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+					hostPathFileOrCreate := corev1.HostPathFileOrCreate
 					wantVolumeMounts := []*corev1.VolumeMount{
 						{
-							Name:      pointerVolumeName,
-							MountPath: pointerVolumePath,
-							ReadOnly:  false,
+							Name:      registryVolumeName,
+							MountPath: registryVolumePath,
 						},
 						{
 							Name:      podLogVolumeName,
@@ -173,10 +173,11 @@ func Test_LogCollectionFeature_Configure(t *testing.T) {
 					}
 					wantVolumes := []*corev1.Volume{
 						{
-							Name: pointerVolumeName,
+							Name: registryVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/custom/temp/storage",
+									Path: "/custom/temp/storage/" + registrySubPath,
+									Type: &hostPathFileOrCreate,
 								},
 							},
 						},
@@ -217,12 +218,14 @@ func Test_LogCollectionFeature_Configure(t *testing.T) {
 }
 
 func getWantVolumes() []*corev1.Volume {
+	hostPathFileOrCreate := corev1.HostPathFileOrCreate
 	wantVolumes := []*corev1.Volume{
 		{
-			Name: pointerVolumeName,
+			Name: registryVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
-					Path: common.DefaultLogTempStoragePath,
+					Path: common.DefaultLogTempStoragePath + "/" + registrySubPath,
+					Type: &hostPathFileOrCreate,
 				},
 			},
 		},
@@ -257,9 +260,8 @@ func getWantVolumes() []*corev1.Volume {
 func getWantVolumeMounts() []*corev1.VolumeMount {
 	wantVolumeMounts := []*corev1.VolumeMount{
 		{
-			Name:      pointerVolumeName,
-			MountPath: pointerVolumePath,
-			ReadOnly:  false,
+			Name:      registryVolumeName,
+			MountPath: registryVolumePath,
 		},
 		{
 			Name:      podLogVolumeName,


### PR DESCRIPTION
### What does this PR do?

When log collection is enabled, mount only `registry.json` via a dedicated `HostPath` volume (`FileOrCreate`) at `/opt/datadog-agent/run/registry.json`, instead of replacing the entire `pointerdir` emptyDir volume with a HostPath to `/var/lib/datadog-agent/logs`.

### Motivation

The full HostPath mount gives the container read/write access to everything in `/var/lib/datadog-agent/logs` on the node. In practice only `registry.json` (the log offset tracking file) needs to survive pod restarts — the rest of `/opt/datadog-agent/run` is ephemeral. Scoping the HostPath to the single file reduces the host filesystem exposure to the minimum required.

Using `HostPathFileOrCreate` ensures Kubernetes creates an empty regular file on the node if none exists yet, avoiding the pitfall where a missing subPath gets created as a directory by the kubelet.

### Additional Notes

- `pointerdir` emptyDir remains the backing volume for `/opt/datadog-agent/run` in all cases.
    - will be renamed to `datadog` run: https://github.com/DataDog/datadog-operator/pull/2985
- A new `logregistry` HostPath volume is added only when log collection is enabled.

### Minimum Agent Versions

N/A — operator-side change only.

### Describe your test plan

Unit tests updated to assert the new volume name, HostPath (file path including `registry.json`), `FileOrCreate` type, and mount path.

```
go test ./internal/controller/datadogagent/feature/logcollection/...
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits