### PR TITLE
correct policy issuer in staging for release-dashboard-api to ticino

### DIFF
--- a/.github/chainguard/release-dashboard-api-staging.sts.yaml
+++ b/.github/chainguard/release-dashboard-api-staging.sts.yaml
@@ -1,5 +1,5 @@
 # Issued to: rapid-agent-delivery/release-dashboard-api on us1 staging
-issuer: https://vault.us1.staging.dog/v1/identity/oidc
+issuer: https://ticino.identity.local-cluster.local-dc.fabric.dog:8443/v1/issuer/sycamore
 subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.staging.dog
 
 permissions:

--- a/.github/chainguard/release-dashboard-api.sts.yaml
+++ b/.github/chainguard/release-dashboard-api.sts.yaml
@@ -1,5 +1,5 @@
 # Issued to: rapid-agent-delivery/release-dashboard-api on us1 prod
-issuer: https://vault.us1.prod.dog/v1/identity/oidc
+issuer: https://ticino.identity.local-cluster.local-dc.fabric.dog:8443/v1/issuer/sycamore
 subject: rapid-agent-delivery.release-dashboard-api@kubernetes.us1.prod.dog
 
 permissions:


### PR DESCRIPTION
What does this PR do?
change the policy issuer for release-dashboard-api to ticino since its the one supported by RAPID in staging

Describe how you validated your changes
can only test the policy works after merging changes