### PR TITLE
Stop mounting debugfs in process-agent

### DIFF
--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -117,7 +117,7 @@ func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 	// debugfs volume mount
 	debugfsVol, debugfsVolMount := volume.GetVolumes(common.DebugfsVolumeName, common.DebugfsPath, common.DebugfsPath, false)
 	managers.Volume().AddVolume(&debugfsVol)
-	managers.VolumeMount().AddVolumeMountToContainers(&debugfsVolMount, []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName, apicommon.SystemProbeContainerName})
+	managers.VolumeMount().AddVolumeMountToContainer(&debugfsVolMount, apicommon.SystemProbeContainerName)
 
 	// socket volume mount (needs write perms for the system probe container but not the others)
 	socketVol, socketVolMount := volume.GetVolumesEmptyDir(common.SystemProbeSocketVolumeName, common.SystemProbeSocketVolumePath, false)

--- a/internal/controller/datadogagent/feature/npm/feature_test.go
+++ b/internal/controller/datadogagent/feature/npm/feature_test.go
@@ -102,11 +102,6 @@ func Test_npmFeature_Configure(t *testing.T) {
 				MountPath: common.CgroupsMountPath,
 				ReadOnly:  true,
 			},
-			{
-				Name:      common.DebugfsVolumeName,
-				MountPath: common.DebugfsPath,
-				ReadOnly:  false,
-			},
 		}
 
 		wantProcessAgentVolMounts := append(wantVolumeMounts, corev1.VolumeMount{
@@ -116,6 +111,10 @@ func Test_npmFeature_Configure(t *testing.T) {
 		})
 
 		wantSystemProbeAgentVolMounts := append(wantVolumeMounts, corev1.VolumeMount{
+			Name:      common.DebugfsVolumeName,
+			MountPath: common.DebugfsPath,
+			ReadOnly:  false,
+		}, corev1.VolumeMount{
 			Name:      common.SystemProbeSocketVolumeName,
 			MountPath: common.SystemProbeSocketVolumePath,
 			ReadOnly:  false,

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -133,7 +133,7 @@ func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provi
 
 	debugfsVol, debugfsVolMount := volume.GetVolumes(common.DebugfsVolumeName, common.DebugfsPath, common.DebugfsPath, false)
 	managers.Volume().AddVolume(&debugfsVol)
-	managers.VolumeMount().AddVolumeMountToContainers(&debugfsVolMount, []apicommon.AgentContainerName{apicommon.ProcessAgentContainerName, apicommon.SystemProbeContainerName})
+	managers.VolumeMount().AddVolumeMountToContainer(&debugfsVolMount, apicommon.SystemProbeContainerName)
 
 	// socket volume mount (needs write perms for the system probe container but not the others)
 	socketVol, socketVolMount := volume.GetVolumesEmptyDir(common.SystemProbeSocketVolumeName, common.SystemProbeSocketVolumePath, false)

--- a/internal/controller/datadogagent/feature/usm/feature_test.go
+++ b/internal/controller/datadogagent/feature/usm/feature_test.go
@@ -106,11 +106,6 @@ func Test_usmFeature_Configure(t *testing.T) {
 				ReadOnly:  true,
 			},
 			{
-				Name:      common.DebugfsVolumeName,
-				MountPath: common.DebugfsPath,
-				ReadOnly:  false,
-			},
-			{
 				Name:      common.SystemProbeSocketVolumeName,
 				MountPath: common.SystemProbeSocketVolumePath,
 				ReadOnly:  true,


### PR DESCRIPTION
## Summary
- Mount debugfs only in system-probe for NPM and USM (matching helm-chart and no process-agent code path appear to make use of it, most likely an oversight from years ago)


## Tests
- go test ./internal/controller/datadogagent/feature/npm ./internal/controller/datadogagent/feature/usm
- staging validation