### PR TITLE
fix(dogstatsd): always set DSD environment variables on Core Agent container

### DIFF
--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -191,27 +191,19 @@ func (f *dogstatsdFeature) ManageSingleContainerNodeAgent(managers feature.PodTe
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
-	// When the Data Plane feature is enabled, and handling DogStatsD, we apply the DSD configuration to the Data Plane
-	// container instead. On Agent >= 7.75, the Core Agent observes DD_DATA_PLANE_ENABLED and
-	// DD_DATA_PLANE_DOGSTATSD_ENABLED (set by the dataplane feature) and disables its own DSD server
-	// automatically. On older agents those flags are unknown, so we set DD_USE_DOGSTATSD=false
-	// explicitly to prevent a bind conflict between Core Agent DSD and ADP DSD.
-	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled {
-		f.manageNodeAgent(apicommon.AgentDataPlaneContainerName, managers, provider)
-		if !f.agentSupportsADPDelegation {
-			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
-				Name:  common.DDDogstatsdEnabled,
-				Value: "false",
-			})
-		}
-	} else {
-		f.manageNodeAgent(apicommon.CoreAgentContainerName, managers, provider)
+	// When the Data Plane feature is enabled, and handling DogStatsD, we must ensure that the Core Agent does not also
+	// try to handle DogStatsD, as it would cause a bind conflict.
+	//
+	// On Agent >= 7.75, the Core Agent observes `DD_DATA_PLANE_ENABLED` and `DD_DATA_PLANE_DOGSTATSD_ENABLED` (set by
+	// the dataplane feature) and disables its own DSD server automatically. On older agents those flags are unknown, so
+	// we set `DD_USE_DOGSTATSD` to `false` explicitly to prevent a bind conflict between Core Agent DSD and ADP DSD.
+	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled && !f.agentSupportsADPDelegation {
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+			Name:  common.DDDogstatsdEnabled,
+			Value: "false",
+		})
 	}
 
-	return nil
-}
-
-func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentContainerName, managers feature.PodTemplateManagers, provider string) error {
 	// udp
 	dogstatsdPort := &corev1.ContainerPort{
 		Name:          defaultDogstatsdPortName,
@@ -230,17 +222,17 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 				dsdPortEnvVarValue = int(f.hostPortHostPort)
 			}
 		}
-		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 			// defaults to 8125 in datadog-agent code
 			Name:  DDDogstatsdPort,
 			Value: strconv.Itoa(dsdPortEnvVarValue),
 		})
 	}
-	managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 		Name:  DDDogstatsdNonLocalTraffic,
 		Value: strconv.FormatBool(f.nonLocalTraffic),
 	})
-	managers.Port().AddPortToContainer(agentContainerName, dogstatsdPort)
+	managers.Port().AddPortToContainer(apicommon.CoreAgentContainerName, dogstatsdPort)
 
 	// uds
 	if f.udsEnabled {
@@ -250,7 +242,7 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
 
 		socketVol.VolumeSource.HostPath.Type = &volType
-		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, apicommon.CoreAgentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
 		managers.Volume().AddVolume(&socketVol)
 		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
 			Name:  DDDogstatsdSocket,
@@ -259,11 +251,11 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 	}
 
 	if f.originDetectionEnabled {
-		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 			Name:  DDDogstatsdOriginDetection,
 			Value: "true",
 		})
-		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 			Name:  DDDogstatsdOriginDetectionClient,
 			Value: "true",
 		})
@@ -273,7 +265,7 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 		// Tag cardinality is only configured if origin detection is enabled.
 		// The value validation happens at the Agent level - if the lower(string) is not `low`, `orchestrator` or `high`, the Agent defaults to `low`.
 		if f.tagCardinality != "" {
-			managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 				Name:  DDDogstatsdTagCardinality,
 				Value: f.tagCardinality,
 			})
@@ -284,7 +276,7 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 	if f.mapperProfiles != nil {
 		// configdata
 		if f.mapperProfiles.ConfigData != nil {
-			managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 				Name:  DDDogstatsdMapperProfiles,
 				Value: apiutils.YAMLToJSONString(*f.mapperProfiles.ConfigData),
 			})
@@ -296,7 +288,7 @@ func (f *dogstatsdFeature) manageNodeAgent(agentContainerName apicommon.AgentCon
 			cmSelector := corev1.ConfigMapKeySelector{}
 			cmSelector.Name = f.mapperProfiles.ConfigMap.Name
 			cmSelector.Key = f.mapperProfiles.ConfigMap.Items[0].Key
-			managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
 				Name:      DDDogstatsdMapperProfiles,
 				ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &cmSelector},
 			})

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -179,18 +179,17 @@ func (f *dogstatsdFeature) ManageClusterAgent(managers feature.PodTemplateManage
 // It should do nothing if the feature doesn't need to configure it.
 func (f *dogstatsdFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers, provider string) error {
 	f.manageNodeAgent(apicommon.UnprivilegedSingleAgentContainerName, managers, provider)
-	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled && !f.agentSupportsADPDelegation {
-		managers.EnvVar().AddEnvVarToContainer(apicommon.UnprivilegedSingleAgentContainerName, &corev1.EnvVar{
-			Name:  common.DDDogstatsdEnabled,
-			Value: "false",
-		})
-	}
 	return nil
 }
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers, provider string) error {
+	f.manageNodeAgent(apicommon.CoreAgentContainerName, managers, provider)
+	return nil
+}
+
+func (f *dogstatsdFeature) manageNodeAgent(containerName apicommon.AgentContainerName, managers feature.PodTemplateManagers, provider string) error {
 	// When the Data Plane feature is enabled, and handling DogStatsD, we must ensure that the Core Agent does not also
 	// try to handle DogStatsD, as it would cause a bind conflict.
 	//
@@ -198,7 +197,7 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 	// the dataplane feature) and disables its own DSD server automatically. On older agents those flags are unknown, so
 	// we set `DD_USE_DOGSTATSD` to `false` explicitly to prevent a bind conflict between Core Agent DSD and ADP DSD.
 	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled && !f.agentSupportsADPDelegation {
-		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 			Name:  common.DDDogstatsdEnabled,
 			Value: "false",
 		})
@@ -222,17 +221,17 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 				dsdPortEnvVarValue = int(f.hostPortHostPort)
 			}
 		}
-		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 			// defaults to 8125 in datadog-agent code
 			Name:  DDDogstatsdPort,
 			Value: strconv.Itoa(dsdPortEnvVarValue),
 		})
 	}
-	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+	managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 		Name:  DDDogstatsdNonLocalTraffic,
 		Value: strconv.FormatBool(f.nonLocalTraffic),
 	})
-	managers.Port().AddPortToContainer(apicommon.CoreAgentContainerName, dogstatsdPort)
+	managers.Port().AddPortToContainer(containerName, dogstatsdPort)
 
 	// uds
 	if f.udsEnabled {
@@ -242,7 +241,7 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
 
 		socketVol.VolumeSource.HostPath.Type = &volType
-		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, apicommon.CoreAgentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
+		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, containerName, merger.OverrideCurrentVolumeMountMergeFunction)
 		managers.Volume().AddVolume(&socketVol)
 		managers.EnvVar().AddEnvVar(&corev1.EnvVar{
 			Name:  DDDogstatsdSocket,
@@ -251,11 +250,11 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 	}
 
 	if f.originDetectionEnabled {
-		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 			Name:  DDDogstatsdOriginDetection,
 			Value: "true",
 		})
-		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+		managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 			Name:  DDDogstatsdOriginDetectionClient,
 			Value: "true",
 		})
@@ -265,7 +264,7 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 		// Tag cardinality is only configured if origin detection is enabled.
 		// The value validation happens at the Agent level - if the lower(string) is not `low`, `orchestrator` or `high`, the Agent defaults to `low`.
 		if f.tagCardinality != "" {
-			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+			managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 				Name:  DDDogstatsdTagCardinality,
 				Value: f.tagCardinality,
 			})
@@ -276,7 +275,7 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 	if f.mapperProfiles != nil {
 		// configdata
 		if f.mapperProfiles.ConfigData != nil {
-			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+			managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 				Name:  DDDogstatsdMapperProfiles,
 				Value: apiutils.YAMLToJSONString(*f.mapperProfiles.ConfigData),
 			})
@@ -288,7 +287,7 @@ func (f *dogstatsdFeature) ManageNodeAgent(managers feature.PodTemplateManagers,
 			cmSelector := corev1.ConfigMapKeySelector{}
 			cmSelector.Name = f.mapperProfiles.ConfigMap.Name
 			cmSelector.Key = f.mapperProfiles.ConfigMap.Items[0].Key
-			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+			managers.EnvVar().AddEnvVarToContainer(containerName, &corev1.EnvVar{
 				Name:      DDDogstatsdMapperProfiles,
 				ValueFrom: &corev1.EnvVarSource{ConfigMapKeyRef: &cmSelector},
 			})

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -231,7 +231,13 @@ func (f *dogstatsdFeature) manageNodeAgent(containerName apicommon.AgentContaine
 		Name:  DDDogstatsdNonLocalTraffic,
 		Value: strconv.FormatBool(f.nonLocalTraffic),
 	})
-	managers.Port().AddPortToContainer(containerName, dogstatsdPort)
+	// When ADP is handling DogStatsD, the UDP port binding must go to the ADP container so that
+	// ADP binds port 8125 (and owns the HostPort). The Core Agent must not bind it to avoid conflicts.
+	portContainerName := containerName
+	if f.dataPlaneEnabled && f.dataPlaneDogstatsdEnabled {
+		portContainerName = apicommon.AgentDataPlaneContainerName
+	}
+	managers.Port().AddPortToContainer(portContainerName, dogstatsdPort)
 
 	// uds
 	if f.udsEnabled {

--- a/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
@@ -507,6 +507,26 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				},
 			),
 		},
+		{
+			Name: "data plane + dogstatsd + host port enabled - UDP port binding on ADP container, not Core Agent",
+			DDA: testutils.NewDefaultDatadogAgentBuilder().
+				WithDataPlaneEnabled(true).
+				WithDataPlaneDogstatsdEnabled(true).
+				WithDogstatsdHostPortEnabled(true).
+				BuildWithDefaults(),
+			WantConfigure: true,
+			Agent: test.NewDefaultComponentTest().WithWantFunc(
+				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+					mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+					adpPorts := mgr.PortMgr.PortsByC[apicommon.AgentDataPlaneContainerName]
+					assert.NotEmpty(t, adpPorts, "ADP container should have the DSD UDP port binding when ADP handles DogStatsD")
+
+					coreAgentPorts := mgr.PortMgr.PortsByC[apicommon.CoreAgentContainerName]
+					assert.Empty(t, coreAgentPorts, "Core Agent container should NOT have the DSD UDP port binding when ADP handles DogStatsD")
+				},
+			),
+		},
 	}
 
 	tests.Run(t, buildDogstatsdFeature)

--- a/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
@@ -392,9 +392,9 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 
-					// Verify DogStatsD config is applied to ADP container
-					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AgentDataPlaneContainerName]
-					assert.NotEmpty(t, adpEnvVars, "ADP container should have DogStatsD env vars")
+					// Verify DogStatsD config is applied to Core Agent container
+					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+					assert.NotEmpty(t, adpEnvVars, "Core Agent container should have DogStatsD env vars")
 				},
 			),
 		},
@@ -409,8 +409,8 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 
 					// Verify DogStatsD config is applied to ADP container
-					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AgentDataPlaneContainerName]
-					assert.NotEmpty(t, adpEnvVars, "ADP container should have DogStatsD env vars when dogstatsd defaults to enabled")
+					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+					assert.NotEmpty(t, adpEnvVars, "Core Agent container should have DogStatsD env vars when dogstatsd defaults to enabled")
 				},
 			),
 		},
@@ -425,9 +425,9 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 					mgr := mgrInterface.(*fake.PodTemplateManagers)
 
-					// Verify DogStatsD config is applied to ADP container
-					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.AgentDataPlaneContainerName]
-					assert.NotEmpty(t, adpEnvVars, "ADP container should have DogStatsD env vars")
+					// Verify DogStatsD config is applied to Core Agent container
+					adpEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+					assert.NotEmpty(t, adpEnvVars, "Core Agent container should have DogStatsD env vars")
 				},
 			),
 		},


### PR DESCRIPTION
### What does this PR do?

This PR updates the `dogstatsd` feature to set the relevant DSD-specific environment variables on the Core Agent container whether or not ADP is enabled.

### Motivation

Originally, based on how ADP worked, we needed to do the conditional split: add DSD settings directly on the ADP container when enabled. However, with ADP 1.0.0, this has changed: Core Agent authoritatively provides configuration to ADP, and so we want all configuration to be provided to the Core Agent, which then provides it to ADP.

As such, we need to move these environment variables back to the Core Agent container to ensure they flow to ADP as intended.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

To be updated.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits