### PR TITLE
Remove non-existent setsidaccept4 syscall from seccomp allowlist

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -255,7 +255,6 @@ func DefaultSyscallsForSystemProbe() []string {
 		"setresuid",
 		"setrlimit",
 		"setsid",
-		"setsidaccept4",
 		"setsockopt",
 		"setuid",
 		"setuid32",


### PR DESCRIPTION
## Summary

- `setsidaccept4` is not a real Linux syscall — it appears to be a typo where `setsid` and `accept4` were accidentally concatenated when the seccomp profile was first added in eb3cc9e6
- Both `setsid` and `accept4` already appear correctly as separate entries in `DefaultSyscallsForSystemProbe()`
- This removes the phantom entry so the seccomp allowlist matches only real syscalls

## Test plan
- [ ] Verify `setsidaccept4` does not appear in `/usr/include/asm/unistd.h` or any Linux syscall table (it doesn't)
- [ ] Confirm `accept4` (line 97) and `setsid` (line 257) remain in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)