### PR TITLE
[VULN-82131] Fix CVE 2026-39820: bump golang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 env:
-  GO_VERSION: 1.25.9
+  GO_VERSION: 1.25.10
 on:
   push:
 # Permission forced by repo-level setting; only elevate on job-level

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.25.9
+  GO_VERSION: 1.25.10
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   # packages: read
 env:
-  GO_VERSION: 1.25.9
+  GO_VERSION: 1.25.10
 jobs:
   build-linux-binary:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/yaml-mapper.yml
+++ b/.github/workflows/yaml-mapper.yml
@@ -12,7 +12,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.25.9
+  GO_VERSION: 1.25.10
 jobs:
   yaml-mapper-test:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/images/mirror/library/golang:1.25.9
+image: registry.ddbuild.io/images/mirror/library/golang:1.25.10
 variables:
   NIGHTLY_BUILD_CONDUCTOR_NAME: "operator-nightly-build"
   PROJECTNAME: "datadog-operator"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG FIPS_ENABLED=false
 
 # Build the manager binary
-FROM golang:1.25.9 AS builder
+FROM golang:1.25.10 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator/api
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.56.0

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.9 AS builder
+FROM golang:1.25.10 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator
 
 go 1.25.7
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.63.0-rc.1 // indirect

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.9
+go 1.25.10
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 use (
 	.

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator/test/e2e
 
 go 1.25.8
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/DataDog/datadog-agent/test/e2e-framework v0.78.0-devel


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/DataDog/image-vuln-scans/issues/3282

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits