### PR TITLE
[Host Profiler] Remove seccomp configmap and use profile baked into image

### DIFF
--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
-	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
 var errHostPIDDisabledManually = errors.New("Host PID is required for host profiler")
@@ -65,19 +64,11 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Dat
 	}
 }
 
-func (o *hostProfilerFeature) seccompConfigMapName() string {
-	return fmt.Sprintf("%s-%s", constants.GetDDAName(o.owner), agentSecurityConfigMapSuffixName)
-}
-
 func (o *hostProfilerFeature) ManageDependencies(managers feature.ResourceManagers) error {
 	if o.hostPIDDisabledManually {
 		return errHostPIDDisabledManually
 	}
-	return managers.ConfigMapManager().AddConfigMap(
-		o.seccompConfigMapName(),
-		o.owner.GetNamespace(),
-		defaultSeccompConfigData(),
-	)
+	return nil
 }
 
 func (o *hostProfilerFeature) ManageClusterAgent(managers feature.PodTemplateManagers) error {
@@ -125,19 +116,6 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 	// AppArmor: unconfined so the default containerd profile doesn't block ptrace cross-profile,
 	// which host-profiler requires to read /proc/<pid>/map_files for process profiling.
 	managers.Annotation().AddAnnotation(common.AppArmorAnnotationKey+"/"+string(apicommon.HostProfiler), "unconfined")
-
-	// host-profiler-security ConfigMap volume (contains the seccomp profile JSON)
-	secVol := corev1.Volume{
-		Name: securityVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: o.seccompConfigMapName(),
-				},
-			},
-		},
-	}
-	managers.Volume().AddVolume(&secVol)
 
 	// seccomp-root EmptyDir volume (shared with system-probe when both are enabled; VolumeManager deduplicates)
 	seccompRootVol := common.GetVolumeForSeccomp()

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -211,6 +212,9 @@ func resolveHostProfilerImage(dda metav1.Object) string {
 	override, ok := overrides[string(apicommon.HostProfiler)]
 	if !ok || override.Name == "" {
 		return ""
+	}
+	if override.Tag != "" && !strings.Contains(override.Name, ":") {
+		return override.Name + ":" + override.Tag
 	}
 	return override.Name
 }

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -1,6 +1,7 @@
 package hostprofiler
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -21,6 +22,7 @@ var errHostPIDDisabledManually = errors.New("Host PID is required for host profi
 type hostProfilerFeature struct {
 	owner                   metav1.Object
 	hostPIDDisabledManually bool
+	hostProfilerImage       string
 
 	logger logr.Logger
 }
@@ -52,6 +54,11 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Dat
 	if !featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnableHostProfilerAnnotation) {
 		return feature.RequiredComponents{}
 	}
+
+	// Resolve the host-profiler image now, during Configure, so ManageNodeAgent can use
+	// the correct image for the seccomp init container and profile name. The experimental
+	// image override is applied after ManageNodeAgent runs, so we must read it here.
+	o.hostProfilerImage = resolveHostProfilerImage(dda)
 
 	return feature.RequiredComponents{
 		Agent: feature.RequiredComponent{
@@ -102,11 +109,19 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 		hostProfilerContainer.SecurityContext = &corev1.SecurityContext{}
 	}
 
+	// Use the pre-resolved image (set in Configure) so that experimental image overrides,
+	// which are applied after ManageNodeAgent, are correctly reflected in the seccomp profile
+	// name and the init container image.
+	hostProfilerImage := o.hostProfilerImage
+	if hostProfilerImage == "" {
+		hostProfilerImage = hostProfilerContainer.Image
+	}
+
 	sc := hostProfilerContainer.SecurityContext
 	sc.AllowPrivilegeEscalation = ptr.To(false)
 	sc.SeccompProfile = &corev1.SeccompProfile{
 		Type:             corev1.SeccompProfileTypeLocalhost,
-		LocalhostProfile: ptr.To(seccompProfileName),
+		LocalhostProfile: ptr.To(seccompProfileName(hostProfilerImage)),
 	}
 	sc.Capabilities = &corev1.Capabilities{
 		Drop: []corev1.Capability{"ALL"},
@@ -123,7 +138,7 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 
 	// Init container: copy seccomp profile JSON to the kubelet seccomp directory on the host.
 	// Appended after the base init containers (init-volume, init-config) added by default.go.
-	initContainer := buildSeccompSetupInitContainer(hostProfilerContainer.Image)
+	initContainer := buildSeccompSetupInitContainer(hostProfilerImage)
 	managers.PodTemplateSpec().Spec.InitContainers = append(managers.PodTemplateSpec().Spec.InitContainers, initContainer)
 
 	// Tracingfs volume
@@ -172,4 +187,30 @@ func (o *hostProfilerFeature) ManageClusterChecksRunner(managers feature.PodTemp
 
 func (o *hostProfilerFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers) error {
 	return nil
+}
+
+// resolveHostProfilerImage returns the host-profiler image from the experimental image override annotation,
+// if present. This is needed because experimental overrides run after ManageNodeAgent, so we read them early
+// here to use the correct image for the seccomp init container and profile name.
+func resolveHostProfilerImage(dda metav1.Object) string {
+	annotations := dda.GetAnnotations()
+	if annotations == nil {
+		return ""
+	}
+	raw, ok := annotations["experimental.agent.datadoghq.com/image-override-config"]
+	if !ok || raw == "" {
+		return ""
+	}
+	var overrides map[string]struct {
+		Name string `json:"name,omitempty"`
+		Tag  string `json:"tag,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(raw), &overrides); err != nil {
+		return ""
+	}
+	override, ok := overrides[string(apicommon.HostProfiler)]
+	if !ok || override.Name == "" {
+		return ""
+	}
+	return override.Name
 }

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -57,9 +57,10 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Dat
 	}
 
 	// Resolve the host-profiler image now, during Configure, so ManageNodeAgent can use
-	// the correct image for the seccomp init container and profile name. The experimental
-	// image override is applied after ManageNodeAgent runs, so we must read it here.
-	o.hostProfilerImage = resolveHostProfilerImage(dda)
+	// the correct image for the seccomp init container and profile name. Both the
+	// experimental annotation and spec.override.nodeAgent.image are applied after
+	// ManageNodeAgent runs, so we must read them here.
+	o.hostProfilerImage = resolveHostProfilerImage(dda, ddaSpec)
 
 	return feature.RequiredComponents{
 		Agent: feature.RequiredComponent{
@@ -190,31 +191,38 @@ func (o *hostProfilerFeature) ManageOtelAgentGateway(managers feature.PodTemplat
 	return nil
 }
 
-// resolveHostProfilerImage returns the host-profiler image from the experimental image override annotation,
-// if present. This is needed because experimental overrides run after ManageNodeAgent, so we read them early
-// here to use the correct image for the seccomp init container and profile name.
-func resolveHostProfilerImage(dda metav1.Object) string {
-	annotations := dda.GetAnnotations()
-	if annotations == nil {
-		return ""
+// resolveHostProfilerImage returns the host-profiler image to use for the seccomp init container
+// and profile name. Both override sources are applied after ManageNodeAgent runs, so we read them
+// during Configure instead. Priority: experimental annotation > spec.override.nodeAgent.image > "".
+func resolveHostProfilerImage(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec) string {
+	// 1. Experimental per-container image override annotation.
+	if annotations := dda.GetAnnotations(); annotations != nil {
+		if raw := annotations["experimental.agent.datadoghq.com/image-override-config"]; raw != "" {
+			var overrides map[string]struct {
+				Name string `json:"name,omitempty"`
+				Tag  string `json:"tag,omitempty"`
+			}
+			if err := json.Unmarshal([]byte(raw), &overrides); err == nil {
+				if o, ok := overrides[string(apicommon.HostProfiler)]; ok && o.Name != "" {
+					if o.Tag != "" && !strings.Contains(o.Name, ":") {
+						return o.Name + ":" + o.Tag
+					}
+					return o.Name
+				}
+			}
+		}
 	}
-	raw, ok := annotations["experimental.agent.datadoghq.com/image-override-config"]
-	if !ok || raw == "" {
-		return ""
+
+	// 2. spec.override.nodeAgent.image — applied to all agent containers including host-profiler.
+	if ddaSpec != nil {
+		if componentOverride, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok && componentOverride.Image != nil {
+			img := componentOverride.Image
+			if img.Name != "" && img.Tag != "" && !strings.Contains(img.Name, ":") {
+				return img.Name + ":" + img.Tag
+			}
+			return img.Name
+		}
 	}
-	var overrides map[string]struct {
-		Name string `json:"name,omitempty"`
-		Tag  string `json:"tag,omitempty"`
-	}
-	if err := json.Unmarshal([]byte(raw), &overrides); err != nil {
-		return ""
-	}
-	override, ok := overrides[string(apicommon.HostProfiler)]
-	if !ok || override.Name == "" {
-		return ""
-	}
-	if override.Tag != "" && !strings.Contains(override.Name, ":") {
-		return override.Name + ":" + override.Tag
-	}
-	return override.Name
+
+	return ""
 }

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
@@ -50,31 +49,8 @@ func Test_hostProfilerFeature_Configure(t *testing.T) {
 			WantConfigure: true,
 			Agent:         testExpectedAgent(apicommon.HostProfiler, defaultVolumeMounts),
 		},
-		{
-			Name: "host profiler enabled - dependencies",
-			DDA: testutils.NewDatadogAgentBuilder().
-				WithName("foo").
-				WithAnnotations(map[string]string{"agent.datadoghq.com/host-profiler-enabled": "true"}).
-				Build(),
-			WantConfigure:        true,
-			WantDependenciesFunc: testExpectedDependencies,
-		},
 	}
 	tests.Run(t, buildHostProfilerFeature)
-}
-
-func testExpectedDependencies(t testing.TB, storeClient store.StoreClient) {
-	obj, found := storeClient.Get(kubernetes.ConfigMapKind, "", "foo-host-profiler-seccomp")
-	assert.True(t, found, "host-profiler-seccomp ConfigMap should be created")
-	if !found {
-		return
-	}
-	cm, ok := obj.(*corev1.ConfigMap)
-	assert.True(t, ok)
-	assert.Contains(t, cm.Data, seccompKey, "ConfigMap should contain the seccomp profile key")
-	assert.Contains(t, cm.Data[seccompKey], "SCMP_ACT_ERRNO", "seccomp profile should deny by default")
-	assert.Contains(t, cm.Data[seccompKey], `"bpf"`, "bpf syscall must be in the profile")
-	assert.Contains(t, cm.Data[seccompKey], `"perf_event_open"`, "perf_event_open must be in the profile")
 }
 
 func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expectedVolumeMount []corev1.VolumeMount) *test.ComponentTest {
@@ -143,16 +119,6 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				annotations := mgr.AnnotationMgr.Annotations
 				assert.True(t, apiutils.IsEqualStruct(annotations, expectedAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, expectedAnnotations))
 
-				// host-profiler-security ConfigMap volume
-				secVolumeFound := false
-				for _, v := range mgr.VolumeMgr.Volumes {
-					if v.Name == securityVolumeName {
-						secVolumeFound = true
-						assert.NotNil(t, v.ConfigMap, "host-profiler-security volume should reference a ConfigMap")
-					}
-				}
-				assert.True(t, secVolumeFound, "host-profiler-security volume should be present")
-
 				// seccomp-root volume
 				seccompRootFound := false
 				for _, v := range mgr.VolumeMgr.Volumes {
@@ -162,7 +128,7 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				}
 				assert.True(t, seccompRootFound, "seccomp-root volume should be present")
 
-				// Init container: host-profiler-seccomp-setup
+				// Init container: host-profiler-seccomp-setup copies from the image path
 				var setupContainer *corev1.Container
 				for i := range mgr.Tpl.Spec.InitContainers {
 					if mgr.Tpl.Spec.InitContainers[i].Name == "host-profiler-seccomp-setup" {
@@ -173,13 +139,14 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				assert.NotNil(t, setupContainer, "host-profiler-seccomp-setup init container should be present")
 				if setupContainer != nil {
 					assert.Equal(t, hostProfilerImage, setupContainer.Image)
+					assert.Contains(t, setupContainer.Command, seccompSourcePath, "cp source should be the in-image seccomp path")
 					expectedDst := common.SeccompRootVolumePath + "/" + seccompProfileName
 					assert.Contains(t, setupContainer.Command, expectedDst, "cp command should target the kubelet seccomp path")
+					// Init container should only mount seccomp-root, not the ConfigMap volume
 					mountNames := map[string]bool{}
 					for _, m := range setupContainer.VolumeMounts {
 						mountNames[m.Name] = true
 					}
-					assert.True(t, mountNames[securityVolumeName], "init container should mount host-profiler-security")
 					assert.True(t, mountNames[common.SeccompRootVolumeName], "init container should mount seccomp-root")
 				}
 			},
@@ -199,32 +166,4 @@ func TestDefaultCapabilities(t *testing.T) {
 	assert.True(t, capSet["PERFMON"], "host-profiler requires PERFMON for perf_event_open")
 	assert.True(t, capSet["CHECKPOINT_RESTORE"], "host-profiler requires CHECKPOINT_RESTORE for /proc/<pid>/map_files access")
 	assert.True(t, capSet["SYS_PTRACE"], "host-profiler requires SYS_PTRACE for process tracing")
-}
-
-func TestDefaultSyscalls(t *testing.T) {
-	syscalls := defaultSyscalls()
-
-	syscallSet := make(map[string]bool)
-	for _, s := range syscalls {
-		syscallSet[s] = true
-	}
-
-	assert.NotEmpty(t, syscalls)
-	assert.True(t, syscallSet["bpf"], "host-profiler requires bpf syscall")
-	assert.True(t, syscallSet["perf_event_open"], "host-profiler requires perf_event_open")
-	assert.True(t, syscallSet["openat"], "host-profiler requires openat for /proc/<pid>/map_files access")
-	assert.True(t, syscallSet["read"], "host-profiler requires read")
-	assert.False(t, syscallSet["ptrace"], "host-profiler should not need ptrace syscall (uses /proc instead)")
-}
-
-func TestDefaultSeccompConfigData(t *testing.T) {
-	data := defaultSeccompConfigData()
-
-	assert.Contains(t, data, seccompKey, "seccomp configmap should have the host-profiler key")
-
-	profile := data[seccompKey]
-	assert.Contains(t, profile, "SCMP_ACT_ERRNO", "default action should be SCMP_ACT_ERRNO")
-	assert.Contains(t, profile, "SCMP_ACT_ALLOW", "syscalls should be allowed")
-	assert.Contains(t, profile, `"bpf"`, "bpf syscall must be in the profile")
-	assert.Contains(t, profile, `"perf_event_open"`, "perf_event_open syscall must be in the profile")
 }

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -106,7 +106,7 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 					assert.False(t, *sc.AllowPrivilegeEscalation, "AllowPrivilegeEscalation must be false")
 					assert.NotNil(t, sc.SeccompProfile)
 					assert.Equal(t, corev1.SeccompProfileTypeLocalhost, sc.SeccompProfile.Type)
-					assert.Equal(t, seccompProfileName, *sc.SeccompProfile.LocalhostProfile)
+					assert.Equal(t, seccompProfileName(hostProfilerImage), *sc.SeccompProfile.LocalhostProfile)
 					assert.NotNil(t, sc.Capabilities)
 					assert.Contains(t, sc.Capabilities.Drop, corev1.Capability("ALL"))
 					assert.True(t, apiutils.IsEqualStruct(sc.Capabilities.Add, defaultCapabilities()), "capabilities.Add \ndiff = %s", cmp.Diff(sc.Capabilities.Add, defaultCapabilities()))
@@ -140,7 +140,7 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				if setupContainer != nil {
 					assert.Equal(t, hostProfilerImage, setupContainer.Image)
 					assert.Contains(t, setupContainer.Command, seccompSourcePath, "cp source should be the in-image seccomp path")
-					expectedDst := common.SeccompRootVolumePath + "/" + seccompProfileName
+					expectedDst := common.SeccompRootVolumePath + "/" + seccompProfileName(hostProfilerImage)
 					assert.Contains(t, setupContainer.Command, expectedDst, "cp command should target the kubelet seccomp path")
 					// Init container should only mount seccomp-root, not the ConfigMap volume
 					mountNames := map[string]bool{}

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -151,6 +152,66 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				}
 			},
 		)
+}
+
+func TestResolveHostProfilerImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			want:        "",
+		},
+		{
+			name:        "annotation absent",
+			annotations: map[string]string{"some.other/annotation": "value"},
+			want:        "",
+		},
+		{
+			name: "host-profiler override present",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler:v2"}}`,
+			},
+			want: "gcr.io/x/host-profiler:v2",
+		},
+		{
+			name: "override for different container",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"agent":{"name":"gcr.io/x/agent:v2"}}`,
+			},
+			want: "",
+		},
+		{
+			name: "name without tag, tag field set",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler","tag":"v2"}}`,
+			},
+			want: "gcr.io/x/host-profiler:v2",
+		},
+		{
+			name: "name with tag, tag field also set — name wins",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler:v1","tag":"v2"}}`,
+			},
+			want: "gcr.io/x/host-profiler:v1",
+		},
+		{
+			name: "malformed json",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `not-json`,
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dda := &metav1.ObjectMeta{Annotations: tt.annotations}
+			assert.Equal(t, tt.want, resolveHostProfilerImage(dda))
+		})
+	}
 }
 
 func TestDefaultCapabilities(t *testing.T) {

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
@@ -158,12 +159,12 @@ func TestResolveHostProfilerImage(t *testing.T) {
 	tests := []struct {
 		name        string
 		annotations map[string]string
+		ddaSpec     *v2alpha1.DatadogAgentSpec
 		want        string
 	}{
 		{
-			name:        "no annotations",
-			annotations: nil,
-			want:        "",
+			name: "no annotations, no spec override",
+			want: "",
 		},
 		{
 			name:        "annotation absent",
@@ -171,45 +172,66 @@ func TestResolveHostProfilerImage(t *testing.T) {
 			want:        "",
 		},
 		{
-			name: "host-profiler override present",
+			name: "experimental annotation — full ref in name",
 			annotations: map[string]string{
 				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler:v2"}}`,
 			},
 			want: "gcr.io/x/host-profiler:v2",
 		},
 		{
-			name: "override for different container",
-			annotations: map[string]string{
-				"experimental.agent.datadoghq.com/image-override-config": `{"agent":{"name":"gcr.io/x/agent:v2"}}`,
-			},
-			want: "",
-		},
-		{
-			name: "name without tag, tag field set",
+			name: "experimental annotation — name and tag fields",
 			annotations: map[string]string{
 				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler","tag":"v2"}}`,
 			},
 			want: "gcr.io/x/host-profiler:v2",
 		},
 		{
-			name: "name with tag, tag field also set — name wins",
+			name: "experimental annotation — name with tag takes precedence over tag field",
 			annotations: map[string]string{
 				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler:v1","tag":"v2"}}`,
 			},
 			want: "gcr.io/x/host-profiler:v1",
 		},
 		{
-			name: "malformed json",
+			name: "experimental annotation — different container, ignored",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"agent":{"name":"gcr.io/x/agent:v2"}}`,
+			},
+			want: "",
+		},
+		{
+			name: "experimental annotation — malformed json",
 			annotations: map[string]string{
 				"experimental.agent.datadoghq.com/image-override-config": `not-json`,
 			},
 			want: "",
 		},
+		{
+			name: "spec.override.nodeAgent.image",
+			ddaSpec: &v2alpha1.DatadogAgentSpec{
+				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.NodeAgentComponentName: {Image: &v2alpha1.AgentImageConfig{Name: "gcr.io/x/agent", Tag: "7.99.0"}},
+				},
+			},
+			want: "gcr.io/x/agent:7.99.0",
+		},
+		{
+			name: "experimental annotation takes precedence over spec.override.nodeAgent.image",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler:v2"}}`,
+			},
+			ddaSpec: &v2alpha1.DatadogAgentSpec{
+				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.NodeAgentComponentName: {Image: &v2alpha1.AgentImageConfig{Tag: "7.99.0"}},
+				},
+			},
+			want: "gcr.io/x/host-profiler:v2",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dda := &metav1.ObjectMeta{Annotations: tt.annotations}
-			assert.Equal(t, tt.want, resolveHostProfilerImage(dda))
+			assert.Equal(t, tt.want, resolveHostProfilerImage(dda, tt.ddaSpec))
 		})
 	}
 }

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -7,7 +7,6 @@ package hostprofiler
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -15,11 +14,9 @@ import (
 )
 
 const (
-	securityVolumeName               = "host-profiler-security"
-	securityVolumePath               = "/etc/config/host-profiler"
-	seccompKey                       = "host-profiler-seccomp.json"
-	agentSecurityConfigMapSuffixName = "host-profiler-seccomp"
-	seccompProfileName               = "host-profiler"
+	// seccompSourcePath is the path to the seccomp profile baked into the collector image.
+	seccompSourcePath  = "/etc/dd-host-profiler/seccomp.json"
+	seccompProfileName = "host-profiler"
 )
 
 func defaultCapabilities() []corev1.Capability {
@@ -34,143 +31,16 @@ func defaultCapabilities() []corev1.Capability {
 	}
 }
 
-func defaultSyscalls() []string {
-	return []string{
-		"accept4",
-		"access",
-		"arch_prctl",
-		"bind",
-		"bpf",
-		"brk",
-		"chmod",
-		"clone",
-		"clone3",
-		"close",
-		"connect",
-		"dup3",
-		"epoll_create1",
-		"epoll_ctl",
-		"epoll_pwait",
-		"epoll_wait",
-		"eventfd2",
-		"execve",
-		"exit",
-		"exit_group",
-		"faccessat2",
-		"fcntl",
-		"fstat",
-		"fstatfs",
-		"futex",
-		"getcwd",
-		"getdents64",
-		"getpeername",
-		"getpid",
-		"getrandom",
-		"getsockname",
-		"getsockopt",
-		"gettid",
-		"getrlimit",
-		"ioctl",
-		"listen",
-		"lseek",
-		"madvise",
-		"mmap",
-		"mprotect",
-		"munmap",
-		"nanosleep",
-		"newfstatat",
-		"openat",
-		"openat2",
-		"perf_event_open",
-		"pidfd_open",
-		"pidfd_send_signal",
-		"pipe2",
-		"prctl",
-		"pread64",
-		"prlimit64",
-		"process_vm_readv",
-		"read",
-		"readlinkat",
-		"rename",
-		"renameat",
-		"renameat2",
-		"recvmsg",
-		"restart_syscall",
-		"rseq",
-		"rt_sigaction",
-		"rt_sigprocmask",
-		"rt_sigreturn",
-		"sched_getaffinity",
-		"sched_yield",
-		"sendto",
-		"set_robust_list",
-		"set_tid_address",
-		"setrlimit",
-		"setsockopt",
-		"sigaltstack",
-		"socket",
-		"statfs",
-		"statx",
-		"sysinfo",
-		"tgkill",
-		"umask",
-		"uname",
-		"unlinkat",
-		"wait4",
-		"waitid",
-		"write",
-	}
-}
-
-func defaultSeccompConfigData() map[string]string {
-	syscalls := fmt.Sprintf(`["%s"]`, strings.Join(defaultSyscalls(), `","`))
-
-	return map[string]string{
-		seccompKey: fmt.Sprintf(`{
-			"defaultAction": "SCMP_ACT_ERRNO",
-			"architectures": [
-				"SCMP_ARCH_X86_64",
-				"SCMP_ARCH_AARCH64"
-			],
-			"syscalls": [
-				{
-				"names": %s,
-				"action": "SCMP_ACT_ALLOW"
-				},
-				{
-				"names": [
-					"kill"
-				],
-				"action": "SCMP_ACT_ALLOW",
-				"args": [
-					{
-					"index": 1,
-					"value": 0,
-					"op": "SCMP_CMP_EQ"
-					}
-				],
-				"comment": "allow process liveness check via kill(pid, 0)"
-				}
-			]
-		}
-		`, syscalls),
-	}
-}
-
 func buildSeccompSetupInitContainer(image string) corev1.Container {
 	return corev1.Container{
 		Name:  "host-profiler-seccomp-setup",
 		Image: image,
 		Command: []string{
 			"cp",
-			fmt.Sprintf("%s/%s", securityVolumePath, seccompKey),
+			seccompSourcePath,
 			fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName),
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      securityVolumeName,
-				MountPath: securityVolumePath,
-			},
 			common.GetVolumeMountForSeccomp(),
 		},
 	}

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -35,6 +35,7 @@ func defaultCapabilities() []corev1.Capability {
 		"DAC_READ_SEARCH",
 		"SYSLOG",
 		"CHECKPOINT_RESTORE",
+		"IPC_LOCK",
 	}
 }
 

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -6,6 +6,7 @@
 package hostprofiler
 
 import (
+	"crypto/sha256"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,9 +16,15 @@ import (
 
 const (
 	// seccompSourcePath is the path to the seccomp profile baked into the collector image.
-	seccompSourcePath  = "/etc/dd-host-profiler/seccomp.json"
-	seccompProfileName = "host-profiler"
+	seccompSourcePath = "/etc/dd-host-profiler/seccomp.json"
 )
+
+// seccompProfileName returns a profile name unique to the image, avoiding
+// races when multiple host-profiler versions coexist on the same node.
+func seccompProfileName(imageRef string) string {
+	h := sha256.Sum256([]byte(imageRef))
+	return fmt.Sprintf("host-profiler-%x", h[:4])
+}
 
 func defaultCapabilities() []corev1.Capability {
 	return []corev1.Capability{
@@ -38,7 +45,7 @@ func buildSeccompSetupInitContainer(image string) corev1.Container {
 		Command: []string{
 			"cp",
 			seccompSourcePath,
-			fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName),
+			fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName(image)),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			common.GetVolumeMountForSeccomp(),


### PR DESCRIPTION
### What does this PR do?

Leverages the seccomp profile now bundled in the Host Profiler's image.
https://github.com/DataDog/datadog-agent/pull/51545

### Motivation

Before this, the seccomp profile was living in 3 different places:
- `datadog-operator`
- datadog's `helm-charts`
- Standalone documentation

Bundling the seccomp directly in the image and using it as an `initContainer` enables us the version the seccomp profile with profiler versions and maintain only one copy.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Used this branch alongside the datadog-agent PR's standalone image to test.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits