### PR TITLE
[CASCL-1304] Fix Fargate profile name in `dd-cluster-info` ConfigMap

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify.go
@@ -49,7 +49,12 @@ func Classify(ctx context.Context, k8sClient kubernetes.Interface, asg Autoscali
 		NodeManagement: map[NodeManager]map[string][]string{},
 	}
 
-	asgCandidates, err := classifyByLabels(ctx, k8sClient, info)
+	fargateProfileByNode, err := fargateProfilesByNode(ctx, k8sClient)
+	if err != nil {
+		return nil, err
+	}
+
+	asgCandidates, err := classifyByLabels(ctx, k8sClient, fargateProfileByNode, info)
 	if err != nil {
 		return nil, err
 	}
@@ -66,6 +71,35 @@ func Classify(ctx context.Context, k8sClient kubernetes.Interface, asg Autoscali
 	return info, nil
 }
 
+// fargateProfilesByNode lists Pods that carry the
+// `eks.amazonaws.com/fargate-profile` label (server-side filtered) and indexes
+// the profile name by the Node the Pod is scheduled on. EKS stamps that label
+// on the Pod, not on the Node, so the Node listing alone cannot recover the
+// profile name. A Fargate node hosts exactly one user pod, so the map is
+// uncontested in practice.
+func fargateProfilesByNode(ctx context.Context, k8sClient kubernetes.Interface) (map[string]string, error) {
+	const fargateProfileLabel = "eks.amazonaws.com/fargate-profile"
+
+	out := map[string]string{}
+	p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return k8sClient.CoreV1().Pods(corev1.NamespaceAll).List(ctx, opts)
+	})
+	opts := metav1.ListOptions{LabelSelector: fargateProfileLabel}
+	if err := p.EachListItem(ctx, opts, func(obj runtime.Object) error {
+		pod := obj.(*corev1.Pod)
+		if pod.Spec.NodeName == "" {
+			return nil
+		}
+		if profile := pod.Labels[fargateProfileLabel]; profile != "" {
+			out[pod.Spec.NodeName] = profile
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list Fargate pods: %w", err)
+	}
+	return out, nil
+}
+
 // asgCandidate is a node that needs an AWS API call to determine whether
 // it's in an ASG (asg bucket) or not (standalone bucket).
 type asgCandidate struct {
@@ -77,7 +111,7 @@ type asgCandidate struct {
 // decision tree (Fargate, Karpenter, EKS managed node group, unknown). Nodes
 // with an AWS EC2 providerID that don't match any of the above are returned
 // as ASG candidates for resolveASGs to bucket as asg or standalone.
-func classifyByLabels(ctx context.Context, k8sClient kubernetes.Interface, info *ClusterInfo) ([]asgCandidate, error) {
+func classifyByLabels(ctx context.Context, k8sClient kubernetes.Interface, fargateProfileByNode map[string]string, info *ClusterInfo) ([]asgCandidate, error) {
 	var candidates []asgCandidate
 
 	p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
@@ -85,7 +119,7 @@ func classifyByLabels(ctx context.Context, k8sClient kubernetes.Interface, info 
 	})
 	if err := p.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
 		node := obj.(*corev1.Node)
-		if mgr, entity, ok := classifyNodeByLabel(node); ok {
+		if mgr, entity, ok := classifyNodeByLabel(node, fargateProfileByNode); ok {
 			addToBucket(info, mgr, entity, node.Name)
 			return nil
 		}
@@ -106,12 +140,13 @@ func classifyByLabels(ctx context.Context, k8sClient kubernetes.Interface, info 
 	return candidates, nil
 }
 
-// classifyNodeByLabel applies steps 1-3 of the decision tree using only the
-// Node labels and name. Returns false when the node needs an AWS API lookup
-// or the unknown-bucket fallback.
-func classifyNodeByLabel(node *corev1.Node) (NodeManager, string, bool) {
+// classifyNodeByLabel applies steps 1-3 of the decision tree using the Node
+// labels, the Node name, and a pre-built nodeName→Fargate-profile index.
+// Returns false when the node needs an AWS API lookup or the unknown-bucket
+// fallback.
+func classifyNodeByLabel(node *corev1.Node, fargateProfileByNode map[string]string) (NodeManager, string, bool) {
 	if node.Labels["eks.amazonaws.com/compute-type"] == "fargate" || strings.HasPrefix(node.Name, "fargate-ip-") {
-		return NodeManagerFargate, node.Labels["eks.amazonaws.com/fargate-profile"], true
+		return NodeManagerFargate, fargateProfileByNode[node.Name], true
 	}
 
 	if v := node.Labels["karpenter.sh/nodepool"]; v != "" {

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 // fakeASG implements AutoscalingDescriber, returning a static instance->ASG
@@ -167,6 +169,43 @@ func TestClassify_FargateMultipleProfiles(t *testing.T) {
 		info.NodeManagement[NodeManagerFargate]["fp-team-a"])
 	assert.Equal(t, []string{"fargate-b"},
 		info.NodeManagement[NodeManagerFargate]["fp-team-b"])
+}
+
+// TestClassify_FargatePendingPodSkipped guards the empty-NodeName branch of
+// fargateProfilesByNode: a Pod that carries the Fargate label but isn't yet
+// scheduled onto a Node must not populate the index (and must not panic).
+func TestClassify_FargatePendingPodSkipped(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		node("fargate-a", "", map[string]string{"eks.amazonaws.com/compute-type": "fargate"}),
+		// Scheduled pod -> profile resolves normally.
+		pod("workload-a", "team-a", "fargate-a", map[string]string{
+			"eks.amazonaws.com/fargate-profile": "fp-team-a",
+		}),
+		// Pending pod (no NodeName yet) -> must be ignored.
+		pod("workload-pending", "team-a", "", map[string]string{
+			"eks.amazonaws.com/fargate-profile": "fp-team-a",
+		}),
+	)
+
+	info, err := Classify(t.Context(), clientset, &fakeASG{}, "c")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"fargate-a"},
+		info.NodeManagement[NodeManagerFargate]["fp-team-a"])
+}
+
+// TestClassify_FargatePodListErrorPropagates guards the error path of
+// fargateProfilesByNode: a failing Pod listing must surface to the caller
+// of Classify wrapped with a recognisable message.
+func TestClassify_FargatePodListErrorPropagates(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependReactor("list", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewServiceUnavailable("test failure")
+	})
+
+	_, err := Classify(t.Context(), clientset, &fakeASG{}, "c")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list Fargate pods")
 }
 
 func TestClassify_ASGAndStandalone(t *testing.T) {

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify_test.go
@@ -49,6 +49,13 @@ func node(name string, providerID string, labels map[string]string) *corev1.Node
 	}
 }
 
+func pod(name, namespace, nodeName string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+		Spec:       corev1.PodSpec{NodeName: nodeName},
+	}
+}
+
 func deploymentWith(namespace, name string, labels map[string]string, image string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, Labels: labels},
@@ -83,12 +90,17 @@ func TestClassify_EmptyCluster(t *testing.T) {
 
 func TestClassify_AllBucketsByLabel(t *testing.T) {
 	objs := []runtime.Object{
-		// fargate via label
+		// fargate via label; profile name comes from the hosted Pod's label
+		// (EKS stamps `eks.amazonaws.com/fargate-profile` on the Pod, not the
+		// Node).
 		node("fargate-by-label", "aws:///us-east-1a/fargate-abc", map[string]string{
-			"eks.amazonaws.com/compute-type":    "fargate",
+			"eks.amazonaws.com/compute-type": "fargate",
+		}),
+		pod("workload", "default", "fargate-by-label", map[string]string{
 			"eks.amazonaws.com/fargate-profile": "fp-default",
 		}),
-		// fargate via name fallback (no compute-type label)
+		// fargate via name fallback (no compute-type label, no Pod yet
+		// scheduled) — exercises the empty-key fallback path.
 		node("fargate-ip-10-0-0-1.eu-west-3.compute.internal", "", nil),
 		// karpenter via primary label
 		node("kp-primary", "aws:///us-east-1a/i-0aaa", map[string]string{
@@ -134,6 +146,27 @@ func TestClassify_AllBucketsByLabel(t *testing.T) {
 	assert.Equal(t, []string{"orphan"},
 		info.NodeManagement[NodeManagerUnknown][""])
 	assert.Empty(t, asg.calls, "label-only nodes must not trigger AWS calls")
+}
+
+func TestClassify_FargateMultipleProfiles(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		node("fargate-a", "", map[string]string{"eks.amazonaws.com/compute-type": "fargate"}),
+		node("fargate-b", "", map[string]string{"eks.amazonaws.com/compute-type": "fargate"}),
+		pod("workload-a", "team-a", "fargate-a", map[string]string{
+			"eks.amazonaws.com/fargate-profile": "fp-team-a",
+		}),
+		pod("workload-b", "team-b", "fargate-b", map[string]string{
+			"eks.amazonaws.com/fargate-profile": "fp-team-b",
+		}),
+	)
+
+	info, err := Classify(t.Context(), clientset, &fakeASG{}, "c")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"fargate-a"},
+		info.NodeManagement[NodeManagerFargate]["fp-team-a"])
+	assert.Equal(t, []string{"fargate-b"},
+		info.NodeManagement[NodeManagerFargate]["fp-team-b"])
 }
 
 func TestClassify_ASGAndStandalone(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fix the empty Fargate profile-name bucket key in the `dd-cluster-info`
ConfigMap written at the end of `kubectl datadog autoscaling cluster install`.

Before the fix, on a real EKS cluster the snapshot looked like:

```yaml
nodeManagement:
    fargate:
        "":
            - fargate-ip-10-11-232-98.eu-west-3.compute.internal
            - fargate-ip-10-11-234-113.eu-west-3.compute.internal
```

After the fix:

```yaml
nodeManagement:
    fargate:
        dd-karpenter-lenaic-karpenter-test:
            - fargate-ip-10-11-233-199.eu-west-3.compute.internal
            - fargate-ip-10-11-233-23.eu-west-3.compute.internal
            - fargate-ip-10-11-234-235.eu-west-3.compute.internal
```

### Motivation

Root cause: `classifyNodeByLabel` (introduced in #2945) read the Fargate
profile name from a label on the **Node**:

```go
return NodeManagerFargate, node.Labels["eks.amazonaws.com/fargate-profile"], true
```

EKS does not put that label on the Node — it stamps it on the **Pod**
scheduled on the Fargate node. Verified on a live cluster: the Fargate
Node only carries `eks.amazonaws.com/compute-type=fargate` and topology
labels; the hosted pod is the one carrying `eks.amazonaws.com/fargate-profile`.
So the read always returned an empty string, and the ConfigMap collapsed
every Fargate node into the `fargate: { "": [...] }` bucket — making the
profile information unusable for the follow-up migration tooling.

Tracked in [CASCL-1304](https://datadoghq.atlassian.net/browse/CASCL-1304).

### Additional Notes

- The new `fargateProfilesByNode` helper lists Pods cluster-wide with a
  server-side label-existence selector
  (`LabelSelector: "eks.amazonaws.com/fargate-profile"`) and builds a
  `nodeName → profileName` index. On non-Fargate clusters the filtered
  list returns empty cheaply; the install path already does cluster-wide
  `Nodes.List` and `Deployments.List` so the incremental `pods.list`
  perm is small.
- A Fargate node with no Pod yet scheduled still falls into the
  empty-key bucket — acceptable race window for a one-shot informational
  snapshot.
- No new AWS permission required; the fix is pure Kubernetes API.

### Minimum Agent Versions

* Agent: N/A (kubectl plugin only — no Agent/Cluster Agent code path is touched)
* Cluster Agent: N/A

### Describe your test plan

- Unit tests in `cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify_test.go`:
  - `TestClassify_AllBucketsByLabel` updated to put the profile label on
    a Pod scheduled on the Fargate node; preserves the empty-key fallback
    coverage via the name-fallback case (no pod yet scheduled).
  - `TestClassify_FargateMultipleProfiles` (new) verifies two distinct
    Fargate profiles produce two distinct bucket keys.
  - Run with:
    ```bash
    go test ./cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/...
    ```
- End-to-end on a real EKS cluster (verified on `lenaic-karpenter-test`):
  ```bash
  make kubectl-datadog
  kubectl datadog autoscaling cluster install --cluster-name <cluster>
  kubectl -n dd-karpenter get cm/dd-cluster-info -o yaml
  ```
  Cross-check the `fargate` bucket keys against
  `aws eks list-fargate-profiles --cluster-name <cluster>`.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CASCL-1304]: https://datadoghq.atlassian.net/browse/CASCL-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ