### PR TITLE
[CONTP-1585] Add SLO support to DatadogGenericResource

### DIFF
--- a/api/datadoghq/v1alpha1/datadoggenericresource_types.go
+++ b/api/datadoghq/v1alpha1/datadoggenericresource_types.go
@@ -17,6 +17,7 @@ const (
 	Downtime              SupportedResourcesType = "downtime"
 	Monitor               SupportedResourcesType = "monitor"
 	Notebook              SupportedResourcesType = "notebook"
+	SLO                   SupportedResourcesType = "slo"
 	SyntheticsAPITest     SupportedResourcesType = "synthetics_api_test"
 	SyntheticsBrowserTest SupportedResourcesType = "synthetics_browser_test"
 )
@@ -25,7 +26,7 @@ const (
 // +k8s:openapi-gen=true
 type DatadogGenericResourceSpec struct {
 	// Type is the type of the API object
-	// +kubebuilder:validation:Enum=dashboard;downtime;monitor;notebook;synthetics_api_test;synthetics_browser_test
+	// +kubebuilder:validation:Enum=dashboard;downtime;monitor;notebook;slo;synthetics_api_test;synthetics_browser_test
 	Type SupportedResourcesType `json:"type"`
 	// JsonSpec is the specification of the API object
 	// +kubebuilder:validation:MinLength=1
@@ -54,8 +55,9 @@ type DatadogGenericResourceStatus struct {
 	LastForceSyncTime *metav1.Time `json:"lastForceSyncTime,omitempty"`
 	// State is the live Datadog-side state of the underlying resource as last
 	// fetched from the Datadog API. Values are resource-type dependent — for
-	// Monitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. Only
-	// populated for resource types that expose live state.
+	// Monitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. For SLOs:
+	// breached, warning, ok, no_data. Only populated for resource types that
+	// expose live state.
 	State string `json:"state,omitempty"`
 	// StateLastUpdateTime is the last time State was successfully refreshed from Datadog.
 	StateLastUpdateTime *metav1.Time `json:"stateLastUpdateTime,omitempty"`

--- a/api/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -1223,7 +1223,7 @@ func schema_datadog_operator_api_datadoghq_v1alpha1_DatadogGenericResourceStatus
 					},
 					"state": {
 						SchemaProps: spec.SchemaProps{
-							Description: "State is the live Datadog-side state of the underlying resource as last fetched from the Datadog API. Values are resource-type dependent — for Monitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. Only populated for resource types that expose live state.",
+							Description: "State is the live Datadog-side state of the underlying resource as last fetched from the Datadog API. Values are resource-type dependent — for Monitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. For SLOs: breached, warning, ok, no_data. Only populated for resource types that expose live state.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/v1/datadoghq.com_datadoggenericresources.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadoggenericresources.yaml
@@ -69,6 +69,7 @@ spec:
                     - downtime
                     - monitor
                     - notebook
+                    - slo
                     - synthetics_api_test
                     - synthetics_browser_test
                   type: string
@@ -161,8 +162,9 @@ spec:
                   description: |-
                     State is the live Datadog-side state of the underlying resource as last
                     fetched from the Datadog API. Values are resource-type dependent — for
-                    Monitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. Only
-                    populated for resource types that expose live state.
+                    Monitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. For SLOs:
+                    breached, warning, ok, no_data. Only populated for resource types that
+                    expose live state.
                   type: string
                 stateLastTransitionTime:
                   description: StateLastTransitionTime is the last time State changed value.

--- a/config/crd/bases/v1/datadoghq.com_datadoggenericresources_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadoggenericresources_v1alpha1.json
@@ -29,6 +29,7 @@
             "downtime",
             "monitor",
             "notebook",
+            "slo",
             "synthetics_api_test",
             "synthetics_browser_test"
           ],
@@ -128,7 +129,7 @@
           "type": "string"
         },
         "state": {
-          "description": "State is the live Datadog-side state of the underlying resource as last\nfetched from the Datadog API. Values are resource-type dependent — for\nMonitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. Only\npopulated for resource types that expose live state.",
+          "description": "State is the live Datadog-side state of the underlying resource as last\nfetched from the Datadog API. Values are resource-type dependent — for\nMonitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. For SLOs:\nbreached, warning, ok, no_data. Only populated for resource types that\nexpose live state.",
           "type": "string"
         },
         "stateLastTransitionTime": {

--- a/docs/datadog_generic_resource.md
+++ b/docs/datadog_generic_resource.md
@@ -43,14 +43,15 @@ A `DatadogGenericResource` object has two fields:
 
 ## Supported Resources
 
-| Type                      | Operator Version | Json template                                                           | Example manifest                                                                     |
-|---------------------------|:----------------:|------------------------------------------------------------------------ |:------------------------------------------------------------------------------------:|
-| `notebook`                | v1.12.0          | https://docs.datadoghq.com/api/latest/notebooks/#create-a-notebook      | [Notebook manifest](../examples/datadoggenericresource/notebook-sample.yaml)         |
-| `synthetics_api_test`     | v1.12.0          | https://docs.datadoghq.com/api/latest/synthetics/#create-an-api-test    | [API test manifest](../examples/datadoggenericresource/api-test-sample.yaml)         |
-| `synthetics_browser_test` | v1.12.0          | https://docs.datadoghq.com/api/latest/synthetics/#create-a-browser-test | [Browser test manifest](../examples/datadoggenericresource/browser-test-sample.yaml) |
-| `monitor`                 | v1.13.0          | https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor        | [Monitor manifest](../examples/datadoggenericresource/monitor-sample.yaml)           |
-| `downtime`                | v1.22.0          | https://docs.datadoghq.com/api/latest/downtimes/#schedule-a-downtime    | [Downtime manifest](../examples/datadoggenericresource/downtime-sample.yaml)         |
-| `dashboard`               | v1.27.0          | https://docs.datadoghq.com/api/latest/dashboards/#create-a-dashboard    | [Dashboard manifest](../examples/datadoggenericresource/dashboard-sample.yaml)       |
+| Type                      | Operator Version | Json template                                                                         | Example manifest                                                                     |
+|---------------------------|:----------------:|---------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------:|
+| `notebook`                | v1.12.0          | https://docs.datadoghq.com/api/latest/notebooks/#create-a-notebook                    | [Notebook manifest](../examples/datadoggenericresource/notebook-sample.yaml)         |
+| `synthetics_api_test`     | v1.12.0          | https://docs.datadoghq.com/api/latest/synthetics/#create-an-api-test                  | [API test manifest](../examples/datadoggenericresource/api-test-sample.yaml)         |
+| `synthetics_browser_test` | v1.12.0          | https://docs.datadoghq.com/api/latest/synthetics/#create-a-browser-test               | [Browser test manifest](../examples/datadoggenericresource/browser-test-sample.yaml) |
+| `monitor`                 | v1.13.0          | https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor                      | [Monitor manifest](../examples/datadoggenericresource/monitor-sample.yaml)           |
+| `downtime`                | v1.22.0          | https://docs.datadoghq.com/api/latest/downtimes/#schedule-a-downtime                  | [Downtime manifest](../examples/datadoggenericresource/downtime-sample.yaml)         |
+| `dashboard`               | v1.27.0          | https://docs.datadoghq.com/api/latest/dashboards/#create-a-dashboard                  | [Dashboard manifest](../examples/datadoggenericresource/dashboard-sample.yaml)       |
+| `slo`                     | v1.28.0          | https://docs.datadoghq.com/api/latest/service-level-objectives/#create-an-slo-object  | [SLO manifest](../examples/datadoggenericresource/slo-sample.yaml)                   |
 
 ## Prerequisites
 
@@ -170,7 +171,7 @@ For resource types that expose a live state in the Datadog backend, the controll
 
 | Field | Description |
 | --- | --- |
-| `.status.state` | Live state as reported by Datadog. Values are resource-type dependent. For Monitors: `OK`, `Alert`, `Warn`, `No Data`, `Skipped`, `Ignored`, `Unknown`. |
+| `.status.state` | Live state as reported by Datadog. Values are resource-type dependent. For Monitors: `OK`, `Alert`, `Warn`, `No Data`, `Skipped`, `Ignored`, `Unknown`. For SLOs: `breached`, `warning`, `ok`, `no_data`. |
 | `.status.stateLastUpdateTime` | Last time `state` was successfully refreshed from the Datadog API. |
 | `.status.stateLastTransitionTime` | Last time `state` changed value. |
 | `.status.conditions[type=StateSynced]` | `True` after a successful state refresh; `False` with `reason=GetError` when the most recent refresh failed (last-known `state` is preserved). |
@@ -184,7 +185,7 @@ kubectl wait --for=condition=StateSynced datadoggenericresource/<name>
 
 The controller refreshes `state` roughly every 60 seconds during reconciliation. Failures are visible only via the `StateSynced` condition — they do not break the reconcile loop and the last-known `state` is retained until a subsequent refresh succeeds.
 
-This information is currently surfaced for `monitor` resources. Resource types that do not expose live Datadog-side state (e.g., `dashboard`, `notebook`) leave these fields empty.
+This information is currently surfaced for `monitor` and `slo` resources. Resource types that do not expose live Datadog-side state (e.g., `dashboard`, `notebook`) leave these fields empty.
 
 ## Comparison with existing CRDs
 

--- a/docs/datadog_generic_resource_dev.md
+++ b/docs/datadog_generic_resource_dev.md
@@ -14,11 +14,11 @@ The general steps to add a new type can be summarized to:
 1. In `api/datadoghq/v1alpha1/datadoggenericresource_types.go`:
     1. Add a new constant of type `SupportedResourcesType`.
     2. Append its value to the `kubebuilder:validation:Enum` marker on the `Type` field in `DatadogGenericResourceSpec`.
-2. Generate the updated CRD with `make generate`.
+2. Regenerate generated code and CRD manifests with `make generate && make manifests`.
 
-## Adding the API client to `DatadogGenericClient`
-1. Add the new client (from the [Datadog Go client](https://github.com/DataDog/datadog-api-client-go)) to the `DatadogGenericClient` struct inside `pkg/datadogclient/client.go`.
-2. Reference it in `InitDatadogGenericClient` function within the same file.
+## Adding the API client to `GenericClients`
+1. Add the new client (from the [Datadog Go client](https://github.com/DataDog/datadog-api-client-go)) to the `GenericClients` struct inside `pkg/datadogclient/client.go`.
+2. Reference it in `InitGenericClients` function within the same file.
 
 ## Adding the resource handler and CRUD operations
 
@@ -36,7 +36,7 @@ The general steps to add a new type can be summarized to:
         * `deleteResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error`: call the API Delete method using `instance.Status.Id`.
         * `refreshState(auth context.Context, instance *v1alpha1.DatadogGenericResource) (*string, error)`: fetch the live Datadog-side state of the resource and return it as a `*string`. **Return `(nil, nil)` for resource types that do not expose live state** — the controller will skip status mutation and leave the state fields and the `StateSynced` condition untouched. On error, return `(nil, err)` and the controller will preserve the last-known state and flip the `StateSynced` condition to False with `reason=GetError`. See `monitors.go` for a reference implementation and the other handlers (`dashboards.go`, `downtimes.go`, …) for the no-op pattern.
     3. Optionally define helper functions (`create<Resource>`, `get<Resource>`, etc.) for the raw API calls if it helps readability.
-2. `internal/controller/datadoggenericresource/utils.go`: Add your handler to the `buildHandlers` function, mapping the new `SupportedResourcesType` to a `<Resource>Handler` initialized with the appropriate client from `DatadogGenericClient`:
+2. `internal/controller/datadoggenericresource/utils.go`: Add your handler to the `buildHandlers` function, mapping the new `SupportedResourcesType` to a `<Resource>Handler` initialized with the appropriate client from `GenericClients`:
     ```go
     v1alpha1.<Resource>: &<Resource>Handler{client: clients.<Resource>Client},
     ```

--- a/examples/datadoggenericresource/slo-sample.yaml
+++ b/examples/datadoggenericresource/slo-sample.yaml
@@ -1,0 +1,27 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogGenericResource
+metadata:
+  name: ddgr-slo-sample
+spec:
+  type: slo
+  jsonSpec: |-
+    {
+      "name": "Example Metric SLO",
+      "type": "metric",
+      "description": "Example metric SLO managed by Datadog Generic Resource",
+      "query": {
+        "numerator": "sum:trace.http.request.hits.by_http_status{http.status_code:200}.as_count()",
+        "denominator": "sum:trace.http.request.hits{*}.as_count()"
+      },
+      "thresholds": [
+        {
+          "timeframe": "7d",
+          "target": 99.9,
+          "warning": 99.95
+        }
+      ],
+      "tags": [
+        "test:example-slo",
+        "env:ci"
+      ]
+    }

--- a/internal/controller/datadoggenericresource/delete_idempotency_test.go
+++ b/internal/controller/datadoggenericresource/delete_idempotency_test.go
@@ -112,6 +112,27 @@ func Test_deleteDashboard_idempotent(t *testing.T) {
 	}
 }
 
+func Test_deleteSLO_idempotent(t *testing.T) {
+	for _, tc := range defaultDeleteCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestHTTPServer(tc.statusCode, tc.body)
+			defer server.Close()
+
+			cfg := datadogapi.NewConfiguration()
+			cfg.HTTPClient = server.Client()
+			client := datadogV1.NewServiceLevelObjectivesApi(datadogapi.NewAPIClient(cfg))
+			auth := setupTestAuth(server.URL)
+
+			err := deleteSLO(auth, client, "abc-def-123")
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_deleteSyntheticTest_idempotent(t *testing.T) {
 	for _, tc := range defaultDeleteCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/controller/datadoggenericresource/slos.go
+++ b/internal/controller/datadoggenericresource/slos.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadoggenericresource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+)
+
+type SLOHandler struct {
+	client *datadogV1.ServiceLevelObjectivesApi
+}
+
+func (h *SLOHandler) createResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) (CreateResult, error) {
+	createdSLO, err := createSLO(auth, h.client, instance)
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	var createdTime *metav1.Time
+	if createdSLO.CreatedAt != nil {
+		ct := metav1.Unix(createdSLO.GetCreatedAt(), 0)
+		createdTime = &ct
+	}
+
+	creator := ""
+	if creatorHandle := createdSLO.GetCreator().Handle; creatorHandle != nil {
+		creator = *creatorHandle
+	}
+
+	return CreateResult{
+		ID:          createdSLO.GetId(),
+		CreatedTime: createdTime,
+		Creator:     creator,
+	}, nil
+}
+
+func (h *SLOHandler) getResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := getSLO(auth, h.client, instance.Status.Id)
+	return err
+}
+
+func (h *SLOHandler) updateResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := updateSLO(auth, h.client, instance)
+	return err
+}
+
+func (h *SLOHandler) deleteResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {
+	return deleteSLO(auth, h.client, instance.Status.Id)
+}
+
+func (h *SLOHandler) refreshState(auth context.Context, instance *v1alpha1.DatadogGenericResource) (*string, error) {
+	sloName, err := getSLONameFromSpec(instance)
+	if err != nil {
+		return nil, err
+	}
+	return getSLOState(auth, h.client, instance.Status.Id, sloName)
+}
+
+func createSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi, instance *v1alpha1.DatadogGenericResource) (datadogV1.ServiceLevelObjective, error) {
+	sloCreateData := &datadogV1.ServiceLevelObjectiveRequest{}
+	if err := json.Unmarshal([]byte(instance.Spec.JsonSpec), sloCreateData); err != nil {
+		return datadogV1.ServiceLevelObjective{}, translateClientError(err, "error unmarshalling SLO spec")
+	}
+	slo, _, err := client.CreateSLO(auth, *sloCreateData)
+	if err != nil {
+		return datadogV1.ServiceLevelObjective{}, translateClientError(err, "error creating SLO")
+	}
+
+	data := slo.GetData()
+	if len(data) == 0 {
+		return datadogV1.ServiceLevelObjective{}, fmt.Errorf("error creating SLO: empty response data")
+	}
+	return data[0], nil
+}
+
+func getSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi, sloID string) (*datadogV1.SLOResponseData, error) {
+	slo, _, err := client.GetSLO(auth, sloID, datadogV1.GetSLOOptionalParameters{})
+	if err != nil {
+		return nil, translateClientError(err, "error getting SLO")
+	}
+	return slo.Data, nil
+}
+
+func updateSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi, instance *v1alpha1.DatadogGenericResource) (datadogV1.SLOListResponse, error) {
+	sloUpdateData := &datadogV1.ServiceLevelObjective{}
+	if err := json.Unmarshal([]byte(instance.Spec.JsonSpec), sloUpdateData); err != nil {
+		return datadogV1.SLOListResponse{}, translateClientError(err, "error unmarshalling SLO spec")
+	}
+	sloUpdated, _, err := client.UpdateSLO(auth, instance.Status.Id, *sloUpdateData)
+	if err != nil {
+		return datadogV1.SLOListResponse{}, translateClientError(err, "error updating SLO")
+	}
+	return sloUpdated, nil
+}
+
+func deleteSLO(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi, sloID string) error {
+	force := "false"
+	optionalParams := datadogV1.DeleteSLOOptionalParameters{
+		Force: &force,
+	}
+	_, httpResponse, err := client.DeleteSLO(auth, sloID, optionalParams)
+	if err != nil {
+		// Deletion is idempotent for finalization: if the SLO was already removed
+		// in Datadog (for example from the UI), allow the Kubernetes finalizer to clear.
+		// Retry other errors (e.g. 400, 401, 429, 5XX).
+		if httpResponse != nil && httpResponse.StatusCode == 404 {
+			return nil
+		}
+		return translateClientError(err, "error deleting SLO")
+	}
+	return nil
+}
+
+func getSLOState(auth context.Context, client *datadogV1.ServiceLevelObjectivesApi, sloID, sloName string) (*string, error) {
+	pageSize := int64(100)
+	searchParams := datadogV1.SearchSLOOptionalParameters{
+		Query:    &sloName,
+		PageSize: &pageSize,
+	}
+
+	response, _, err := client.SearchSLO(auth, searchParams)
+	if err != nil {
+		return nil, translateClientError(err, "error searching SLO")
+	}
+
+	state, err := extractSLOState(response, sloID)
+	if err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func extractSLOState(response datadogV1.SearchSLOResponse, sloID string) (string, error) {
+	data := response.GetData()
+	attributes := data.GetAttributes()
+	for _, slo := range attributes.GetSlos() {
+		sloData := slo.GetData()
+		if sloData.GetId() != sloID {
+			continue
+		}
+
+		sloAttributes := sloData.GetAttributes()
+		for _, status := range sloAttributes.GetOverallStatus() {
+			if state, ok := status.GetStateOk(); ok {
+				return string(*state), nil
+			}
+		}
+		if status, ok := sloAttributes.GetStatusOk(); ok {
+			if state, ok := status.GetStateOk(); ok {
+				return string(*state), nil
+			}
+		}
+
+		return "", fmt.Errorf("error getting SLO state: SLO %s does not include state", sloID)
+	}
+
+	return "", fmt.Errorf("error getting SLO state: SLO %s not found", sloID)
+}
+
+func getSLONameFromSpec(instance *v1alpha1.DatadogGenericResource) (string, error) {
+	sloSpec := struct {
+		Name string `json:"name"`
+	}{}
+	if err := json.Unmarshal([]byte(instance.Spec.JsonSpec), &sloSpec); err != nil {
+		return "", translateClientError(err, "error unmarshalling SLO spec")
+	}
+	if sloSpec.Name == "" {
+		return "", fmt.Errorf("error getting SLO state: SLO spec does not include name")
+	}
+	return sloSpec.Name, nil
+}

--- a/internal/controller/datadoggenericresource/slos_test.go
+++ b/internal/controller/datadoggenericresource/slos_test.go
@@ -1,0 +1,239 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadoggenericresource
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+)
+
+func Test_extractSLOState(t *testing.T) {
+	tests := []struct {
+		name          string
+		response      string
+		expectedState string
+		wantErr       string
+	}{
+		{
+			name: "uses overall status state",
+			response: `{
+				"data": {
+					"attributes": {
+						"slos": [
+							{
+								"data": {
+									"id": "slo-123",
+									"type": "slo",
+									"attributes": {
+										"overall_status": [
+											{"state": "warning", "timeframe": "7d"}
+										],
+										"status": {"state": "ok"}
+									}
+								}
+							}
+						]
+					}
+				}
+			}`,
+			expectedState: "warning",
+		},
+		{
+			name: "falls back to primary status state",
+			response: `{
+				"data": {
+					"attributes": {
+						"slos": [
+							{
+								"data": {
+									"id": "slo-123",
+									"type": "slo",
+									"attributes": {
+										"status": {"state": "breached"}
+									}
+								}
+							}
+						]
+					}
+				}
+			}`,
+			expectedState: "breached",
+		},
+		{
+			name: "filters by SLO ID",
+			response: `{
+				"data": {
+					"attributes": {
+						"slos": [
+							{
+								"data": {
+									"id": "other-slo",
+									"type": "slo",
+									"attributes": {
+										"overall_status": [
+											{"state": "ok", "timeframe": "7d"}
+										]
+									}
+								}
+							},
+							{
+								"data": {
+									"id": "slo-123",
+									"type": "slo",
+									"attributes": {
+										"overall_status": [
+											{"state": "no_data", "timeframe": "7d"}
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			}`,
+			expectedState: "no_data",
+		},
+		{
+			name: "errors when SLO is missing",
+			response: `{
+				"data": {
+					"attributes": {
+						"slos": []
+					}
+				}
+			}`,
+			wantErr: "error getting SLO state: SLO slo-123 not found",
+		},
+		{
+			name: "errors when state is missing",
+			response: `{
+				"data": {
+					"attributes": {
+						"slos": [
+							{
+								"data": {
+									"id": "slo-123",
+									"type": "slo",
+									"attributes": {}
+								}
+							}
+						]
+					}
+				}
+			}`,
+			wantErr: "error getting SLO state: SLO slo-123 does not include state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var response datadogV1.SearchSLOResponse
+			require.NoError(t, json.Unmarshal([]byte(tt.response), &response))
+
+			state, err := extractSLOState(response, "slo-123")
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedState, state)
+		})
+	}
+}
+
+func Test_getSLOState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/slo/search", r.URL.Path)
+		assert.Equal(t, "Example SLO", r.URL.Query().Get("query"))
+		assert.Equal(t, "100", r.URL.Query().Get("page[size]"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": {
+				"attributes": {
+					"slos": [
+						{
+							"data": {
+								"id": "slo-123",
+								"type": "slo",
+								"attributes": {
+									"overall_status": [
+										{"state": "ok", "timeframe": "7d"}
+									]
+								}
+							}
+						}
+					]
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	cfg := datadogapi.NewConfiguration()
+	cfg.HTTPClient = server.Client()
+	client := datadogV1.NewServiceLevelObjectivesApi(datadogapi.NewAPIClient(cfg))
+	auth := setupTestAuth(server.URL)
+
+	state, err := getSLOState(auth, client, "slo-123", "Example SLO")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, "ok", *state)
+}
+
+func Test_getSLONameFromSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		jsonSpec     string
+		expectedName string
+		wantErr      string
+	}{
+		{
+			name:         "returns name",
+			jsonSpec:     `{"name":"Example SLO","type":"metric"}`,
+			expectedName: "Example SLO",
+		},
+		{
+			name:     "invalid JSON",
+			jsonSpec: `{`,
+			wantErr:  "error unmarshalling SLO spec: unexpected end of JSON input",
+		},
+		{
+			name:     "missing name",
+			jsonSpec: `{"type":"metric"}`,
+			wantErr:  "error getting SLO state: SLO spec does not include name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &v1alpha1.DatadogGenericResource{
+				Spec: v1alpha1.DatadogGenericResourceSpec{
+					JsonSpec: tt.jsonSpec,
+				},
+			}
+
+			name, err := getSLONameFromSpec(instance)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedName, name)
+		})
+	}
+}

--- a/internal/controller/datadoggenericresource/utils.go
+++ b/internal/controller/datadoggenericresource/utils.go
@@ -20,6 +20,7 @@ func buildHandlers(clients *datadogclient.GenericClients) map[v1alpha1.Supported
 		v1alpha1.Downtime:              &DowntimeHandler{client: clients.DowntimesClient},
 		v1alpha1.Monitor:               &MonitorHandler{client: clients.MonitorsClient},
 		v1alpha1.Notebook:              &NotebookHandler{client: clients.NotebooksClient},
+		v1alpha1.SLO:                   &SLOHandler{client: clients.SLOsClient},
 		v1alpha1.SyntheticsAPITest:     &SyntheticsAPITestHandler{client: clients.SyntheticsClient},
 		v1alpha1.SyntheticsBrowserTest: &SyntheticsBrowserTestHandler{client: clients.SyntheticsClient},
 	}

--- a/pkg/datadogclient/client.go
+++ b/pkg/datadogclient/client.go
@@ -38,6 +38,7 @@ type GenericClients struct {
 	SyntheticsClient *datadogV1.SyntheticsApi
 	NotebooksClient  *datadogV1.NotebooksApi
 	MonitorsClient   *datadogV1.MonitorsApi
+	SLOsClient       *datadogV1.ServiceLevelObjectivesApi
 	DowntimesClient  *datadogV2.DowntimesApi
 }
 
@@ -50,6 +51,7 @@ func InitGenericClients() *GenericClients {
 		SyntheticsClient: datadogV1.NewSyntheticsApi(apiClient),
 		NotebooksClient:  datadogV1.NewNotebooksApi(apiClient),
 		MonitorsClient:   datadogV1.NewMonitorsApi(apiClient),
+		SLOsClient:       datadogV1.NewServiceLevelObjectivesApi(apiClient),
 		DowntimesClient:  datadogV2.NewDowntimesApi(apiClient),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds Service Level Objective (SLO) as a supported `DatadogGenericResource` type.

This includes:
* the CRD enum update a generic-resource: 6daebcb5201cd7434c041e5d8bb8646f0ec0429f
* SLO handler with create/get/update/delete/state refresh support: 3ad825101bed5acdacd05524a023cf034732afe4
* docs, and a sample manifest: 94fe5b281fb3f7bb64b7a4f07d135c61d47ff7f9
* small update to dev guide: 3f150bd3edaca869e4e10d70a05c6ae6840a68d1

### Motivation

https://datadoghq.atlassian.net/browse/CONTP-1585

Users can already manage SLOs through the dedicated `DatadogSLO` CRD, but `DatadogGenericResource` should also support SLOs so users can manage the API object directly from JSON and benefit from DDGR's generic reconciliation flow.

### Additional Notes

SLO status refresh uses the SLO search endpoint with the SLO name from `spec.jsonSpec`, then filters results by the Datadog SLO ID stored in `.status.id` before surfacing `overall_status[].state` into `.status.state`.

### Minimum Agent Versions

No minimum Agent or Cluster Agent version is required.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- Deploy the Operator with `DatadogGenericResource` enabled.
- Apply `examples/datadoggenericresource/slo-sample.yaml`.
- Verify in the Datadog UI that the SLO is created.
- Edit the DDGR manifest with `k edit ddgr ddgr-slo-sample` and change the warning threshold.
- Verify in the Datadog UI that the warning threshold update is live.
- Verify the DDGR status with `k get ddgr`.
    ```console
    ╰─❯ k get ddgr
    NAME              ID                                 SYNC STATUS   STATE      LAST STATE SYNC        AGE
    ddgr-slo-sample   c77dd9bd5cca5336a1d21048bb2436c8   OK            breached   2026-06-02T11:51:51Z   18m
    ```
- Delete the DDGR resource and verify the SLO is deleted.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits