### PR TITLE
Align OTel collector config mount with Helm

### DIFF
--- a/internal/controller/datadogagent/feature/otelcollector/configmap_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/configmap_test.go
@@ -20,7 +20,7 @@ func Test_buildOtelCollectorConfigMap(t *testing.T) {
 	// check config map
 	configMapWant := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "-otel-agent-config",
+			Name: "-otel-config",
 			Annotations: map[string]string{
 				"checksum/otel_agent-custom-config": "8e715f9526c27c6cd06ba9a9d8913451",
 			},
@@ -34,9 +34,9 @@ func Test_buildOtelCollectorConfigMap(t *testing.T) {
 	assert.True(t, ok)
 
 	otelCollectorFeature.owner = &metav1.ObjectMeta{
-		Name: "-otel-agent-config",
+		Name: "-otel-config",
 	}
-	otelCollectorFeature.configMapName = "-otel-agent-config"
+	otelCollectorFeature.configMapName = "-otel-config"
 	otelCollectorFeature.customConfig = &v2alpha1.CustomConfig{}
 	otelCollectorFeature.customConfig.ConfigData = &defaultconfig.DefaultOtelCollectorConfig
 
@@ -52,7 +52,7 @@ func Test_buildOtelCollectorConfigMapWithGateway(t *testing.T) {
 	// check config map with gateway enabled
 	configMapWant := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: ddaName + "-otel-agent-config",
+			Name: ddaName + "-otel-config",
 			Annotations: map[string]string{
 				"checksum/otel_agent-custom-config": "9a9429a6e4d1662ef90e6e84b6416fa6",
 			},
@@ -68,7 +68,7 @@ func Test_buildOtelCollectorConfigMapWithGateway(t *testing.T) {
 	otelCollectorFeature.owner = &metav1.ObjectMeta{
 		Name: ddaName,
 	}
-	otelCollectorFeature.configMapName = ddaName + "-otel-agent-config"
+	otelCollectorFeature.configMapName = ddaName + "-otel-config"
 	otelCollectorFeature.customConfig = &v2alpha1.CustomConfig{}
 	otelCollectorFeature.customConfig.ConfigData = &gatewayConfig
 	otelCollectorFeature.otelGatewayEnabled = true

--- a/internal/controller/datadogagent/feature/otelcollector/const.go
+++ b/internal/controller/datadogagent/feature/otelcollector/const.go
@@ -6,8 +6,9 @@
 package otelcollector
 
 const (
-	otelAgentVolumeName = "otel-agent-config-volume"
+	otelAgentVolumeName = "otelconfig"
 	otelConfigFileName  = "otel-config.yaml"
+	otelConfigPath      = "/etc/otel-agent"
 	// DefaultOTelAgentConf default otel agent ConfigMap name
-	defaultOTelAgentConf string = "otel-agent-config"
+	defaultOTelAgentConf string = "otel-config"
 )

--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -299,11 +299,12 @@ func (o *otelCollectorFeature) ManageNodeAgent(managers feature.PodTemplateManag
 	commands := []string{}
 	if o.customConfig != nil && o.customConfig.ConfigMap != nil && len(o.customConfig.ConfigMap.Items) > 0 {
 		for _, item := range o.customConfig.ConfigMap.Items {
-			commands = append(commands, common.ConfigVolumePath+"/otel/"+item.Path)
+			commands = append(commands, otelConfigPath+"/"+item.Path)
 		}
 		volMount := corev1.VolumeMount{
 			Name:      otelAgentVolumeName,
-			MountPath: common.ConfigVolumePath + "/otel/",
+			MountPath: otelConfigPath,
+			ReadOnly:  true,
 		}
 		managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.OtelAgent)
 
@@ -312,8 +313,12 @@ func (o *otelCollectorFeature) ManageNodeAgent(managers feature.PodTemplateManag
 		// - no conf.ConfigMap.Items provided, but conf.ConfigMap.Name provided. We assume only one item/ name otel-config.yaml
 		// - when configData is used
 		// - when no config is passed (we use DefaultOtelCollectorConfig)
-		commands = append(commands, common.ConfigVolumePath+"/"+otelConfigFileName)
-		volMount := volume.GetVolumeMountWithSubPath(otelAgentVolumeName, common.ConfigVolumePath+"/"+otelConfigFileName, otelConfigFileName)
+		commands = append(commands, otelConfigPath+"/"+otelConfigFileName)
+		volMount := corev1.VolumeMount{
+			Name:      otelAgentVolumeName,
+			MountPath: otelConfigPath,
+			ReadOnly:  true,
+		}
 		managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.OtelAgent)
 	}
 

--- a/internal/controller/datadogagent/feature/otelcollector/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature_test.go
@@ -48,7 +48,7 @@ var (
 		httpPort: 4318,
 		grpcPort: 4317,
 	}
-	defaultLocalObjectReferenceName = "-otel-agent-config"
+	defaultLocalObjectReferenceName = "-otel-config"
 	defaultExpectedEnvVars          = expectedEnvVars{
 		agent_ipc_port: expectedEnvVar{
 			present: true,
@@ -88,8 +88,7 @@ var (
 	defaultVolumeMounts = []corev1.VolumeMount{
 		{
 			Name:      otelAgentVolumeName,
-			MountPath: common.ConfigVolumePath + "/" + otelConfigFileName,
-			SubPath:   otelConfigFileName,
+			MountPath: otelConfigPath,
 			ReadOnly:  true,
 		},
 	}
@@ -161,7 +160,8 @@ func Test_otelCollectorFeature_Configure(t *testing.T) {
 			Agent: testExpectedAgent(apicommon.OtelAgent, defaultExpectedPorts, defaultExpectedEnvVars, map[string]string{}, []corev1.VolumeMount{
 				{
 					Name:      otelAgentVolumeName,
-					MountPath: common.ConfigVolumePath + "/otel/",
+					MountPath: otelConfigPath,
+					ReadOnly:  true,
 				},
 			},
 				[]corev1.Volume{
@@ -489,12 +489,48 @@ func testExpectedAgent(
 	expectedAnnotations map[string]string,
 	expectedVolumeMount []corev1.VolumeMount,
 	expectedVolume []corev1.Volume) *test.ComponentTest {
-	return test.NewDefaultComponentTest().WithWantFunc(
+	return test.NewDefaultComponentTest().WithCreateFunc(
+		func(t testing.TB) (feature.PodTemplateManagers, string) {
+			newPTS := corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    string(apicommon.CoreAgentContainerName),
+							Image:   images.GetLatestAgentImage(),
+							Command: []string{"agent", "run"},
+						},
+						{
+							Name:    string(apicommon.OtelAgent),
+							Image:   images.GetLatestAgentImage(),
+							Command: []string{"otel-agent"},
+						},
+					},
+				},
+			}
+			return fake.NewPodTemplateManagers(t, newPTS), kubernetes.DefaultProvider
+		},
+	).WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
 
 			agentMounts := mgr.VolumeMountMgr.VolumeMountsByC[agentContainerName]
 			assert.True(t, apiutils.IsEqualStruct(agentMounts, expectedVolumeMount), "%s volume mounts \ndiff = %s", agentContainerName, cmp.Diff(agentMounts, expectedVolumeMount))
+
+			expectedArgs := []string{"--config=" + otelConfigPath + "/" + otelConfigFileName}
+			if len(expectedVolume) > 0 && expectedVolume[0].ConfigMap != nil && len(expectedVolume[0].ConfigMap.Items) > 0 {
+				expectedArgs = nil
+				for _, item := range expectedVolume[0].ConfigMap.Items {
+					expectedArgs = append(expectedArgs, "--config="+otelConfigPath+"/"+item.Path)
+				}
+			}
+			foundContainer := false
+			for _, container := range mgr.PodTemplateSpec().Spec.Containers {
+				if container.Name == string(agentContainerName) {
+					foundContainer = true
+					assert.Equal(t, expectedArgs, container.Args)
+				}
+			}
+			assert.True(t, foundContainer, "expected container %s to be present", agentContainerName)
 
 			volumes := mgr.VolumeMgr.Volumes
 			assert.True(t, apiutils.IsEqualStruct(volumes, expectedVolume), "Volumes \ndiff = %s", cmp.Diff(volumes, expectedVolume))
@@ -606,17 +642,17 @@ func testExpectedDepsCreatedCM(t testing.TB, store store.StoreClient) {
 	// modifying WantDependenciesFunc definition.
 	if t.Name() == "Test_otelCollectorFeature_Configure/otel_agent_enabled_with_configMap" {
 		// configMap is provided by user, no need to create it.
-		_, found := store.Get(kubernetes.ConfigMapKind, "", "-otel-agent-config")
+		_, found := store.Get(kubernetes.ConfigMapKind, "", "-otel-config")
 		assert.False(t, found)
 		return
 	}
 	if t.Name() == "Test_otelCollectorFeature_Configure/otel_agent_enabled_with_configMap_multi_items" {
 		// configMap is provided by user, no need to create it.
-		_, found := store.Get(kubernetes.ConfigMapKind, "", "-otel-agent-config")
+		_, found := store.Get(kubernetes.ConfigMapKind, "", "-otel-config")
 		assert.False(t, found)
 		return
 	}
-	configMapObject, found := store.Get(kubernetes.ConfigMapKind, "", "-otel-agent-config")
+	configMapObject, found := store.Get(kubernetes.ConfigMapKind, "", "-otel-config")
 	assert.True(t, found)
 
 	configMap := configMapObject.(*corev1.ConfigMap)


### PR DESCRIPTION
### What does this PR do?

Aligns the operator-managed OTel Collector config mount with the Datadog Helm chart defaults.

This updates the node-agent OTel collector feature to:
- mount the OTel config volume at `/etc/otel-agent`
- pass `--config=/etc/otel-agent/otel-config.yaml` or `--config=/etc/otel-agent/<item.path>`
- use the Helm-style volume name `otelconfig`
- use the Helm-style generated ConfigMap suffix `-otel-config`

User-provided `features.otelCollector.conf.configMap.name` values are still honored as-is.

### Motivation

The Helm chart mounts `otel-config.yaml` under `/etc/otel-agent`, while the operator previously mounted the standalone OTel config under `/etc/datadog-agent`. Matching Helm keeps the generated Kubernetes resources consistent across installation methods and avoids unnecessary differences in the `otel-agent` config path (also matching the required allowlist for GKE Autopilot)

### Additional Notes

The OTel Agent Gateway config path is not changed in this PR; this only updates the DaemonSet/node-agent OTel collector config handled by `features.otelCollector`.

### Minimum Agent Versions

No new minimum versions introduced by this change.

* Agent: existing OTel Agent minimum applies
* Cluster Agent: N/A

### Describe your test plan

```bash
go test ./internal/controller/datadogagent/feature/otelcollector
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits