### PR TITLE
enforce min agent version for CNM direct send

### DIFF
--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/utils"
 )
 
 func init() {
@@ -44,7 +45,7 @@ func (f *npmFeature) ID() feature.IDType {
 }
 
 // Configure is used to configure the feature from a v2alpha1.DatadogAgent instance.
-func (f *npmFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
+func (f *npmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
 	if ddaSpec.Features == nil {
 		return
 	}
@@ -54,9 +55,17 @@ func (f *npmFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSp
 			apicommon.CoreAgentContainerName,
 			apicommon.SystemProbeContainerName,
 		}
-		if !apiutils.BoolValue(ddaSpec.Features.NPM.DirectSend) {
+
+		directSendEnabled := apiutils.BoolValue(ddaSpec.Features.NPM.DirectSend)
+		const directSendMinVersion = "7.77.0-0"
+		defaultIfVersionUnknown := false
+		if !utils.IsAboveMinVersion(common.GetComponentVersion(dda, v2alpha1.NodeAgentComponentName), directSendMinVersion, &defaultIfVersionUnknown) {
+			directSendEnabled = false
+		}
+		if !directSendEnabled {
 			containers = append(containers, apicommon.ProcessAgentContainerName)
 		}
+		f.directSend = directSendEnabled
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
@@ -67,7 +76,6 @@ func (f *npmFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSp
 		npm := ddaSpec.Features.NPM
 		f.collectDNSStats = apiutils.BoolValue(npm.CollectDNSStats)
 		f.enableConntrack = apiutils.BoolValue(npm.EnableConntrack)
-		f.directSend = apiutils.BoolValue(npm.DirectSend)
 	}
 
 	return reqComp

--- a/internal/controller/datadogagent/feature/npm/feature_test.go
+++ b/internal/controller/datadogagent/feature/npm/feature_test.go
@@ -42,7 +42,15 @@ func Test_npmFeature_Configure(t *testing.T) {
 	ddaNPMEnabledConfig.Spec.Features.NPM.EnableConntrack = ptr.To(false)
 
 	ddaCNMDirectSendEnabledConfig := ddaNPMEnabled.DeepCopy()
+	ddaCNMDirectSendEnabledConfig.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+		v2alpha1.NodeAgentComponentName: {
+			Image: &v2alpha1.AgentImageConfig{Tag: "7.77.0"},
+		},
+	}
 	ddaCNMDirectSendEnabledConfig.Spec.Features.NPM.DirectSend = ptr.To(true)
+
+	ddaCNMDirectSendEnabledUnsupportedAgentVersionConfig := ddaCNMDirectSendEnabledConfig.DeepCopy()
+	ddaCNMDirectSendEnabledUnsupportedAgentVersionConfig.Spec.Override[v2alpha1.NodeAgentComponentName].Image.Tag = "7.76.0"
 
 	npmFeatureEnvVarWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -278,6 +286,12 @@ func Test_npmFeature_Configure(t *testing.T) {
 			DDA:           ddaCNMDirectSendEnabledConfig,
 			WantConfigure: true,
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(cnmDirectSendWantFunc),
+		},
+		{
+			Name:          "CNM enabled, Direct Send enabled on unsupported agent version",
+			DDA:           ddaCNMDirectSendEnabledUnsupportedAgentVersionConfig,
+			WantConfigure: true,
+			Agent:         test.NewDefaultComponentTest().WithWantFunc(npmAgentNodeWantFunc),
 		},
 	}
 

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/utils"
 )
 
 func init() {
@@ -53,19 +54,23 @@ func (f *usmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 			apicommon.CoreAgentContainerName,
 			apicommon.SystemProbeContainerName,
 		}
-		if ddaSpec.Features.NPM == nil || !apiutils.BoolValue(ddaSpec.Features.NPM.DirectSend) {
+
+		directSendEnabled := ddaSpec.Features.NPM != nil && apiutils.BoolValue(ddaSpec.Features.NPM.DirectSend)
+		const directSendMinVersion = "7.77.0-0"
+		defaultIfVersionUnknown := false
+		if !utils.IsAboveMinVersion(common.GetComponentVersion(dda, v2alpha1.NodeAgentComponentName), directSendMinVersion, &defaultIfVersionUnknown) {
+			directSendEnabled = false
+		}
+		if !directSendEnabled {
 			containers = append(containers, apicommon.ProcessAgentContainerName)
 		}
+		f.directSend = directSendEnabled
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
 				IsRequired: ptr.To(true),
 				Containers: containers,
 			},
-		}
-
-		if ddaSpec.Features.NPM != nil {
-			f.directSend = apiutils.BoolValue(ddaSpec.Features.NPM.DirectSend)
 		}
 	}
 

--- a/internal/controller/datadogagent/feature/usm/feature_test.go
+++ b/internal/controller/datadogagent/feature/usm/feature_test.go
@@ -39,10 +39,17 @@ func Test_usmFeature_Configure(t *testing.T) {
 	{
 		ddaUSMEnabled.Spec.Features.USM.Enabled = ptr.To(true)
 	}
+
 	ddaUSMDirectSendEnabled := ddaUSMEnabled.DeepCopy()
-	{
-		ddaUSMDirectSendEnabled.Spec.Features.NPM = &v2alpha1.NPMFeatureConfig{DirectSend: ptr.To(true)}
+	ddaUSMDirectSendEnabled.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+		v2alpha1.NodeAgentComponentName: {
+			Image: &v2alpha1.AgentImageConfig{Tag: "7.77.0"},
+		},
 	}
+	ddaUSMDirectSendEnabled.Spec.Features.NPM = &v2alpha1.NPMFeatureConfig{DirectSend: ptr.To(true)}
+
+	ddaUSMDirectSendEnabledUnsupportedAgentVersionConfig := ddaUSMDirectSendEnabled.DeepCopy()
+	ddaUSMDirectSendEnabledUnsupportedAgentVersionConfig.Spec.Override[v2alpha1.NodeAgentComponentName].Image.Tag = "7.76.0"
 
 	usmAgentNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -230,6 +237,12 @@ func Test_usmFeature_Configure(t *testing.T) {
 			DDA:           ddaUSMDirectSendEnabled,
 			WantConfigure: true,
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(usmDirectSendNodeWantFunc),
+		},
+		{
+			Name:          "USM enabled, Direct Send enabled on unsupported agent version",
+			DDA:           ddaUSMDirectSendEnabledUnsupportedAgentVersionConfig,
+			WantConfigure: true,
+			Agent:         test.NewDefaultComponentTest().WithWantFunc(usmAgentNodeWantFunc),
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Requires agent 7.77.0+ to enable the CNM/USM direct send feature

### Motivation

CNM/USM direct send does not work below 7.77.0

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.77.0
* Cluster Agent: n/a

### Describe your test plan

Added test cases.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits