### PR TITLE
[CASCL-1304] Add e2e assertion for `dd-cluster-info` ConfigMap

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -24,6 +24,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-operator v1.24.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.0-alpha.1
 	k8s.io/cli-runtime v0.35.3
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
@@ -80,7 +81,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.93.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.18 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
@@ -286,7 +287,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0 // indirect
 	helm.sh/helm/v3 v3.20.2 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -121,8 +121,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.93.1 h1:5FhzzN6JmlGQF6c04kDIb5KNGm6Kn
 github.com/aws/aws-sdk-go-v2/service/s3 v1.93.1/go.mod h1:79S2BdqCJpScXZA2y+cpZuocWsjGjJINyXnOsf5DTz8=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.67.7 h1:0q42w8/mywPCzQD1IoWIBUCYfBJc5+fLwtZNpHffBSM=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.67.7/go.mod h1:urlU9nfKJEfi0+8T9luB3f3Y0UnomH/yxI7tTrfH9es=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8 h1:31Llf5VfrZ78YvYs7sWcS7L2m3waikzRc6q1nYenVS4=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.67.8/go.mod h1:/jgaDlU1UImoxTxhRNxXHvBAPqPZQ8oCjcPbbkR6kac=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.14 h1:GcLE9ba5ehAQma6wlopUesYg/hbcOhFNWTjELkiWkh4=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.14/go.mod h1:WSvS1NLr7JaPunCXqpJnWk1Bjo7IxzZXrZi1QQCkuqM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.18 h1:mP49nTpfKtpXLt5SLn8Uv8z6W+03jYVoOSAl/c02nog=

--- a/test/e2e/tests/autoscaling_suite/autoscaling_test.go
+++ b/test/e2e/tests/autoscaling_suite/autoscaling_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
@@ -22,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -229,6 +232,10 @@ func (s *autoscalingSuite) TestAutoscalingDefault() {
 	s.Run("Install with defaults", func() {
 		s.testInstall()
 		s.waitForAllPodsRunning(ctx)
+	})
+
+	s.Run("Verify dd-cluster-info ConfigMap", func() {
+		s.verifyDDClusterInfoConfigMap(ctx)
 	})
 
 	s.Run("Install is idempotent", func() {
@@ -484,6 +491,124 @@ func (s *autoscalingSuite) verifyKarpenterInstalled(ctx context.Context) {
 	s.Assert().Truef(exists, "Karpenter Helm release not found")
 
 	t.Log("Karpenter installation verified successfully")
+}
+
+// ddClusterInfo mirrors the wire format of the dd-cluster-info ConfigMap
+// payload. It is duplicated rather than imported from
+// cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo to avoid
+// pulling controller-runtime, karpenter, and the AWS autoscaling SDK
+// into the e2e test binary. Keep the YAML tags in sync with that
+// package's types.go.
+type ddClusterInfo struct {
+	APIVersion     string                                  `yaml:"apiVersion"`
+	ClusterName    string                                  `yaml:"clusterName"`
+	ClusterARN     string                                  `yaml:"clusterArn"`
+	Region         string                                  `yaml:"region"`
+	GeneratedAt    time.Time                               `yaml:"generatedAt"`
+	NodeManagement map[string]map[string]ddNodeManagerInfo `yaml:"nodeManagement"`
+	Autoscaling    struct {
+		ClusterAutoscaler struct {
+			Present bool `yaml:"present"`
+		} `yaml:"clusterAutoscaler"`
+		Karpenter struct {
+			Present          bool   `yaml:"present"`
+			Namespace        string `yaml:"namespace"`
+			Name             string `yaml:"name"`
+			Version          string `yaml:"version"`
+			ManagedByDatadog bool   `yaml:"managedByDatadog"`
+			InstallerVersion string `yaml:"installerVersion"`
+		} `yaml:"karpenter"`
+		EKSAutoMode struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"eksAutoMode"`
+	} `yaml:"autoscaling"`
+}
+
+type ddNodeManagerInfo struct {
+	Nodes            []string `yaml:"nodes"`
+	ManagedByDatadog bool     `yaml:"managedByDatadog"`
+}
+
+// verifyDDClusterInfoConfigMap asserts that the dd-cluster-info ConfigMap
+// was written by `install` with the expected shape: ConfigMap metadata,
+// schema version, cluster identity, an EKS managed node group bucket
+// covering both Linux and Linux-ARM groups, a Fargate bucket containing
+// the install-time `dd-karpenter-<cluster>` profile flagged as
+// ManagedByDatadog, and an Autoscaling block reporting our Karpenter as
+// the only autoscaler. The full YAML payload is logged unconditionally
+// so any assertion failure can be debugged from CI logs alone.
+func (s *autoscalingSuite) verifyDDClusterInfoConfigMap(ctx context.Context) {
+	const (
+		configMapName    = "dd-cluster-info"
+		configMapDataKey = "cluster-info"
+		apiVersion       = "v1"
+	)
+
+	t := s.T()
+	t.Log("Verifying dd-cluster-info ConfigMap...")
+
+	client := s.Env().KubernetesCluster.Client()
+
+	cm, err := client.CoreV1().ConfigMaps(karpenterNamespace).Get(ctx, configMapName, metav1.GetOptions{})
+	require.NoErrorf(t, err, "fetching ConfigMap %s/%s after install", karpenterNamespace, configMapName)
+
+	payload := cm.Data[configMapDataKey]
+	t.Logf("dd-cluster-info ConfigMap payload:\n%s", payload)
+
+	assert.Equal(t, "kubectl-datadog", cm.Labels["app.kubernetes.io/managed-by"], "managed-by label")
+	require.NotEmpty(t, payload, "ConfigMap data key %q is empty", configMapDataKey)
+
+	var info ddClusterInfo
+	require.NoError(t, yaml.Unmarshal([]byte(payload), &info), "failed to unmarshal cluster-info payload")
+
+	assert.Equal(t, apiVersion, info.APIVersion, "APIVersion")
+	assert.Equal(t, s.clusterName, info.ClusterName, "ClusterName")
+	assert.Regexp(t, `^arn:aws:eks:[^:]+:\d+:cluster/`+regexp.QuoteMeta(s.clusterName)+`$`, info.ClusterARN, "ClusterARN")
+	assert.Equal(t, s.awsCfg.Region, info.Region, "Region")
+	assert.WithinDuration(t, time.Now(), info.GeneratedAt, 30*time.Minute, "GeneratedAt should be recent")
+
+	ngBucket := info.NodeManagement["eksManagedNodeGroup"]
+	if assert.Len(t, ngBucket, 2, "expected 2 EKS managed node groups (linux + linux-arm)") {
+		var sawLinux, sawLinuxARM bool
+		for name := range ngBucket {
+			// Check linux-arm first because the substring "linux" matches both
+			// node group names.
+			if strings.Contains(name, "linux-arm") {
+				sawLinuxARM = true
+			} else if strings.Contains(name, "linux") {
+				sawLinux = true
+			}
+		}
+		assert.True(t, sawLinux, "expected an EKS managed node group whose name contains 'linux'; got %v", ngBucket)
+		assert.True(t, sawLinuxARM, "expected an EKS managed node group whose name contains 'linux-arm'; got %v", ngBucket)
+	}
+
+	fargateBucket := info.NodeManagement["fargate"]
+	ddKarpenterProfile := "dd-karpenter-" + s.clusterName
+	if assert.Contains(t, fargateBucket, ddKarpenterProfile, "Fargate bucket should contain the install-time profile") {
+		assert.True(t, fargateBucket[ddKarpenterProfile].ManagedByDatadog, "%q Fargate profile should be ManagedByDatadog", ddKarpenterProfile)
+	}
+
+	// The default install creates a Karpenter NodePool per inferred
+	// hardware shape; the snapshot flags every NodePool labelled by
+	// kubectl-datadog as ManagedByDatadog, even before any node has
+	// been provisioned on it.
+	karpenterBucket := info.NodeManagement["karpenter"]
+	if assert.NotEmpty(t, karpenterBucket, "Karpenter bucket should contain at least one Datadog-managed NodePool") {
+		for name, entry := range karpenterBucket {
+			assert.Truef(t, strings.HasPrefix(name, "dd-karpenter-"), "NodePool %q should have the kubectl-datadog name prefix", name)
+			assert.Truef(t, entry.ManagedByDatadog, "NodePool %q should be ManagedByDatadog", name)
+		}
+	}
+
+	assert.False(t, info.Autoscaling.ClusterAutoscaler.Present, "ClusterAutoscaler should not be present")
+	assert.True(t, info.Autoscaling.Karpenter.Present, "Karpenter should be present")
+	assert.Equal(t, karpenterNamespace, info.Autoscaling.Karpenter.Namespace, "Karpenter namespace")
+	assert.Equal(t, "karpenter", info.Autoscaling.Karpenter.Name, "Karpenter Helm release name")
+	assert.True(t, info.Autoscaling.Karpenter.ManagedByDatadog, "Karpenter should be ManagedByDatadog")
+	assert.NotEmpty(t, info.Autoscaling.Karpenter.InstallerVersion, "Karpenter InstallerVersion")
+	assert.Regexp(t, `^v?\d+\.\d+\.\d+`, info.Autoscaling.Karpenter.Version, "Karpenter Version")
+	assert.False(t, info.Autoscaling.EKSAutoMode.Enabled, "EKS auto-mode should be disabled")
 }
 
 // verifyKarpenterPodsComputeType asserts that all Karpenter controller pods

--- a/test/e2e/tests/autoscaling_suite/autoscaling_test.go
+++ b/test/e2e/tests/autoscaling_suite/autoscaling_test.go
@@ -531,17 +531,24 @@ type ddNodeManagerInfo struct {
 
 // verifyDDClusterInfoConfigMap asserts that the dd-cluster-info ConfigMap
 // was written by `install` with the expected shape: ConfigMap metadata,
-// schema version, cluster identity, an EKS managed node group bucket
-// covering both Linux and Linux-ARM groups, a Fargate bucket containing
-// the install-time `dd-karpenter-<cluster>` profile flagged as
-// ManagedByDatadog, and an Autoscaling block reporting our Karpenter as
-// the only autoscaler. The full YAML payload is logged unconditionally
-// so any assertion failure can be debugged from CI logs alone.
+// schema version, cluster identity, the two EKS managed node groups
+// provisioned by the e2e harness, the two Fargate profiles (the harness'
+// own and the install-time `dd-karpenter-<cluster>` profile), the two
+// Karpenter NodePools created by `--inference-method=nodegroups`, and an
+// Autoscaling block reporting our Karpenter as the only autoscaler. The
+// full YAML payload is logged unconditionally so any assertion failure
+// can be debugged from CI logs alone.
 func (s *autoscalingSuite) verifyDDClusterInfoConfigMap(ctx context.Context) {
 	const (
 		configMapName    = "dd-cluster-info"
 		configMapDataKey = "cluster-info"
 		apiVersion       = "v1"
+		// Node names follow the kubelet default for AWS: "ip-<addr>.internal"
+		// suffixed by either ".ec2" (us-east-1) or ".<region>.compute" (other
+		// regions). Nodes scheduled on Fargate carry the extra "fargate-"
+		// prefix.
+		eksNodeNameRe     = `^ip-[0-9-]+\..+\.internal$`
+		fargateNodeNameRe = `^fargate-ip-[0-9-]+\..+\.internal$`
 	)
 
 	t := s.T()
@@ -567,37 +574,55 @@ func (s *autoscalingSuite) verifyDDClusterInfoConfigMap(ctx context.Context) {
 	assert.Equal(t, s.awsCfg.Region, info.Region, "Region")
 	assert.WithinDuration(t, time.Now(), info.GeneratedAt, 30*time.Minute, "GeneratedAt should be recent")
 
+	// The e2e harness provisions one x86_64 and one ARM64 EKS managed
+	// node group, each with DesiredSize=1. We don't pin the generated
+	// node group names because Pulumi's DisplayName truncates them in a
+	// non-deterministic way once the cluster name approaches the 37-char
+	// prefix budget.
 	ngBucket := info.NodeManagement["eksManagedNodeGroup"]
-	if assert.Len(t, ngBucket, 2, "expected 2 EKS managed node groups (linux + linux-arm)") {
-		var sawLinux, sawLinuxARM bool
-		for name := range ngBucket {
-			// Check linux-arm first because the substring "linux" matches both
-			// node group names.
-			if strings.Contains(name, "linux-arm") {
-				sawLinuxARM = true
-			} else if strings.Contains(name, "linux") {
-				sawLinux = true
+	if assert.Len(t, ngBucket, 2, "expected 2 EKS managed node groups (one per architecture)") {
+		for name, entry := range ngBucket {
+			assert.Falsef(t, entry.ManagedByDatadog, "EKS managed node group %q should not be ManagedByDatadog", name)
+			if assert.Lenf(t, entry.Nodes, 1, "EKS managed node group %q should have exactly 1 node (DesiredSize=1)", name) {
+				assert.Regexpf(t, eksNodeNameRe, entry.Nodes[0], "node %q in EKS managed node group %q", entry.Nodes[0], name)
 			}
 		}
-		assert.True(t, sawLinux, "expected an EKS managed node group whose name contains 'linux'; got %v", ngBucket)
-		assert.True(t, sawLinuxARM, "expected an EKS managed node group whose name contains 'linux-arm'; got %v", ngBucket)
 	}
 
+	// The Fargate bucket holds two profiles: the e2e harness' own
+	// (covering kube-system + the `agent.datadoghq.com/sidecar=fargate`
+	// label) and the install-time `dd-karpenter-<cluster>` profile
+	// hosting the Karpenter controller pods. Only the latter carries
+	// the kubectl-datadog ownership tag.
 	fargateBucket := info.NodeManagement["fargate"]
 	ddKarpenterProfile := "dd-karpenter-" + s.clusterName
-	if assert.Contains(t, fargateBucket, ddKarpenterProfile, "Fargate bucket should contain the install-time profile") {
-		assert.True(t, fargateBucket[ddKarpenterProfile].ManagedByDatadog, "%q Fargate profile should be ManagedByDatadog", ddKarpenterProfile)
+	if assert.Len(t, fargateBucket, 2, "expected 2 Fargate profiles (harness + install-time)") {
+		for name, entry := range fargateBucket {
+			assert.NotEmptyf(t, entry.Nodes, "Fargate profile %q should have at least one node", name)
+			for _, node := range entry.Nodes {
+				assert.Regexpf(t, fargateNodeNameRe, node, "node %q in Fargate profile %q", node, name)
+			}
+			if name == ddKarpenterProfile {
+				assert.Truef(t, entry.ManagedByDatadog, "install-time Fargate profile %q should be ManagedByDatadog", name)
+			} else {
+				assert.Falsef(t, entry.ManagedByDatadog, "non-install Fargate profile %q should not be ManagedByDatadog", name)
+			}
+		}
+		assert.Contains(t, fargateBucket, ddKarpenterProfile, "Fargate bucket should contain the install-time profile")
 	}
 
-	// The default install creates a Karpenter NodePool per inferred
-	// hardware shape; the snapshot flags every NodePool labelled by
-	// kubectl-datadog as ManagedByDatadog, even before any node has
-	// been provisioned on it.
+	// `--inference-method=nodegroups` (the default) introspects the two
+	// EKS managed node groups and emits one Karpenter NodePool per
+	// distinct hardware shape. The snapshot is written at install time,
+	// before Karpenter has provisioned any node, so the Nodes lists are
+	// empty here — the NodePools are still surfaced (with
+	// ManagedByDatadog=true) so the migration tool sees the destination.
 	karpenterBucket := info.NodeManagement["karpenter"]
-	if assert.NotEmpty(t, karpenterBucket, "Karpenter bucket should contain at least one Datadog-managed NodePool") {
+	if assert.Len(t, karpenterBucket, 2, "expected 2 Karpenter NodePools (one per node group architecture)") {
 		for name, entry := range karpenterBucket {
 			assert.Truef(t, strings.HasPrefix(name, "dd-karpenter-"), "NodePool %q should have the kubectl-datadog name prefix", name)
 			assert.Truef(t, entry.ManagedByDatadog, "NodePool %q should be ManagedByDatadog", name)
+			assert.Emptyf(t, entry.Nodes, "NodePool %q should have no nodes at install time; got %v", name, entry.Nodes)
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Adds a `Verify dd-cluster-info ConfigMap` sub-test to `TestAutoscalingDefault`
in `test/e2e/tests/autoscaling_suite/autoscaling_test.go`. The sub-test
fetches the `dd-cluster-info` ConfigMap that
`kubectl datadog autoscaling cluster install` writes in the `dd-karpenter`
namespace, unmarshals its YAML payload, and asserts every deterministic
field of the snapshot:

- ConfigMap metadata (name, namespace, `app.kubernetes.io/managed-by` label, data key).
- Schema version, ClusterName, ClusterARN (matched against a regex anchored
  on `s.clusterName`), Region, and a 30-minute freshness bound on `GeneratedAt`.
- `NodeManagement.eksManagedNodeGroup` contains exactly two entries whose
  names match the `linux` and `linux-arm` patterns provisioned by the
  e2e-framework.
- `NodeManagement.fargate` contains the install-time `dd-karpenter-<cluster>`
  profile, flagged as `ManagedByDatadog`.
- `NodeManagement.karpenter` is non-empty and every entry has the
  `dd-karpenter-` name prefix and `ManagedByDatadog: true`.
- `Autoscaling.ClusterAutoscaler.Present == false`, `EKSAutoMode.Enabled == false`,
  and Karpenter is present in `dd-karpenter`, named `karpenter`, with
  `ManagedByDatadog`, a populated `InstallerVersion`, and a SemVer-shaped
  `Version`.

The full YAML payload is logged unconditionally so any assertion failure
can be debugged from CI logs alone.

### Motivation

PRs [#2945](https://github.com/DataDog/datadog-operator/pull/2945) and [#2980](https://github.com/DataDog/datadog-operator/pull/2980) introduced the `dd-cluster-info` ConfigMap as the source of truth consumed by the
follow-up Karpenter migration tool. No e2e coverage was asserting that
the ConfigMap actually gets written with the expected shape after a real
install on EKS. This adds that coverage as a sub-test of the existing
default install flow, so it shares the cluster provisioning and install
steps with the other autoscaling tests — no extra infrastructure cost.

Jira: [CASCL-1304](https://datadoghq.atlassian.net/browse/CASCL-1304).

### Additional Notes

The `dd-cluster-info` payload is unmarshaled into a locally-defined
wire-format struct rather than importing the producer's
`cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo` package, to
avoid pulling controller-runtime, karpenter, and the AWS autoscaling SDK
transitive dependencies into the e2e test module. The duplication is
documented and kept minimal.

### Minimum Agent Versions

No agent-side change.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- The new sub-test runs as part of the existing autoscaling e2e suite on
  the EKS GitLab job; no new pipeline wiring required.
- Locally, the additions pass `go vet`, `go build`, and golangci-lint
  for the `test/e2e` module.
- The full ConfigMap YAML is logged via `t.Logf` so any future field
  drift surfaces directly in CI logs.

### Checklist

- [x] PR has at least one valid label: `enhancement`
- [x] PR has a milestone or the `qa/skip-qa` label (`qa/skip-qa`: this is
  test-only and doesn't affect user-facing behavior)
- [x] All commits are signed

[CASCL-1304]: https://datadoghq.atlassian.net/browse/CASCL-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ