### PR TITLE
[CASCL-1292] Wire Karpenter check as endpoint check on Fargate

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/apply/run.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/apply/run.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/helm"
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/guess"
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/k8s"
+	"github.com/DataDog/datadog-operator/pkg/plugin/common"
 	"github.com/DataDog/datadog-operator/pkg/version"
 
 	_ "embed"
@@ -350,9 +351,31 @@ func installHelmChart(ctx context.Context, configFlags *genericclioptions.Config
 // 1 vCPU / 2 GiB is the smallest valid Fargate combination for 1 vCPU and
 // matches the chart's documented example for existing-nodes.
 //
+// The Karpenter OpenMetrics check is wired differently per install mode:
+//   - existing-nodes: pod-level Autodiscovery annotation, picked up by the
+//     node agent colocated with the controller pod.
+//   - fargate: endpoint-check annotation on the Karpenter Service, paired
+//     with `ad.datadoghq.com/endpoints.resolve: ip`. The default `auto`
+//     resolution would attach the backing Pod's NodeName to each scheduled
+//     check and the cluster agent would dispatch them to the (non-existent)
+//     node agent on the Fargate node. The `ip` value tells the cluster agent
+//     to ignore what's behind each endpoint IP, leaving the check as a plain
+//     cluster check dispatched to the cluster check runner.
+//
 // In fargate mode, the service account is annotated with the IRSA role ARN so
 // the controller can assume the role via sts:AssumeRoleWithWebIdentity.
 func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn string) map[string]any {
+	const karpenterCheckConfig = `{
+  "karpenter": {
+    "init_config": {},
+    "instances": [
+      {
+        "openmetrics_endpoint": "http://%%host%%:8080/metrics"
+      }
+    ]
+  }
+}`
+
 	values := map[string]any{
 		// See guess.InstalledByLabel for why these keys are Datadog-namespaced.
 		"additionalLabels": map[string]any{
@@ -363,18 +386,6 @@ func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn strin
 			"clusterName":       clusterName,
 			"interruptionQueue": clusterName,
 		},
-		"podAnnotations": map[string]any{
-			"ad.datadoghq.com/controller.checks": `{
-  "karpenter": {
-    "init_config": {},
-    "instances": [
-      {
-        "openmetrics_endpoint": "http://%%host%%:8080/metrics"
-      }
-    ]
-  }
-}`,
-		},
 		"controller": map[string]any{
 			"resources": map[string]any{
 				"requests": map[string]any{"cpu": "1", "memory": "2Gi"},
@@ -384,10 +395,20 @@ func karpenterHelmValues(clusterName string, mode InstallMode, irsaRoleArn strin
 	}
 
 	if mode == InstallModeFargate {
+		values["service"] = map[string]any{
+			"annotations": map[string]any{
+				common.ADPrefix + "endpoints.checks":  karpenterCheckConfig,
+				common.ADPrefix + "endpoints.resolve": "ip",
+			},
+		}
 		values["serviceAccount"] = map[string]any{
 			"annotations": map[string]any{
 				"eks.amazonaws.com/role-arn": irsaRoleArn,
 			},
+		}
+	} else {
+		values["podAnnotations"] = map[string]any{
+			common.ADPrefix + "controller.checks": karpenterCheckConfig,
 		}
 	}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/apply/run_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/apply/run_test.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,25 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/guess"
+	"github.com/DataDog/datadog-operator/pkg/plugin/common"
 )
+
+// assertKarpenterCheckConfig parses the JSON body of a Datadog Autodiscovery
+// annotation and asserts it declares the `karpenter` OpenMetrics check on
+// port 8080. Used to keep the assertion robust to whitespace/formatting
+// changes in the embedded JSON literal.
+func assertKarpenterCheckConfig(t *testing.T, raw string) {
+	t.Helper()
+	var parsed map[string]struct {
+		InitConfig map[string]any   `json:"init_config"`
+		Instances  []map[string]any `json:"instances"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &parsed), "annotation body must be valid JSON")
+	check, ok := parsed["karpenter"]
+	require.True(t, ok, "annotation must declare a `karpenter` check")
+	require.Len(t, check.Instances, 1, "the `karpenter` check must have exactly one instance")
+	assert.Equal(t, "http://%%host%%:8080/metrics", check.Instances[0]["openmetrics_endpoint"])
+}
 
 func TestKarpenterHelmValues(t *testing.T) {
 	t.Run("existing-nodes mode carries Datadog ownership labels and no IRSA annotation", func(t *testing.T) {
@@ -30,6 +49,19 @@ func TestKarpenterHelmValues(t *testing.T) {
 			"existing-nodes mode must not annotate the ServiceAccount with an IRSA role")
 	})
 
+	t.Run("existing-nodes mode wires the Karpenter check as a pod-level annotation", func(t *testing.T) {
+		values := karpenterHelmValues("my-cluster", InstallModeExistingNodes, "")
+
+		podAnnotations, ok := values["podAnnotations"].(map[string]any)
+		require.True(t, ok, "existing-nodes mode must set podAnnotations for the colocated node agent")
+		raw, ok := podAnnotations[common.ADPrefix+"controller.checks"].(string)
+		require.True(t, ok, "pod-level Autodiscovery annotation must be present")
+		assertKarpenterCheckConfig(t, raw)
+
+		assert.NotContains(t, values, "service",
+			"existing-nodes mode must not configure an endpoint check on the Service")
+	})
+
 	t.Run("fargate mode annotates the ServiceAccount with the IRSA role ARN", func(t *testing.T) {
 		const arn = "arn:aws:iam::123456789012:role/dd-karpenter"
 		values := karpenterHelmValues("my-cluster", InstallModeFargate, arn)
@@ -39,6 +71,24 @@ func TestKarpenterHelmValues(t *testing.T) {
 		annotations, ok := serviceAccount["annotations"].(map[string]any)
 		require.True(t, ok)
 		assert.Equal(t, arn, annotations["eks.amazonaws.com/role-arn"])
+	})
+
+	t.Run("fargate mode wires the Karpenter check as a Service endpoint check", func(t *testing.T) {
+		values := karpenterHelmValues("my-cluster", InstallModeFargate, "arn:aws:iam::123456789012:role/dd-karpenter")
+
+		service, ok := values["service"].(map[string]any)
+		require.True(t, ok, "fargate mode must set service.annotations for the cluster check runner")
+		annotations, ok := service["annotations"].(map[string]any)
+		require.True(t, ok)
+		raw, ok := annotations[common.ADPrefix+"endpoints.checks"].(string)
+		require.True(t, ok, "Service-level endpoint-check annotation must be present")
+		assertKarpenterCheckConfig(t, raw)
+
+		assert.Equal(t, "ip", annotations[common.ADPrefix+"endpoints.resolve"],
+			"`resolve: ip` is required to force the cluster agent to dispatch the check to the cluster check runner instead of the (non-existent) node agent on the Fargate node")
+
+		assert.NotContains(t, values, "podAnnotations",
+			"fargate mode must not set the pod-level annotation (no node agent on Fargate)")
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

When `kubectl datadog autoscaling cluster install` runs with `--install-mode=fargate` (the default since #2891), the Karpenter controllers are deployed on EKS Fargate nodes where no Datadog node agent runs. The existing pod-level `ad.datadoghq.com/controller.checks` Autodiscovery annotation therefore never fires and no `karpenter.*` metrics are collected anywhere.

This PR fixes that regression by wiring the OpenMetrics check differently per install mode:

- **`--install-mode=fargate`**: declare the check as a Datadog **endpoint check** via annotations on the Karpenter `Service` (`ad.datadoghq.com/endpoints.checks` + `ad.datadoghq.com/endpoints.resolve: ip`). The `resolve: ip` annotation is what makes this work for pods running on Fargate: it tells the cluster agent to ignore the Pod behind each endpoint IP, leaving the check as a plain cluster check dispatched to a cluster check runner (instead of the default behavior of attaching the backing Pod's NodeName and dispatching to the non-existent Fargate node agent).
- **`--install-mode=existing-nodes`**: keep the pre-existing pod-level annotation — a node agent is colocated with the controller and the previous mechanism works as designed.

The JSON check payload is identical in both modes and is now extracted to a single function-scoped `const` so the two branches cannot drift.

### Motivation

Restore Karpenter controller metric collection after the Fargate-by-default migration in #2891. Without this fix, no `karpenter.*` metrics flow at all when users adopt the default install mode.

The sidecar-injection alternative (Datadog admission controller mutating webhook for Fargate pods) is not viable here: it requires API/APP key secrets and matching RBAC objects to be pre-installed in the Karpenter namespace, which `kubectl-datadog` does not provision (and cannot, since it has no knowledge of the Datadog credentials).

### Additional Notes

The `endpoints.resolve: ip` trick is documented for non-Pod-backed endpoints in the [Datadog endpoint checks docs](https://docs.datadoghq.com/containers/cluster_agent/endpointschecks/), but its applicability to Pod-backed endpoints on Fargate was confirmed against the cluster agent source — `comp/core/autodiscovery/providers/kube_endpoints_common.go` in `DataDog/datadog-agent`. With `resolve: ip`, the resolution function is `nil` (the cluster agent "explicitly ignores what's behind this address"), so no `NodeName` is set and the check is treated as a regular cluster check.

### Minimum Agent Versions

No minimum agent change required.

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. On an EKS cluster with the Datadog Operator (cluster agent + cluster check runner deployed), run:
   ```
   kubectl datadog autoscaling cluster install
   ```
2. Verify the Karpenter Service carries the new annotations:
   ```
   kubectl -n dd-karpenter get svc karpenter -o jsonpath='{.metadata.annotations}'
   ```
   Expected: `ad.datadoghq.com/endpoints.checks` and `ad.datadoghq.com/endpoints.resolve=ip`.
3. Verify the controller pods do **not** carry the pod-level annotation in Fargate mode.
4. In the Datadog backend, confirm `karpenter.*` metrics flow with one series per controller replica (`kube_endpoint_ip` tag differs per replica).
5. Regression check on `--install-mode=existing-nodes`: pod-level annotation present, no Service annotations added, metrics flow via the colocated node agent as before.

Unit tests: `go test ./cmd/kubectl-datadog/autoscaling/cluster/apply/...` covers both modes' annotation placement.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)