### PR TITLE
feat(csi-driver): enable cluster-agent auto-detection for SSI

### DIFF
--- a/api/datadoghq/v1alpha1/datadogcsidriver_types.go
+++ b/api/datadoghq/v1alpha1/datadogcsidriver_types.go
@@ -30,6 +30,12 @@ type DatadogCSIDriverSpec struct {
 	// +optional
 	RegistrarImage *v2alpha1.AgentImageConfig `json:"registrarImage,omitempty"`
 
+	// APMEnabled toggles APM Single Step Instrumentation (SSI) library mount
+	// support in the Datadog CSI driver.
+	// Default: true
+	// +optional
+	APMEnabled *bool `json:"apmEnabled,omitempty"`
+
 	// APMSocketPath is the host path to the APM socket.
 	// Default: /var/run/datadog/apm.socket
 	// +optional

--- a/api/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/api/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -514,6 +514,11 @@ func (in *DatadogCSIDriverSpec) DeepCopyInto(out *DatadogCSIDriverSpec) {
 		*out = new(v2alpha1.AgentImageConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.APMEnabled != nil {
+		in, out := &in.APMEnabled, &out.APMEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.APMSocketPath != nil {
 		in, out := &in.APMSocketPath, &out.APMSocketPath
 		*out = new(string)

--- a/api/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -732,6 +732,13 @@ func schema_datadog_operator_api_datadoghq_v1alpha1_DatadogCSIDriverSpec(ref com
 							Ref:         ref("github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.AgentImageConfig"),
 						},
 					},
+					"apmEnabled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APMEnabled toggles APM Single Step Instrumentation (SSI) library mount support in the Datadog CSI driver. Default: true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"apmSocketPath": {
 						SchemaProps: spec.SchemaProps{
 							Description: "APMSocketPath is the host path to the APM socket. Default: /var/run/datadog/apm.socket",

--- a/config/crd/bases/v1/datadoghq.com_datadogcsidrivers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogcsidrivers.yaml
@@ -48,6 +48,12 @@ spec:
             spec:
               description: DatadogCSIDriverSpec defines the desired state of DatadogCSIDriver
               properties:
+                apmEnabled:
+                  description: |-
+                    APMEnabled toggles APM Single Step Instrumentation (SSI) library mount
+                    support in the Datadog CSI driver.
+                    Default: true
+                  type: boolean
                 apmSocketPath:
                   description: |-
                     APMSocketPath is the host path to the APM socket.

--- a/config/crd/bases/v1/datadoghq.com_datadogcsidrivers_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogcsidrivers_v1alpha1.json
@@ -17,6 +17,10 @@
       "additionalProperties": false,
       "description": "DatadogCSIDriverSpec defines the desired state of DatadogCSIDriver",
       "properties": {
+        "apmEnabled": {
+          "description": "APMEnabled toggles APM Single Step Instrumentation (SSI) library mount\nsupport in the Datadog CSI driver.\nDefault: true",
+          "type": "boolean"
+        },
         "apmSocketPath": {
           "description": "APMSocketPath is the host path to the APM socket.\nDefault: /var/run/datadog/apm.socket",
           "type": "string"

--- a/internal/controller/datadogagent/feature/admissioncontroller/rbac.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/rbac.go
@@ -50,6 +50,18 @@ func (f *admissionControllerFeature) getRBACClusterPolicyRules() []rbacv1.Policy
 			},
 			Verbs: []string{rbac.GetVerb},
 		},
+		// CSIDrivers — required by the admission controller to auto-detect the
+		// Datadog CSI driver and route SSI library injection through CSI mode
+		// instead of init containers.
+		{
+			APIGroups: []string{rbac.StorageAPIGroup},
+			Resources: []string{rbac.CSIDriversResource},
+			Verbs: []string{
+				rbac.GetVerb,
+				rbac.ListVerb,
+				rbac.WatchVerb,
+			},
+		},
 		// Deployments, Replicasets, Statefulsets, Daemonsets
 		{
 			APIGroups: []string{rbac.AppsAPIGroup},

--- a/internal/controller/datadogcsidriver/const.go
+++ b/internal/controller/datadogcsidriver/const.go
@@ -54,6 +54,10 @@ const (
 	appLabelKey                     = "app"
 	admissionControllerEnabledLabel = "admission.datadoghq.com/enabled"
 
+	// apmEnabledAnnotationKey is set on the managed CSIDriver resource to expose
+	// the operator's APM/SSI intent.
+	apmEnabledAnnotationKey = "csi.datadoghq.com/apm-enabled"
+
 	// finalizerName is the finalizer for CSIDriver object cleanup
 	finalizerName = "finalizer.datadoghq.com/csi-driver"
 )

--- a/internal/controller/datadogcsidriver/controller.go
+++ b/internal/controller/datadogcsidriver/controller.go
@@ -182,13 +182,15 @@ func (r *Reconciler) reconcileCSIDriver(ctx context.Context, instance *v1alpha1.
 		return nil
 	}
 
-	// Full replacement of spec and labels ensures any external drift is reverted,
-	// including fields added manually (e.g. via kubectl edit).
+	// Full replacement of spec, labels and annotations ensures any external drift
+	// is reverted, including fields added manually (e.g. via kubectl edit).
 	if !apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) ||
-		!apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) {
+		!apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) ||
+		!apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) {
 		logger.Info("Updating CSIDriver to match desired state", "csidriver", desired.Name)
 		current.Spec = desired.Spec
 		current.Labels = desired.Labels
+		current.Annotations = desired.Annotations
 		if err := r.client.Update(ctx, current); err != nil {
 			return fmt.Errorf("updating CSIDriver: %w", err)
 		}

--- a/internal/controller/datadogcsidriver/controller_test.go
+++ b/internal/controller/datadogcsidriver/controller_test.go
@@ -97,6 +97,8 @@ func TestReconcile_CreatesResources(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, csiDriverName, csiDriver.Name)
 	assert.Equal(t, "datadog-operator", csiDriver.Labels[kubernetes.AppKubernetesManageByLabelKey])
+	// APM/SSI annotation defaults to "true" when Spec.APMEnabled is unset.
+	assert.Equal(t, "true", csiDriver.Annotations[apmEnabledAnnotationKey])
 	assert.False(t, *csiDriver.Spec.AttachRequired)
 	assert.True(t, *csiDriver.Spec.PodInfoOnMount)
 	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecyclePersistent)
@@ -487,11 +489,110 @@ func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
 	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
 }
 
+func TestReconcile_APMEnabledDisabled(t *testing.T) {
+	instance := defaultCSIDriverCR()
+	instance.Spec.APMEnabled = ptr.To(false)
+
+	r, c := newTestReconciler(t, instance)
+	ctx := context.Background()
+
+	// Reconcile twice (finalizer + create)
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	// Annotation reflects the disabled intent.
+	csiDriver := &storagev1.CSIDriver{}
+	err = c.Get(ctx, types.NamespacedName{Name: csiDriverName}, csiDriver)
+	require.NoError(t, err)
+	assert.Equal(t, "false", csiDriver.Annotations[apmEnabledAnnotationKey])
+
+	// DD_APM_ENABLED env var on the csi-node-driver container is flipped too.
+	ds := &appsv1.DaemonSet{}
+	err = c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds)
+	require.NoError(t, err)
+	csiContainer := ds.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, v1alpha1.CSINodeDriverContainerName, csiContainer.Name)
+	apmEnv := findEnvVar(csiContainer.Env, "DD_APM_ENABLED")
+	require.NotNil(t, apmEnv, "DD_APM_ENABLED env var should be set")
+	assert.Equal(t, "false", apmEnv.Value)
+}
+
+func TestReconcile_APMEnabledDefaultsToTrue(t *testing.T) {
+	instance := defaultCSIDriverCR() // APMEnabled left unset
+
+	r, c := newTestReconciler(t, instance)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	ds := &appsv1.DaemonSet{}
+	err = c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds)
+	require.NoError(t, err)
+	csiContainer := ds.Spec.Template.Spec.Containers[0]
+	apmEnv := findEnvVar(csiContainer.Env, "DD_APM_ENABLED")
+	require.NotNil(t, apmEnv, "DD_APM_ENABLED env var should be set")
+	assert.Equal(t, "true", apmEnv.Value)
+}
+
+func TestReconcile_CSIDriverAnnotationDriftIsReconciled(t *testing.T) {
+	instance := defaultCSIDriverCR()
+	r, c := newTestReconciler(t, instance)
+	ctx := context.Background()
+
+	// Reconcile to create resources.
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	// Drift: flip the annotation and add an unrelated one.
+	csiDriver := &storagev1.CSIDriver{}
+	err = c.Get(ctx, types.NamespacedName{Name: csiDriverName}, csiDriver)
+	require.NoError(t, err)
+	csiDriver.Annotations[apmEnabledAnnotationKey] = "false"
+	csiDriver.Annotations["foo.example.com/bar"] = "baz"
+	err = c.Update(ctx, csiDriver)
+	require.NoError(t, err)
+
+	// Reconcile again and verify drift is reverted (annotation map is replaced).
+	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
+	require.NoError(t, err)
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	err = c.Get(ctx, types.NamespacedName{Name: csiDriverName}, csiDriver)
+	require.NoError(t, err)
+	assert.Equal(t, "true", csiDriver.Annotations[apmEnabledAnnotationKey])
+	_, hasForeign := csiDriver.Annotations["foo.example.com/bar"]
+	assert.False(t, hasForeign, "unmanaged annotation should be reverted")
+}
+
 // findCondition returns the condition with the given type, or nil.
 func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
 	for i := range conditions {
 		if conditions[i].Type == condType {
 			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// findEnvVar returns the env var with the given name, or nil.
+func findEnvVar(envs []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			return &envs[i]
 		}
 	}
 	return nil

--- a/internal/controller/datadogcsidriver/csidriver.go
+++ b/internal/controller/datadogcsidriver/csidriver.go
@@ -6,6 +6,8 @@
 package datadogcsidriver
 
 import (
+	"strconv"
+
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -23,6 +25,9 @@ func buildCSIDriverObject(instance *datadoghqv1alpha1.DatadogCSIDriver) *storage
 				kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
 				kubernetes.AppKubernetesPartOfLabelKey:   object.NewPartOfLabelValue(instance).String(),
 			},
+			Annotations: map[string]string{
+				apmEnabledAnnotationKey: strconv.FormatBool(isAPMEnabled(instance)),
+			},
 		},
 		Spec: storagev1.CSIDriverSpec{
 			AttachRequired: ptr.To(false),
@@ -33,4 +38,10 @@ func buildCSIDriverObject(instance *datadoghqv1alpha1.DatadogCSIDriver) *storage
 			},
 		},
 	}
+}
+
+// isAPMEnabled returns the user-configured APM/SSI intent for the CSI driver.
+// Defaults to true when the field is unset, matching the helm chart behavior.
+func isAPMEnabled(instance *datadoghqv1alpha1.DatadogCSIDriver) bool {
+	return ptr.Deref(instance.Spec.APMEnabled, true)
 }

--- a/internal/controller/datadogcsidriver/daemonset.go
+++ b/internal/controller/datadogcsidriver/daemonset.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -131,7 +132,7 @@ func buildCSIDriverContainer(instance *datadoghqv1alpha1.DatadogCSIDriver, drive
 			},
 			{
 				Name:  constants.DDAPMEnabled,
-				Value: "true",
+				Value: strconv.FormatBool(isAPMEnabled(instance)),
 			},
 		},
 		Ports: []corev1.ContainerPort{

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -53,6 +53,7 @@ const (
 	ControllerRevisionsResource                       = "controllerrevisions"
 	ConfigMapsResource                                = "configmaps"
 	CronjobsResource                                  = "cronjobs"
+	CSIDriversResource                                = "csidrivers"
 	CustomResourceDefinitionsResource                 = "customresourcedefinitions"
 	DaemonsetsResource                                = "daemonsets"
 	DatadogAgentsResource                             = "datadogagents"


### PR DESCRIPTION
### What does this PR do?

Wire up cluster-agent auto-detection of the Datadog CSI driver for SSI library injection on the operator side, mirroring two helm-charts PRs:

- Add `get`/`list`/`watch` on `csidrivers.storage.k8s.io` to the cluster-agent's `ClusterRole`, rendered whenever the admission controller is enabled. Mirrors [DataDog/helm-charts#2684](https://github.com/DataDog/helm-charts/pull/2684).
- Expose a new `DatadogCSIDriverSpec.APMEnabled` toggle (`*bool`, default `true`) on the `DatadogCSIDriver` CRD. When set, the operator propagates the intent in two places — exactly like the chart does:
  - `DD_APM_ENABLED` env var on the `csi-node-driver` container, which actually toggles SSI library mount support inside the driver process.
  - `csi.datadoghq.com/apm-enabled` annotation on the managed `k8s.csi.datadoghq.com` `CSIDriver` resource, read by the cluster-agent admission controller via the `workloadmeta-kubeapiserver` CSIDriver collector to route SSI injection through CSI mode (instead of falling back to init-container injection).

  Mirrors [DataDog/helm-charts#2685](https://github.com/DataDog/helm-charts/pull/2685).

`reconcileCSIDriver` is also extended to revert annotation drift, on par with its existing handling of `Spec` and `Labels`.

### Motivation

The cluster-agent's admission controller now uses the `workloadmeta-kubeapiserver` CSIDriver collector to discover CSI providers at runtime. Without:

1. RBAC on `csidrivers.storage.k8s.io`, the collector cannot start.
2. The `csi.datadoghq.com/apm-enabled` annotation on our `CSIDriver`, the collector cannot tell which driver is APM-capable.

In either case, the admission controller silently falls back to init-container injection — even when the Datadog CSI driver is installed via the operator. This PR brings the operator to functional parity with the helm chart so SSI injection routes through the CSI driver when both components are installed.

Cluster-agent counterpart: [DataDog/datadog-agent#50353](https://github.com/DataDog/datadog-agent/pull/50353).

### Additional Notes

- `Spec.APMEnabled` follows the existing `DatadogCSIDriver` defaulting convention (no `+kubebuilder:default` marker, no central defaulting function): defaults are applied in runtime via a `ptr.Deref(..., true)` helper, exactly like `Spec.APMSocketPath` / `Spec.DSDSocketPath`. Reading any of these directly off the spec is therefore avoided in the codebase — all call sites go through the `isAPMEnabled` / `getAPMSocketPath` / `getDSDSocketPath` helpers.
- The new RBAC rule lives in the `admissioncontroller` feature's `getRBACClusterPolicyRules()`, so it is only applied when `Features.AdmissionController.Enabled=true`. This matches the helm chart's gating on `clusterAgent.admissionController.enabled` — no new flag introduced.
- No new release note / chart values exposed beyond `apmEnabled` on the `DatadogCSIDriver` CRD.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A (no Node Agent change required)
* Cluster Agent: v7.81.0 (first release containing [DataDog/datadog-agent#50353](https://github.com/DataDog/datadog-agent/pull/50353))

### Describe your test plan

**Automated**

- `make generate manifests` — regenerates `zz_generated.deepcopy.go`, `zz_generated.openapi.go` and the `DatadogCSIDriver` CRD (`config/crd/bases/v1/datadoghq.com_datadogcsidrivers.yaml` + `.json`) to pick up the new `apmEnabled` field and updated godoc.
- `go test ./internal/controller/datadogcsidriver/... ./internal/controller/datadogagent/feature/admissioncontroller/... ./pkg/kubernetes/rbac/...` — all green.
- `make lint` — `0 issues.` (golangci-lint v2.11.3 + `go vet`).

New unit tests added in `internal/controller/datadogcsidriver/controller_test.go`:
- `TestReconcile_CreatesResources` extended to assert `csi.datadoghq.com/apm-enabled=true` on the default-created `CSIDriver`.
- `TestReconcile_APMEnabledDisabled` — `Spec.APMEnabled=false` flips both the annotation and `DD_APM_ENABLED` to `"false"`.
- `TestReconcile_APMEnabledDefaultsToTrue` — covers the unset default path explicitly.
- `TestReconcile_CSIDriverAnnotationDriftIsReconciled` — annotation drift (modified value + foreign key) is reverted on the next reconciliation.
