### PR TITLE
Add GKE Autopilot support for CSI driver with v1.1.0 WorkloadAllowlist

### DIFF
--- a/internal/controller/datadogcsidriver/autopilot.go
+++ b/internal/controller/datadogcsidriver/autopilot.go
@@ -6,99 +6,89 @@
 package datadogcsidriver
 
 import (
-	"strings"
-
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/pkg/allowlistsynchronizer"
 )
 
 const (
-	// GKEAutopilotAnnotation enables GKE Autopilot mode for the CSI driver.
-	// When set to "true", the controller creates an AllowlistSynchronizer and
-	// adds the cloud.google.com/matching-allowlist label to the DaemonSet.
-	GKEAutopilotAnnotation = "csi.datadoghq.com/gke-autopilot"
-
-	// GKEAutopilotAllowlistVersionAnnotation allows overriding the CSI driver
-	// WorkloadAllowlist version. If not set, defaults to v1.1.0.
-	GKEAutopilotAllowlistVersionAnnotation = "csi.datadoghq.com/gke-autopilot-allowlist-version"
-
-	// GKEAutopilotLegacyAnnotation indicates the cluster is running legacy Autopilot
-	// (only AllowlistedV2Workload CRD, not WorkloadAllowlist). When set to "true",
-	// the storage-dir volume and DD_APM_ENABLED env var are removed from the DaemonSet
-	// because no updated exemption exists for legacy Autopilot.
-	GKEAutopilotLegacyAnnotation = "csi.datadoghq.com/gke-autopilot-legacy"
-
 	// GKEMatchingAllowlistLabelKey is the label key used by GKE Autopilot to match
 	// workloads with WorkloadAllowlists.
 	GKEMatchingAllowlistLabelKey = "cloud.google.com/matching-allowlist"
+
+	// WorkloadAllowlist is the CRD Kind for modern GKE Autopilot (>= 1.32.1-gke.1729000)
+	workloadAllowlistKind = "WorkloadAllowlist"
+
+	// AllowlistedV2Workload is the CRD Kind for legacy GKE Autopilot
+	allowlistedV2WorkloadKind = "AllowlistedV2Workload"
 )
 
-// IsGKEAutopilotEnabled returns true if the CSI driver is configured for GKE Autopilot.
-func IsGKEAutopilotEnabled(instance *datadoghqv1alpha1.DatadogCSIDriver) bool {
-	if instance == nil {
-		return false
+// GKEAutopilotMode represents the detected GKE Autopilot mode
+type GKEAutopilotMode int
+
+const (
+	// GKEAutopilotModeNone means not running on GKE Autopilot
+	GKEAutopilotModeNone GKEAutopilotMode = iota
+	// GKEAutopilotModeModern means running on GKE Autopilot with WorkloadAllowlist support (>= 1.32.1-gke.1729000)
+	GKEAutopilotModeModern
+	// GKEAutopilotModeLegacy means running on legacy GKE Autopilot (only AllowlistedV2Workload)
+	GKEAutopilotModeLegacy
+)
+
+// DetectGKEAutopilotMode detects the GKE Autopilot mode based on available CRDs
+func DetectGKEAutopilotMode(platformInfo PlatformInfo) GKEAutopilotMode {
+	if platformInfo == nil {
+		return GKEAutopilotModeNone
 	}
-	ann := instance.GetAnnotations()
-	if ann == nil {
-		return false
+
+	// Modern Autopilot has WorkloadAllowlist CRD
+	if platformInfo.IsResourceSupported(workloadAllowlistKind) {
+		return GKEAutopilotModeModern
 	}
-	return strings.EqualFold(ann[GKEAutopilotAnnotation], "true")
+
+	// Legacy Autopilot only has AllowlistedV2Workload CRD
+	if platformInfo.IsResourceSupported(allowlistedV2WorkloadKind) {
+		return GKEAutopilotModeLegacy
+	}
+
+	return GKEAutopilotModeNone
 }
 
-// IsGKEAutopilotLegacy returns true if the cluster is running legacy Autopilot
-// (only AllowlistedV2Workload CRD, not the newer WorkloadAllowlist).
-func IsGKEAutopilotLegacy(instance *datadoghqv1alpha1.DatadogCSIDriver) bool {
-	if instance == nil {
-		return false
-	}
-	ann := instance.GetAnnotations()
-	if ann == nil {
-		return false
-	}
-	return strings.EqualFold(ann[GKEAutopilotLegacyAnnotation], "true")
+// IsGKEAutopilot returns true if running on any version of GKE Autopilot
+func IsGKEAutopilot(platformInfo PlatformInfo) bool {
+	return DetectGKEAutopilotMode(platformInfo) != GKEAutopilotModeNone
 }
 
-// GetGKEAutopilotAllowlistVersion returns the configured WorkloadAllowlist version
-// from annotations, or empty string to use the default.
-func GetGKEAutopilotAllowlistVersion(instance *datadoghqv1alpha1.DatadogCSIDriver) string {
-	if instance == nil {
-		return ""
-	}
-	ann := instance.GetAnnotations()
-	if ann == nil {
-		return ""
-	}
-	return ann[GKEAutopilotAllowlistVersionAnnotation]
+// IsGKEAutopilotModern returns true if running on modern GKE Autopilot with WorkloadAllowlist support
+func IsGKEAutopilotModern(platformInfo PlatformInfo) bool {
+	return DetectGKEAutopilotMode(platformInfo) == GKEAutopilotModeModern
+}
+
+// IsGKEAutopilotLegacy returns true if running on legacy GKE Autopilot
+func IsGKEAutopilotLegacy(platformInfo PlatformInfo) bool {
+	return DetectGKEAutopilotMode(platformInfo) == GKEAutopilotModeLegacy
 }
 
 // CreateCSIAllowlistSynchronizerIfNeeded creates the AllowlistSynchronizer for the
-// CSI driver if GKE Autopilot is enabled and not in legacy mode.
-func CreateCSIAllowlistSynchronizerIfNeeded(instance *datadoghqv1alpha1.DatadogCSIDriver) {
-	if !IsGKEAutopilotEnabled(instance) {
-		return
-	}
-	if IsGKEAutopilotLegacy(instance) {
+// CSI driver if running on modern GKE Autopilot (with WorkloadAllowlist support).
+func CreateCSIAllowlistSynchronizerIfNeeded(instance *datadoghqv1alpha1.DatadogCSIDriver, platformInfo PlatformInfo) {
+	if !IsGKEAutopilotModern(platformInfo) {
 		return
 	}
 
-	version := GetGKEAutopilotAllowlistVersion(instance)
 	partOfLabel := object.NewPartOfLabelValue(instance).String()
-	allowlistsynchronizer.CreateCSIAllowlistSynchronizer(version, partOfLabel)
+	// Use empty string to get the default version (v1.1.0)
+	allowlistsynchronizer.CreateCSIAllowlistSynchronizer("", partOfLabel)
 }
 
 // GetGKEAutopilotLabels returns the labels needed for the CSI driver DaemonSet
-// on GKE Autopilot. Returns nil if Autopilot is not enabled or is in legacy mode.
-func GetGKEAutopilotLabels(instance *datadoghqv1alpha1.DatadogCSIDriver) map[string]string {
-	if !IsGKEAutopilotEnabled(instance) {
-		return nil
-	}
-	if IsGKEAutopilotLegacy(instance) {
+// on GKE Autopilot. Returns nil if not on modern Autopilot.
+func GetGKEAutopilotLabels(platformInfo PlatformInfo) map[string]string {
+	if !IsGKEAutopilotModern(platformInfo) {
 		return nil
 	}
 
-	version := GetGKEAutopilotAllowlistVersion(instance)
 	return map[string]string{
-		GKEMatchingAllowlistLabelKey: allowlistsynchronizer.GetCSIMatchingAllowlistLabelValue(version),
+		GKEMatchingAllowlistLabelKey: allowlistsynchronizer.CSIMatchingAllowlistLabel,
 	}
 }

--- a/internal/controller/datadogcsidriver/autopilot.go
+++ b/internal/controller/datadogcsidriver/autopilot.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogcsidriver
+
+import (
+	"strings"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
+	"github.com/DataDog/datadog-operator/pkg/allowlistsynchronizer"
+)
+
+const (
+	// GKEAutopilotAnnotation enables GKE Autopilot mode for the CSI driver.
+	// When set to "true", the controller creates an AllowlistSynchronizer and
+	// adds the cloud.google.com/matching-allowlist label to the DaemonSet.
+	GKEAutopilotAnnotation = "csi.datadoghq.com/gke-autopilot"
+
+	// GKEAutopilotAllowlistVersionAnnotation allows overriding the CSI driver
+	// WorkloadAllowlist version. If not set, defaults to v1.1.0.
+	GKEAutopilotAllowlistVersionAnnotation = "csi.datadoghq.com/gke-autopilot-allowlist-version"
+
+	// GKEAutopilotLegacyAnnotation indicates the cluster is running legacy Autopilot
+	// (only AllowlistedV2Workload CRD, not WorkloadAllowlist). When set to "true",
+	// the storage-dir volume and DD_APM_ENABLED env var are removed from the DaemonSet
+	// because no updated exemption exists for legacy Autopilot.
+	GKEAutopilotLegacyAnnotation = "csi.datadoghq.com/gke-autopilot-legacy"
+
+	// GKEMatchingAllowlistLabelKey is the label key used by GKE Autopilot to match
+	// workloads with WorkloadAllowlists.
+	GKEMatchingAllowlistLabelKey = "cloud.google.com/matching-allowlist"
+)
+
+// IsGKEAutopilotEnabled returns true if the CSI driver is configured for GKE Autopilot.
+func IsGKEAutopilotEnabled(instance *datadoghqv1alpha1.DatadogCSIDriver) bool {
+	if instance == nil {
+		return false
+	}
+	ann := instance.GetAnnotations()
+	if ann == nil {
+		return false
+	}
+	return strings.EqualFold(ann[GKEAutopilotAnnotation], "true")
+}
+
+// IsGKEAutopilotLegacy returns true if the cluster is running legacy Autopilot
+// (only AllowlistedV2Workload CRD, not the newer WorkloadAllowlist).
+func IsGKEAutopilotLegacy(instance *datadoghqv1alpha1.DatadogCSIDriver) bool {
+	if instance == nil {
+		return false
+	}
+	ann := instance.GetAnnotations()
+	if ann == nil {
+		return false
+	}
+	return strings.EqualFold(ann[GKEAutopilotLegacyAnnotation], "true")
+}
+
+// GetGKEAutopilotAllowlistVersion returns the configured WorkloadAllowlist version
+// from annotations, or empty string to use the default.
+func GetGKEAutopilotAllowlistVersion(instance *datadoghqv1alpha1.DatadogCSIDriver) string {
+	if instance == nil {
+		return ""
+	}
+	ann := instance.GetAnnotations()
+	if ann == nil {
+		return ""
+	}
+	return ann[GKEAutopilotAllowlistVersionAnnotation]
+}
+
+// CreateCSIAllowlistSynchronizerIfNeeded creates the AllowlistSynchronizer for the
+// CSI driver if GKE Autopilot is enabled and not in legacy mode.
+func CreateCSIAllowlistSynchronizerIfNeeded(instance *datadoghqv1alpha1.DatadogCSIDriver) {
+	if !IsGKEAutopilotEnabled(instance) {
+		return
+	}
+	if IsGKEAutopilotLegacy(instance) {
+		return
+	}
+
+	version := GetGKEAutopilotAllowlistVersion(instance)
+	partOfLabel := object.NewPartOfLabelValue(instance).String()
+	allowlistsynchronizer.CreateCSIAllowlistSynchronizer(version, partOfLabel)
+}
+
+// GetGKEAutopilotLabels returns the labels needed for the CSI driver DaemonSet
+// on GKE Autopilot. Returns nil if Autopilot is not enabled or is in legacy mode.
+func GetGKEAutopilotLabels(instance *datadoghqv1alpha1.DatadogCSIDriver) map[string]string {
+	if !IsGKEAutopilotEnabled(instance) {
+		return nil
+	}
+	if IsGKEAutopilotLegacy(instance) {
+		return nil
+	}
+
+	version := GetGKEAutopilotAllowlistVersion(instance)
+	return map[string]string{
+		GKEMatchingAllowlistLabelKey: allowlistsynchronizer.GetCSIMatchingAllowlistLabelValue(version),
+	}
+}

--- a/internal/controller/datadogcsidriver/autopilot_test.go
+++ b/internal/controller/datadogcsidriver/autopilot_test.go
@@ -9,71 +9,138 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/allowlistsynchronizer"
 )
 
-func TestIsGKEAutopilotEnabled(t *testing.T) {
+func TestDetectGKEAutopilotMode(t *testing.T) {
 	tests := []struct {
-		name        string
-		instance    *v1alpha1.DatadogCSIDriver
-		expected    bool
+		name         string
+		platformInfo PlatformInfo
+		expected     GKEAutopilotMode
 	}{
 		{
-			name:     "nil instance",
-			instance: nil,
-			expected: false,
+			name:         "nil platformInfo",
+			platformInfo: nil,
+			expected:     GKEAutopilotModeNone,
 		},
 		{
-			name: "no annotations",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{},
+			name: "no Autopilot CRDs",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{},
 			},
-			expected: false,
+			expected: GKEAutopilotModeNone,
 		},
 		{
-			name: "autopilot not set",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"other-annotation": "value",
-					},
+			name: "modern Autopilot (WorkloadAllowlist)",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"WorkloadAllowlist": true,
 				},
 			},
+			expected: GKEAutopilotModeModern,
+		},
+		{
+			name: "modern Autopilot with both CRDs",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"WorkloadAllowlist":     true,
+					"AllowlistedV2Workload": true,
+				},
+			},
+			expected: GKEAutopilotModeModern,
+		},
+		{
+			name: "legacy Autopilot (AllowlistedV2Workload only)",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"AllowlistedV2Workload": true,
+				},
+			},
+			expected: GKEAutopilotModeLegacy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, DetectGKEAutopilotMode(tt.platformInfo))
+		})
+	}
+}
+
+func TestIsGKEAutopilot(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformInfo PlatformInfo
+		expected     bool
+	}{
+		{
+			name:         "nil platformInfo",
+			platformInfo: nil,
+			expected:     false,
+		},
+		{
+			name: "no Autopilot CRDs",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{},
+			},
 			expected: false,
 		},
 		{
-			name: "autopilot enabled (lowercase)",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation: "true",
-					},
+			name: "modern Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"WorkloadAllowlist": true,
 				},
 			},
 			expected: true,
 		},
 		{
-			name: "autopilot enabled (uppercase)",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation: "TRUE",
-					},
+			name: "legacy Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"AllowlistedV2Workload": true,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsGKEAutopilot(tt.platformInfo))
+		})
+	}
+}
+
+func TestIsGKEAutopilotModern(t *testing.T) {
+	tests := []struct {
+		name         string
+		platformInfo PlatformInfo
+		expected     bool
+	}{
+		{
+			name: "modern Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"WorkloadAllowlist": true,
 				},
 			},
 			expected: true,
 		},
 		{
-			name: "autopilot disabled",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation: "false",
-					},
+			name: "legacy Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"AllowlistedV2Workload": true,
 				},
+			},
+			expected: false,
+		},
+		{
+			name: "not Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{},
 			},
 			expected: false,
 		},
@@ -81,154 +148,89 @@ func TestIsGKEAutopilotEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, IsGKEAutopilotEnabled(tt.instance))
+			assert.Equal(t, tt.expected, IsGKEAutopilotModern(tt.platformInfo))
 		})
 	}
 }
 
 func TestIsGKEAutopilotLegacy(t *testing.T) {
 	tests := []struct {
-		name     string
-		instance *v1alpha1.DatadogCSIDriver
-		expected bool
+		name         string
+		platformInfo PlatformInfo
+		expected     bool
 	}{
 		{
-			name:     "nil instance",
-			instance: nil,
-			expected: false,
-		},
-		{
-			name: "legacy not set",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation: "true",
-					},
+			name: "modern Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"WorkloadAllowlist": true,
 				},
 			},
 			expected: false,
 		},
 		{
-			name: "legacy enabled",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation:       "true",
-						GKEAutopilotLegacyAnnotation: "true",
-					},
+			name: "legacy Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"AllowlistedV2Workload": true,
 				},
 			},
 			expected: true,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, IsGKEAutopilotLegacy(tt.instance))
-		})
-	}
-}
-
-func TestGetGKEAutopilotAllowlistVersion(t *testing.T) {
-	tests := []struct {
-		name     string
-		instance *v1alpha1.DatadogCSIDriver
-		expected string
-	}{
 		{
-			name:     "nil instance",
-			instance: nil,
-			expected: "",
-		},
-		{
-			name: "version not set",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation: "true",
-					},
-				},
+			name: "not Autopilot",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{},
 			},
-			expected: "",
-		},
-		{
-			name: "custom version set",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation:                 "true",
-						GKEAutopilotAllowlistVersionAnnotation: "v2.0.0",
-					},
-				},
-			},
-			expected: "v2.0.0",
+			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, GetGKEAutopilotAllowlistVersion(tt.instance))
+			assert.Equal(t, tt.expected, IsGKEAutopilotLegacy(tt.platformInfo))
 		})
 	}
 }
 
 func TestGetGKEAutopilotLabels(t *testing.T) {
 	tests := []struct {
-		name     string
-		instance *v1alpha1.DatadogCSIDriver
-		expected map[string]string
+		name         string
+		platformInfo PlatformInfo
+		expected     map[string]string
 	}{
 		{
-			name: "autopilot disabled returns nil",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{},
+			name: "not Autopilot returns nil",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{},
 			},
 			expected: nil,
 		},
 		{
-			name: "autopilot legacy returns nil",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation:       "true",
-						GKEAutopilotLegacyAnnotation: "true",
-					},
+			name: "legacy Autopilot returns nil",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"AllowlistedV2Workload": true,
 				},
 			},
 			expected: nil,
 		},
 		{
-			name: "autopilot enabled returns matching-allowlist label",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation: "true",
-					},
+			name: "modern Autopilot returns matching-allowlist label",
+			platformInfo: &mockPlatformInfo{
+				supportedResources: map[string]bool{
+					"WorkloadAllowlist": true,
 				},
 			},
 			expected: map[string]string{
 				GKEMatchingAllowlistLabelKey: allowlistsynchronizer.CSIMatchingAllowlistLabel,
 			},
 		},
-		{
-			name: "autopilot with custom version",
-			instance: &v1alpha1.DatadogCSIDriver{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						GKEAutopilotAnnotation:                 "true",
-						GKEAutopilotAllowlistVersionAnnotation: "v2.0.0",
-					},
-				},
-			},
-			expected: map[string]string{
-				GKEMatchingAllowlistLabelKey: "datadog-datadog-csi-driver-daemonset-exemption-v2.0.0",
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetGKEAutopilotLabels(tt.instance)
+			result := GetGKEAutopilotLabels(tt.platformInfo)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/controller/datadogcsidriver/autopilot_test.go
+++ b/internal/controller/datadogcsidriver/autopilot_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogcsidriver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/allowlistsynchronizer"
+)
+
+func TestIsGKEAutopilotEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		instance    *v1alpha1.DatadogCSIDriver
+		expected    bool
+	}{
+		{
+			name:     "nil instance",
+			instance: nil,
+			expected: false,
+		},
+		{
+			name: "no annotations",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: false,
+		},
+		{
+			name: "autopilot not set",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"other-annotation": "value",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "autopilot enabled (lowercase)",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "autopilot enabled (uppercase)",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation: "TRUE",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "autopilot disabled",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsGKEAutopilotEnabled(tt.instance))
+		})
+	}
+}
+
+func TestIsGKEAutopilotLegacy(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *v1alpha1.DatadogCSIDriver
+		expected bool
+	}{
+		{
+			name:     "nil instance",
+			instance: nil,
+			expected: false,
+		},
+		{
+			name: "legacy not set",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation: "true",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "legacy enabled",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation:       "true",
+						GKEAutopilotLegacyAnnotation: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsGKEAutopilotLegacy(tt.instance))
+		})
+	}
+}
+
+func TestGetGKEAutopilotAllowlistVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *v1alpha1.DatadogCSIDriver
+		expected string
+	}{
+		{
+			name:     "nil instance",
+			instance: nil,
+			expected: "",
+		},
+		{
+			name: "version not set",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation: "true",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "custom version set",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation:                 "true",
+						GKEAutopilotAllowlistVersionAnnotation: "v2.0.0",
+					},
+				},
+			},
+			expected: "v2.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetGKEAutopilotAllowlistVersion(tt.instance))
+		})
+	}
+}
+
+func TestGetGKEAutopilotLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		instance *v1alpha1.DatadogCSIDriver
+		expected map[string]string
+	}{
+		{
+			name: "autopilot disabled returns nil",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: nil,
+		},
+		{
+			name: "autopilot legacy returns nil",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation:       "true",
+						GKEAutopilotLegacyAnnotation: "true",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "autopilot enabled returns matching-allowlist label",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation: "true",
+					},
+				},
+			},
+			expected: map[string]string{
+				GKEMatchingAllowlistLabelKey: allowlistsynchronizer.CSIMatchingAllowlistLabel,
+			},
+		},
+		{
+			name: "autopilot with custom version",
+			instance: &v1alpha1.DatadogCSIDriver{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						GKEAutopilotAnnotation:                 "true",
+						GKEAutopilotAllowlistVersionAnnotation: "v2.0.0",
+					},
+				},
+			},
+			expected: map[string]string{
+				GKEMatchingAllowlistLabelKey: "datadog-datadog-csi-driver-daemonset-exemption-v2.0.0",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetGKEAutopilotLabels(tt.instance)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/controller/datadogcsidriver/controller.go
+++ b/internal/controller/datadogcsidriver/controller.go
@@ -100,6 +100,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogCS
 	// from a previous controller version) would be carried forward.
 	instance.Status.Conditions = nil
 
+	// Create AllowlistSynchronizer for GKE Autopilot if enabled (non-blocking)
+	CreateCSIAllowlistSynchronizerIfNeeded(instance)
+
 	// Reconcile CSIDriver object (cluster-scoped)
 	if err := r.reconcileCSIDriver(ctx, instance); err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{

--- a/internal/controller/datadogcsidriver/controller.go
+++ b/internal/controller/datadogcsidriver/controller.go
@@ -35,17 +35,24 @@ const (
 
 // Reconciler reconciles a DatadogCSIDriver object
 type Reconciler struct {
-	client   client.Client
-	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	client       client.Client
+	scheme       *runtime.Scheme
+	recorder     record.EventRecorder
+	platformInfo PlatformInfo
+}
+
+// PlatformInfo provides cluster capability detection
+type PlatformInfo interface {
+	IsResourceSupported(resource string) bool
 }
 
 // NewReconciler creates a new DatadogCSIDriver reconciler
-func NewReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, platformInfo PlatformInfo) *Reconciler {
 	return &Reconciler{
-		client:   client,
-		scheme:   scheme,
-		recorder: recorder,
+		client:       client,
+		scheme:       scheme,
+		recorder:     recorder,
+		platformInfo: platformInfo,
 	}
 }
 
@@ -100,8 +107,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogCS
 	// from a previous controller version) would be carried forward.
 	instance.Status.Conditions = nil
 
-	// Create AllowlistSynchronizer for GKE Autopilot if enabled (non-blocking)
-	CreateCSIAllowlistSynchronizerIfNeeded(instance)
+	// Create AllowlistSynchronizer for GKE Autopilot if detected (non-blocking)
+	CreateCSIAllowlistSynchronizerIfNeeded(instance, r.platformInfo)
 
 	// Reconcile CSIDriver object (cluster-scoped)
 	if err := r.reconcileCSIDriver(ctx, instance); err != nil {
@@ -201,7 +208,7 @@ func (r *Reconciler) reconcileCSIDriver(ctx context.Context, instance *v1alpha1.
 }
 
 func (r *Reconciler) reconcileDaemonSet(ctx context.Context, instance *v1alpha1.DatadogCSIDriver) error {
-	desired := buildDaemonSet(instance)
+	desired := buildDaemonSet(instance, r.platformInfo)
 
 	if err := controllerutil.SetControllerReference(instance, desired, r.scheme); err != nil {
 		return fmt.Errorf("setting owner reference: %w", err)

--- a/internal/controller/datadogcsidriver/controller_test.go
+++ b/internal/controller/datadogcsidriver/controller_test.go
@@ -496,3 +496,129 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 	}
 	return nil
 }
+
+func TestReconcile_GKEAutopilotEnabled(t *testing.T) {
+	instance := defaultCSIDriverCR()
+	instance.Annotations = map[string]string{
+		GKEAutopilotAnnotation: "true",
+	}
+
+	r, c := newTestReconciler(t, instance)
+	ctx := context.Background()
+
+	// Reconcile twice (finalizer + create)
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	ds := &appsv1.DaemonSet{}
+	err = c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds)
+	require.NoError(t, err)
+
+	// Verify the matching-allowlist label is set
+	assert.Equal(t, "datadog-datadog-csi-driver-daemonset-exemption-v1.1.0",
+		ds.Spec.Template.Labels[GKEMatchingAllowlistLabelKey])
+
+	// Verify storage-dir volume exists (modern Autopilot)
+	volumeNames := make([]string, 0, len(ds.Spec.Template.Spec.Volumes))
+	for _, v := range ds.Spec.Template.Spec.Volumes {
+		volumeNames = append(volumeNames, v.Name)
+	}
+	assert.Contains(t, volumeNames, storageDirVolumeName)
+
+	// Verify DD_APM_ENABLED env var exists (modern Autopilot)
+	csiContainer := ds.Spec.Template.Spec.Containers[0]
+	found := false
+	for _, env := range csiContainer.Env {
+		if env.Name == "DD_APM_ENABLED" {
+			found = true
+			assert.Equal(t, "true", env.Value)
+			break
+		}
+	}
+	assert.True(t, found, "DD_APM_ENABLED should be set for modern Autopilot")
+
+	// Verify storage-dir mount exists
+	mountNames := make([]string, 0, len(csiContainer.VolumeMounts))
+	for _, m := range csiContainer.VolumeMounts {
+		mountNames = append(mountNames, m.Name)
+	}
+	assert.Contains(t, mountNames, storageDirVolumeName)
+}
+
+func TestReconcile_GKEAutopilotLegacy(t *testing.T) {
+	instance := defaultCSIDriverCR()
+	instance.Annotations = map[string]string{
+		GKEAutopilotAnnotation:       "true",
+		GKEAutopilotLegacyAnnotation: "true",
+	}
+
+	r, c := newTestReconciler(t, instance)
+	ctx := context.Background()
+
+	// Reconcile twice (finalizer + create)
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	ds := &appsv1.DaemonSet{}
+	err = c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds)
+	require.NoError(t, err)
+
+	// Verify matching-allowlist label is NOT set (legacy mode)
+	_, hasLabel := ds.Spec.Template.Labels[GKEMatchingAllowlistLabelKey]
+	assert.False(t, hasLabel, "matching-allowlist label should not be set for legacy Autopilot")
+
+	// Verify storage-dir volume does NOT exist (legacy Autopilot)
+	volumeNames := make([]string, 0, len(ds.Spec.Template.Spec.Volumes))
+	for _, v := range ds.Spec.Template.Spec.Volumes {
+		volumeNames = append(volumeNames, v.Name)
+	}
+	assert.NotContains(t, volumeNames, storageDirVolumeName)
+
+	// Verify DD_APM_ENABLED env var does NOT exist (legacy Autopilot)
+	csiContainer := ds.Spec.Template.Spec.Containers[0]
+	for _, env := range csiContainer.Env {
+		assert.NotEqual(t, "DD_APM_ENABLED", env.Name, "DD_APM_ENABLED should not be set for legacy Autopilot")
+	}
+
+	// Verify storage-dir mount does NOT exist
+	mountNames := make([]string, 0, len(csiContainer.VolumeMounts))
+	for _, m := range csiContainer.VolumeMounts {
+		mountNames = append(mountNames, m.Name)
+	}
+	assert.NotContains(t, mountNames, storageDirVolumeName)
+}
+
+func TestReconcile_GKEAutopilotCustomVersion(t *testing.T) {
+	instance := defaultCSIDriverCR()
+	instance.Annotations = map[string]string{
+		GKEAutopilotAnnotation:                 "true",
+		GKEAutopilotAllowlistVersionAnnotation: "v2.0.0",
+	}
+
+	r, c := newTestReconciler(t, instance)
+	ctx := context.Background()
+
+	// Reconcile twice (finalizer + create)
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	ds := &appsv1.DaemonSet{}
+	err = c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds)
+	require.NoError(t, err)
+
+	// Verify the matching-allowlist label uses custom version
+	assert.Equal(t, "datadog-datadog-csi-driver-daemonset-exemption-v2.0.0",
+		ds.Spec.Template.Labels[GKEMatchingAllowlistLabelKey])
+}

--- a/internal/controller/datadogcsidriver/controller_test.go
+++ b/internal/controller/datadogcsidriver/controller_test.go
@@ -35,7 +35,23 @@ const (
 	testName      = "datadog-csi"
 )
 
+// mockPlatformInfo implements PlatformInfo for testing
+type mockPlatformInfo struct {
+	supportedResources map[string]bool
+}
+
+func (m *mockPlatformInfo) IsResourceSupported(resource string) bool {
+	if m.supportedResources == nil {
+		return false
+	}
+	return m.supportedResources[resource]
+}
+
 func newTestReconciler(t *testing.T, objects ...client.Object) (*Reconciler, client.Client) {
+	return newTestReconcilerWithPlatformInfo(t, &mockPlatformInfo{}, objects...)
+}
+
+func newTestReconcilerWithPlatformInfo(t *testing.T, platformInfo PlatformInfo, objects ...client.Object) (*Reconciler, client.Client) {
 	t.Helper()
 	s := scheme.Scheme
 	s.AddKnownTypes(v1alpha1.GroupVersion,
@@ -52,7 +68,7 @@ func newTestReconciler(t *testing.T, objects ...client.Object) (*Reconciler, cli
 	// Set the default controller-runtime logger so ctrl.LoggerFrom(ctx) works in tests
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	recorder := record.NewFakeRecorder(10)
-	r := NewReconciler(c, s, recorder)
+	r := NewReconciler(c, s, recorder, platformInfo)
 
 	return r, c
 }
@@ -497,13 +513,16 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 	return nil
 }
 
-func TestReconcile_GKEAutopilotEnabled(t *testing.T) {
+func TestReconcile_GKEAutopilotModern(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	instance.Annotations = map[string]string{
-		GKEAutopilotAnnotation: "true",
+	// Mock modern Autopilot: WorkloadAllowlist CRD is available
+	platformInfo := &mockPlatformInfo{
+		supportedResources: map[string]bool{
+			"WorkloadAllowlist": true,
+		},
 	}
 
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconcilerWithPlatformInfo(t, platformInfo, instance)
 	ctx := context.Background()
 
 	// Reconcile twice (finalizer + create)
@@ -551,12 +570,14 @@ func TestReconcile_GKEAutopilotEnabled(t *testing.T) {
 
 func TestReconcile_GKEAutopilotLegacy(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	instance.Annotations = map[string]string{
-		GKEAutopilotAnnotation:       "true",
-		GKEAutopilotLegacyAnnotation: "true",
+	// Mock legacy Autopilot: only AllowlistedV2Workload CRD is available
+	platformInfo := &mockPlatformInfo{
+		supportedResources: map[string]bool{
+			"AllowlistedV2Workload": true,
+		},
 	}
 
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconcilerWithPlatformInfo(t, platformInfo, instance)
 	ctx := context.Background()
 
 	// Reconcile twice (finalizer + create)
@@ -596,14 +617,14 @@ func TestReconcile_GKEAutopilotLegacy(t *testing.T) {
 	assert.NotContains(t, mountNames, storageDirVolumeName)
 }
 
-func TestReconcile_GKEAutopilotCustomVersion(t *testing.T) {
+func TestReconcile_NotGKEAutopilot(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	instance.Annotations = map[string]string{
-		GKEAutopilotAnnotation:                 "true",
-		GKEAutopilotAllowlistVersionAnnotation: "v2.0.0",
+	// Mock non-Autopilot cluster: no Autopilot CRDs
+	platformInfo := &mockPlatformInfo{
+		supportedResources: map[string]bool{},
 	}
 
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconcilerWithPlatformInfo(t, platformInfo, instance)
 	ctx := context.Background()
 
 	// Reconcile twice (finalizer + create)
@@ -618,7 +639,25 @@ func TestReconcile_GKEAutopilotCustomVersion(t *testing.T) {
 	err = c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds)
 	require.NoError(t, err)
 
-	// Verify the matching-allowlist label uses custom version
-	assert.Equal(t, "datadog-datadog-csi-driver-daemonset-exemption-v2.0.0",
-		ds.Spec.Template.Labels[GKEMatchingAllowlistLabelKey])
+	// Verify matching-allowlist label is NOT set (not Autopilot)
+	_, hasLabel := ds.Spec.Template.Labels[GKEMatchingAllowlistLabelKey]
+	assert.False(t, hasLabel, "matching-allowlist label should not be set for non-Autopilot clusters")
+
+	// Verify storage-dir volume exists (not Autopilot, full functionality)
+	volumeNames := make([]string, 0, len(ds.Spec.Template.Spec.Volumes))
+	for _, v := range ds.Spec.Template.Spec.Volumes {
+		volumeNames = append(volumeNames, v.Name)
+	}
+	assert.Contains(t, volumeNames, storageDirVolumeName)
+
+	// Verify DD_APM_ENABLED env var exists (not Autopilot, full functionality)
+	csiContainer := ds.Spec.Template.Spec.Containers[0]
+	found := false
+	for _, env := range csiContainer.Env {
+		if env.Name == "DD_APM_ENABLED" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "DD_APM_ENABLED should be set for non-Autopilot clusters")
 }

--- a/internal/controller/datadogcsidriver/daemonset.go
+++ b/internal/controller/datadogcsidriver/daemonset.go
@@ -28,6 +28,9 @@ func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.Daemon
 	apmSocketDir := filepath.Dir(apmSocketPath)
 	dsdSocketDir := filepath.Dir(dsdSocketPath)
 
+	// Check if running on GKE Autopilot legacy mode (gate out storage-dir and DD_APM_ENABLED)
+	isLegacyAutopilot := IsGKEAutopilotLegacy(instance)
+
 	labels := map[string]string{
 		appLabelKey: csiDsName,
 	}
@@ -36,8 +39,13 @@ func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.Daemon
 		admissionControllerEnabledLabel: "false",
 	}
 
-	volumes := buildVolumes(driverName, apmSocketDir, dsdSocketDir)
-	csiDriverContainer := buildCSIDriverContainer(instance, driverName, apmSocketPath, dsdSocketPath, apmSocketDir, dsdSocketDir)
+	// Add GKE Autopilot matching-allowlist label if enabled (modern Autopilot only)
+	for k, v := range GetGKEAutopilotLabels(instance) {
+		podLabels[k] = v
+	}
+
+	volumes := buildVolumes(driverName, apmSocketDir, dsdSocketDir, isLegacyAutopilot)
+	csiDriverContainer := buildCSIDriverContainer(instance, driverName, apmSocketPath, dsdSocketPath, apmSocketDir, dsdSocketDir, isLegacyAutopilot)
 	registrarContainer := buildRegistrarContainer(instance, driverName)
 
 	revisionHistoryLimit := int32(10)
@@ -79,7 +87,7 @@ func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.Daemon
 	return ds
 }
 
-func buildCSIDriverContainer(instance *datadoghqv1alpha1.DatadogCSIDriver, driverName, apmSocketPath, dsdSocketPath, apmSocketDir, dsdSocketDir string) corev1.Container {
+func buildCSIDriverContainer(instance *datadoghqv1alpha1.DatadogCSIDriver, driverName, apmSocketPath, dsdSocketPath, apmSocketDir, dsdSocketDir string, isLegacyAutopilot bool) corev1.Container {
 	privileged := true
 	readOnlyRootFS := true
 	bidirectional := corev1.MountPropagationBidirectional
@@ -88,10 +96,6 @@ func buildCSIDriverContainer(instance *datadoghqv1alpha1.DatadogCSIDriver, drive
 		{
 			Name:      pluginDirVolumeName,
 			MountPath: pluginDirMountPath,
-		},
-		{
-			Name:      storageDirVolumeName,
-			MountPath: storageDirMountPath,
 		},
 		{
 			Name:      apmSocketVolumeName,
@@ -105,11 +109,40 @@ func buildCSIDriverContainer(instance *datadoghqv1alpha1.DatadogCSIDriver, drive
 		},
 	}
 
+	// storage-dir is required for SSI but not allowed on legacy GKE Autopilot
+	// (no WorkloadAllowlist exemption exists for it on clusters < 1.32.1-gke.1729000)
+	if !isLegacyAutopilot {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      storageDirVolumeName,
+			MountPath: storageDirMountPath,
+		})
+	}
+
 	if dsdSocketDir != apmSocketDir {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      dsdSocketVolumeName,
 			MountPath: dsdSocketDir,
 			ReadOnly:  true,
+		})
+	}
+
+	env := []corev1.EnvVar{
+		{
+			Name: envNodeID,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+	}
+
+	// DD_APM_ENABLED is required for SSI but not allowed on legacy GKE Autopilot
+	// (no WorkloadAllowlist exemption exists for it on clusters < 1.32.1-gke.1729000)
+	if !isLegacyAutopilot {
+		env = append(env, corev1.EnvVar{
+			Name:  constants.DDAPMEnabled,
+			Value: "true",
 		})
 	}
 
@@ -120,20 +153,7 @@ func buildCSIDriverContainer(instance *datadoghqv1alpha1.DatadogCSIDriver, drive
 			fmt.Sprintf("--apm-host-socket-path=%s", apmSocketPath),
 			fmt.Sprintf("--dsd-host-socket-path=%s", dsdSocketPath),
 		},
-		Env: []corev1.EnvVar{
-			{
-				Name: envNodeID,
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "spec.nodeName",
-					},
-				},
-			},
-			{
-				Name:  constants.DDAPMEnabled,
-				Value: "true",
-			},
-		},
+		Env: env,
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: csiDriverPort,
@@ -180,7 +200,7 @@ func buildRegistrarContainer(instance *datadoghqv1alpha1.DatadogCSIDriver, drive
 	}
 }
 
-func buildVolumes(driverName, apmSocketDir, dsdSocketDir string) []corev1.Volume {
+func buildVolumes(driverName, apmSocketDir, dsdSocketDir string, isLegacyAutopilot bool) []corev1.Volume {
 	dirOrCreate := corev1.HostPathDirectoryOrCreate
 	dir := corev1.HostPathDirectory
 
@@ -190,15 +210,6 @@ func buildVolumes(driverName, apmSocketDir, dsdSocketDir string) []corev1.Volume
 			VolumeSource: corev1.VolumeSource{
 				HostPath: &corev1.HostPathVolumeSource{
 					Path: fmt.Sprintf(kubeletPluginsDirFmt, driverName),
-					Type: &dirOrCreate,
-				},
-			},
-		},
-		{
-			Name: storageDirVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: fmt.Sprintf(kubeletStorageDirFmt, driverName),
 					Type: &dirOrCreate,
 				},
 			},
@@ -230,6 +241,20 @@ func buildVolumes(driverName, apmSocketDir, dsdSocketDir string) []corev1.Volume
 				},
 			},
 		},
+	}
+
+	// storage-dir is required for SSI but not allowed on legacy GKE Autopilot
+	// (no WorkloadAllowlist exemption exists for it on clusters < 1.32.1-gke.1729000)
+	if !isLegacyAutopilot {
+		volumes = append(volumes, corev1.Volume{
+			Name: storageDirVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: fmt.Sprintf(kubeletStorageDirFmt, driverName),
+					Type: &dirOrCreate,
+				},
+			},
+		})
 	}
 
 	if dsdSocketDir != apmSocketDir {

--- a/internal/controller/datadogcsidriver/daemonset.go
+++ b/internal/controller/datadogcsidriver/daemonset.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/images"
 )
 
-func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.DaemonSet {
+func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver, platformInfo PlatformInfo) *appsv1.DaemonSet {
 	driverName := csiDriverName
 	apmSocketPath := getAPMSocketPath(instance)
 	dsdSocketPath := getDSDSocketPath(instance)
@@ -29,7 +29,7 @@ func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.Daemon
 	dsdSocketDir := filepath.Dir(dsdSocketPath)
 
 	// Check if running on GKE Autopilot legacy mode (gate out storage-dir and DD_APM_ENABLED)
-	isLegacyAutopilot := IsGKEAutopilotLegacy(instance)
+	isLegacyAutopilot := IsGKEAutopilotLegacy(platformInfo)
 
 	labels := map[string]string{
 		appLabelKey: csiDsName,
@@ -39,10 +39,8 @@ func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.Daemon
 		admissionControllerEnabledLabel: "false",
 	}
 
-	// Add GKE Autopilot matching-allowlist label if enabled (modern Autopilot only)
-	for k, v := range GetGKEAutopilotLabels(instance) {
-		podLabels[k] = v
-	}
+	// Add GKE Autopilot matching-allowlist label if on modern Autopilot
+	maps.Copy(podLabels, GetGKEAutopilotLabels(platformInfo))
 
 	volumes := buildVolumes(driverName, apmSocketDir, dsdSocketDir, isLegacyAutopilot)
 	csiDriverContainer := buildCSIDriverContainer(instance, driverName, apmSocketPath, dsdSocketPath, apmSocketDir, dsdSocketDir, isLegacyAutopilot)

--- a/internal/controller/datadogcsidriver_controller.go
+++ b/internal/controller/datadogcsidriver_controller.go
@@ -27,10 +27,11 @@ import (
 
 // DatadogCSIDriverReconciler reconciles a DatadogCSIDriver object.
 type DatadogCSIDriverReconciler struct {
-	Client   client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	internal *datadogcsidriver.Reconciler
+	Client       client.Client
+	Scheme       *runtime.Scheme
+	Recorder     record.EventRecorder
+	PlatformInfo *kubernetes.PlatformInfo
+	internal     *datadogcsidriver.Reconciler
 }
 
 // RBACs for DatadogCSIDriver objects
@@ -60,7 +61,7 @@ func (r *DatadogCSIDriverReconciler) Reconcile(ctx context.Context, instance *da
 
 // SetupWithManager creates a new DatadogCSIDriver controller.
 func (r *DatadogCSIDriverReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.internal = datadogcsidriver.NewReconciler(r.Client, r.Scheme, r.Recorder)
+	r.internal = datadogcsidriver.NewReconciler(r.Client, r.Scheme, r.Recorder, r.PlatformInfo)
 
 	or := reconcile.AsReconciler[*datadoghqv1alpha1.DatadogCSIDriver](r.Client, r)
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -257,8 +257,9 @@ func startDatadogCSIDriver(logger logr.Logger, mgr manager.Manager, pInfo kubern
 	}
 
 	return (&DatadogCSIDriverReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(csiDriverControllerName),
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		Recorder:     mgr.GetEventRecorderFor(csiDriverControllerName),
+		PlatformInfo: &pInfo,
 	}).SetupWithManager(mgr)
 }

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer.go
@@ -21,6 +21,16 @@ import (
 // daemonset WorkloadAllowlist. v1.0.5 includes the system-probe / NPM
 // exemptions required by the NPM feature on GKE Autopilot.
 const DefaultWorkloadAllowlistVersion = "v1.0.5"
+
+// DefaultCSIWorkloadAllowlistVersion is the default version of the Datadog
+// CSI driver WorkloadAllowlist. v1.1.0 includes the storage-dir hostPath and
+// DD_APM_ENABLED env var exemptions required for SSI on GKE Autopilot >= 1.32.1-gke.1729000.
+const DefaultCSIWorkloadAllowlistVersion = "v1.1.0"
+
+// CSIMatchingAllowlistLabel is the label value for cloud.google.com/matching-allowlist
+// that must be set on the CSI driver DaemonSet to match the v1.1.0 WorkloadAllowlist.
+const CSIMatchingAllowlistLabel = "datadog-datadog-csi-driver-daemonset-exemption-v1.1.0"
+
 const allowlistSynchronizerFieldOwner = "datadog-operator-allowlist-synchronizer"
 
 var workloadAllowlistVersionRegexp = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
@@ -137,4 +147,99 @@ func CreateAllowlistSynchronizer(version, partOfLabel string) {
 	}
 
 	logger.V(1).Info("Successfully applied AllowlistSynchronizer", "version", resolvedVersion)
+}
+
+// resolveCSIWorkloadAllowlistVersion returns the requested CSI allowlist version if it
+// is non-empty and well-formed, otherwise it falls back to
+// DefaultCSIWorkloadAllowlistVersion (logging the malformed input).
+func resolveCSIWorkloadAllowlistVersion(version string) string {
+	if version == "" {
+		return DefaultCSIWorkloadAllowlistVersion
+	}
+	if !workloadAllowlistVersionRegexp.MatchString(version) {
+		logger.Info("Ignoring malformed CSI WorkloadAllowlist version override, falling back to default",
+			"requested", version, "default", DefaultCSIWorkloadAllowlistVersion)
+		return DefaultCSIWorkloadAllowlistVersion
+	}
+	return version
+}
+
+func applyCSIAllowlistSynchronizerResource(k8sClient client.Client, version, partOfLabel string) error {
+	obj := &AllowlistSynchronizer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: SchemeGroupVersion.String(),
+			Kind:       "AllowlistSynchronizer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "datadog-csi-synchronizer",
+			Labels: map[string]string{
+				"app.kubernetes.io/created-by":           "datadog-operator",
+				kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
+				kubernetes.AppKubernetesNameLabelKey:     "datadog-csi-allowlist-synchronizer",
+				kubernetes.AppKubernetesPartOfLabelKey:   partOfLabel,
+			},
+		},
+		Spec: AllowlistSynchronizerSpec{
+			AllowlistPaths: []string{
+				fmt.Sprintf("Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-%s.yaml", version),
+			},
+		},
+	}
+
+	return k8sClient.Patch(
+		context.TODO(),
+		obj,
+		client.Apply,
+		client.FieldOwner(allowlistSynchronizerFieldOwner),
+		client.ForceOwnership,
+	)
+}
+
+// CreateCSIAllowlistSynchronizer creates a GKE AllowlistSynchronizer Custom Resource (auto.gke.io/v1)
+// for the Datadog CSI driver WorkloadAllowlist if it doesn't exist.
+// The AllowlistSynchronizer is needed so that GKE Autopilot can sync the Datadog CSI driver
+// WorkloadAllowlist to the cluster. See the CRD reference:
+// https://cloud.google.com/kubernetes-engine/docs/reference/crds/allowlistsynchronizer
+//
+// version selects the WorkloadAllowlist YAML to point at. Pass an empty string
+// to use DefaultCSIWorkloadAllowlistVersion. Malformed versions also fall back to
+// the default.
+func CreateCSIAllowlistSynchronizer(version, partOfLabel string) {
+	resolvedVersion := resolveCSIWorkloadAllowlistVersion(version)
+
+	cfg, configErr := config.GetConfig()
+	if configErr != nil {
+		logger.Error(configErr, "failed to load kubeconfig")
+		return
+	}
+
+	scheme := runtime.NewScheme()
+	if SchemeErr := SchemeBuilder.AddToScheme(scheme); SchemeErr != nil {
+		logger.Error(SchemeErr, "failed to register AllowlistSynchronizer scheme")
+		return
+	}
+
+	k8sClient, clientErr := client.New(cfg, client.Options{Scheme: scheme})
+	if clientErr != nil {
+		logger.Error(clientErr, "failed to create kubernetes client")
+		return
+	}
+
+	if err := applyCSIAllowlistSynchronizerResource(k8sClient, resolvedVersion, partOfLabel); err != nil {
+		logger.Error(err, "failed to apply CSI AllowlistSynchronizer resource")
+		return
+	}
+
+	logger.V(1).Info("Successfully applied CSI AllowlistSynchronizer", "version", resolvedVersion)
+}
+
+// GetCSIMatchingAllowlistLabelValue returns the value for the cloud.google.com/matching-allowlist
+// label that should be set on the CSI driver DaemonSet. If a custom version is provided and valid,
+// it computes the label value; otherwise it returns CSIMatchingAllowlistLabel (the default for v1.1.0).
+func GetCSIMatchingAllowlistLabelValue(version string) string {
+	resolvedVersion := resolveCSIWorkloadAllowlistVersion(version)
+	if resolvedVersion == DefaultCSIWorkloadAllowlistVersion {
+		return CSIMatchingAllowlistLabel
+	}
+	return fmt.Sprintf("datadog-datadog-csi-driver-daemonset-exemption-%s", resolvedVersion)
 }

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
@@ -115,3 +115,120 @@ func TestApplyAllowlistSynchronizerResource_UpdatesExistingResource(t *testing.T
 	assert.Equal(t, "datadog-operator", got.Labels[kubernetes.AppKubernetesManageByLabelKey])
 	assert.Equal(t, "datadog-allowlist-synchronizer", got.Labels[kubernetes.AppKubernetesNameLabelKey])
 }
+
+func TestDefaultCSIWorkloadAllowlistVersion(t *testing.T) {
+	assert.Equal(t, "v1.1.0", DefaultCSIWorkloadAllowlistVersion)
+}
+
+func TestCSIMatchingAllowlistLabel(t *testing.T) {
+	assert.Equal(t, "datadog-datadog-csi-driver-daemonset-exemption-v1.1.0", CSIMatchingAllowlistLabel)
+}
+
+func TestResolveCSIWorkloadAllowlistVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty falls back to default", input: "", expected: DefaultCSIWorkloadAllowlistVersion},
+		{name: "well-formed override is preserved", input: "v2.0.0", expected: "v2.0.0"},
+		{name: "malformed falls back to default (no v prefix)", input: "1.1.0", expected: DefaultCSIWorkloadAllowlistVersion},
+		{name: "malformed falls back to default (extra suffix)", input: "v1.1.0-beta", expected: DefaultCSIWorkloadAllowlistVersion},
+		{name: "malformed falls back to default (random)", input: "garbage", expected: DefaultCSIWorkloadAllowlistVersion},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, resolveCSIWorkloadAllowlistVersion(tt.input))
+		})
+	}
+}
+
+func TestApplyCSIAllowlistSynchronizerResource_AllowlistPath(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, SchemeBuilder.AddToScheme(scheme))
+
+	tests := []struct {
+		name       string
+		version    string
+		expectPath string
+	}{
+		{
+			name:       "default version",
+			version:    DefaultCSIWorkloadAllowlistVersion,
+			expectPath: "Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml",
+		},
+		{
+			name:       "user override",
+			version:    "v2.0.0",
+			expectPath: "Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v2.0.0.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			require.NoError(t, applyCSIAllowlistSynchronizerResource(c, tt.version, "default-csi"))
+
+			got := &AllowlistSynchronizer{}
+			require.NoError(t, c.Get(context.TODO(), client.ObjectKey{Name: "datadog-csi-synchronizer"}, got))
+			require.Len(t, got.Spec.AllowlistPaths, 1)
+			assert.Equal(t, tt.expectPath, got.Spec.AllowlistPaths[0])
+			assert.Empty(t, got.Annotations)
+			assert.Equal(t, "datadog-operator", got.Labels["app.kubernetes.io/created-by"])
+			assert.Equal(t, "datadog-operator", got.Labels[kubernetes.AppKubernetesManageByLabelKey])
+			assert.Equal(t, "datadog-csi-allowlist-synchronizer", got.Labels[kubernetes.AppKubernetesNameLabelKey])
+			assert.Equal(t, "default-csi", got.Labels[kubernetes.AppKubernetesPartOfLabelKey])
+		})
+	}
+}
+
+func TestApplyCSIAllowlistSynchronizerResource_UpdatesExistingResource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, SchemeBuilder.AddToScheme(scheme))
+
+	existing := &AllowlistSynchronizer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: SchemeGroupVersion.String(),
+			Kind:       "AllowlistSynchronizer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "datadog-csi-synchronizer",
+			Labels: map[string]string{
+				kubernetes.AppKubernetesPartOfLabelKey: "old-owner",
+			},
+		},
+		Spec: AllowlistSynchronizerSpec{
+			AllowlistPaths: []string{
+				"Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.0.1.yaml",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	require.NoError(t, applyCSIAllowlistSynchronizerResource(c, "v1.1.0", "default-csi"))
+
+	got := &AllowlistSynchronizer{}
+	require.NoError(t, c.Get(context.TODO(), client.ObjectKey{Name: "datadog-csi-synchronizer"}, got))
+	require.Len(t, got.Spec.AllowlistPaths, 1)
+	assert.Equal(t, "Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml", got.Spec.AllowlistPaths[0])
+	assert.Equal(t, "default-csi", got.Labels[kubernetes.AppKubernetesPartOfLabelKey])
+	assert.Equal(t, "datadog-operator", got.Labels[kubernetes.AppKubernetesManageByLabelKey])
+	assert.Equal(t, "datadog-csi-allowlist-synchronizer", got.Labels[kubernetes.AppKubernetesNameLabelKey])
+}
+
+func TestGetCSIMatchingAllowlistLabelValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected string
+	}{
+		{name: "empty uses default", version: "", expected: CSIMatchingAllowlistLabel},
+		{name: "default version returns constant", version: "v1.1.0", expected: CSIMatchingAllowlistLabel},
+		{name: "custom version computes label", version: "v2.0.0", expected: "datadog-datadog-csi-driver-daemonset-exemption-v2.0.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GetCSIMatchingAllowlistLabelValue(tt.version))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds GKE Autopilot support for the Datadog CSI driver controller. The operator auto-detects the cluster type via `PlatformInfo` and:
- Creates an `AllowlistSynchronizer` (`datadog-csi-synchronizer`) pointing to the v1.1.0 WorkloadAllowlist on modern Autopilot
- Adds the `cloud.google.com/matching-allowlist` label to the CSI driver DaemonSet
- Supports legacy Autopilot mode (< 1.32.1-gke.1729000) by gating out `storage-dir` hostPath and `DD_APM_ENABLED` env var

### Motivation

Google merged a Gerrit change that publishes a new WorkloadAllowlist v1.1.0 for the Datadog CSI driver on GKE Autopilot. This allowlist additionally exempts the `storage-dir` hostPath and `DD_APM_ENABLED` env var, which are required to enable Single Step Instrumentation (SSI) on GKE Autopilot >= 1.32.1-gke.1729000.

The Helm chart already has a PR opened to support this: https://github.com/DataDog/helm-charts/pull/2642. 
This PR brings feature parity to the operator.

### Additional Notes

**Auto-detection via CRDs:**
The operator automatically detects GKE Autopilot mode by checking for the presence of CRDs:
- `WorkloadAllowlist` → Modern Autopilot (>= 1.32.1-gke.1729000): full SSI support
- `AllowlistedV2Workload` only → Legacy Autopilot: `storage-dir` and `DD_APM_ENABLED` gated out
- Neither → Non-Autopilot cluster: full functionality, no Autopilot-specific resources

No user configuration required.

### Minimum Agent Versions

N/A — This is a CSI driver infrastructure change, not an Agent feature.

### Describe your test plan