### PR TITLE
[CASCL-1292] Point the no-private-subnet error at all the install options

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/common/eks/privatesubnets.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/eks/privatesubnets.go
@@ -78,7 +78,7 @@ func GetClusterPrivateSubnets(ctx context.Context, ec2Client DescribeRouteTables
 	}
 
 	if len(privateSubnets) == 0 {
-		return nil, fmt.Errorf("no private subnet found for cluster %s; pass --fargate-subnets to override auto-detection", aws.ToString(cluster.Name))
+		return nil, fmt.Errorf("no private subnet found for cluster %s; fargate mode requires a private subnet in the cluster VPC — add one or pass --fargate-subnets to specify them explicitly, or use --install-mode=existing-nodes to deploy on existing nodes instead of Fargate", aws.ToString(cluster.Name))
 	}
 
 	return privateSubnets, nil

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/eks/privatesubnets_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/eks/privatesubnets_test.go
@@ -60,7 +60,7 @@ func TestGetClusterPrivateSubnets(t *testing.T) {
 		ec2Err          error
 		expectedPrivate []string
 		expectError     bool
-		errorContains   string
+		errorContains   []string
 	}{
 		{
 			name:           "mix of public and private with explicit associations",
@@ -173,8 +173,13 @@ func TestGetClusterPrivateSubnets(t *testing.T) {
 					Routes:       []ec2types.Route{igwRoute()},
 				},
 			},
-			expectError:   true,
-			errorContains: "no private subnet found",
+			expectError: true,
+			errorContains: []string{
+				"no private subnet found",
+				"requires a private subnet in the cluster VPC",
+				"--fargate-subnets",
+				"--install-mode=existing-nodes",
+			},
 		},
 		{
 			name:           "transit gateway route does not mark subnet public",
@@ -195,14 +200,14 @@ func TestGetClusterPrivateSubnets(t *testing.T) {
 			name:          "cluster without VPC configuration",
 			cluster:       &ekstypes.Cluster{},
 			expectError:   true,
-			errorContains: "no VPC configuration",
+			errorContains: []string{"no VPC configuration"},
 		},
 		{
 			name:           "DescribeRouteTables error propagates",
 			clusterSubnets: []string{"subnet-a"},
 			ec2Err:         errors.New("boom"),
 			expectError:    true,
-			errorContains:  "failed to describe route tables",
+			errorContains:  []string{"failed to describe route tables"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -222,8 +227,8 @@ func TestGetClusterPrivateSubnets(t *testing.T) {
 
 			if tc.expectError {
 				require.Error(t, err)
-				if tc.errorContains != "" {
-					assert.Contains(t, err.Error(), tc.errorContains)
+				for _, want := range tc.errorContains {
+					assert.Contains(t, err.Error(), want)
 				}
 				return
 			}


### PR DESCRIPTION
### What does this PR do?

Expands the error message shown by `kubectl datadog autoscaling cluster install` when its default `fargate` mode auto-detects **no private subnet** in the cluster VPC. The message now names all three ways forward instead of only one:

- add a private subnet to the cluster VPC, or
- pass `--fargate-subnets` to specify them explicitly, or
- use `--install-mode=existing-nodes` to deploy on existing nodes instead of Fargate.

### Motivation

During QA of the Fargate mode (CASCL-1292), a tester hit the private-subnet requirement on a VPC with only public subnets. Fargate is the default mode and the requirement is a hard AWS constraint (`AWS::EKS::FargateProfile` only accepts private subnets). The old message mentioned only `--fargate-subnets`, so the tester had to discover on their own that `--install-mode=existing-nodes` installs with no subnet requirement at all.

### Additional Notes

Deliberately minimal: a single error-message change in `GetClusterPrivateSubnets` plus a test update. No behavior change for successful installs.

### Minimum Agent Versions

No minimum Agent/Cluster Agent version required.

### Describe your test plan

- Unit: `TestGetClusterPrivateSubnets` now asserts the no-subnet error mentions the private-subnet requirement, `--fargate-subnets`, and `--install-mode=existing-nodes`.
- `go test ./cmd/kubectl-datadog/autoscaling/...`, `make lint` (0 issues), `go vet`, `gofmt` all pass.

### Checklist

- [x] PR has at least one valid label: `enhancement`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed
