### PR TITLE
feat(appsec): add ingress-nginx proxy injection support

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -358,7 +358,9 @@ rules:
 - apiGroups:
   - gateway.envoyproxy.io
   resources:
+  - backend
   - envoyextensionpolicies
+  - envoypatchpolicies
   verbs:
   - create
   - delete
@@ -417,6 +419,22 @@ rules:
   - create
   - delete
   - get
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - networking.k8s.io
   resources:

--- a/internal/controller/datadogagent/feature/appsec/config.go
+++ b/internal/controller/datadogagent/feature/appsec/config.go
@@ -34,9 +34,6 @@ type Config struct {
 	SidecarResourcesLimitsCPU      string
 	SidecarResourcesLimitsMemory   string
 	SidecarBodyParsingSizeLimit    string
-	// NginxInitImage overrides the init container image for nginx-datadog module injection.
-	// Maps to DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE on the cluster-agent.
-	NginxInitImage string
 	// NginxModuleMountPath overrides the mount path for the nginx-datadog module inside the controller pod.
 	// Maps to DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH on the cluster-agent.
 	NginxModuleMountPath string
@@ -94,7 +91,6 @@ func FromAnnotations(annotations map[string]string) (config Config, err error) {
 	config.SidecarResourcesLimitsCPU = annotations[AnnotationSidecarResourcesLimitsCPU]
 	config.SidecarResourcesLimitsMemory = annotations[AnnotationSidecarResourcesLimitsMemory]
 	config.SidecarBodyParsingSizeLimit = annotations[AnnotationSidecarBodyParsingSizeLimit]
-	config.NginxInitImage = annotations[AnnotationNginxInitImage]
 	config.NginxModuleMountPath = annotations[AnnotationNginxModuleMountPath]
 
 	// Validate the configuration before returning

--- a/internal/controller/datadogagent/feature/appsec/config.go
+++ b/internal/controller/datadogagent/feature/appsec/config.go
@@ -101,6 +101,13 @@ func FromAnnotations(annotations map[string]string) (config Config, err error) {
 	return config, nil
 }
 
+func (c Config) requiresNginxSupport() bool {
+	if c.NginxModuleMountPath != "" {
+		return true
+	}
+	return slices.Contains(c.Proxies, "ingress-nginx")
+}
+
 func (c Config) isEnabled() bool {
 	if !c.Enabled {
 		return false

--- a/internal/controller/datadogagent/feature/appsec/config.go
+++ b/internal/controller/datadogagent/feature/appsec/config.go
@@ -34,6 +34,12 @@ type Config struct {
 	SidecarResourcesLimitsCPU      string
 	SidecarResourcesLimitsMemory   string
 	SidecarBodyParsingSizeLimit    string
+	// NginxInitImage overrides the init container image for nginx-datadog module injection.
+	// Maps to DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE on the cluster-agent.
+	NginxInitImage string
+	// NginxModuleMountPath overrides the mount path for the nginx-datadog module inside the controller pod.
+	// Maps to DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH on the cluster-agent.
+	NginxModuleMountPath string
 }
 
 // FromAnnotations creates an appsec.Config from an annotation map and validates it.
@@ -88,6 +94,8 @@ func FromAnnotations(annotations map[string]string) (config Config, err error) {
 	config.SidecarResourcesLimitsCPU = annotations[AnnotationSidecarResourcesLimitsCPU]
 	config.SidecarResourcesLimitsMemory = annotations[AnnotationSidecarResourcesLimitsMemory]
 	config.SidecarBodyParsingSizeLimit = annotations[AnnotationSidecarBodyParsingSizeLimit]
+	config.NginxInitImage = annotations[AnnotationNginxInitImage]
+	config.NginxModuleMountPath = annotations[AnnotationNginxModuleMountPath]
 
 	// Validate the configuration before returning
 	if err = config.Validate(); err != nil {

--- a/internal/controller/datadogagent/feature/appsec/const.go
+++ b/internal/controller/datadogagent/feature/appsec/const.go
@@ -43,8 +43,6 @@ const (
 	AnnotationSidecarResourcesLimitsMemory = "agent.datadoghq.com/appsec.sidecar.resources.limits.memory"
 	// AnnotationSidecarBodyParsingSizeLimit is the sidecar body parsing size limit
 	AnnotationSidecarBodyParsingSizeLimit = "agent.datadoghq.com/appsec.sidecar.body_parsing_size_limit"
-	// AnnotationNginxInitImage is the init container image for nginx-datadog module injection
-	AnnotationNginxInitImage = "agent.datadoghq.com/appsec.nginx.init_image"
 	// AnnotationNginxModuleMountPath is the mount path for the nginx-datadog module inside the controller pod
 	AnnotationNginxModuleMountPath = "agent.datadoghq.com/appsec.nginx.module_mount_path"
 )
@@ -86,8 +84,6 @@ const (
 	DDAdmissionControllerAppsecSidecarResourcesLimitsMemory = "DD_ADMISSION_CONTROLLER_APPSEC_SIDECAR_RESOURCES_LIMITS_MEMORY"
 	// DDAdmissionControllerAppsecSidecarBodyParsingSizeLimit is the sidecar body parsing size limit
 	DDAdmissionControllerAppsecSidecarBodyParsingSizeLimit = "DD_ADMISSION_CONTROLLER_APPSEC_SIDECAR_BODY_PARSING_SIZE_LIMIT"
-	// DDAdmissionControllerAppsecNginxInitImage is the init container image for nginx-datadog module injection
-	DDAdmissionControllerAppsecNginxInitImage = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE"
 	// DDAdmissionControllerAppsecNginxModuleMountPath is the mount path for the nginx-datadog module inside the controller pod
 	DDAdmissionControllerAppsecNginxModuleMountPath = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH"
 )

--- a/internal/controller/datadogagent/feature/appsec/const.go
+++ b/internal/controller/datadogagent/feature/appsec/const.go
@@ -43,6 +43,10 @@ const (
 	AnnotationSidecarResourcesLimitsMemory = "agent.datadoghq.com/appsec.sidecar.resources.limits.memory"
 	// AnnotationSidecarBodyParsingSizeLimit is the sidecar body parsing size limit
 	AnnotationSidecarBodyParsingSizeLimit = "agent.datadoghq.com/appsec.sidecar.body_parsing_size_limit"
+	// AnnotationNginxInitImage is the init container image for nginx-datadog module injection
+	AnnotationNginxInitImage = "agent.datadoghq.com/appsec.nginx.init_image"
+	// AnnotationNginxModuleMountPath is the mount path for the nginx-datadog module inside the controller pod
+	AnnotationNginxModuleMountPath = "agent.datadoghq.com/appsec.nginx.module_mount_path"
 )
 
 const (
@@ -82,9 +86,13 @@ const (
 	DDAdmissionControllerAppsecSidecarResourcesLimitsMemory = "DD_ADMISSION_CONTROLLER_APPSEC_SIDECAR_RESOURCES_LIMITS_MEMORY"
 	// DDAdmissionControllerAppsecSidecarBodyParsingSizeLimit is the sidecar body parsing size limit
 	DDAdmissionControllerAppsecSidecarBodyParsingSizeLimit = "DD_ADMISSION_CONTROLLER_APPSEC_SIDECAR_BODY_PARSING_SIZE_LIMIT"
+	// DDAdmissionControllerAppsecNginxInitImage is the init container image for nginx-datadog module injection
+	DDAdmissionControllerAppsecNginxInitImage = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_INIT_IMAGE"
+	// DDAdmissionControllerAppsecNginxModuleMountPath is the mount path for the nginx-datadog module inside the controller pod
+	DDAdmissionControllerAppsecNginxModuleMountPath = "DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH"
 )
 
-var allowedProxyValues = []string{"envoy-gateway", "istio", "istio-gateway"}
+var allowedProxyValues = []string{"envoy-gateway", "istio", "istio-gateway", "ingress-nginx"}
 
 // AllowedProxyValues returns the proxy types that the current RBAC supports.
 // The returned slice must not be modified.

--- a/internal/controller/datadogagent/feature/appsec/const.go
+++ b/internal/controller/datadogagent/feature/appsec/const.go
@@ -7,6 +7,9 @@ package appsec
 
 const ClusterAgentMinVersion = "7.76.0"
 
+// ClusterAgentNginxMinVersion is the minimum cluster-agent version for ingress-nginx injection (explicit config only)
+const ClusterAgentNginxMinVersion = "7.79.0"
+
 // Appsec proxy injection annotations (Preview feature)
 const (
 	// AnnotationInjectorEnabled enables AppSec proxy integration

--- a/internal/controller/datadogagent/feature/appsec/feature.go
+++ b/internal/controller/datadogagent/feature/appsec/feature.go
@@ -180,7 +180,6 @@ func (f *appsecFeature) ManageClusterAgent(managers feature.PodTemplateManagers,
 		DDAdmissionControllerAppsecSidecarResourcesLimitsCPU:      f.config.SidecarResourcesLimitsCPU,
 		DDAdmissionControllerAppsecSidecarResourcesLimitsMemory:   f.config.SidecarResourcesLimitsMemory,
 		DDAdmissionControllerAppsecSidecarBodyParsingSizeLimit:    f.config.SidecarBodyParsingSizeLimit,
-		DDAdmissionControllerAppsecNginxInitImage:                 f.config.NginxInitImage,
 		DDAdmissionControllerAppsecNginxModuleMountPath:           f.config.NginxModuleMountPath,
 	} {
 		if value != "" {

--- a/internal/controller/datadogagent/feature/appsec/feature.go
+++ b/internal/controller/datadogagent/feature/appsec/feature.go
@@ -58,19 +58,20 @@ func (f *appsecFeature) ID() feature.IDType {
 	return feature.AppsecIDType
 }
 
-func isAboveMinVersion(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
-	// Agent version must >= 7.73.0 to run appsec feature
+func clusterAgentVersion(ddaSpec *v2alpha1.DatadogAgentSpec) string {
 	if ddaSpec == nil {
-		return utils.IsAboveMinVersion(images.AgentLatestVersion, ClusterAgentMinVersion, nil)
+		return images.AgentLatestVersion
 	}
-
-	image := images.AgentLatestVersion
 	if clusterAgent, ok := ddaSpec.Override[v2alpha1.ClusterAgentComponentName]; ok {
 		if clusterAgent.Image != nil {
-			image = common.GetAgentVersionFromImage(*clusterAgent.Image)
+			return common.GetAgentVersionFromImage(*clusterAgent.Image)
 		}
 	}
-	return utils.IsAboveMinVersion(image, ClusterAgentMinVersion, nil)
+	return images.AgentLatestVersion
+}
+
+func isAboveMinVersion(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
+	return utils.IsAboveMinVersion(clusterAgentVersion(ddaSpec), ClusterAgentMinVersion, nil)
 }
 
 // Configure is used to configure the feature from a v2alpha1.DatadogAgent instance.
@@ -89,6 +90,11 @@ func (f *appsecFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAg
 
 	if !f.config.isEnabled() {
 		f.logger.V(1).Info("feature is disabled")
+		return feature.RequiredComponents{}
+	}
+
+	if f.config.requiresNginxSupport() && !utils.IsAboveMinVersion(clusterAgentVersion(ddaSpec), ClusterAgentNginxMinVersion, nil) {
+		f.logger.Info("ingress-nginx injection requires cluster-agent >= " + ClusterAgentNginxMinVersion)
 		return feature.RequiredComponents{}
 	}
 

--- a/internal/controller/datadogagent/feature/appsec/feature.go
+++ b/internal/controller/datadogagent/feature/appsec/feature.go
@@ -180,6 +180,8 @@ func (f *appsecFeature) ManageClusterAgent(managers feature.PodTemplateManagers,
 		DDAdmissionControllerAppsecSidecarResourcesLimitsCPU:      f.config.SidecarResourcesLimitsCPU,
 		DDAdmissionControllerAppsecSidecarResourcesLimitsMemory:   f.config.SidecarResourcesLimitsMemory,
 		DDAdmissionControllerAppsecSidecarBodyParsingSizeLimit:    f.config.SidecarBodyParsingSizeLimit,
+		DDAdmissionControllerAppsecNginxInitImage:                 f.config.NginxInitImage,
+		DDAdmissionControllerAppsecNginxModuleMountPath:           f.config.NginxModuleMountPath,
 	} {
 		if value != "" {
 			if err := addEnvVar(key, value); err != nil {

--- a/internal/controller/datadogagent/feature/appsec/feature_test.go
+++ b/internal/controller/datadogagent/feature/appsec/feature_test.go
@@ -324,7 +324,74 @@ func TestAppsecFeature(t *testing.T) {
 				envVar{name: DDAppsecProxyEnabled, value: "true", present: true},
 				envVar{name: DDClusterAgentAppsecInjectorEnabled, value: "true", present: true},
 				envVar{name: DDClusterAgentAppsecInjectorMode, value: "external", present: true},
-				envVar{name: DDClusterAgentAppsecInjectorProcessorServiceName, value: "appsec-processor", present: true},
+					envVar{name: DDClusterAgentAppsecInjectorProcessorServiceName, value: "appsec-processor", present: true},
+				),
+		},
+		{
+			Name: "Appsec enabled with nginx init image and mount path",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithClusterAgentTag("7.76.0").
+				WithAnnotations(map[string]string{
+					AnnotationInjectorEnabled:      "true",
+					AnnotationInjectorAutoDetect:   "true",
+					AnnotationNginxInitImage:       "datadog/ingress-nginx-injection:7.77.0",
+					AnnotationNginxModuleMountPath: "/modules_mount",
+				}).
+				Build(),
+			WantConfigure: true,
+			ClusterAgent: assertEnv(
+				envVar{name: DDAppsecProxyEnabled, value: "true", present: true},
+				envVar{name: DDClusterAgentAppsecInjectorEnabled, value: "true", present: true},
+				envVar{name: DDAdmissionControllerAppsecNginxInitImage, value: "datadog/ingress-nginx-injection:7.77.0", present: true},
+				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, value: "/modules_mount", present: true},
+			),
+		},
+		{
+			Name: "Appsec enabled without nginx annotations does not inject nginx env vars",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithClusterAgentTag("7.76.0").
+				WithAnnotations(map[string]string{
+					AnnotationInjectorEnabled:    "true",
+					AnnotationInjectorAutoDetect: "true",
+				}).
+				Build(),
+			WantConfigure: true,
+			ClusterAgent: assertEnv(
+				envVar{name: DDAdmissionControllerAppsecNginxInitImage, present: false},
+				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, present: false},
+			),
+		},
+		{
+			Name: "Appsec enabled with empty nginx annotations does not inject nginx env vars",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithClusterAgentTag("7.76.0").
+				WithAnnotations(map[string]string{
+					AnnotationInjectorEnabled:      "true",
+					AnnotationInjectorAutoDetect:   "true",
+					AnnotationNginxInitImage:       "",
+					AnnotationNginxModuleMountPath: "",
+				}).
+				Build(),
+			WantConfigure: true,
+			ClusterAgent: assertEnv(
+				envVar{name: DDAdmissionControllerAppsecNginxInitImage, present: false},
+				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, present: false},
+			),
+		},
+		{
+			Name: "Appsec enabled with only nginx init image annotation",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithClusterAgentTag("7.76.0").
+				WithAnnotations(map[string]string{
+					AnnotationInjectorEnabled:    "true",
+					AnnotationInjectorAutoDetect: "true",
+					AnnotationNginxInitImage:     "datadog/ingress-nginx-injection:latest",
+				}).
+				Build(),
+			WantConfigure: true,
+			ClusterAgent: assertEnv(
+				envVar{name: DDAdmissionControllerAppsecNginxInitImage, value: "datadog/ingress-nginx-injection:latest", present: true},
+				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, present: false},
 			),
 		},
 	}.Run(t, buildAppsecFeature)
@@ -698,6 +765,48 @@ func TestFromAnnotations(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "nginx annotations parsed correctly",
+			annotations: map[string]string{
+				AnnotationInjectorEnabled:      "true",
+				AnnotationInjectorAutoDetect:   "true",
+				AnnotationNginxInitImage:       "datadog/ingress-nginx-injection:7.77.0",
+				AnnotationNginxModuleMountPath: "/custom/modules",
+			},
+			wantConfig: Config{
+				Enabled:              true,
+				AutoDetect:           ptr.To(true),
+				NginxInitImage:       "datadog/ingress-nginx-injection:7.77.0",
+				NginxModuleMountPath: "/custom/modules",
+			},
+			wantErr: false,
+		},
+		{
+			name: "nginx annotations unset results in empty fields",
+			annotations: map[string]string{
+				AnnotationInjectorEnabled:    "true",
+				AnnotationInjectorAutoDetect: "true",
+			},
+			wantConfig: Config{
+				Enabled:    true,
+				AutoDetect: ptr.To(true),
+			},
+			wantErr: false,
+		},
+		{
+			name: "nginx annotations empty string results in empty fields",
+			annotations: map[string]string{
+				AnnotationInjectorEnabled:      "true",
+				AnnotationInjectorAutoDetect:   "true",
+				AnnotationNginxInitImage:       "",
+				AnnotationNginxModuleMountPath: "",
+			},
+			wantConfig: Config{
+				Enabled:    true,
+				AutoDetect: ptr.To(true),
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -715,6 +824,8 @@ func TestFromAnnotations(t *testing.T) {
 				assert.Equal(t, tt.wantConfig.ProcessorPort, config.ProcessorPort)
 				assert.Equal(t, tt.wantConfig.ProcessorServiceName, config.ProcessorServiceName)
 				assert.Equal(t, tt.wantConfig.ProcessorServiceNamespace, config.ProcessorServiceNamespace)
+				assert.Equal(t, tt.wantConfig.NginxInitImage, config.NginxInitImage)
+				assert.Equal(t, tt.wantConfig.NginxModuleMountPath, config.NginxModuleMountPath)
 			}
 		})
 	}
@@ -812,6 +923,14 @@ func TestConfigValidate(t *testing.T) {
 			config: Config{
 				Enabled: true,
 				Proxies: []string{"istio-gateway"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ingress-nginx is a valid proxy value",
+			config: Config{
+				Enabled: true,
+				Proxies: []string{"ingress-nginx"},
 			},
 			wantErr: false,
 		},

--- a/internal/controller/datadogagent/feature/appsec/feature_test.go
+++ b/internal/controller/datadogagent/feature/appsec/feature_test.go
@@ -328,9 +328,21 @@ func TestAppsecFeature(t *testing.T) {
 			),
 		},
 		{
-			Name: "Appsec enabled with nginx module mount path",
+			Name: "Appsec enabled with nginx module mount path requires cluster-agent >= 7.79.0",
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithClusterAgentTag("7.76.0").
+				WithAnnotations(map[string]string{
+					AnnotationInjectorEnabled:      "true",
+					AnnotationInjectorAutoDetect:   "true",
+					AnnotationNginxModuleMountPath: "/modules_mount",
+				}).
+				Build(),
+			WantConfigure: false,
+		},
+		{
+			Name: "Appsec enabled with nginx module mount path on 7.79.0",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithClusterAgentTag("7.79.0").
 				WithAnnotations(map[string]string{
 					AnnotationInjectorEnabled:      "true",
 					AnnotationInjectorAutoDetect:   "true",
@@ -357,6 +369,18 @@ func TestAppsecFeature(t *testing.T) {
 			ClusterAgent: assertEnv(
 				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, present: false},
 			),
+		},
+		{
+			Name: "Appsec enabled with ingress-nginx proxy on old cluster-agent is rejected",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithClusterAgentTag("7.76.0").
+				WithAnnotations(map[string]string{
+					AnnotationInjectorEnabled:    "true",
+					AnnotationInjectorAutoDetect: "true",
+					AnnotationInjectorProxies:    `["ingress-nginx"]`,
+				}).
+				Build(),
+			WantConfigure: false,
 		},
 		{
 			Name: "Appsec enabled with empty nginx annotations does not inject nginx env vars",

--- a/internal/controller/datadogagent/feature/appsec/feature_test.go
+++ b/internal/controller/datadogagent/feature/appsec/feature_test.go
@@ -324,17 +324,16 @@ func TestAppsecFeature(t *testing.T) {
 				envVar{name: DDAppsecProxyEnabled, value: "true", present: true},
 				envVar{name: DDClusterAgentAppsecInjectorEnabled, value: "true", present: true},
 				envVar{name: DDClusterAgentAppsecInjectorMode, value: "external", present: true},
-					envVar{name: DDClusterAgentAppsecInjectorProcessorServiceName, value: "appsec-processor", present: true},
-				),
+				envVar{name: DDClusterAgentAppsecInjectorProcessorServiceName, value: "appsec-processor", present: true},
+			),
 		},
 		{
-			Name: "Appsec enabled with nginx init image and mount path",
+			Name: "Appsec enabled with nginx module mount path",
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithClusterAgentTag("7.76.0").
 				WithAnnotations(map[string]string{
 					AnnotationInjectorEnabled:      "true",
 					AnnotationInjectorAutoDetect:   "true",
-					AnnotationNginxInitImage:       "datadog/ingress-nginx-injection:7.77.0",
 					AnnotationNginxModuleMountPath: "/modules_mount",
 				}).
 				Build(),
@@ -342,7 +341,6 @@ func TestAppsecFeature(t *testing.T) {
 			ClusterAgent: assertEnv(
 				envVar{name: DDAppsecProxyEnabled, value: "true", present: true},
 				envVar{name: DDClusterAgentAppsecInjectorEnabled, value: "true", present: true},
-				envVar{name: DDAdmissionControllerAppsecNginxInitImage, value: "datadog/ingress-nginx-injection:7.77.0", present: true},
 				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, value: "/modules_mount", present: true},
 			),
 		},
@@ -357,7 +355,6 @@ func TestAppsecFeature(t *testing.T) {
 				Build(),
 			WantConfigure: true,
 			ClusterAgent: assertEnv(
-				envVar{name: DDAdmissionControllerAppsecNginxInitImage, present: false},
 				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, present: false},
 			),
 		},
@@ -368,29 +365,11 @@ func TestAppsecFeature(t *testing.T) {
 				WithAnnotations(map[string]string{
 					AnnotationInjectorEnabled:      "true",
 					AnnotationInjectorAutoDetect:   "true",
-					AnnotationNginxInitImage:       "",
 					AnnotationNginxModuleMountPath: "",
 				}).
 				Build(),
 			WantConfigure: true,
 			ClusterAgent: assertEnv(
-				envVar{name: DDAdmissionControllerAppsecNginxInitImage, present: false},
-				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, present: false},
-			),
-		},
-		{
-			Name: "Appsec enabled with only nginx init image annotation",
-			DDA: testutils.NewDatadogAgentBuilder().
-				WithClusterAgentTag("7.76.0").
-				WithAnnotations(map[string]string{
-					AnnotationInjectorEnabled:    "true",
-					AnnotationInjectorAutoDetect: "true",
-					AnnotationNginxInitImage:     "datadog/ingress-nginx-injection:latest",
-				}).
-				Build(),
-			WantConfigure: true,
-			ClusterAgent: assertEnv(
-				envVar{name: DDAdmissionControllerAppsecNginxInitImage, value: "datadog/ingress-nginx-injection:latest", present: true},
 				envVar{name: DDAdmissionControllerAppsecNginxModuleMountPath, present: false},
 			),
 		},
@@ -766,17 +745,15 @@ func TestFromAnnotations(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "nginx annotations parsed correctly",
+			name: "nginx module mount path parsed correctly",
 			annotations: map[string]string{
 				AnnotationInjectorEnabled:      "true",
 				AnnotationInjectorAutoDetect:   "true",
-				AnnotationNginxInitImage:       "datadog/ingress-nginx-injection:7.77.0",
 				AnnotationNginxModuleMountPath: "/custom/modules",
 			},
 			wantConfig: Config{
 				Enabled:              true,
 				AutoDetect:           ptr.To(true),
-				NginxInitImage:       "datadog/ingress-nginx-injection:7.77.0",
 				NginxModuleMountPath: "/custom/modules",
 			},
 			wantErr: false,
@@ -798,7 +775,6 @@ func TestFromAnnotations(t *testing.T) {
 			annotations: map[string]string{
 				AnnotationInjectorEnabled:      "true",
 				AnnotationInjectorAutoDetect:   "true",
-				AnnotationNginxInitImage:       "",
 				AnnotationNginxModuleMountPath: "",
 			},
 			wantConfig: Config{
@@ -824,7 +800,6 @@ func TestFromAnnotations(t *testing.T) {
 				assert.Equal(t, tt.wantConfig.ProcessorPort, config.ProcessorPort)
 				assert.Equal(t, tt.wantConfig.ProcessorServiceName, config.ProcessorServiceName)
 				assert.Equal(t, tt.wantConfig.ProcessorServiceNamespace, config.ProcessorServiceNamespace)
-				assert.Equal(t, tt.wantConfig.NginxInitImage, config.NginxInitImage)
 				assert.Equal(t, tt.wantConfig.NginxModuleMountPath, config.NginxModuleMountPath)
 			}
 		})

--- a/internal/controller/datadogagent/feature/appsec/rbac.go
+++ b/internal/controller/datadogagent/feature/appsec/rbac.go
@@ -112,5 +112,35 @@ func getRBACPolicyRules() []rbacv1.PolicyRule {
 				rbac.UpdateVerb,
 			},
 		},
+		// AppSec proxy injection - ingress-nginx
+		{
+			APIGroups: []string{rbac.NetworkingAPIGroup},
+			Resources: []string{rbac.IngressClassesResource},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.ListVerb,
+				rbac.WatchVerb,
+			},
+		},
+		// AppSec proxy injection - ingress-nginx ConfigMap management
+		// SECURITY NOTE: Cluster-wide and unscoped because ConfigMap names are
+		// derived dynamically from the controller's --configmap arg
+		// (e.g. datadog-appsec-<original-name>) and cannot be predicted at
+		// RBAC definition time. The reconciler/cleanup paths filter by labels:
+		//   appsec.datadoghq.com/watched-configmap=true
+		//   app.kubernetes.io/component=datadog-appsec-injector
+		// Consider namespace-scoped Roles if blast-radius reduction is needed.
+		{
+			APIGroups: []string{rbac.CoreAPIGroup},
+			Resources: []string{rbac.ConfigMapsResource},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.ListVerb,
+				rbac.WatchVerb,
+				rbac.CreateVerb,
+				rbac.UpdateVerb,
+				rbac.DeleteVerb,
+			},
+		},
 	}
 }

--- a/internal/controller/datadogagent/feature/appsec/rbac_test.go
+++ b/internal/controller/datadogagent/feature/appsec/rbac_test.go
@@ -110,6 +110,56 @@ func TestAppsecRBACPolicyRules(t *testing.T) {
 		}
 	}
 	assert.True(t, foundEnvoyRule, "Should have Envoy Gateway permissions")
+
+	// Test IngressClasses watch permissions (new - ingress-nginx)
+	var foundIngressClassesRule bool
+	for _, rule := range rules {
+		if len(rule.APIGroups) > 0 && rule.APIGroups[0] == rbac.NetworkingAPIGroup {
+			if len(rule.Resources) > 0 && rule.Resources[0] == rbac.IngressClassesResource {
+				assert.Contains(t, rule.Verbs, rbac.GetVerb)
+				assert.Contains(t, rule.Verbs, rbac.ListVerb)
+				assert.Contains(t, rule.Verbs, rbac.WatchVerb)
+				assert.NotContains(t, rule.Verbs, rbac.PatchVerb, "IngressClasses rule should not have patch permission")
+				foundIngressClassesRule = true
+			}
+		}
+	}
+	assert.True(t, foundIngressClassesRule, "Should have IngressClasses watch permissions for ingress-nginx")
+
+	// Test wider ConfigMap management permissions (new - ingress-nginx)
+	var foundWiderConfigMapsRule bool
+	for _, rule := range rules {
+		if len(rule.APIGroups) > 0 && rule.APIGroups[0] == rbac.CoreAPIGroup {
+			if len(rule.Resources) > 0 && rule.Resources[0] == rbac.ConfigMapsResource {
+				if len(rule.Verbs) > 2 { // The wider rule has 6 verbs; existing rule has 2
+					assert.Contains(t, rule.Verbs, rbac.GetVerb)
+					assert.Contains(t, rule.Verbs, rbac.ListVerb)
+					assert.Contains(t, rule.Verbs, rbac.WatchVerb)
+					assert.Contains(t, rule.Verbs, rbac.CreateVerb)
+					assert.Contains(t, rule.Verbs, rbac.UpdateVerb)
+					assert.Contains(t, rule.Verbs, rbac.DeleteVerb)
+					foundWiderConfigMapsRule = true
+				}
+			}
+		}
+	}
+	assert.True(t, foundWiderConfigMapsRule, "Should have wider ConfigMaps management permissions for ingress-nginx")
+
+	// Test that the existing [get, update] ConfigMaps rule is preserved
+	var foundExistingConfigMapsRule bool
+	for _, rule := range rules {
+		if len(rule.APIGroups) > 0 && rule.APIGroups[0] == rbac.CoreAPIGroup {
+			if len(rule.Resources) > 0 && rule.Resources[0] == rbac.ConfigMapsResource {
+				if len(rule.Verbs) == 2 {
+					assert.Contains(t, rule.Verbs, rbac.GetVerb)
+					assert.Contains(t, rule.Verbs, rbac.UpdateVerb)
+					assert.NotContains(t, rule.Verbs, rbac.DeleteVerb, "Existing configmaps rule should not have delete")
+					foundExistingConfigMapsRule = true
+				}
+			}
+		}
+	}
+	assert.True(t, foundExistingConfigMapsRule, "Existing [get, update] ConfigMaps rule must still be present (backwards compatibility)")
 }
 
 func TestGetAppsecRBACResourceName(t *testing.T) {

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -118,11 +118,14 @@ type DatadogAgentReconciler struct {
 // Configure Appsec Gateway Integration
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;patch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways;gatewayclasses;httproutes,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;delete;create;patch
-// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoyextensionpolicies,verbs=get;delete;create
+// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoyextensionpolicies;envoypatchpolicies;backend,verbs=get;delete;create
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;create;delete
+// +kubebuilder:rbac:groups=networking.istio.io,resources=gateways,verbs=get;list;watch
 
 // Configure Private Action Runner k8s remediation
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;statefulsets;replicasets,verbs=get;list;watch

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -72,6 +72,7 @@ const (
 	ExtendedDaemonSetReplicaSetResource               = "extendeddaemonsetreplicasets"
 	HorizontalPodAutoscalersRecource                  = "horizontalpodautoscalers"
 	IngressesResource                                 = "ingresses"
+	IngressClassesResource                            = "ingressclasses"
 	JobsResource                                      = "jobs"
 	LeasesResource                                    = "leases"
 	LimitRangesResource                               = "limitranges"


### PR DESCRIPTION
### What does this PR do?

Adds operator support for the new AppSec ingress-nginx admission-controller injection feature introduced in cluster-agent PR [#49318](https://github.com/DataDog/datadog-agent/pull/49318) (merged 2026-04-17).

The cluster-agent now supports a third proxy type for AppSec injection (ingress-nginx, alongside Envoy Gateway and Istio). This PR surfaces the new configuration knob and the required RBAC permissions so users deploying the cluster-agent via the datadog-operator can use the feature.

**Changes:**
- New annotation `agent.datadoghq.com/appsec.nginx.module_mount_path` — overrides the mount path inside the controller pod where the `nginx-datadog` module is exposed
- The annotation forwards to the cluster-agent as `DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH` env var (only when non-empty; cluster-agent owns the default)
- Two new ClusterRole rules added to the AppSec feature RBAC:
  - `networking.k8s.io/ingressclasses [get, list, watch]` — for discovering ingress-nginx controllers
  - `""/configmaps [get, list, watch, create, update, delete]` — for managing the DD-owned ConfigMaps that prepend the WAF config (cluster-wide, unscoped; see security note in `rbac.go`)
- `"ingress-nginx"` added to the `allowedProxyValues` whitelist

### Motivation

Cluster-agent PR #49318 extended AppSec proxy injection to ingress-nginx. Without this operator change, users deploying via the datadog-operator cannot use the feature because:
1. The cluster-agent lacks the RBAC permissions to watch `IngressClass` resources and manage the DD-owned ConfigMaps
2. There is no way to override the module mount path

### Additional Notes

- **Annotation-based** (not CRD fields): matches the existing AppSec proxy injection pattern — Envoy/Istio sidecar config is already annotation-based via `agent.datadoghq.com/appsec.*`
- **Additive-only RBAC**: the existing `configmaps [get, update]` rule is preserved unchanged; the new wider rule is appended as a separate entry
- **No CRD schema changes**: `make generate && make manifests` produces zero diff
- **Security note** on the new configmaps rule is verbatim from the cluster-agent briefing — the reconciler filters by labels `appsec.datadoghq.com/watched-configmap=true` and `app.kubernetes.io/component=datadog-appsec-injector` at runtime
- The init image override (`appsec.nginx.init_image`) was descoped: the cluster-agent appends the ingress-nginx controller version to the init image reference, making a user-supplied tagged image unsafe to forward. This will be addressed on the cluster-agent side separately.
- Sister change: `briefing-datadog-helm-chart-ingress-nginx-appsec.md` tracks the corresponding Helm chart update (separate PR)

### Minimum Agent Versions

* Agent: N/A (operator-side change only)
* Cluster Agent: v7.76.0 (minimum already enforced by `ClusterAgentMinVersion` constant; cluster-agent ignores unknown env vars on older versions)

### Describe your test plan

#### Unit tests

Tests added (TDD) covering:
- `TestConfigValidate`: `"ingress-nginx"` accepted as valid proxy value
- `TestFromAnnotations`: happy path, unset annotation, empty-string annotation
- `TestAppsecFeature`: env var emitted when annotation set; absent when feature disabled, annotation empty, or annotation unset
- `TestAppsecRBACPolicyRules`: both new rules present; existing `[get, update]` rule preserved

```bash
go test ./internal/controller/datadogagent/feature/appsec/... -v -count=1
```

#### QA on kind

**Prerequisites:**
- A kind cluster: `kind create cluster`
- The operator built from this branch: `make docker-build IMG=datadog/operator:dev`
- Load it into kind: `kind load docker-image datadog/operator:dev`

**Step 1 — Deploy the operator with a DatadogAgent that has AppSec injection enabled:**

```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  annotations:
    agent.datadoghq.com/appsec.injector.enabled: "true"
    agent.datadoghq.com/appsec.injector.autoDetect: "true"
    agent.datadoghq.com/appsec.nginx.module_mount_path: "/custom/modules"
spec:
  global:
    credentials:
      apiKey: <your-api-key>
  features:
    clusterAgent:
      replicas: 1
```

**Step 2 — Verify the ClusterRole includes the new RBAC rules:**

```bash
# Get the generated ClusterRole name
CR_NAME=$(kubectl get clusterrole -l app.kubernetes.io/managed-by=datadog-operator \
  -o jsonpath='{.items[*].metadata.name}' | tr " " "\n" | grep appsec)

# Verify ingressclasses rule
kubectl get clusterrole "$CR_NAME" -o json \
  | jq '.rules[] | select(.resources[] == "ingressclasses")'
# Expected: apiGroups=["networking.k8s.io"], verbs=["get","list","watch"]

# Verify new configmaps rule (the one with 6 verbs, not the existing 2-verb rule)
kubectl get clusterrole "$CR_NAME" -o json \
  | jq '[.rules[] | select(.resources[] == "configmaps")] | .[] | select(.verbs | length > 2)'
# Expected: apiGroups=[""], verbs=["get","list","watch","create","update","delete"]

# Verify existing configmaps rule still present
kubectl get clusterrole "$CR_NAME" -o json \
  | jq '[.rules[] | select(.resources[] == "configmaps")] | .[] | select(.verbs | length == 2)'
# Expected: apiGroups=[""], verbs=["get","update"]
```

**Step 3 — Verify the cluster-agent container has the env var:**

```bash
DCA_POD=$(kubectl get pods -l app.kubernetes.io/name=datadog-cluster-agent \
  -o jsonpath='{.items[0].metadata.name}')

# Verify module mount path env var is set
kubectl exec "$DCA_POD" -- env | grep DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH
# Expected: DD_ADMISSION_CONTROLLER_APPSEC_NGINX_MODULE_MOUNT_PATH=/custom/modules
```

**Step 4 — Verify env var is absent when annotation is not set:**

Remove the `appsec.nginx.module_mount_path` annotation from the DatadogAgent, wait for reconciliation, and verify:

```bash
kubectl exec "$DCA_POD" -- env | grep DD_ADMISSION_CONTROLLER_APPSEC_NGINX
# Expected: no output (env var not present — cluster-agent uses its own default)
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
