### PR TITLE
e2e: fix CI timeouts, assertion bug, registry, and toolchain

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -258,6 +258,8 @@ go_e2e_deps:
   tags: ["arch:amd64"]
   variables:
     KUBERNETES_CPU_REQUEST: 16
+    GOPATH: $CI_PROJECT_DIR/.gopath
+    GOCACHE: $CI_PROJECT_DIR/.gocache
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       variables:
@@ -272,6 +274,11 @@ go_e2e_deps:
   before_script:
     - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-operator --policy self.gitlab.deps-fetch)
   script:
+    - |
+      # Pre-download Go modules and toolchain into the project-local cache
+      pushd test/e2e
+      GOWORK=off go mod download
+      popd
     - |
       if [ ! -f pulumi_plugins.tar.xz ]; then
         # Pre-download Pulumi plugins used by e2e scenarios and components
@@ -292,6 +299,15 @@ go_e2e_deps:
         prefix: "pulumi_plugins"
       paths:
         - pulumi_plugins.tar.xz
+    - key:
+        files:
+          - test/e2e/go.mod
+          - test/e2e/go.sum
+        prefix: "e2e_go_modules"
+      paths:
+        - .gopath/pkg/mod
+        - .gocache
+      policy: $POLICY
 
 .on_run_e2e_base:
   # Skip if only .md files are changed
@@ -348,9 +364,19 @@ go_e2e_deps:
     E2E_AWS_PUBLIC_KEY_PATH: /tmp/agent-qa-ssh-key.pub
     E2E_AWS_PRIVATE_KEY_PATH: /tmp/agent-qa-ssh-key
     E2E_KEY_PAIR_NAME: ci.datadog-operator
-    # Temporary workaround from https://github.com/golang/go/issues/75031
-    GOTOOLCHAIN: go1.25.0+auto
+    GOPATH: $CI_PROJECT_DIR/.gopath
+    GOCACHE: $CI_PROJECT_DIR/.gocache
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  cache:
+    - key:
+        files:
+          - test/e2e/go.mod
+          - test/e2e/go.sum
+        prefix: "e2e_go_modules"
+      paths:
+        - .gopath/pkg/mod
+        - .gocache
+      policy: pull
   before_script:
     # Extract cached Pulumi plugins
     - mkdir -p ~/.pulumi && tar xJf pulumi_plugins.tar.xz -C ~/.pulumi
@@ -389,6 +415,7 @@ trigger_e2e_operator_image:
 e2e:
   extends: .e2e_aws_base
   stage: e2e
+  timeout: 2h
   needs:
     - "trigger_e2e_operator_image"
     - "go_e2e_deps"

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ENVTEST_K8S_VERSION = 1.30
 # Default timeout for `go test` when running E2E tests.
 # (E2E provisioning can hang; having a finite timeout ensures we get goroutine dumps
 # instead of the CI job timing out with no actionable logs.)
-E2E_GO_TEST_TIMEOUT ?= 55m
+E2E_GO_TEST_TIMEOUT ?= 90m
 E2E_AUTOSCALING_GO_TEST_TIMEOUT ?= 140m
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/test/e2e/manifests/apm/datadog-agent-apm.yaml
+++ b/test/e2e/manifests/apm/datadog-agent-apm.yaml
@@ -6,6 +6,7 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-apm
 spec:
   global:
+    registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
   features:

--- a/test/e2e/manifests/datadog-agent-ccr-enabled.yaml
+++ b/test/e2e/manifests/datadog-agent-ccr-enabled.yaml
@@ -7,6 +7,7 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-ccr-enabled
 spec:
   global:
+    registry: public.ecr.aws/datadog
     clusterAgentToken: thisisa32characterstoken00000000
     kubelet:
       tlsVerify: false

--- a/test/e2e/manifests/datadog-agent-logs.yaml
+++ b/test/e2e/manifests/datadog-agent-logs.yaml
@@ -7,6 +7,7 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-logs
 spec:
   global:
+    registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
   features:

--- a/test/e2e/manifests/datadog-agent-minimum.yaml
+++ b/test/e2e/manifests/datadog-agent-minimum.yaml
@@ -6,5 +6,6 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-minimum
 spec:
   global:
+    registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-adp.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-adp.yaml
@@ -6,6 +6,7 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-dsd-udp-adp
 spec:
   global:
+    registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
   features:

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp.yaml
@@ -6,6 +6,7 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-dsd-udp
 spec:
   global:
+    registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
   features:

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds-adp.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds-adp.yaml
@@ -6,6 +6,7 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-dsd-uds-adp
 spec:
   global:
+    registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
   features:

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds.yaml
@@ -6,6 +6,7 @@ metadata:
     agent.datadoghq.com/e2e-test: datadog-agent-dsd-uds
 spec:
   global:
+    registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
   features:

--- a/test/e2e/tests/utils/utils.go
+++ b/test/e2e/tests/utils/utils.go
@@ -6,6 +6,7 @@
 package utils
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -42,51 +43,58 @@ func VerifyAgentPods(t *testing.T, c *assert.CollectT, namespace string, k8sClie
 	VerifyNumPodsForSelector(t, c, namespace, k8sClient, len(nodesList.Items), selector)
 }
 
+func sortedMapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func VerifyCheck(c *assert.CollectT, collectorOutput string, checkName string) {
-	var runningChecks map[string]any
-
 	checksJson := common.ParseCollectorJson(collectorOutput)
-	if checksJson != nil {
-		runnerStats, runnerStatsOk := checksJson["runnerStats"].(map[string]any)
-		if !runnerStatsOk {
-			assert.Fail(c, "runnerStats field is not a map or is nil")
-			return
+	if !assert.NotNilf(c, checksJson, "collector status output did not parse as JSON while looking for check %q; output snippet: %.500s", checkName, collectorOutput) {
+		return
+	}
+
+	runnerStats, runnerStatsOk := checksJson["runnerStats"].(map[string]any)
+	if !assert.Truef(c, runnerStatsOk, "runnerStats field missing in collector status while looking for check %q; top-level keys: %v", checkName, sortedMapKeys(checksJson)) {
+		return
+	}
+
+	runningChecks, checksOk := runnerStats["Checks"].(map[string]any)
+	if !assert.Truef(c, checksOk, "Checks field missing in runnerStats while looking for check %q", checkName) {
+		return
+	}
+
+	check, found := runningChecks[checkName].(map[string]any)
+	if !assert.Truef(c, found, "check %q not found or not yet running; running checks: %v", checkName, sortedMapKeys(runningChecks)) {
+		return
+	}
+
+	for _, instance := range check {
+		instanceMap, instanceOk := instance.(map[string]any)
+		if !instanceOk {
+			continue
 		}
 
-		var checksOk bool
-		runningChecks, checksOk = runnerStats["Checks"].(map[string]any)
-		if !checksOk {
-			assert.Fail(c, "Checks field is not a map or is nil")
-			return
+		checkNameVal, checkNameOk := instanceMap["CheckName"].(string)
+		if checkNameOk {
+			assert.Equal(c, checkName, checkNameVal)
 		}
 
-		if check, found := runningChecks[checkName].(map[string]any); found {
-			for _, instance := range check {
-				instanceMap, instanceOk := instance.(map[string]any)
-				if !instanceOk {
-					continue
-				}
+		lastError, exists := instanceMap["LastError"].(string)
+		assert.True(c, exists)
+		assert.Empty(c, lastError)
 
-				checkNameVal, checkNameOk := instanceMap["CheckName"].(string)
-				if checkNameOk {
-					assert.Equal(c, checkName, checkNameVal)
-				}
+		totalErrors, exists := instanceMap["TotalErrors"].(float64)
+		assert.True(c, exists)
+		assert.Zero(c, totalErrors)
 
-				lastError, exists := instanceMap["LastError"].(string)
-				assert.True(c, exists)
-				assert.Empty(c, lastError)
-
-				totalErrors, exists := instanceMap["TotalErrors"].(float64)
-				assert.True(c, exists)
-				assert.Zero(c, totalErrors)
-
-				totalMetricSamples, exists := instanceMap["TotalMetricSamples"].(float64)
-				assert.True(c, exists)
-				assert.Greater(c, totalMetricSamples, float64(0))
-			}
-		} else {
-			assert.Failf(c, "Check not found", "Check %s not found or not yet running", checkName)
-		}
+		totalMetricSamples, exists := instanceMap["TotalMetricSamples"].(float64)
+		assert.True(c, exists)
+		assert.Greater(c, totalMetricSamples, float64(0))
 	}
 }
 


### PR DESCRIPTION
Four changes to fix the e2e breakage introduced by the agent 7.79.1 bump (dbe65ff4a):

1. Remove GOTOOLCHAIN workaround: go1.25.0+auto was a temporary fix for golang/go#75031, resolved in go1.25.10 which is already the declared toolchain in test/e2e/go.mod.

2. Add Go module caching: go_e2e_deps now runs `go mod download` and caches .gopath/pkg/mod + .gocache keyed on go.mod+go.sum. The e2e jobs pull from this cache. Eliminates the ~55-minute cold-download overhead (toolchain + 280+ modules) that consumed the entire 60-minute CI budget before any test could run.

3. Increase timeouts: e2e GitLab job to 2h (safety net; warm-cache runs complete in ~35m) and E2E_GO_TEST_TIMEOUT in Makefile from 55m to 90m, keeping the go test deadline well inside the job wall-clock limit.

4. Add public.ecr.aws/datadog registry to all DDA manifests: tests run on EC2 where pulling from the public ECR gallery is faster and avoids rate limits on docker.io/gcr.io.

5. Fix VerifyCheck silent-pass bug: when agent status collector -j returns empty or unparseable output the function previously returned without any assertion, masking the real failure. Now asserts on nil JSON and missing fields, and includes the list of running checks in failure messages for easier diagnosis.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits