### PR TITLE
Change ADP default health port to 5400

### DIFF
--- a/internal/controller/datadogagent/common/envvar.go
+++ b/internal/controller/datadogagent/common/envvar.go
@@ -32,6 +32,7 @@ const (
 	DDDataPlaneDogstatsdEnabled           = "DD_DATA_PLANE_DOGSTATSD_ENABLED"
 	DDDataPlaneOTLPEnabled                = "DD_DATA_PLANE_OTLP_ENABLED"
 	DDDataPlaneRemoteAgentEnabled         = "DD_DATA_PLANE_REMOTE_AGENT_ENABLED"
+	DDDataPlaneAPIListenAddress           = "DD_DATA_PLANE_API_LISTEN_ADDRESS"
 	DDDataPlaneUseNewConfigStreamEndpoint = "DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT"
 	DDKubernetesPodResourcesSocket        = "DD_KUBERNETES_KUBELET_PODRESOURCES_SOCKET"
 	DDKubernetesUseEndpointSlices         = "DD_KUBERNETES_USE_ENDPOINT_SLICES"

--- a/internal/controller/datadogagent/feature/dataplane/feature.go
+++ b/internal/controller/datadogagent/feature/dataplane/feature.go
@@ -6,6 +6,8 @@
 package dataplane
 
 import (
+	"fmt"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
 func init() {
@@ -110,6 +113,13 @@ func (f *dataPlaneFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 		managers.EnvVar().AddEnvVarToContainer(apicommon.AgentDataPlaneContainerName, &corev1.EnvVar{
 			Name:  common.DDDataPlaneUseNewConfigStreamEndpoint,
 			Value: "true",
+		})
+
+		// Explicitly set the API listen address so the operator controls which port ADP
+		// listens on, keeping probes in sync regardless of ADP's compiled-in default.
+		managers.EnvVar().AddEnvVarToContainer(apicommon.AgentDataPlaneContainerName, &corev1.EnvVar{
+			Name:  common.DDDataPlaneAPIListenAddress,
+			Value: fmt.Sprintf("0.0.0.0:%d", constants.DefaultADPHealthPort),
 		})
 
 		if f.dogstatsdEnabled {

--- a/internal/controller/datadogagent/feature/dataplane/feature_test.go
+++ b/internal/controller/datadogagent/feature/dataplane/feature_test.go
@@ -6,6 +6,7 @@
 package dataplane
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 )
 
@@ -28,6 +30,10 @@ func Test_dataPlaneFeature(t *testing.T) {
 	dataPlaneDogstatsdEnabledEnvVar := &corev1.EnvVar{
 		Name:  common.DDDataPlaneDogstatsdEnabled,
 		Value: "true",
+	}
+	dataPlaneAPIListenAddressEnvVar := &corev1.EnvVar{
+		Name:  common.DDDataPlaneAPIListenAddress,
+		Value: fmt.Sprintf("0.0.0.0:%d", constants.DefaultADPHealthPort),
 	}
 
 	tests := test.FeatureTestSuite{
@@ -88,6 +94,9 @@ func Test_dataPlaneFeature(t *testing.T) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 					agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
 					assert.Contains(t, agentEnvVars, dataPlaneEnabledEnvVar, "DD_DATA_PLANE_ENABLED should be set when Data Plane is enabled via CRD")
+
+					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AgentDataPlaneContainerName]
+					assert.Contains(t, adpEnvVars, dataPlaneAPIListenAddressEnvVar, "DD_DATA_PLANE_API_LISTEN_ADDRESS should be set on ADP container")
 				},
 			),
 		},

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -46,7 +46,7 @@ const (
 	// DefaultAgentHealthPort default agent health port
 	DefaultAgentHealthPort int32 = 5555
 
-	DefaultADPHealthPort = 5100
+	DefaultADPHealthPort = 5400
 
 	// DefaultApmPort default apm port
 	DefaultApmPort = 8126


### PR DESCRIPTION


### What does this PR do?

Set DD_DATA_PLANE_API_LISTEN_ADDRESS explicitly on the ADP container so the operator controls the listen port, keeping probes in sync regardless of ADP's compiled-in default.

### Motivation

We needed to change ADP's default listen port to avoid potential conflicts with existing Agent installs.

Ref: https://github.com/DataDog/saluki/pull/1652

### Minimum Agent Versions

N/A

### Describe your test plan

I believe the e2e testing is sufficient. In particular, test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-adp.yaml

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits