### PR TITLE
Make CNM team owner of the npm feature, not ndm-core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@ README.md               @DataDog/documentation  @DataDog/container-platform
 /internal/controller/datadogagent/feature/livecontainer             @DataDog/container-experiences  @DataDog/container-platform
 /internal/controller/datadogagent/feature/liveprocess               @DataDog/container-experiences  @DataDog/container-platform
 /internal/controller/datadogagent/feature/logcollection             @DataDog/agent-log-pipelines    @DataDog/container-platform
-/internal/controller/datadogagent/feature/npm                       @DataDog/ndm-core               @DataDog/container-platform
+/internal/controller/datadogagent/feature/npm                       @DataDog/cloud-network-monitoring @DataDog/container-platform
 /internal/controller/datadogagent/feature/oomkill                   @DataDog/ebpf-platform          @DataDog/container-platform
 /internal/controller/datadogagent/feature/orchestratorexplorer      @DataDog/kubernetes-experiences @DataDog/container-platform
 /internal/controller/datadogagent/feature/otelagentgateway          @DataDog/opentelemetry-agent    @DataDog/container-platform


### PR DESCRIPTION
### What does this PR do?

cloud-network-monitoring team owns network performance monitoring (previous name of CNM), not NDM core who work on network device monitoring (SNMP polling)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits