### PR TITLE
[CONTP-1589] Add DDGR force sync period configuration

### DIFF
--- a/docs/datadog_generic_resource.md
+++ b/docs/datadog_generic_resource.md
@@ -77,6 +77,8 @@ To deploy a `DatadogGenericResource` with the Datadog Operator, follow the steps
       helm install datadog-operator datadog/datadog-operator -f values.yaml
       ```
 
+   By default, the Operator only watches its own namespace, so it will manage any `DatadogGenericResource` objects within its own namespace. To deploy `DatadogGenericResource` objects in other namespaces, configure the Operator [`watchNamespaces`][3] section with those namespaces. The DDGR controller can also be scoped independently with the `DD_GENERIC_RESOURCE_WATCH_NAMESPACE` environment variable, which takes a comma-separated list of namespaces and falls back to `WATCH_NAMESPACE` when unset.
+
 3. Create a file with the spec of your `DatadogGenericResource` configuration. An example configuration is:
     ```yaml
     apiVersion: datadoghq.com/v1alpha1
@@ -153,6 +155,8 @@ To deploy a `DatadogGenericResource` with the Datadog Operator, follow the steps
     ```
 
 Further example manifests are provided [in the supported resources table](#supported-resources).
+
+By default, the Operator ensures that the API resource definition stays in sync with the `DatadogGenericResource` every **60** minutes (per resource). This interval can be adjusted using the environment variable `DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD`, which specifies the number of minutes. For example, setting this variable to `"30"` changes the interval to 30 minutes.
 
 
 ## Comparison with existing CRDs

--- a/internal/controller/datadoggenericresource/controller.go
+++ b/internal/controller/datadoggenericresource/controller.go
@@ -3,6 +3,8 @@ package datadoggenericresource
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,30 +31,56 @@ import (
 )
 
 const (
-	defaultRequeuePeriod       = 60 * time.Second
-	defaultErrRequeuePeriod    = 5 * time.Second
-	defaultForceSyncPeriod     = 60 * time.Minute
-	datadogGenericResourceKind = "DatadogGenericResource"
+	defaultRequeuePeriod                   = 60 * time.Second
+	defaultErrRequeuePeriod                = 5 * time.Second
+	defaultForceSyncPeriod                 = 60 * time.Minute
+	datadogGenericResourceKind             = "DatadogGenericResource"
+	DDGenericResourceForceSyncPeriodEnvVar = "DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD"
 )
 
 type Reconciler struct {
-	client       client.Client
-	credsManager *config.CredentialManager
-	handlers     map[v1alpha1.SupportedResourcesType]ResourceHandler
-	scheme       *runtime.Scheme
-	log          logr.Logger
-	recorder     record.EventRecorder
+	client          client.Client
+	credsManager    *config.CredentialManager
+	handlers        map[v1alpha1.SupportedResourcesType]ResourceHandler
+	forceSyncPeriod *time.Duration
+	scheme          *runtime.Scheme
+	log             logr.Logger
+	recorder        record.EventRecorder
 }
 
 func NewReconciler(client client.Client, credsManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) *Reconciler {
 	return &Reconciler{
-		client:       client,
-		credsManager: credsManager,
-		handlers:     buildHandlers(datadogclient.InitGenericClients()),
-		scheme:       scheme,
-		log:          log,
-		recorder:     recorder,
+		client:          client,
+		credsManager:    credsManager,
+		handlers:        buildHandlers(datadogclient.InitGenericClients()),
+		forceSyncPeriod: forceSyncPeriodFromEnv(log),
+		scheme:          scheme,
+		log:             log,
+		recorder:        recorder,
 	}
+}
+
+func forceSyncPeriodFromEnv(logger logr.Logger) *time.Duration {
+	forceSyncPeriod := defaultForceSyncPeriod
+
+	if userForceSyncPeriod, ok := os.LookupEnv(DDGenericResourceForceSyncPeriodEnvVar); ok {
+		forceSyncPeriodInt, err := strconv.Atoi(userForceSyncPeriod)
+		if err != nil {
+			logger.Error(err, "Invalid value for generic resource force sync period. Defaulting to 60 minutes.")
+		} else {
+			forceSyncPeriod = time.Duration(forceSyncPeriodInt) * time.Minute
+		}
+	}
+
+	logger.Info("Setting generic resource force sync period", "minutes", int(forceSyncPeriod.Minutes()))
+	return &forceSyncPeriod
+}
+
+func (r *Reconciler) getForceSyncPeriod() time.Duration {
+	if r.forceSyncPeriod == nil {
+		return defaultForceSyncPeriod
+	}
+	return *r.forceSyncPeriod
 }
 
 func (r *Reconciler) getHandler(resourceType v1alpha1.SupportedResourcesType) ResourceHandler {
@@ -73,6 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogGe
 	}
 
 	now := metav1.NewTime(time.Now())
+	forceSyncPeriod := r.getForceSyncPeriod()
 
 	var result ctrl.Result
 	var err error
@@ -103,7 +132,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogGe
 		if instanceSpecHash != statusSpecHash {
 			logger.Info("DatadogGenericResource manifest has changed")
 			shouldUpdate = true
-		} else if instance.Status.LastForceSyncTime == nil || ((defaultForceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
+		} else if instance.Status.LastForceSyncTime == nil || ((forceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
 			// Periodically force a sync with the API to ensure parity
 			// Make sure it exists before trying any updates. If it doesn't, set shouldCreate
 			err = handler.getResource(auth, instance)

--- a/internal/controller/datadoggenericresource/controller.go
+++ b/internal/controller/datadoggenericresource/controller.go
@@ -35,14 +35,14 @@ const (
 	defaultErrRequeuePeriod                = 5 * time.Second
 	defaultForceSyncPeriod                 = 60 * time.Minute
 	datadogGenericResourceKind             = "DatadogGenericResource"
-	DDGenericResourceForceSyncPeriodEnvVar = "DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD"
+	ddGenericResourceForceSyncPeriodEnvVar = "DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD"
 )
 
 type Reconciler struct {
 	client          client.Client
 	credsManager    *config.CredentialManager
 	handlers        map[v1alpha1.SupportedResourcesType]ResourceHandler
-	forceSyncPeriod *time.Duration
+	forceSyncPeriod time.Duration
 	scheme          *runtime.Scheme
 	log             logr.Logger
 	recorder        record.EventRecorder
@@ -60,27 +60,22 @@ func NewReconciler(client client.Client, credsManager *config.CredentialManager,
 	}
 }
 
-func forceSyncPeriodFromEnv(logger logr.Logger) *time.Duration {
+func forceSyncPeriodFromEnv(logger logr.Logger) time.Duration {
 	forceSyncPeriod := defaultForceSyncPeriod
 
-	if userForceSyncPeriod, ok := os.LookupEnv(DDGenericResourceForceSyncPeriodEnvVar); ok {
+	if userForceSyncPeriod, ok := os.LookupEnv(ddGenericResourceForceSyncPeriodEnvVar); ok {
 		forceSyncPeriodInt, err := strconv.Atoi(userForceSyncPeriod)
 		if err != nil {
 			logger.Error(err, "Invalid value for generic resource force sync period. Defaulting to 60 minutes.")
+		} else if forceSyncPeriodInt < 1 {
+			logger.Error(fmt.Errorf("force sync period must be at least 1 minute"), "Invalid value for generic resource force sync period. Defaulting to 60 minutes.")
 		} else {
 			forceSyncPeriod = time.Duration(forceSyncPeriodInt) * time.Minute
 		}
 	}
 
 	logger.Info("Setting generic resource force sync period", "minutes", int(forceSyncPeriod.Minutes()))
-	return &forceSyncPeriod
-}
-
-func (r *Reconciler) getForceSyncPeriod() time.Duration {
-	if r.forceSyncPeriod == nil {
-		return defaultForceSyncPeriod
-	}
-	return *r.forceSyncPeriod
+	return forceSyncPeriod
 }
 
 func (r *Reconciler) getHandler(resourceType v1alpha1.SupportedResourcesType) ResourceHandler {
@@ -101,7 +96,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogGe
 	}
 
 	now := metav1.NewTime(time.Now())
-	forceSyncPeriod := r.getForceSyncPeriod()
 
 	var result ctrl.Result
 	var err error
@@ -132,7 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogGe
 		if instanceSpecHash != statusSpecHash {
 			logger.Info("DatadogGenericResource manifest has changed")
 			shouldUpdate = true
-		} else if instance.Status.LastForceSyncTime == nil || ((forceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
+		} else if instance.Status.LastForceSyncTime == nil || ((r.forceSyncPeriod - now.Sub(instance.Status.LastForceSyncTime.Time)) <= 0) {
 			// Periodically force a sync with the API to ensure parity
 			// Make sure it exists before trying any updates. If it doesn't, set shouldCreate
 			err = handler.getResource(auth, instance)

--- a/internal/controller/datadoggenericresource/controller_test.go
+++ b/internal/controller/datadoggenericresource/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/stretchr/testify/assert"
@@ -197,9 +198,10 @@ func TestReconcileGenericResource_Reconcile(t *testing.T) {
 				handlers: map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
 					mockSubresource: &MockHandler{},
 				},
-				scheme:   s,
-				recorder: recorder,
-				log:      logf.Log.WithName(tt.name),
+				forceSyncPeriod: defaultForceSyncPeriod,
+				scheme:          s,
+				recorder:        recorder,
+				log:             logf.Log.WithName(tt.name),
 			}
 
 			// First action
@@ -245,14 +247,54 @@ func TestReconcileGenericResource_Reconcile(t *testing.T) {
 	}
 }
 
-func TestReconcileGenericResource_ForceSyncPeriodFromEnv(t *testing.T) {
+func TestForceSyncPeriodFromEnv(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	logger := logf.Log.WithName("force-sync-period-test")
+
+	tests := []struct {
+		name     string
+		envValue string
+		want     time.Duration
+	}{
+		{
+			name:     "valid value",
+			envValue: "1",
+			want:     time.Minute,
+		},
+		{
+			name:     "invalid string falls back to default",
+			envValue: "abc",
+			want:     defaultForceSyncPeriod,
+		},
+		{
+			name:     "zero falls back to default",
+			envValue: "0",
+			want:     defaultForceSyncPeriod,
+		},
+		{
+			name:     "negative value falls back to default",
+			envValue: "-1",
+			want:     defaultForceSyncPeriod,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(ddGenericResourceForceSyncPeriodEnvVar, tt.envValue)
+
+			assert.Equal(t, tt.want, forceSyncPeriodFromEnv(logger))
+		})
+	}
+}
+
+func TestReconcileGenericResource_ForceSyncPeriodTriggersRemoteUpdate(t *testing.T) {
 	resetMockHandlerState()
 	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
 	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
-	t.Setenv(DDGenericResourceForceSyncPeriodEnvVar, "0")
+	forceSyncPeriod := time.Minute
 
 	eventBroadcaster := record.NewBroadcaster()
-	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileGenericResource_ForceSyncPeriodFromEnv"})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileGenericResource_ForceSyncPeriodTriggersRemoteUpdate"})
 
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	logger := logf.Log.WithName("force-sync-period-test")
@@ -266,7 +308,7 @@ func TestReconcileGenericResource_ForceSyncPeriodFromEnv(t *testing.T) {
 		handlers: map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
 			mockSubresource: &MockHandler{},
 		},
-		forceSyncPeriod: forceSyncPeriodFromEnv(logger),
+		forceSyncPeriod: forceSyncPeriod,
 		scheme:          s,
 		recorder:        recorder,
 		log:             logger,
@@ -289,8 +331,16 @@ func TestReconcileGenericResource_ForceSyncPeriodFromEnv(t *testing.T) {
 	assert.Equal(t, 0, mockGetCalls)
 	assert.Equal(t, 0, mockUpdateCalls)
 
-	// With DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD=0, the next reconcile should
-	// force a remote get and update even though the spec hash is unchanged.
+	obj := &datadoghqv1alpha1.DatadogGenericResource{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, obj)
+	assert.NoError(t, err)
+	lastForceSyncTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	obj.Status.LastForceSyncTime = &lastForceSyncTime
+	err = r.client.Status().Update(context.TODO(), obj)
+	assert.NoError(t, err)
+
+	// Once the configured force-sync period has elapsed, the next reconcile
+	// should force a remote get and update even though the spec hash is unchanged.
 	result, err = reconcileRequest(r, context.TODO(), req)
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{RequeueAfter: defaultRequeuePeriod}, result)

--- a/internal/controller/datadoggenericresource/controller_test.go
+++ b/internal/controller/datadoggenericresource/controller_test.go
@@ -191,17 +191,16 @@ func TestReconcileGenericResource_Reconcile(t *testing.T) {
 			defer os.Unsetenv("DD_API_KEY")
 			defer os.Unsetenv("DD_APP_KEY")
 
-			// Set up — use mock handler builder so tests don't hit real APIs
-			r := &Reconciler{
-				client:       fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build(),
-				credsManager: config.NewCredentialManager(fake.NewClientBuilder().Build()),
-				handlers: map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
-					mockSubresource: &MockHandler{},
-				},
-				forceSyncPeriod: defaultForceSyncPeriod,
-				scheme:          s,
-				recorder:        recorder,
-				log:             logf.Log.WithName(tt.name),
+			// Use mock handlers so tests don't hit real APIs.
+			r := NewReconciler(
+				fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build(),
+				config.NewCredentialManager(fake.NewClientBuilder().Build()),
+				s,
+				logf.Log.WithName(tt.name),
+				recorder,
+			)
+			r.handlers = map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
+				mockSubresource: &MockHandler{},
 			}
 
 			// First action
@@ -291,7 +290,7 @@ func TestReconcileGenericResource_ForceSyncPeriodTriggersRemoteUpdate(t *testing
 	resetMockHandlerState()
 	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
 	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
-	forceSyncPeriod := time.Minute
+	t.Setenv(ddGenericResourceForceSyncPeriodEnvVar, "1")
 
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileGenericResource_ForceSyncPeriodTriggersRemoteUpdate"})
@@ -302,16 +301,15 @@ func TestReconcileGenericResource_ForceSyncPeriodTriggersRemoteUpdate(t *testing
 	s := scheme.Scheme
 	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogGenericResource{})
 
-	r := &Reconciler{
-		client:       fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build(),
-		credsManager: config.NewCredentialManager(fake.NewClientBuilder().Build()),
-		handlers: map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
-			mockSubresource: &MockHandler{},
-		},
-		forceSyncPeriod: forceSyncPeriod,
-		scheme:          s,
-		recorder:        recorder,
-		log:             logger,
+	r := NewReconciler(
+		fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build(),
+		config.NewCredentialManager(fake.NewClientBuilder().Build()),
+		s,
+		logger,
+		recorder,
+	)
+	r.handlers = map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
+		mockSubresource: &MockHandler{},
 	}
 
 	err := r.client.Create(context.TODO(), mockGenericResource())

--- a/internal/controller/datadoggenericresource/controller_test.go
+++ b/internal/controller/datadoggenericresource/controller_test.go
@@ -245,6 +245,59 @@ func TestReconcileGenericResource_Reconcile(t *testing.T) {
 	}
 }
 
+func TestReconcileGenericResource_ForceSyncPeriodFromEnv(t *testing.T) {
+	resetMockHandlerState()
+	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+	t.Setenv(DDGenericResourceForceSyncPeriodEnvVar, "0")
+
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileGenericResource_ForceSyncPeriodFromEnv"})
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	logger := logf.Log.WithName("force-sync-period-test")
+
+	s := scheme.Scheme
+	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogGenericResource{})
+
+	r := &Reconciler{
+		client:       fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build(),
+		credsManager: config.NewCredentialManager(fake.NewClientBuilder().Build()),
+		handlers: map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
+			mockSubresource: &MockHandler{},
+		},
+		forceSyncPeriod: forceSyncPeriodFromEnv(logger),
+		scheme:          s,
+		recorder:        recorder,
+		log:             logger,
+	}
+
+	err := r.client.Create(context.TODO(), mockGenericResource())
+	assert.NoError(t, err)
+
+	req := newRequest(resourcesNamespace, resourcesName)
+
+	// Add finalizer, then create the Datadog resource.
+	result, err := reconcileRequest(r, context.TODO(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{Requeue: true}, result)
+
+	result, err = reconcileRequest(r, context.TODO(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{RequeueAfter: defaultRequeuePeriod}, result)
+	assert.Equal(t, 1, mockCreateCalls)
+	assert.Equal(t, 0, mockGetCalls)
+	assert.Equal(t, 0, mockUpdateCalls)
+
+	// With DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD=0, the next reconcile should
+	// force a remote get and update even though the spec hash is unchanged.
+	result, err = reconcileRequest(r, context.TODO(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{RequeueAfter: defaultRequeuePeriod}, result)
+	assert.Equal(t, 1, mockGetCalls)
+	assert.Equal(t, 1, mockUpdateCalls)
+}
+
 func newRequest(ns, name string) reconcile.Request {
 	return reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/internal/controller/datadoggenericresource/mock_handler_test.go
+++ b/internal/controller/datadoggenericresource/mock_handler_test.go
@@ -17,6 +17,8 @@ var (
 	mockUpdateErr       error
 	mockDeleteErr       error
 	mockCreateCalls     int
+	mockGetCalls        int
+	mockUpdateCalls     int
 	mockDeleteCalls     int
 )
 
@@ -34,10 +36,12 @@ func (h *MockHandler) createResource(context.Context, *v1alpha1.DatadogGenericRe
 }
 
 func (h *MockHandler) getResource(context.Context, *v1alpha1.DatadogGenericResource) error {
+	mockGetCalls++
 	return mockGetErr
 }
 
 func (h *MockHandler) updateResource(context.Context, *v1alpha1.DatadogGenericResource) error {
+	mockUpdateCalls++
 	return mockUpdateErr
 }
 
@@ -53,5 +57,7 @@ func resetMockHandlerState() {
 	mockUpdateErr = nil
 	mockDeleteErr = nil
 	mockCreateCalls = 0
+	mockGetCalls = 0
+	mockUpdateCalls = 0
 	mockDeleteCalls = 0
 }


### PR DESCRIPTION
### What does this PR do?

Adds `DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD` to configure the `DatadogGenericResource` force-sync interval, matching the existing monitor/dashboard/SLO behavior. The value is resolved once when the DDGR controller starts, logged at info level, and reused during reconciliation.

The configured value must be at least one minute. Non-integer values, `0`, and negative values are rejected once during controller startup and fall back to the default 60-minute force-sync period.

Also documents DDGR force sync and the existing DDGR namespace watch environment variable.

### Motivation

`DatadogGenericResource` already force-syncs remote resources every 60 minutes, but unlike related Datadog resource controllers, the interval was not configurable. This makes DDGR behavior easier to tune and easier to validate when remote resources drift from Kubernetes source of truth.

Rejecting values below one minute avoids surprising behavior where `0` or negative durations would force an update on every reconciliation loop.

### Additional Notes

`DD_GENERIC_RESOURCE_WATCH_NAMESPACE` already existed and falls back to `WATCH_NAMESPACE`; this PR only documents that behavior.

The reconcile tests construct the DDGR reconciler through `NewReconciler` and then override the resource handlers with mocks, so the production force-sync initialization path is covered without calling real Datadog APIs.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Automated validation:

```shell
go test -count=1 ./internal/controller/datadoggenericresource
```

The tests cover valid force-sync configuration, invalid string values, `0`, negative values, and an elapsed force-sync period triggering a remote update.

Manual QA:

1. Start the operator with the DDGR controller enabled and an invalid force-sync period:

   ```shell
   DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD=abc
   ```

   Verify the operator logs contain this error once during controller startup:

   ```json
   {"level":"ERROR","logger":"controllers.DatadogGenericResource","msg":"Invalid value for generic resource force sync period. Defaulting to 60 minutes.","error":"strconv.Atoi: parsing \"abc\": invalid syntax"}
   ```

2. Restart the operator with a valid five-minute force-sync period:

   ```shell
   DD_GENERIC_RESOURCE_FORCE_SYNC_PERIOD=5
   ```

   Verify the operator logs contain this info log during controller startup:

   ```json
   {"level":"INFO","logger":"controllers.DatadogGenericResource","msg":"Setting generic resource force sync period","minutes":5}
   ```

3. Apply the notebook DDGR sample:

   ```shell
   kubectl apply -f examples/datadoggenericresource/notebook-sample.yaml
   ```

   Wait for the resource to be created and record the Datadog notebook ID:

   ```shell
   kubectl get datadoggenericresource ddgr-notebook-sample -o jsonpath='{.status.id}'
   ```

4. In the Datadog UI, open that notebook and make a visible edit, for example change the notebook name from `Example-Notebook` to `Example-Notebook edited from UI`.

5. Wait at least five minutes, then verify the operator force-sync restored the notebook to the Kubernetes spec from `examples/datadoggenericresource/notebook-sample.yaml`, including the original notebook name `Example-Notebook`.

6. Clean up the sample resource:

   ```shell
   kubectl delete -f examples/datadoggenericresource/notebook-sample.yaml
   ```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
