### PR TITLE
[FA] Fix false-positive abort and timeout in experiment reconciler

### DIFF
--- a/internal/controller/datadogagent/controller_experiment_integration_test.go
+++ b/internal/controller/datadogagent/controller_experiment_integration_test.go
@@ -232,10 +232,10 @@ func Test_Experiment_AbortOnManualChange(t *testing.T) {
 	reconcileN(t, r, ns, name, 1)
 	assert.Equal(t, v2alpha1.ExperimentPhaseRunning, mustGetExperimentPhase(t, r, ns, name))
 
-	// Patch revision timestamps to a recent time so the timeout path in
-	// handleRollback is not accidentally triggered before the abort check runs.
+	// Patch revision timestamps outside the grace period but within timeout so
+	// neither path fires before the manual-change abort check runs.
 	for _, rev := range listOwnedRevisions(t, r.client, ns, uid) {
-		rev.CreationTimestamp = metav1.Now()
+		rev.CreationTimestamp = metav1.NewTime(time.Now().Add(-20 * time.Second))
 		assert.NoError(t, r.client.Update(context.TODO(), &rev))
 	}
 
@@ -472,18 +472,19 @@ func Test_Experiment_Abort_AnnotatesOnlyExperimentRevision(t *testing.T) {
 	// Daemon writes start annotations and reconcile processes them → running.
 	simulateDaemonStart(t, r.client, nsName, "exp-1")
 
-	// Patch timestamps so timeout doesn't fire before abort.
+	// Patch timestamps outside the grace period but within timeout so neither
+	// path fires before the manual-change abort check runs.
 	for _, rev := range listOwnedRevisions(t, r.client, ns, uid) {
-		rev.CreationTimestamp = metav1.Now()
+		rev.CreationTimestamp = metav1.NewTime(time.Now().Add(-20 * time.Second))
 		assert.NoError(t, r.client.Update(context.TODO(), &rev))
 	}
 
 	reconcileN(t, r, ns, name, 1)
 	assert.Equal(t, v2alpha1.ExperimentPhaseRunning, mustGetExperimentPhase(t, r, ns, name))
 
-	// Patch timestamps again after reconcile so timeout doesn't fire before abort.
+	// Patch timestamps again after reconcile so neither path fires before abort.
 	for _, rev := range listOwnedRevisions(t, r.client, ns, uid) {
-		rev.CreationTimestamp = metav1.Now()
+		rev.CreationTimestamp = metav1.NewTime(time.Now().Add(-20 * time.Second))
 		assert.NoError(t, r.client.Update(context.TODO(), &rev))
 	}
 

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -41,6 +41,13 @@ const (
 // gets a fresh timestamp when the same spec is re-applied.
 const annotationExperimentRollback = "operator.datadoghq.com/experiment-rollback"
 
+// abortGracePeriod is the window after a new ControllerRevision is created
+// during which abortExperiment skips the spec-match check. The controller's
+// own spec settling (defaults, transient annotations) may not yet be reflected
+// in the newest revision on the immediately following reconcile, so we wait
+// for the system to stabilize before interpreting a mismatch as a user change.
+const abortGracePeriod = 10 * time.Second
+
 // annotationExperimentPromoted marks a ControllerRevision whose experiment was
 // promoted. The annotation tells handleRollback to skip the timeout check so
 // the stale CreationTimestamp doesn't cause a false timeout when a subsequent
@@ -111,7 +118,7 @@ func (r *Reconciler) manageExperiment(
 			r.annotateRevision(ctx, rev, annotationExperimentPromoted)
 		}
 	}
-	r.abortExperiment(ctx, instance, experiment, newStatus, revList)
+	r.abortExperiment(ctx, instance, experiment, newStatus, revList, now)
 
 	// Clear annotations only if the entire experiment management cycle did
 	// not mutate the experiment status. Clearing bumps the DDA's
@@ -366,12 +373,19 @@ func (r *Reconciler) abortExperiment(
 	experiment *v2alpha1.ExperimentStatus,
 	newStatus *v2alpha1.DatadogAgentStatus,
 	revisions []appsv1.ControllerRevision,
+	now metav1.Time,
 ) {
+	// Guard 1: skip when the pre-reconcile experiment was not running.
+	// This prevents abort from firing on the first reconcile of a NEW experiment
+	// started after a terminal state (promoted/terminated): processExperimentSignal
+	// sets newStatus.Experiment.Phase = Running for the new experiment, but the old
+	// experiment (instance.Status.Experiment) is still in a terminal phase.
 	if experiment.Phase != v2alpha1.ExperimentPhaseRunning {
 		return
 	}
+	// Guard 2: skip when processExperimentSignal or handleRollback already set a
+	// terminal phase in this reconcile cycle — don't overwrite or log spuriously.
 	if newStatus.Experiment.Phase != v2alpha1.ExperimentPhaseRunning {
-		// handleRollback already determined a terminal phase (e.g. timeout); don't overwrite or log.
 		return
 	}
 	// On the first reconcile after experiment start, the new revision hasn't
@@ -381,6 +395,15 @@ func (r *Reconciler) abortExperiment(
 	// when fewer than 2 revisions exist.
 	if len(revisions) < 2 {
 		return
+	}
+	// Skip the check immediately after a new revision is created. Transient
+	// annotation differences between the snapshot and the next reconcile's
+	// instance can cause a false positive on the very first reconcile after
+	// experiment start. Wait for the system to stabilize.
+	if rev := highestRevision(revisions); rev != nil {
+		if now.Sub(rev.CreationTimestamp.Time) < abortGracePeriod {
+			return
+		}
 	}
 	if findMostRecentMatchingRevision(revisions, instance) != nil {
 		// Spec matches a known revision — no manual change detected.
@@ -445,6 +468,19 @@ func (r *Reconciler) handleRollback(
 		}
 	}
 	if rev != nil {
+		if len(revisions) < 2 {
+			// The experiment revision hasn't been created yet (manageRevision runs
+			// after manageExperiment). The only existing revision is the pre-experiment
+			// baseline whose timestamp can be arbitrarily old. Skip the timeout check
+			// to avoid an immediate rollback on the very first reconcile.
+			//
+			// Note: if manageRevision fails persistently, len stays at 1 and this
+			// guard keeps the experiment alive indefinitely. That is intentional:
+			// the timeout clock should not start until the experiment is recorded.
+			// Persistent manageRevision failures are observable via controller error
+			// events on the DDA.
+			return nil
+		}
 		elapsed := now.Sub(rev.CreationTimestamp.Time)
 		if elapsed >= getExperimentTimeout(r.options.ExperimentTimeout) {
 			logger.Info("Experiment timed out, rolling back", "elapsed", elapsed.String())

--- a/internal/controller/datadogagent/experiment_test.go
+++ b/internal/controller/datadogagent/experiment_test.go
@@ -37,10 +37,11 @@ func TestManageExperiment_AbortsOnManualChange(t *testing.T) {
 		Phase: v2alpha1.ExperimentPhaseRunning,
 	}
 
-	// Set recent timestamps so the timeout path in handleRollback does not fire.
+	// Set timestamps outside the grace period but within timeout so neither
+	// path fires unexpectedly.
 	revList := mustListRevisions(t, r, instanceC)
 	for i := range revList {
-		revList[i].CreationTimestamp = metav1.Now()
+		revList[i].CreationTimestamp = metav1.NewTime(time.Now().Add(-20 * time.Second))
 	}
 
 	status := &v2alpha1.DatadogAgentStatus{
@@ -278,6 +279,28 @@ func TestHandleRollback_NoTimeoutOnFirstReconcile(t *testing.T) {
 	assert.Equal(t, v2alpha1.ExperimentPhaseRunning, newStatus.Experiment.Phase)
 }
 
+func TestHandleRollback_NoTimeoutOnFirstReconcile_SpecMatchesBaseline(t *testing.T) {
+	r, c := newRevisionTestReconciler(t)
+
+	// Single revision for the pre-experiment spec, with an old timestamp.
+	instanceA := newRevisionTestOwner("test-dda", "default")
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	revList := mustListRevisions(t, r, instanceA)
+	require.Len(t, revList, 1)
+	revList[0].CreationTimestamp = metav1.NewTime(time.Now().Add(-ExperimentDefaultTimeout - time.Hour))
+
+	// instanceA spec still matches the baseline revision — the experiment started
+	// but the spec patch hasn't been applied yet. findMostRecentMatchingRevision
+	// returns the baseline (rev != nil), but len < 2, so timeout must not fire.
+	instanceA.Status.Experiment = &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseRunning}
+	require.NoError(t, c.Create(context.Background(), instanceA))
+
+	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: instanceA.Status.Experiment.DeepCopy()}
+	require.NoError(t, r.handleRollback(context.Background(), instanceA, newStatus, metav1.Now(), revList))
+	assert.Equal(t, v2alpha1.ExperimentPhaseRunning, newStatus.Experiment.Phase,
+		"timeout must not fire with a single revision even when spec matches it and timestamp is old")
+}
+
 // TestHandleRollback_PostRollbackSetsTerminated verifies the reconcile-2 scenario:
 // the spec has already been restored to the pre-experiment value (e.g. by a
 // previous reconcile whose status write 409'd), so phase is still running and
@@ -482,9 +505,9 @@ func TestAbortExperiment_ThreeRevisions_AnnotatesOnlyHighest(t *testing.T) {
 	revList := mustListRevisions(t, r, instanceA)
 	require.Len(t, revList, 3)
 
-	// Set recent timestamps so timeout doesn't fire first.
+	// Set OLD timestamps so revisions are outside the grace period.
 	for i := range revList {
-		revList[i].CreationTimestamp = metav1.Now()
+		revList[i].CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Minute))
 	}
 
 	// Simulate manual spec change (specD) — doesn't match any revision.
@@ -494,7 +517,7 @@ func TestAbortExperiment_ThreeRevisions_AnnotatesOnlyHighest(t *testing.T) {
 	instanceD.Status.Experiment = &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseRunning}
 
 	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: instanceD.Status.Experiment.DeepCopy()}
-	r.abortExperiment(context.Background(), instanceD, instanceD.Status.Experiment, newStatus, revList)
+	r.abortExperiment(context.Background(), instanceD, instanceD.Status.Experiment, newStatus, revList, metav1.Now())
 	assert.Equal(t, v2alpha1.ExperimentPhaseAborted, newStatus.Experiment.Phase)
 
 	// Verify: only rev3 (experiment, highest) is annotated.
@@ -509,6 +532,44 @@ func TestAbortExperiment_ThreeRevisions_AnnotatesOnlyHighest(t *testing.T) {
 			assert.False(t, hasAnnotation, "rev1 (old baseline) should NOT be annotated")
 		}
 	}
+}
+
+func TestAbortExperiment_GracePeriod_SkipsNewRevision(t *testing.T) {
+	r, _ := newRevisionTestReconciler(t)
+
+	instanceA := newRevisionTestOwner("test-dda", "default")
+	_, err := r.ensureRevision(context.Background(), instanceA, nil, false)
+	require.NoError(t, err)
+
+	instanceB := newRevisionTestOwner("test-dda", "default")
+	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
+	_, err = r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	require.NoError(t, err)
+
+	revList := mustListRevisions(t, r, instanceA)
+	require.Len(t, revList, 2)
+
+	// Highest revision was just created — within the grace period.
+	for i := range revList {
+		if revList[i].Revision == 2 {
+			revList[i].CreationTimestamp = metav1.Now()
+		} else {
+			revList[i].CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Minute))
+		}
+	}
+
+	// instanceC has a spec that doesn't match any revision (simulates the
+	// transient annotation mismatch seen immediately after experiment start).
+	unknownSite := "transient-mismatch.example.com"
+	instanceC := newRevisionTestOwner("test-dda", "default")
+	instanceC.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{Site: &unknownSite}}
+	instanceC.Status.Experiment = &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseRunning}
+
+	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: instanceC.Status.Experiment.DeepCopy()}
+	r.abortExperiment(context.Background(), instanceC, instanceC.Status.Experiment, newStatus, revList, metav1.Now())
+
+	// Grace period active → abort must NOT fire.
+	assert.Equal(t, v2alpha1.ExperimentPhaseRunning, newStatus.Experiment.Phase)
 }
 
 func TestHandleRollback_Timeout(t *testing.T) {

--- a/internal/controller/datadogagent/revision.go
+++ b/internal/controller/datadogagent/revision.go
@@ -235,7 +235,8 @@ func datadogAnnotations(all map[string]string) map[string]string {
 	for k, v := range all {
 		if strings.Contains(k, ".datadoghq.com/") &&
 			!strings.HasPrefix(k, "experiment.datadoghq.com/") &&
-			!strings.HasPrefix(k, "fleet.datadoghq.com/") {
+			!strings.HasPrefix(k, "fleet.datadoghq.com/") &&
+			!strings.HasPrefix(k, "fleet.") {
 			filtered[k] = v
 		}
 	}


### PR DESCRIPTION
## Summary

- Fixes a false-positive experiment abort on the first reconcile after start: the spec-match check is skipped when fewer than 2 revisions exist (the experiment revision hasn't been created yet by `manageRevision`) and an abort grace period is applied immediately after a new revision is created.
- Fixes a false timeout on experiment start: the timeout check in `handleRollback` is skipped when fewer than 2 revisions exist, preventing the pre-experiment baseline's arbitrarily-old timestamp from triggering an immediate rollback.
- Documents the intent of the dual-guard pattern in `abortExperiment` (guard 1: skip on new experiment after terminal state; guard 2: skip if this reconcile cycle already set a terminal phase).

## Test plan

- [ ] `go test ./internal/controller/datadogagent/...` passes
- [ ] `TestHandleRollback_NoTimeoutOnFirstReconcile` covers `rev == nil` path (spec differs from baseline)
- [ ] `TestHandleRollback_NoTimeoutOnFirstReconcile_SpecMatchesBaseline` covers `rev != nil` path (spec still matches baseline)
- [ ] `TestAbortExperiment_GracePeriod_SkipsNewRevision` covers abort grace period
- [ ] `Test_Experiment_StateTransitions` matrix (24 subtests) covers all terminal-state → new-experiment transitions