### PR TITLE
Use resolved image for host-profiler seccomp init

### DIFF
--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -95,34 +95,31 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 	// Security context: drop all caps, add only what host-profiler needs, lock down privilege escalation,
 	// and apply a localhost seccomp profile. AllowPrivilegeEscalation must be explicitly false so that
 	// runc applies the seccomp filter before its own setuid/setgid/capset calls during container setup.
-	hpFound := false
+	var hostProfilerContainer *corev1.Container
 	for i := range managers.PodTemplateSpec().Spec.Containers {
-
-		if managers.PodTemplateSpec().Spec.Containers[i].Name != string(apicommon.HostProfiler) {
-			continue
+		if managers.PodTemplateSpec().Spec.Containers[i].Name == string(apicommon.HostProfiler) {
+			hostProfilerContainer = &managers.PodTemplateSpec().Spec.Containers[i]
+			break
 		}
-
-		hostProfilerContainer := &managers.PodTemplateSpec().Spec.Containers[i]
-		if hostProfilerContainer.SecurityContext == nil {
-			hostProfilerContainer.SecurityContext = &corev1.SecurityContext{}
-		}
-
-		sc := hostProfilerContainer.SecurityContext
-		sc.AllowPrivilegeEscalation = ptr.To(false)
-		sc.SeccompProfile = &corev1.SeccompProfile{
-			Type:             corev1.SeccompProfileTypeLocalhost,
-			LocalhostProfile: ptr.To(seccompProfileName),
-		}
-		sc.Capabilities = &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-			Add:  defaultCapabilities(),
-		}
-		hpFound = true
-		break
 	}
 
-	if !hpFound {
+	if hostProfilerContainer == nil {
 		return fmt.Errorf("host-profiler container not found in pod template spec")
+	}
+
+	if hostProfilerContainer.SecurityContext == nil {
+		hostProfilerContainer.SecurityContext = &corev1.SecurityContext{}
+	}
+
+	sc := hostProfilerContainer.SecurityContext
+	sc.AllowPrivilegeEscalation = ptr.To(false)
+	sc.SeccompProfile = &corev1.SeccompProfile{
+		Type:             corev1.SeccompProfileTypeLocalhost,
+		LocalhostProfile: ptr.To(seccompProfileName),
+	}
+	sc.Capabilities = &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+		Add:  defaultCapabilities(),
 	}
 
 	// AppArmor: unconfined so the default containerd profile doesn't block ptrace cross-profile,
@@ -148,7 +145,7 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 
 	// Init container: copy seccomp profile JSON to the kubelet seccomp directory on the host.
 	// Appended after the base init containers (init-volume, init-config) added by default.go.
-	initContainer := buildSeccompSetupInitContainer()
+	initContainer := buildSeccompSetupInitContainer(hostProfilerContainer.Image)
 	managers.PodTemplateSpec().Spec.InitContainers = append(managers.PodTemplateSpec().Spec.InitContainers, initContainer)
 
 	// Tracingfs volume

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -80,13 +80,14 @@ func testExpectedDependencies(t testing.TB, storeClient store.StoreClient) {
 func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expectedVolumeMount []corev1.VolumeMount) *test.ComponentTest {
 	// Pre-populate both containers so ManageNodeAgent can find and mutate the host-profiler SecurityContext.
 	// This mirrors the real flow where default.go's hostProfilerContainer() runs before features.
+	hostProfilerImage := "gcr.io/datadoghq/agent:7.99.0-fips"
 	hostProfilerPTS := corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{Name: string(apicommon.CoreAgentContainerName), Image: images.GetLatestAgentImage()},
 				{
 					Name:  string(apicommon.HostProfiler),
-					Image: images.GetLatestAgentImage(),
+					Image: hostProfilerImage,
 					SecurityContext: &corev1.SecurityContext{
 						ReadOnlyRootFilesystem: ptr.To(true),
 					},
@@ -171,6 +172,7 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				}
 				assert.NotNil(t, setupContainer, "host-profiler-seccomp-setup init container should be present")
 				if setupContainer != nil {
+					assert.Equal(t, hostProfilerImage, setupContainer.Image)
 					expectedDst := common.SeccompRootVolumePath + "/" + seccompProfileName
 					assert.Contains(t, setupContainer.Command, expectedDst, "cp command should target the kubelet seccomp path")
 					mountNames := map[string]bool{}

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
-	"github.com/DataDog/datadog-operator/pkg/images"
 )
 
 const (
@@ -180,10 +179,10 @@ func defaultSeccompConfigData() map[string]string {
 	}
 }
 
-func buildSeccompSetupInitContainer() corev1.Container {
+func buildSeccompSetupInitContainer(image string) corev1.Container {
 	return corev1.Container{
 		Name:  "host-profiler-seccomp-setup",
-		Image: images.GetLatestAgentImage(),
+		Image: image,
 		Command: []string{
 			"cp",
 			fmt.Sprintf("%s/%s", securityVolumePath, seccompKey),


### PR DESCRIPTION
## What changed

The host-profiler seccomp setup init container now uses the image from the already-created host-profiler container instead of calling `images.GetLatestAgentImage()` directly.

## Why

The host-profiler container image has already gone through the normal node-agent image resolution flow by the time `ManageNodeAgent` runs. That includes global registry and FIPS handling from `global.ApplyGlobalSettingsNodeAgent` / `updateContainerImages`.

Using `images.GetLatestAgentImage()` for the init container bypassed that resolved image and could make the pod reference a different Agent image than the host-profiler container. In practice, that can force nodes to pull the large Agent image more than once when registry/FIPS/global image settings rewrite the main container image but not this feature-added init container.

Reusing the resolved host-profiler image keeps the init container aligned with the main container and avoids extra image pulls for equivalent Agent content.

## Validation

```bash
go test ./internal/controller/datadogagent/feature/hostprofiler ./internal/controller/datadogagent/component/agent ./internal/controller/datadogagent/feature/test ./internal/controller/datadogagentinternal
```