### PR TITLE
[CASCL-506] Allow minReplicas=0 on DatadogPodAutoscaler

### DIFF
--- a/api/datadoghq/common/datadogpodautoscaler_types.go
+++ b/api/datadoghq/common/datadogpodautoscaler_types.go
@@ -344,8 +344,11 @@ type DatadogPodAutoscalerObjectiveValue struct {
 // DatadogPodAutoscalerConstraints defines constraints that should always be respected.
 // +kubebuilder:object:generate=true
 type DatadogPodAutoscalerConstraints struct {
-	// MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
-	// +kubebuilder:validation:Minimum=1
+	// MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 0. Defaults to 1.
+	// Setting MinReplicas to 0 enables scale-to-zero. Scaling back up from zero requires the
+	// recommendation source to be able to emit signals when no pods are running (e.g. queue-based
+	// metrics); CPU-based recommendations are not usable at 0 replicas.
+	// +kubebuilder:validation:Minimum=0
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
 
 	// MaxReplicas is the upper limit for the number of POD replicas. Needs to be >= minReplicas.

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalerclusterprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalerclusterprofiles.yaml
@@ -304,9 +304,13 @@ spec:
                           minimum: 1
                           type: integer
                         minReplicas:
-                          description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
+                          description: |-
+                            MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 0. Defaults to 1.
+                            Setting MinReplicas to 0 enables scale-to-zero. Scaling back up from zero requires the
+                            recommendation source to be able to emit signals when no pods are running (e.g. queue-based
+                            metrics); CPU-based recommendations are not usable at 0 replicas.
                           format: int32
-                          minimum: 1
+                          minimum: 0
                           type: integer
                       type: object
                     fallback:

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalerclusterprofiles_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalerclusterprofiles_v1alpha2.json
@@ -311,9 +311,9 @@
                   "type": "integer"
                 },
                 "minReplicas": {
-                  "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 1. Defaults to 1.",
+                  "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 0. Defaults to 1.\nSetting MinReplicas to 0 enables scale-to-zero. Scaling back up from zero requires the\nrecommendation source to be able to emit signals when no pods are running (e.g. queue-based\nmetrics); CPU-based recommendations are not usable at 0 replicas.",
                   "format": "int32",
-                  "minimum": 1,
+                  "minimum": 0,
                   "type": "integer"
                 }
               },

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers.yaml
@@ -164,9 +164,13 @@ spec:
                       minimum: 1
                       type: integer
                     minReplicas:
-                      description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
+                      description: |-
+                        MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 0. Defaults to 1.
+                        Setting MinReplicas to 0 enables scale-to-zero. Scaling back up from zero requires the
+                        recommendation source to be able to emit signals when no pods are running (e.g. queue-based
+                        metrics); CPU-based recommendations are not usable at 0 replicas.
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                   type: object
                 owner:
@@ -1115,9 +1119,13 @@ spec:
                       minimum: 1
                       type: integer
                     minReplicas:
-                      description: MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 1. Defaults to 1.
+                      description: |-
+                        MinReplicas is the lower limit for the number of pod replicas. Needs to be >= 0. Defaults to 1.
+                        Setting MinReplicas to 0 enables scale-to-zero. Scaling back up from zero requires the
+                        recommendation source to be able to emit signals when no pods are running (e.g. queue-based
+                        metrics); CPU-based recommendations are not usable at 0 replicas.
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                   type: object
                 fallback:

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha1.json
@@ -190,9 +190,9 @@
               "type": "integer"
             },
             "minReplicas": {
-              "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 1. Defaults to 1.",
+              "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 0. Defaults to 1.\nSetting MinReplicas to 0 enables scale-to-zero. Scaling back up from zero requires the\nrecommendation source to be able to emit signals when no pods are running (e.g. queue-based\nmetrics); CPU-based recommendations are not usable at 0 replicas.",
               "format": "int32",
-              "minimum": 1,
+              "minimum": 0,
               "type": "integer"
             }
           },

--- a/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogpodautoscalers_v1alpha2.json
@@ -359,9 +359,9 @@
               "type": "integer"
             },
             "minReplicas": {
-              "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 1. Defaults to 1.",
+              "description": "MinReplicas is the lower limit for the number of pod replicas. Needs to be \u003e= 0. Defaults to 1.\nSetting MinReplicas to 0 enables scale-to-zero. Scaling back up from zero requires the\nrecommendation source to be able to emit signals when no pods are running (e.g. queue-based\nmetrics); CPU-based recommendations are not usable at 0 replicas.",
               "format": "int32",
-              "minimum": 1,
+              "minimum": 0,
               "type": "integer"
             }
           },


### PR DESCRIPTION
### What does this PR do?

Relaxes the kubebuilder validation on `DatadogPodAutoscalerConstraints.MinReplicas` from `Minimum=1` to `Minimum=0`, so a `DatadogPodAutoscaler` (and `DatadogPodAutoscalerClusterProfile`) with `spec.constraints.minReplicas: 0` is admitted by the API server. CRDs were regenerated via `make manifests`.

### Motivation

Refs https://datadoghq.atlassian.net/browse/CASCL-506 (feature request: support horizontal scale from/to 0).

We hit this in dd-analytics while experimenting with DPA on Airflow Celery worker groups. Workers are queue-driven and idle between DAG runs, so scaling to 0 between bursts is a clear cost win. The CRD currently rejects this configuration outright:

\`\`\`
DatadogPodAutoscaler.datadoghq.com \"airflow-wg-adp-integrations\" is invalid:
spec.constraints.minReplicas: Invalid value: 0:
spec.constraints.minReplicas in body should be greater than or equal to 1
\`\`\`

This PR removes the admission-level block. It is intentionally a minimal change to unblock experimentation/design work on CASCL-506; it does **not** by itself make scale-from-0 work end-to-end -- see Additional Notes.

### Additional Notes

- The horizontal controller in datadog-agent (`pkg/clusteragent/autoscaling/workload/controller_horizontal.go`) already honors any non-nil `MinReplicas`. The hardcoded `defaultMinReplicas = 1` only applies when the field is unset, so this is purely an admission relaxation -- no controller code change is required.
- Scale-**from**-zero still depends on the recommendation source being able to emit a signal at 0 replicas. CPU-based recommendations are unusable at 0 pods (no metrics to read), and a custom-query formula like `(running + queued) / replicas` is undefined at 0 replicas. Queue-length-style external metrics work because the source is external to the workload.
- Updated the `MinReplicas` godoc to call this out explicitly so users don't expect magic scale-up behavior just from setting `minReplicas: 0`.

### Minimum Agent Versions

No agent-side changes are required for this PR (controller already accepts the value). Mentioning for completeness:

* Agent: n/a
* Cluster Agent: n/a

### Describe your test plan

- \`make generate && make manifests\` (run; regenerated CRD YAML/JSON files included in this PR)
- \`go vet ./api/...\` -- clean
- \`go test ./api/datadoghq/common/... ./api/datadoghq/v1alpha2/...\` -- pass

Manual verification (suggested for reviewer): apply the regenerated CRD to a kind cluster, then \`kubectl apply\` a DPA with \`spec.constraints.minReplicas: 0\` and confirm admission succeeds; apply one with \`-1\` and confirm it is still rejected.

### Checklist

- [x] PR has at least one valid label: \`enhancement\`
- [ ] PR has a milestone or the \`qa/skip-qa\` label (deferring to reviewer)
- [x] All commits are signed