### PR TITLE
Undefined CLC Replica Count Remains Undefined

### DIFF
--- a/internal/controller/datadogagent/component/clusterchecksrunner/const.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/const.go
@@ -7,6 +7,4 @@ package clusterchecksrunner
 
 const (
 	pdbMaxUnavailableInstances = 1
-	// DefaultClusterChecksRunnerReplicas default cluster checks runner deployment replicas
-	defaultClusterChecksRunnerReplicas int32 = 1
 )

--- a/internal/controller/datadogagent/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default.go
@@ -47,7 +47,6 @@ func NewDefaultClusterChecksRunnerDeployment(dda metav1.Object, ddaSpec *v2alpha
 	maps.Copy(podTemplate.Annotations, deployment.GetAnnotations())
 
 	deployment.Spec.Template = *podTemplate
-	deployment.Spec.Replicas = ptr.To(defaultClusterChecksRunnerReplicas)
 
 	return deployment
 }


### PR DESCRIPTION
### What does this PR do?

When the replica count for the CLC deployment is undefined, no longer use the default value of 1, instead leave it undefined. The API server will implicitly set this value to 1. This allows for smoother controls with external autoscalers which recommend the replica count being undefined and letting it control the count completely.

### Describe your test plan

You should see 1 CLC runner

```
  apiVersion: datadoghq.com/v2alpha1
  kind: DatadogAgent                                                                                                                                  
  metadata:
    name: datadog                                                                                                                                     
    namespace: system                                                                                                                               
  spec:                                                                                                       
    features:
      clusterChecks:                                                                                                                                  
        enabled: true                                                                                                                               
        useClusterChecksRunners: true
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits