### PR TITLE
[profiles] Add apm feature override

### DIFF
--- a/api/datadoghq/v1alpha1/datadogagentprofile_validation.go
+++ b/api/datadoghq/v1alpha1/datadogagentprofile_validation.go
@@ -78,7 +78,6 @@ func validateFeatures(features *v2alpha1.DatadogFeatures) error {
 		{features.OOMKill, "oomKill"},
 		{features.TCPQueueLength, "tcpQueueLength"},
 		{features.EBPFCheck, "ebpfCheck"},
-		{features.APM, "apm"},
 		{features.ASM, "asm"},
 		{features.CSPM, "cspm"},
 		{features.CWS, "cws"},
@@ -99,6 +98,7 @@ func validateFeatures(features *v2alpha1.DatadogFeatures) error {
 		{features.PrometheusScrape, "prometheusScrape"},
 		{features.HelmCheck, "helmCheck"},
 		{features.ControlPlaneMonitoring, "controlPlaneMonitoring"},
+		{features.DataPlane, "dataPlane"},
 	}
 
 	for _, feature := range unsupportedFeatures {
@@ -109,7 +109,7 @@ func validateFeatures(features *v2alpha1.DatadogFeatures) error {
 		}
 	}
 
-	// GPU is allowed, no error returned
+	// GPU and APM are allowed, no error returned.
 	return nil
 }
 

--- a/api/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
+++ b/api/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
@@ -145,6 +145,20 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 			},
 		},
 	}
+	validAPMFeature := &DatadogAgentProfileSpec{
+		ProfileAffinity: basicProfileAffinity,
+		Config: &v2alpha1.DatadogAgentSpec{
+			Features: &v2alpha1.DatadogFeatures{
+				APM: &v2alpha1.APMFeatureConfig{
+					Enabled: ptr.To(true),
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:           ptr.To(true),
+						EnabledNamespaces: []string{"gpu"},
+					},
+				},
+			},
+		},
+	}
 	invalidFeatures := &DatadogAgentProfileSpec{
 		ProfileAffinity: basicProfileAffinity,
 		Config: &v2alpha1.DatadogAgentSpec{
@@ -152,6 +166,14 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 				NPM: &v2alpha1.NPMFeatureConfig{
 					Enabled: ptr.To(true),
 				},
+			},
+		},
+	}
+	invalidDataPlaneFeature := &DatadogAgentProfileSpec{
+		ProfileAffinity: basicProfileAffinity,
+		Config: &v2alpha1.DatadogAgentSpec{
+			Features: &v2alpha1.DatadogFeatures{
+				DataPlane: &v2alpha1.DataPlaneFeatureConfig{},
 			},
 		},
 	}
@@ -211,9 +233,18 @@ func TestIsValidDatadogAgentProfile(t *testing.T) {
 			spec: validFeaturesNoOverride,
 		},
 		{
+			name: "apm feature override",
+			spec: validAPMFeature,
+		},
+		{
 			name:    "dap with unsupported feature",
 			spec:    invalidFeatures,
 			wantErr: "npm override is not supported",
+		},
+		{
+			name:    "dap with unsupported data plane feature",
+			spec:    invalidDataPlaneFeature,
+			wantErr: "dataPlane override is not supported",
 		},
 	}
 	for _, test := range testCases {

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -103,11 +103,16 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 			Name:      dsName,
 		}
 		maxUnavailable := agentprofile.GetMaxUnavailableFromSpecAndEDS(&instance.Spec, &r.options.ExtendedDaemonsetOptions, nil)
-		appliedProfiles, e := r.reconcileProfiles(ctx, dsNSName, maxUnavailable)
+
+		// Profiles normally render their own DDAIs from the base DDAI. Shared
+		// component config contributed by profiles is accumulated on the default
+		// DDAI, because there is only one Cluster Agent/CCR for the cluster.
+		defaultDDAI := ddai.DeepCopy()
+		appliedProfiles, e := r.reconcileProfiles(ctx, dsNSName, maxUnavailable, defaultDDAI)
 		if e != nil {
 			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
 		}
-		profileDDAIs, e := r.applyProfilesToDDAISpec(ddai, appliedProfiles)
+		profileDDAIs, e := r.applyProfilesToDDAISpec(ddai, defaultDDAI, appliedProfiles)
 		if e != nil {
 			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
 		}

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -39,6 +39,12 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	// SSI is configured on the Cluster Agent, so profile SSI config needs a
+	// shared-component overlay in addition to the normal per-DDAI feature path.
+	err = feature.RegisterProfileSharedConfigOverlay(feature.APMIDType, applyAPMProfileSharedConfigOverlay)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func buildAPMFeature(options *feature.Options) feature.Feature {
@@ -52,6 +58,10 @@ func buildAPMFeature(options *feature.Options) feature.Feature {
 }
 
 type apmFeature struct {
+	// nodeAPMEnabled tracks the node-agent side of APM separately from SSI.
+	// Profiles can contribute SSI Cluster Agent config without enabling trace
+	// agent configuration on the default DDAI.
+	nodeAPMEnabled   bool
 	hostPortEnabled  bool
 	hostPortHostPort int32
 	useHostNetwork   bool
@@ -123,15 +133,33 @@ func shouldEnableAPM(apmConf *v2alpha1.APMFeatureConfig) bool {
 	return false
 }
 
+func shouldConfigureSSI(apmConf *v2alpha1.APMFeatureConfig, ddaSpec *v2alpha1.DatadogAgentSpec) bool {
+	if apmConf == nil || apmConf.SingleStepInstrumentation == nil {
+		return false
+	}
+	// Configure only renders SSI when the shared components it needs can exist.
+	// Profile overlays use the same validation but return an error instead of
+	// silently skipping the profile contribution.
+	return validateSSISharedComponentPrerequisites(ddaSpec) == nil
+}
+
 // Configure is used to configure the feature from a v2alpha1.DatadogAgent instance.
 func (f *apmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
 	f.owner = dda
 	apm := ddaSpec.Features.APM
-	if shouldEnableAPM(apm) {
-		f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.GetName(), ddaSpec)
+	if apm == nil {
+		return reqComp
+	}
+
+	f.serviceAccountName = constants.GetClusterAgentServiceAccount(dda.GetName(), ddaSpec)
+	f.nodeAPMEnabled = shouldEnableAPM(apm)
+	f.processCheckRunsInCoreAgent = featutils.ShouldRunProcessChecksInCoreAgent(ddaSpec)
+
+	// Node APM controls trace-agent configuration and node-scoped dependencies.
+	if f.nodeAPMEnabled {
 		f.useHostNetwork = constants.IsHostNetworkEnabled(ddaSpec, v2alpha1.NodeAgentComponentName)
 
-		// Check if autopilot is enabled and override defaults accordingly
+		// Check if autopilot is enabled and override defaults accordingly.
 		if experimental.IsAutopilotEnabled(dda) {
 			f.hostPortEnabled = true
 			f.udsEnabled = false
@@ -157,47 +185,52 @@ func (f *apmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 		}
 		f.localServiceName = constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec)
 
-		reqComp = feature.RequiredComponents{
-			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
-				Containers: []apicommon.AgentContainerName{
-					apicommon.CoreAgentContainerName,
-					apicommon.TraceAgentContainerName,
-				},
+		reqComp.Agent = feature.RequiredComponent{
+			IsRequired: ptr.To(true),
+			Containers: []apicommon.AgentContainerName{
+				apicommon.CoreAgentContainerName,
+				apicommon.TraceAgentContainerName,
 			},
 		}
+	}
 
-		if apm.SingleStepInstrumentation != nil &&
-			(ddaSpec.Features.AdmissionController != nil && apiutils.BoolValue(ddaSpec.Features.AdmissionController.Enabled)) {
-			// TODO: add debug log in case Admission controller is disabled (it's a required feature).
-			f.singleStepInstrumentation = &instrumentationConfig{}
-			f.singleStepInstrumentation.enabled = apiutils.BoolValue(apm.SingleStepInstrumentation.Enabled)
-			f.singleStepInstrumentation.disabledNamespaces = apm.SingleStepInstrumentation.DisabledNamespaces
-			f.singleStepInstrumentation.enabledNamespaces = apm.SingleStepInstrumentation.EnabledNamespaces
-			f.singleStepInstrumentation.libVersions = apm.SingleStepInstrumentation.LibVersions
-			f.singleStepInstrumentation.languageDetection = &languageDetection{enabled: apiutils.BoolValue(ddaSpec.Features.APM.SingleStepInstrumentation.LanguageDetection.Enabled)}
+	// SSI controls Cluster Agent admission instrumentation config. It is kept
+	// separate from nodeAPMEnabled so a profile can enable SSI for a node group
+	// without turning on trace-agent config in the default DDAI.
+	if shouldConfigureSSI(apm, ddaSpec) {
+		f.singleStepInstrumentation = &instrumentationConfig{}
+		f.singleStepInstrumentation.enabled = apiutils.BoolValue(apm.SingleStepInstrumentation.Enabled)
+		f.singleStepInstrumentation.disabledNamespaces = apm.SingleStepInstrumentation.DisabledNamespaces
+		f.singleStepInstrumentation.enabledNamespaces = apm.SingleStepInstrumentation.EnabledNamespaces
+		f.singleStepInstrumentation.libVersions = apm.SingleStepInstrumentation.LibVersions
+		if apm.SingleStepInstrumentation.LanguageDetection != nil {
+			f.singleStepInstrumentation.languageDetection = &languageDetection{enabled: apiutils.BoolValue(apm.SingleStepInstrumentation.LanguageDetection.Enabled)}
+		}
+		if apm.SingleStepInstrumentation.Injector != nil {
 			f.singleStepInstrumentation.injector = &injector{imageTag: apm.SingleStepInstrumentation.Injector.ImageTag}
-			f.singleStepInstrumentation.injectionMode = string(apm.SingleStepInstrumentation.InjectionMode)
-			if len(apm.SingleStepInstrumentation.Targets) > 0 {
-				if supportsInstrumentationTargets(ddaSpec) {
-					f.singleStepInstrumentation.targets = apm.SingleStepInstrumentation.Targets
-				} else {
-					f.logger.Info("Cannot enable instrumentation targets. features.apm.instrumentation.targets requires agent version >= 7.64.0")
-				}
-			}
-			reqComp.ClusterAgent = feature.RequiredComponent{
-				IsRequired: ptr.To(true),
-				Containers: []apicommon.AgentContainerName{
-					apicommon.ClusterAgentContainerName,
-				},
+		}
+		f.singleStepInstrumentation.injectionMode = string(apm.SingleStepInstrumentation.InjectionMode)
+		if len(apm.SingleStepInstrumentation.Targets) > 0 {
+			if supportsInstrumentationTargets(ddaSpec) {
+				f.singleStepInstrumentation.targets = apm.SingleStepInstrumentation.Targets
+			} else {
+				f.logger.Info(fmt.Sprintf("Cannot enable instrumentation targets. features.apm.instrumentation.targets requires agent version >= %s", minInstrumentationTargetsVersion))
 			}
 		}
+		reqComp.ClusterAgent = feature.RequiredComponent{
+			IsRequired: ptr.To(true),
+			Containers: []apicommon.AgentContainerName{
+				apicommon.ClusterAgentContainerName,
+			},
+		}
+	}
 
-		f.processCheckRunsInCoreAgent = featutils.ShouldRunProcessChecksInCoreAgent(ddaSpec)
+	// Language detection still needs process-agent support on nodes when process
+	// checks are not running in the core agent.
+	if f.nodeAPMEnabled {
 		if f.shouldEnableLanguageDetection() && !f.processCheckRunsInCoreAgent {
 			reqComp.Agent.Containers = append(reqComp.Agent.Containers, apicommon.ProcessAgentContainerName)
 		}
-
 		if apm.ErrorTrackingStandalone != nil {
 			f.errorTrackingStandalone = apiutils.BoolValue(apm.ErrorTrackingStandalone.Enabled)
 		}
@@ -229,80 +262,82 @@ func (f *apmFeature) shouldEnableLanguageDetection() bool {
 // ManageDependencies allows a feature to manage its dependencies.
 // Feature's dependencies should be added in the store.
 func (f *apmFeature) ManageDependencies(managers feature.ResourceManagers) error {
-	platformInfo := managers.Store().GetPlatformInfo()
-	// agent local service
-	if common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), f.forceEnableLocalService) {
-		apmPort := &corev1.ServicePort{
-			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(int(constants.DefaultApmPort)),
-			Port:       constants.DefaultApmPort,
-			Name:       constants.DefaultApmPortName,
-		}
-		if f.hostPortEnabled {
-			apmPort.Port = f.hostPortHostPort
-			apmPort.Name = apmHostPortName
-			if f.useHostNetwork {
-				apmPort.TargetPort = intstr.FromInt(int(f.hostPortHostPort))
+	if f.nodeAPMEnabled {
+		platformInfo := managers.Store().GetPlatformInfo()
+		// agent local service
+		if common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), f.forceEnableLocalService) {
+			apmPort := &corev1.ServicePort{
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt(int(constants.DefaultApmPort)),
+				Port:       constants.DefaultApmPort,
+				Name:       constants.DefaultApmPortName,
+			}
+			if f.hostPortEnabled {
+				apmPort.Port = f.hostPortHostPort
+				apmPort.Name = apmHostPortName
+				if f.useHostNetwork {
+					apmPort.TargetPort = intstr.FromInt(int(f.hostPortHostPort))
+				}
+			}
+
+			serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
+			if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), common.GetAgentLocalServiceSelector(f.owner), []corev1.ServicePort{*apmPort}, &serviceInternalTrafficPolicy); err != nil {
+				return err
 			}
 		}
 
-		serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-		if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), common.GetAgentLocalServiceSelector(f.owner), []corev1.ServicePort{*apmPort}, &serviceInternalTrafficPolicy); err != nil {
-			return err
-		}
-	}
-
-	// network policies
-	if f.hostPortEnabled {
-		policyName, podSelector := objects.GetNetworkPolicyMetadata(f.owner, v2alpha1.NodeAgentComponentName)
-		if f.createKubernetesNetworkPolicy {
-			protocolTCP := corev1.ProtocolTCP
-			ingressRules := []netv1.NetworkPolicyIngressRule{
-				{
-					Ports: []netv1.NetworkPolicyPort{
-						{
-							Port: &intstr.IntOrString{
-								Type:   intstr.Int,
-								IntVal: f.hostPortHostPort,
+		// network policies
+		if f.hostPortEnabled {
+			policyName, podSelector := objects.GetNetworkPolicyMetadata(f.owner, v2alpha1.NodeAgentComponentName)
+			if f.createKubernetesNetworkPolicy {
+				protocolTCP := corev1.ProtocolTCP
+				ingressRules := []netv1.NetworkPolicyIngressRule{
+					{
+						Ports: []netv1.NetworkPolicyPort{
+							{
+								Port: &intstr.IntOrString{
+									Type:   intstr.Int,
+									IntVal: f.hostPortHostPort,
+								},
+								Protocol: &protocolTCP,
 							},
-							Protocol: &protocolTCP,
 						},
 					},
-				},
-			}
-			return managers.NetworkPolicyManager().AddKubernetesNetworkPolicy(
-				policyName,
-				f.owner.GetNamespace(),
-				podSelector,
-				nil,
-				ingressRules,
-				nil,
-			)
-		} else if f.createCiliumNetworkPolicy {
-			policySpecs := []cilium.NetworkPolicySpec{
-				{
-					Description:      "Ingress for APM trace",
-					EndpointSelector: podSelector,
-					Ingress: []cilium.IngressRule{
-						{
-							FromEndpoints: []metav1.LabelSelector{
-								{},
-							},
-							ToPorts: []cilium.PortRule{
-								{
-									Ports: []cilium.PortProtocol{
-										{
-											Port:     strconv.Itoa(int(f.hostPortHostPort)),
-											Protocol: cilium.ProtocolTCP,
+				}
+				return managers.NetworkPolicyManager().AddKubernetesNetworkPolicy(
+					policyName,
+					f.owner.GetNamespace(),
+					podSelector,
+					nil,
+					ingressRules,
+					nil,
+				)
+			} else if f.createCiliumNetworkPolicy {
+				policySpecs := []cilium.NetworkPolicySpec{
+					{
+						Description:      "Ingress for APM trace",
+						EndpointSelector: podSelector,
+						Ingress: []cilium.IngressRule{
+							{
+								FromEndpoints: []metav1.LabelSelector{
+									{},
+								},
+								ToPorts: []cilium.PortRule{
+									{
+										Ports: []cilium.PortProtocol{
+											{
+												Port:     strconv.Itoa(int(f.hostPortHostPort)),
+												Protocol: cilium.ProtocolTCP,
+											},
 										},
 									},
 								},
 							},
 						},
 					},
-				},
+				}
+				return managers.CiliumPolicyManager().AddCiliumPolicy(policyName, f.owner.GetNamespace(), policySpecs)
 			}
-			return managers.CiliumPolicyManager().AddCiliumPolicy(policyName, f.owner.GetNamespace(), policySpecs)
 		}
 	}
 
@@ -424,6 +459,9 @@ func supportsInstrumentationTargets(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 // if SingleContainerStrategy is enabled and can be used with the configured feature set.
 // It should do nothing if the feature doesn't need to configure it.
 func (f *apmFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplateManagers) error {
+	if !f.nodeAPMEnabled {
+		return nil
+	}
 	f.manageNodeAgent(apicommon.UnprivilegedSingleAgentContainerName, managers)
 	return nil
 }
@@ -431,6 +469,9 @@ func (f *apmFeature) ManageSingleContainerNodeAgent(managers feature.PodTemplate
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *apmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
+	if !f.nodeAPMEnabled {
+		return nil
+	}
 	f.manageNodeAgent(apicommon.TraceAgentContainerName, managers)
 	return nil
 }

--- a/internal/controller/datadogagent/feature/apm/feature_test.go
+++ b/internal/controller/datadogagent/feature/apm/feature_test.go
@@ -78,6 +78,34 @@ func TestShouldEnableAPM(t *testing.T) {
 	}
 }
 
+func TestAPMConfigureSSIWithoutNodeAPM(t *testing.T) {
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "datadog",
+			Namespace: "default",
+		},
+		Spec: v2alpha1.DatadogAgentSpec{
+			Features: &v2alpha1.DatadogFeatures{
+				AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{Enabled: ptr.To(true)},
+				APM: &v2alpha1.APMFeatureConfig{
+					Enabled: ptr.To(false),
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:           ptr.To(true),
+						LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+					},
+				},
+			},
+		},
+	}
+
+	feat := buildAPMFeature(&feature.Options{}).(*apmFeature)
+	reqComp := feat.Configure(dda, &dda.Spec, nil)
+
+	assert.False(t, reqComp.Agent.IsEnabled())
+	assert.True(t, reqComp.ClusterAgent.IsEnabled())
+	assert.True(t, feat.shouldEnableLanguageDetection())
+}
+
 func TestAPMFeature(t *testing.T) {
 	tests := test.FeatureTestSuite{
 		{
@@ -323,7 +351,8 @@ func TestAPMFeature(t *testing.T) {
 				WithAPMSingleStepInstrumentationEnabled(true, nil, nil, nil, false, "", nil, "").
 				WithAdmissionControllerEnabled(true).
 				Build(),
-			WantConfigure: false,
+			WantConfigure: true,
+			ClusterAgent:  testAPMInstrumentationWithoutUDS(),
 		},
 		{
 			Name: "step instrumentation w/o AC",
@@ -756,6 +785,27 @@ func testAPMInstrumentation() *test.ComponentTest {
 					Name:  DDAPMReceiverSocket,
 					Value: apmSocketHostPath,
 				},
+				{
+					Name:  DDAPMInstrumentationEnabled,
+					Value: "true",
+				},
+			}
+			assert.True(
+				t,
+				apiutils.IsEqualStruct(agentEnvs, expectedAgentEnvs),
+				"Cluster Agent ENVs \ndiff = %s", cmp.Diff(agentEnvs, expectedAgentEnvs),
+			)
+		},
+	)
+}
+
+func testAPMInstrumentationWithoutUDS() *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+			agentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
+			expectedAgentEnvs := []*corev1.EnvVar{
 				{
 					Name:  DDAPMInstrumentationEnabled,
 					Value: "true",

--- a/internal/controller/datadogagent/feature/apm/profile_overlay.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay.go
@@ -1,0 +1,237 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package apm
+
+import (
+	"fmt"
+	"slices"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+)
+
+func applyAPMProfileSharedConfigOverlay(dst, _ *v2alpha1.DatadogAgentSpec, profileSpec *v2alpha1.DatadogAgentSpec) error {
+	// Only profiles that explicitly enable SSI contribute shared Cluster Agent
+	// config. SSI enabled=false is treated as "no shared overlay".
+	profileSSI, ok := profileSSIOverlayConfig(profileSpec)
+	if !ok {
+		return nil
+	}
+
+	if profileSpec.Features.APM.Enabled != nil && !ptr.Deref(profileSpec.Features.APM.Enabled, false) {
+		return fmt.Errorf("features.apm.enabled must be true or unset when features.apm.instrumentation.enabled is true")
+	}
+	if err := validateSSISharedComponentPrerequisites(dst); err != nil {
+		return err
+	}
+	if len(profileSSI.Targets) > 0 && !supportsInstrumentationTargets(dst) {
+		return fmt.Errorf("features.apm.instrumentation.targets requires Cluster Agent version >= %s", minInstrumentationTargetsVersion)
+	}
+
+	dstSSI := baseSSIForProfileOverlay(dst)
+	if err := mergeSSI(dstSSI, profileSSI); err != nil {
+		return err
+	}
+	dstSSI.Enabled = ptr.To(true)
+	defaultLanguageDetection(dstSSI)
+
+	return nil
+}
+
+// profileSSIOverlayConfig extracts the only APM profile config that affects a
+// shared component. Other APM fields stay on the profile DDAI.
+func profileSSIOverlayConfig(profileSpec *v2alpha1.DatadogAgentSpec) (*v2alpha1.SingleStepInstrumentation, bool) {
+	if profileSpec == nil ||
+		profileSpec.Features == nil ||
+		profileSpec.Features.APM == nil ||
+		profileSpec.Features.APM.SingleStepInstrumentation == nil {
+		return nil, false
+	}
+
+	ssi := profileSpec.Features.APM.SingleStepInstrumentation
+	if !ptr.Deref(ssi.Enabled, false) {
+		return nil, false
+	}
+
+	return ssi, true
+}
+
+func validateSSISharedComponentPrerequisites(spec *v2alpha1.DatadogAgentSpec) error {
+	// SSI is rendered on the Cluster Agent admission controller path, so
+	// profile-contributed SSI is only valid when that shared path exists.
+	if !admissionControllerEnabled(spec) {
+		return fmt.Errorf("features.admissionController.enabled must be true on the base DatadogAgent when APM instrumentation is configured")
+	}
+	if defaultClusterAgentDisabled(spec) {
+		return fmt.Errorf("clusterAgent cannot be disabled on the base DatadogAgent when APM instrumentation is configured")
+	}
+	return nil
+}
+
+func admissionControllerEnabled(spec *v2alpha1.DatadogAgentSpec) bool {
+	return spec != nil &&
+		spec.Features != nil &&
+		spec.Features.AdmissionController != nil &&
+		ptr.Deref(spec.Features.AdmissionController.Enabled, false)
+}
+
+func defaultClusterAgentDisabled(spec *v2alpha1.DatadogAgentSpec) bool {
+	if spec == nil || spec.Override == nil || spec.Override[v2alpha1.ClusterAgentComponentName] == nil {
+		return false
+	}
+	return ptr.Deref(spec.Override[v2alpha1.ClusterAgentComponentName].Disabled, false)
+}
+
+// baseSSIForProfileOverlay returns the SSI config that profile overlays should
+// merge into. When base instrumentation is absent or explicitly disabled, the
+// profile's enabled instrumentation is the first active SSI config, so discard
+// the inactive base block before merging.
+func baseSSIForProfileOverlay(dst *v2alpha1.DatadogAgentSpec) *v2alpha1.SingleStepInstrumentation {
+	if dst.Features == nil {
+		dst.Features = &v2alpha1.DatadogFeatures{}
+	}
+	if dst.Features.APM == nil {
+		dst.Features.APM = &v2alpha1.APMFeatureConfig{}
+	}
+	if dst.Features.APM.SingleStepInstrumentation == nil ||
+		!ptr.Deref(dst.Features.APM.SingleStepInstrumentation.Enabled, false) {
+		dst.Features.APM.SingleStepInstrumentation = &v2alpha1.SingleStepInstrumentation{}
+	}
+	return dst.Features.APM.SingleStepInstrumentation
+}
+
+// mergeSSI applies the profile SSI union rules used for shared Cluster Agent
+// config. Fields that describe sets are unioned; singleton fields reject
+// conflicting values.
+func mergeSSI(dst, src *v2alpha1.SingleStepInstrumentation) error {
+	dst.EnabledNamespaces = appendDeduplicateStrings(dst.EnabledNamespaces, src.EnabledNamespaces)
+	dst.DisabledNamespaces = appendDeduplicateStrings(dst.DisabledNamespaces, src.DisabledNamespaces)
+	if len(dst.EnabledNamespaces) > 0 && len(dst.DisabledNamespaces) > 0 {
+		return fmt.Errorf("features.apm.instrumentation.enabledNamespaces and features.apm.instrumentation.disabledNamespaces cannot both be set")
+	}
+
+	if err := mergeStringMap(&dst.LibVersions, src.LibVersions, "features.apm.instrumentation.libVersions"); err != nil {
+		return err
+	}
+	if err := mergeLanguageDetection(dst, src); err != nil {
+		return err
+	}
+	if err := mergeInjector(dst, src); err != nil {
+		return err
+	}
+	if err := mergeInjectionMode(dst, src); err != nil {
+		return err
+	}
+	if err := mergeSSITargets(&dst.Targets, src.Targets); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func appendDeduplicateStrings(dst []string, src []string) []string {
+	if len(src) == 0 {
+		return dst
+	}
+	out := make([]string, 0, len(dst)+len(src))
+	for _, value := range dst {
+		if !slices.Contains(out, value) {
+			out = append(out, value)
+		}
+	}
+	for _, value := range src {
+		if !slices.Contains(out, value) {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+// mergeStringMap copies profile keys into the shared config and rejects a key
+// that is already set to a different value.
+func mergeStringMap(dst *map[string]string, src map[string]string, field string) error {
+	if len(src) == 0 {
+		return nil
+	}
+	if *dst == nil {
+		*dst = map[string]string{}
+	}
+	for key, value := range src {
+		if existing, ok := (*dst)[key]; ok && existing != value {
+			return fmt.Errorf("%s[%q] has conflicting values %q and %q", field, key, existing, value)
+		}
+		(*dst)[key] = value
+	}
+	return nil
+}
+
+func mergeLanguageDetection(dst, src *v2alpha1.SingleStepInstrumentation) error {
+	if src.LanguageDetection == nil || src.LanguageDetection.Enabled == nil {
+		return nil
+	}
+	if dst.LanguageDetection == nil {
+		dst.LanguageDetection = &v2alpha1.LanguageDetectionConfig{}
+	}
+	return mergeBoolPtr(&dst.LanguageDetection.Enabled, src.LanguageDetection.Enabled, "features.apm.instrumentation.languageDetection.enabled")
+}
+
+func defaultLanguageDetection(dst *v2alpha1.SingleStepInstrumentation) {
+	if dst.LanguageDetection == nil {
+		dst.LanguageDetection = &v2alpha1.LanguageDetectionConfig{}
+	}
+	if dst.LanguageDetection.Enabled == nil {
+		dst.LanguageDetection.Enabled = ptr.To(true)
+	}
+}
+
+func mergeInjector(dst, src *v2alpha1.SingleStepInstrumentation) error {
+	if src.Injector == nil {
+		return nil
+	}
+	if dst.Injector == nil {
+		dst.Injector = &v2alpha1.InjectorConfig{}
+	}
+	return mergeStringLikeField(&dst.Injector.ImageTag, src.Injector.ImageTag, "features.apm.instrumentation.injector.imageTag")
+}
+
+func mergeInjectionMode(dst, src *v2alpha1.SingleStepInstrumentation) error {
+	return mergeStringLikeField(&dst.InjectionMode, src.InjectionMode, "features.apm.instrumentation.injectionMode")
+}
+
+// mergeBoolPtr copies an explicit profile bool into the shared config and
+// rejects an already-set bool with the opposite value.
+func mergeBoolPtr(dst **bool, src *bool, field string) error {
+	srcValue := ptr.Deref(src, false)
+	if *dst != nil && ptr.Deref(*dst, false) != srcValue {
+		return fmt.Errorf("%s has conflicting values", field)
+	}
+	*dst = ptr.To(srcValue)
+	return nil
+}
+
+// mergeStringLikeField copies a non-empty profile scalar into the shared config
+// and rejects an already-set scalar with a different value.
+func mergeStringLikeField[T ~string](dst *T, src T, field string) error {
+	var zero T
+	if src == zero {
+		return nil
+	}
+	if *dst != zero && *dst != src {
+		return fmt.Errorf("%s has conflicting values %q and %q", field, *dst, src)
+	}
+	*dst = src
+	return nil
+}
+
+// mergeSSITargets appends profile targets in profile order. The Cluster Agent
+// uses first-match semantics when evaluating the final target list.
+func mergeSSITargets(dst *[]v2alpha1.SSITarget, src []v2alpha1.SSITarget) error {
+	for _, target := range src {
+		*dst = append(*dst, *target.DeepCopy())
+	}
+	return nil
+}

--- a/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
@@ -14,7 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	featurefake "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 )
 
 func TestAPMProfileSharedConfigOverlay(t *testing.T) {
@@ -470,6 +472,86 @@ func TestAPMProfileSharedConfigOverlay(t *testing.T) {
 			assert.Equal(t, tt.want, tt.dst.Features.APM.SingleStepInstrumentation)
 		})
 	}
+}
+
+// Profile SSI overlays should render the same Cluster Agent config as direct
+// base-DDA SSI config. Node Agent config is intentionally out of scope because
+// profile-owned APM config renders on the profile DDAI instead of the default
+// DDAI.
+func TestAPMProfileSharedConfigOverlayMatchesDirectDDAClusterAgentConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		ssi  *v2alpha1.SingleStepInstrumentation
+	}{
+		{
+			name: "enabled namespaces",
+			ssi: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				EnabledNamespaces: []string{"payments", "checkout"},
+				LibVersions:       map[string]string{"java": "1.43.0", "python": "2.14.0"},
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				Injector:          &v2alpha1.InjectorConfig{ImageTag: "7.66.0"},
+				InjectionMode:     v2alpha1.InjectionModeInitContainer,
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerVersions: map[string]string{"java": "1.43.0"},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "disabled namespaces",
+			ssi: &v2alpha1.SingleStepInstrumentation{
+				Enabled:            ptr.To(true),
+				DisabledNamespaces: []string{"kube-system", "datadog"},
+				LanguageDetection:  &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(false)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			directDDA := testProfileOverlayBaseSpec(false)
+			directDDA.Features.APM.SingleStepInstrumentation = tt.ssi.DeepCopy()
+
+			overlayDDA := testProfileOverlayBaseSpec(false)
+			profile := testProfileOverlayProfileSpec(tt.ssi.DeepCopy())
+			require.NoError(t, applyAPMProfileSharedConfigOverlay(overlayDDA, overlayDDA.DeepCopy(), profile))
+
+			assert.Equal(
+				t,
+				renderAPMClusterAgentEnvVars(t, directDDA),
+				renderAPMClusterAgentEnvVars(t, overlayDDA),
+			)
+		})
+	}
+}
+
+func renderAPMClusterAgentEnvVars(t testing.TB, spec *v2alpha1.DatadogAgentSpec) []*corev1.EnvVar {
+	t.Helper()
+
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog",
+			Namespace: "default",
+		},
+		Spec: *spec.DeepCopy(),
+	}
+	feat := buildAPMFeature(nil).(*apmFeature)
+	reqComp := feat.Configure(dda, &dda.Spec, nil)
+	require.True(t, reqComp.ClusterAgent.IsEnabled())
+
+	mgr := featurefake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
+	require.NoError(t, feat.ManageClusterAgent(mgr))
+
+	return mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
 }
 
 func testProfileOverlayBaseSpec(ssiEnabled bool) *v2alpha1.DatadogAgentSpec {

--- a/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
@@ -1,0 +1,500 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package apm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+)
+
+func TestAPMProfileSharedConfigOverlay(t *testing.T) {
+	tests := []struct {
+		name        string
+		dst         *v2alpha1.DatadogAgentSpec
+		profile     *v2alpha1.DatadogAgentSpec
+		want        *v2alpha1.SingleStepInstrumentation
+		wantErr     string
+		wantNoApply bool
+	}{
+		{
+			name: "profile SSI overlays disabled base SSI and ignores synthetic base defaults",
+			dst:  testProfileOverlayBaseSpec(false),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				EnabledNamespaces: []string{"ml", "training", "ml"},
+				LibVersions: map[string]string{
+					"java":   "1.43.0",
+					"python": "2.14.0",
+				},
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(false)},
+				Injector:          &v2alpha1.InjectorConfig{ImageTag: "7.66.0"},
+				InjectionMode:     v2alpha1.InjectionModeInitContainer,
+			}),
+			want: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				EnabledNamespaces: []string{"ml", "training"},
+				LibVersions: map[string]string{
+					"java":   "1.43.0",
+					"python": "2.14.0",
+				},
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(false)},
+				Injector:          &v2alpha1.InjectorConfig{ImageTag: "7.66.0"},
+				InjectionMode:     v2alpha1.InjectionModeInitContainer,
+			},
+		},
+		{
+			name: "map conflict rejects profile",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.LibVersions = map[string]string{"java": "1.43.0"}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:     ptr.To(true),
+				LibVersions: map[string]string{"java": "1.44.0"},
+			}),
+			wantErr: `features.apm.instrumentation.libVersions["java"] has conflicting values "1.43.0" and "1.44.0"`,
+		},
+		{
+			name: "enabled and disabled namespaces reject final overlay",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.EnabledNamespaces = []string{"default"}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:            ptr.To(true),
+				DisabledNamespaces: []string{"kube-system"},
+			}),
+			wantErr: "features.apm.instrumentation.enabledNamespaces and features.apm.instrumentation.disabledNamespaces cannot both be set",
+		},
+		{
+			name: "language detection conflict rejects profile",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.LanguageDetection = &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(false)},
+			}),
+			wantErr: "features.apm.instrumentation.languageDetection.enabled has conflicting values",
+		},
+		{
+			name: "injector image tag conflict rejects profile",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.Injector = &v2alpha1.InjectorConfig{ImageTag: "7.66.0"}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:  ptr.To(true),
+				Injector: &v2alpha1.InjectorConfig{ImageTag: "7.67.0"},
+			}),
+			wantErr: `features.apm.instrumentation.injector.imageTag has conflicting values "7.66.0" and "7.67.0"`,
+		},
+		{
+			name: "injection mode conflict rejects profile",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.InjectionMode = v2alpha1.InjectionModeInitContainer
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:       ptr.To(true),
+				InjectionMode: v2alpha1.InjectionModeCSI,
+			}),
+			wantErr: `features.apm.instrumentation.injectionMode has conflicting values "init_container" and "csi"`,
+		},
+		{
+			name: "targets append in order",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.Targets = []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerVersions: map[string]string{"java": "1.43.0"},
+					},
+				}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerVersions: map[string]string{"python": "2.14.0"},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+					{
+						Name: "worker",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "worker"},
+						},
+					},
+				},
+			}),
+			want: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				Injector:          &v2alpha1.InjectorConfig{},
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerVersions: map[string]string{"java": "1.43.0"},
+					},
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerVersions: map[string]string{"python": "2.14.0"},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+					{
+						Name: "worker",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "worker"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "same target name with different selector appends",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.Targets = []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+					},
+				}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api-v2"},
+						},
+					},
+				},
+			}),
+			want: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				Injector:          &v2alpha1.InjectorConfig{},
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+					},
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api-v2"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "same target and env var name with different values appends",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.Targets = []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+				}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "false"},
+						},
+					},
+				},
+			}),
+			want: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				Injector:          &v2alpha1.InjectorConfig{},
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "false"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "identical target tracer config appends",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.Targets = []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+				}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+				},
+			}),
+			want: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				Injector:          &v2alpha1.InjectorConfig{},
+				Targets: []v2alpha1.SSITarget{
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+					{
+						Name: "api",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "api"},
+						},
+						TracerConfigs: []corev1.EnvVar{
+							{Name: "DD_TRACE_DEBUG", Value: "true"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unnamed target-only overlay is preserved",
+			dst:  testProfileOverlayBaseSpec(false),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+				Targets: []v2alpha1.SSITarget{
+					{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}}},
+				},
+			}),
+			want: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(true),
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				Targets: []v2alpha1.SSITarget{
+					{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}}},
+				},
+			},
+		},
+		{
+			name: "targets require supported Cluster Agent version",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(false)
+				spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.ClusterAgentComponentName: {Image: &v2alpha1.AgentImageConfig{Name: "gcr.io/datadoghq/cluster-agent:7.63.0"}},
+				}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+				Targets: []v2alpha1.SSITarget{{Name: "api"}},
+			}),
+			wantErr: "features.apm.instrumentation.targets requires Cluster Agent version >= 7.64.0-0",
+		},
+		{
+			name: "enabled false with namespace config is ignored",
+			dst:  testProfileOverlayBaseSpec(false),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(false),
+				EnabledNamespaces: []string{"payments"},
+			}),
+			wantNoApply: true,
+		},
+		{
+			name: "base admission controller disabled with profile SSI enabled rejects profile",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(false)
+				spec.Features.AdmissionController.Enabled = ptr.To(false)
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+			}),
+			wantErr: "features.admissionController.enabled must be true on the base DatadogAgent when APM instrumentation is configured",
+		},
+		{
+			name: "base admission controller disabled with profile APM enabled only is ignored",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(false)
+				spec.Features.AdmissionController.Enabled = ptr.To(false)
+				return spec
+			}(),
+			profile: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayProfileSpec(nil)
+				spec.Features.APM.Enabled = ptr.To(true)
+				return spec
+			}(),
+			wantNoApply: true,
+		},
+		{
+			name: "base cluster agent disabled with profile SSI enabled rejects profile",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(false)
+				spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.ClusterAgentComponentName: {Disabled: ptr.To(true)},
+				}
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled: ptr.To(true),
+			}),
+			wantErr: "clusterAgent cannot be disabled on the base DatadogAgent when APM instrumentation is configured",
+		},
+		{
+			name: "base cluster agent disabled with profile APM enabled only is ignored",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(false)
+				spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+					v2alpha1.ClusterAgentComponentName: {Disabled: ptr.To(true)},
+				}
+				return spec
+			}(),
+			profile: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayProfileSpec(nil)
+				spec.Features.APM.Enabled = ptr.To(true)
+				return spec
+			}(),
+			wantNoApply: true,
+		},
+		{
+			name: "APM disabled profile with SSI enabled is rejected",
+			dst:  testProfileOverlayBaseSpec(false),
+			profile: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+					Enabled: ptr.To(true),
+				})
+				spec.Features.APM.Enabled = ptr.To(false)
+				return spec
+			}(),
+			wantErr: "features.apm.enabled must be true or unset when features.apm.instrumentation.enabled is true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := applyAPMProfileSharedConfigOverlay(tt.dst, tt.dst.DeepCopy(), tt.profile)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNoApply {
+				assert.False(t, *tt.dst.Features.APM.SingleStepInstrumentation.Enabled)
+				return
+			}
+			assert.Equal(t, tt.want, tt.dst.Features.APM.SingleStepInstrumentation)
+		})
+	}
+}
+
+func testProfileOverlayBaseSpec(ssiEnabled bool) *v2alpha1.DatadogAgentSpec {
+	return &v2alpha1.DatadogAgentSpec{
+		Features: &v2alpha1.DatadogFeatures{
+			AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{Enabled: ptr.To(true)},
+			APM: &v2alpha1.APMFeatureConfig{
+				Enabled: ptr.To(false),
+				SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+					Enabled:           ptr.To(ssiEnabled),
+					LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+					Injector:          &v2alpha1.InjectorConfig{},
+				},
+			},
+		},
+	}
+}
+
+func testProfileOverlayProfileSpec(ssi *v2alpha1.SingleStepInstrumentation) *v2alpha1.DatadogAgentSpec {
+	spec := &v2alpha1.DatadogAgentSpec{
+		Features: &v2alpha1.DatadogFeatures{
+			APM: &v2alpha1.APMFeatureConfig{
+				SingleStepInstrumentation: ssi,
+			},
+		},
+	}
+	return spec
+}

--- a/internal/controller/datadogagent/feature/profile_overlay.go
+++ b/internal/controller/datadogagent/feature/profile_overlay.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package feature
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+)
+
+// ProfileSharedConfigOverlayFunc lets a feature lift profile config into shared
+// components owned by the default DDAI, such as the Cluster Agent or Cluster
+// Checks Runner.
+//
+// dst is the accumulated default DDAI spec for the current reconcile and may be
+// mutated by the overlay. base is the original default DDAI spec before any
+// profile overlays were applied, so overlays can distinguish base config from
+// profile-contributed config when needed. profile is the current
+// DatadogAgentProfile config being considered.
+//
+// Example: a profile can enable APM SSI for one node group, but SSI is
+// configured on the Cluster Agent. The APM overlay merges that profile SSI
+// config into dst while leaving the profile-specific node Agent config on the
+// profile DDAI.
+type ProfileSharedConfigOverlayFunc func(dst, base, profile *v2alpha1.DatadogAgentSpec) error
+
+// profileSharedConfigOverlays is populated by feature package init functions
+// through RegisterProfileSharedConfigOverlay.
+var profileSharedConfigOverlays = map[IDType]ProfileSharedConfigOverlayFunc{}
+
+// RegisterProfileSharedConfigOverlay registers profile shared-component merge
+// logic for a feature.
+func RegisterProfileSharedConfigOverlay(id IDType, overlay ProfileSharedConfigOverlayFunc) error {
+	if _, found := profileSharedConfigOverlays[id]; found {
+		return fmt.Errorf("the profile shared config overlay %s is registered already", id)
+	}
+	profileSharedConfigOverlays[id] = overlay
+	return nil
+}
+
+// ApplyProfileSharedConfigOverlays applies all registered profile shared-component
+// overlays to dst. The base spec is the original default DDAI spec before any
+// profile overlays were applied; profile is the DatadogAgentProfile config.
+func ApplyProfileSharedConfigOverlays(dst, base, profile *v2alpha1.DatadogAgentSpec) error {
+	// Registration happens from feature package init functions, so sort IDs to
+	// keep profile overlay behavior deterministic regardless of init order.
+	sortedKeys := make([]IDType, 0, len(profileSharedConfigOverlays))
+	for key := range profileSharedConfigOverlays {
+		sortedKeys = append(sortedKeys, key)
+	}
+	slices.Sort(sortedKeys)
+
+	for _, id := range sortedKeys {
+		if err := profileSharedConfigOverlays[id](dst, base, profile); err != nil {
+			return fmt.Errorf("%s profile shared config overlay failed: %w", id, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -8,6 +8,7 @@ package datadogagent
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/prometheus/client_golang/prometheus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -21,6 +22,7 @@ import (
 	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -39,11 +41,16 @@ func sendProfileEnabledMetric(enabled bool) {
 // - returns a list of profiles that should be applied (including the default profile)
 // - configures node labels based on the profiles that are applied
 // - applies profile status updates in k8s
-func (r *Reconciler) reconcileProfiles(ctx context.Context, dsNSName types.NamespacedName, ddaEDSMaxUnavailable intstr.IntOrString) ([]*v1alpha1.DatadogAgentProfile, error) {
+func (r *Reconciler) reconcileProfiles(ctx context.Context, dsNSName types.NamespacedName, ddaEDSMaxUnavailable intstr.IntOrString, defaultDDAI *v1alpha1.DatadogAgentInternal) ([]*v1alpha1.DatadogAgentProfile, error) {
 	now := metav1.Now()
 	// start with the default profile so that on error, at minimum the default profile is applied
 	defaultProfile := agentprofile.DefaultProfile()
 	appliedProfiles := []*v1alpha1.DatadogAgentProfile{&defaultProfile}
+	// baseDefaultSpec is kept unchanged for overlays that need to compare
+	// against the original DDA. defaultSpec accumulates accepted profile
+	// contributions to shared components such as the Cluster Agent.
+	baseDefaultSpec := defaultDDAI.Spec.DeepCopy()
+	defaultSpec := defaultDDAI.Spec.DeepCopy()
 	// get and sort all profiles
 	profilesList := v1alpha1.DatadogAgentProfileList{}
 	if err := r.client.List(ctx, &profilesList); err != nil {
@@ -67,9 +74,21 @@ func (r *Reconciler) reconcileProfiles(ctx context.Context, dsNSName types.Names
 	csInfo := make(map[types.NamespacedName]*agentprofile.CreateStrategyInfo)
 	for _, profile := range sortedProfiles {
 		profileCopy := profile.DeepCopy() // deep copy to avoid modifying status of original profile
-		if err := r.reconcileProfile(ctx, profileCopy, nodeList, profilesByNode, csInfo, now); err != nil {
+		// Stage profile application so node assignment, create-strategy data,
+		// and shared default-DDAI config commit together. If any profile-level
+		// validation or overlay merge fails, the current reconcile state stays
+		// unchanged and the next profile is evaluated against the last accepted
+		// state.
+		nextProfilesByNode := maps.Clone(profilesByNode)
+		nextCSInfo := agentprofile.CloneCreateStrategyInfoMap(csInfo)
+		nextDefaultSpec := defaultSpec.DeepCopy()
+		if err := r.reconcileProfile(ctx, profileCopy, nodeList, nextProfilesByNode, nextCSInfo, nextDefaultSpec, baseDefaultSpec, now); err != nil {
 			// errors will be validation or conflict errors
 			r.log.Error(err, "unable to reconcile profile", "datadogagentprofile", profileCopy.Name, "datadogagentprofile_namespace", profileCopy.Namespace)
+		} else {
+			profilesByNode = nextProfilesByNode
+			csInfo = nextCSInfo
+			defaultSpec = nextDefaultSpec
 		}
 		agentprofile.GenerateProfileStatusFromConditions(r.log, profileCopy, now)
 		if !agentprofile.IsEqualStatus(&profile.Status, &profileCopy.Status) {
@@ -82,6 +101,9 @@ func (r *Reconciler) reconcileProfiles(ctx context.Context, dsNSName types.Names
 			appliedProfiles = append(appliedProfiles, profileCopy)
 		}
 	}
+	// Persist the accepted shared config back to the default DDAI used later to
+	// render the default-profile DDAI object.
+	defaultDDAI.Spec = *defaultSpec
 
 	// create strategy
 	if agentprofile.CreateStrategyEnabled() {
@@ -123,7 +145,7 @@ func (r *Reconciler) reconcileProfiles(ctx context.Context, dsNSName types.Names
 // - validates the profile
 // - checks for conflicts with existing profiles
 // - updates the profile status based on profile validation and application success
-func (r *Reconciler) reconcileProfile(ctx context.Context, profile *v1alpha1.DatadogAgentProfile, nodeList []corev1.Node, profilesByNode map[string]types.NamespacedName, csInfo map[types.NamespacedName]*agentprofile.CreateStrategyInfo, now metav1.Time) error {
+func (r *Reconciler) reconcileProfile(ctx context.Context, profile *v1alpha1.DatadogAgentProfile, nodeList []corev1.Node, profilesByNode map[string]types.NamespacedName, csInfo map[types.NamespacedName]*agentprofile.CreateStrategyInfo, defaultSpec, baseDefaultSpec *v2alpha1.DatadogAgentSpec, now metav1.Time) error {
 	r.log.Info("reconciling profile", "datadogagentprofile", profile.Name, "datadogagentprofile_namespace", profile.Namespace)
 	// validate profile name, spec, and selectors
 	requirements, err := agentprofile.ValidateProfileAndReturnRequirements(profile)
@@ -136,11 +158,20 @@ func (r *Reconciler) reconcileProfile(ctx context.Context, profile *v1alpha1.Dat
 	metrics.DAPValid.With(prometheus.Labels{"datadogagentprofile": profile.Name}).Set(metrics.TrueValue)
 	profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, agentprofile.NewDatadogAgentProfileCondition(agentprofile.ValidConditionType, metav1.ConditionTrue, now, agentprofile.ValidConditionReason, "Valid manifest"))
 
-	// err can only be conflict
 	if err := agentprofile.ApplyProfileToNodes(profile.ObjectMeta, requirements, nodeList, profilesByNode, csInfo); err != nil {
 		profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, agentprofile.NewDatadogAgentProfileCondition(agentprofile.AppliedConditionType, metav1.ConditionFalse, now, agentprofile.ConflictConditionReason, "Conflict with existing profile"))
 		return err
 	}
+
+	// Some profile config targets shared cluster components instead of the
+	// profile's node Agent. Apply those feature-owned overlays to the staged
+	// default spec after node assignment succeeds, so a rejected overlay also
+	// rejects the profile.
+	if err := feature.ApplyProfileSharedConfigOverlays(defaultSpec, baseDefaultSpec, profile.Spec.Config); err != nil {
+		profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, agentprofile.NewDatadogAgentProfileCondition(agentprofile.AppliedConditionType, metav1.ConditionFalse, now, agentprofile.ConflictConditionReason, err.Error()))
+		return err
+	}
+
 	profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, agentprofile.NewDatadogAgentProfileCondition(agentprofile.AppliedConditionType, metav1.ConditionTrue, now, agentprofile.AppliedConditionReason, "Profile applied"))
 
 	return nil
@@ -162,13 +193,20 @@ func (r *Reconciler) getProfileDaemonSet(ctx context.Context, profile *v1alpha1.
 	return nil, fmt.Errorf("no valid daemonset found")
 }
 
-func (r *Reconciler) applyProfilesToDDAISpec(ddai *v1alpha1.DatadogAgentInternal, profiles []*v1alpha1.DatadogAgentProfile) ([]*v1alpha1.DatadogAgentInternal, error) {
+func (r *Reconciler) applyProfilesToDDAISpec(baseDDAI, defaultDDAI *v1alpha1.DatadogAgentInternal, profiles []*v1alpha1.DatadogAgentProfile) ([]*v1alpha1.DatadogAgentInternal, error) {
 	ddais := []*v1alpha1.DatadogAgentInternal{}
 
 	// For all profiles, create DDAI objects
 	// Note: profiles includes the default profile to allow the default affinity to be set
 	for _, profile := range profiles {
-		mergedDDAI, err := r.computeProfileMerge(ddai, profile)
+		// User profiles are merged from the original base DDAI. The synthetic
+		// default profile is merged from defaultDDAI so it includes shared config
+		// accepted from profiles, for example APM SSI Cluster Agent config.
+		sourceDDAI := baseDDAI
+		if agentprofile.IsDefaultProfile(profile.Namespace, profile.Name) {
+			sourceDDAI = defaultDDAI
+		}
+		mergedDDAI, err := r.computeProfileMerge(sourceDDAI, profile)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -3,6 +3,7 @@ package datadogagent
 import (
 	"context"
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_computeProfileMerge(t *testing.T) {
@@ -1024,13 +1026,104 @@ func Test_reconcileProfile(t *testing.T) {
 
 			profileCopy := tt.profile.DeepCopy()
 			csInfo := make(map[types.NamespacedName]*agentprofile.CreateStrategyInfo)
-			err := r.reconcileProfile(ctx, profileCopy, tt.nodes, tt.profilesByNode, csInfo, now)
+			defaultSpec := &v2alpha1.DatadogAgentSpec{}
+			baseDefaultSpec := defaultSpec.DeepCopy()
+			err := r.reconcileProfile(ctx, profileCopy, tt.nodes, tt.profilesByNode, csInfo, defaultSpec, baseDefaultSpec, now)
 
 			assert.Equal(t, tt.wantErr, err)
 			assert.Equal(t, tt.wantStatus, profileCopy.Status)
 			assert.Equal(t, tt.wantProfilesByNode, tt.profilesByNode)
 		})
 	}
+}
+
+func Test_reconcileProfile_SharedOverlayConflictDoesNotCommitNodeAssignment(t *testing.T) {
+	sch := agenttestutils.TestScheme()
+	ctx := context.Background()
+	now := metav1.Now()
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).Build()
+	logger := logf.Log.WithName("Test_reconcileProfile_SharedOverlayConflictDoesNotCommitNodeAssignment")
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(sch, corev1.EventSource{Component: "Test_reconcileProfile_SharedOverlayConflictDoesNotCommitNodeAssignment"})
+
+	r := &Reconciler{
+		client:   fakeClient,
+		log:      logger,
+		scheme:   sch,
+		recorder: recorder,
+		options:  ReconcilerOptions{},
+	}
+
+	profile := &v1alpha1.DatadogAgentProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gpu",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DatadogAgentProfileSpec{
+			ProfileAffinity: &v1alpha1.ProfileAffinity{
+				ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
+					{
+						Key:      "profile",
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"gpu"},
+					},
+				},
+			},
+			Config: &v2alpha1.DatadogAgentSpec{
+				Features: &v2alpha1.DatadogFeatures{
+					APM: &v2alpha1.APMFeatureConfig{
+						Enabled: ptr.To(true),
+						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+							Enabled:     ptr.To(true),
+							LibVersions: map[string]string{"java": "1.44.0"},
+						},
+					},
+				},
+			},
+		},
+	}
+	nodes := []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node1",
+				Labels: map[string]string{"profile": "gpu"},
+			},
+		},
+	}
+	profilesByNode := map[string]types.NamespacedName{
+		"node1": {Name: "default"},
+	}
+	csInfo := make(map[types.NamespacedName]*agentprofile.CreateStrategyInfo)
+	defaultSpec := &v2alpha1.DatadogAgentSpec{
+		Features: &v2alpha1.DatadogFeatures{
+			AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{Enabled: ptr.To(true)},
+			APM: &v2alpha1.APMFeatureConfig{
+				SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+					Enabled:           ptr.To(true),
+					LibVersions:       map[string]string{"java": "1.43.0"},
+					LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				},
+			},
+		},
+	}
+	baseDefaultSpec := defaultSpec.DeepCopy()
+
+	nextProfilesByNode := maps.Clone(profilesByNode)
+	nextCSInfo := agentprofile.CloneCreateStrategyInfoMap(csInfo)
+	nextDefaultSpec := defaultSpec.DeepCopy()
+	err := r.reconcileProfile(ctx, profile, nodes, nextProfilesByNode, nextCSInfo, nextDefaultSpec, baseDefaultSpec, now)
+
+	assert.Error(t, err)
+	assert.Equal(t, map[string]types.NamespacedName{"node1": {Name: "default"}}, profilesByNode)
+	appliedCondition := metav1.Condition{}
+	for _, condition := range profile.Status.Conditions {
+		if condition.Type == agentprofile.AppliedConditionType {
+			appliedCondition = condition
+			break
+		}
+	}
+	assert.Equal(t, metav1.ConditionFalse, appliedCondition.Status)
+	assert.Equal(t, "1.43.0", defaultSpec.Features.APM.SingleStepInstrumentation.LibVersions["java"])
 }
 
 func Test_reconcileProfiles(t *testing.T) {
@@ -1216,10 +1309,692 @@ func Test_reconcileProfiles(t *testing.T) {
 				Name:      "datadog-agent",
 			}
 			maxUnavailable := intstr.FromInt(1)
-			appliedProfiles, err := r.reconcileProfiles(ctx, dsNSName, maxUnavailable)
+			defaultDDAI := &v1alpha1.DatadogAgentInternal{}
+			appliedProfiles, err := r.reconcileProfiles(ctx, dsNSName, maxUnavailable, defaultDDAI)
 
 			assert.Equal(t, tt.wantErr, err)
 			assert.Equal(t, tt.wantAppliedProfiles, len(appliedProfiles))
 		})
 	}
+}
+
+func Test_reconcileProfiles_APMSharedOverlayMatrix(t *testing.T) {
+	sch := agenttestutils.TestScheme()
+	ctx := context.Background()
+	namespace := "default"
+	baseTime := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	workerNode := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node1",
+			Labels: map[string]string{"profile": "worker"},
+		},
+	}
+
+	tests := []struct {
+		name                string
+		description         string
+		baseSpec            func() *v2alpha1.DatadogAgentSpec
+		profiles            []*v1alpha1.DatadogAgentProfile
+		nodes               []corev1.Node
+		wantProfileApplied  map[string]metav1.ConditionStatus
+		wantProfileMessages map[string]string
+		assertAPM           func(*testing.T, *v2alpha1.APMFeatureConfig)
+		assertSSI           func(*testing.T, *v2alpha1.SingleStepInstrumentation)
+	}{
+		{
+			name:        "base APM off admission on DAP SSI on",
+			description: "Expect the DAP to apply and enable SSI on the default DDAI even though base APM is disabled.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-happy", baseTime, noMatchProfileRequirement("dap-case-happy"), &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:           ptr.To(true),
+						EnabledNamespaces: []string{"payments"},
+						LibVersions:       map[string]string{"java": "1.43.0"},
+						LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+					},
+				}),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-happy": metav1.ConditionTrue},
+			assertAPM: func(t *testing.T, apm *v2alpha1.APMFeatureConfig) {
+				require.NotNil(t, apm)
+				assert.False(t, ptr.Deref(apm.Enabled, true))
+			},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.True(t, ptr.Deref(ssi.Enabled, false))
+				assert.Equal(t, []string{"payments"}, ssi.EnabledNamespaces)
+				assert.Equal(t, "1.43.0", ssi.LibVersions["java"])
+				assert.True(t, ptr.Deref(ssi.LanguageDetection.Enabled, false))
+			},
+		},
+		{
+			name:        "DAP apm enabled false with SSI enabled",
+			description: "Expect the DAP to be rejected because it explicitly disables APM while enabling SSI.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-apm-disabled", baseTime, noMatchProfileRequirement("dap-case-apm-disabled"), &v2alpha1.APMFeatureConfig{
+					Enabled: ptr.To(false),
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled: ptr.To(true),
+					},
+				}),
+			},
+			wantProfileApplied:  map[string]metav1.ConditionStatus{"dap-case-apm-disabled": metav1.ConditionFalse},
+			wantProfileMessages: map[string]string{"dap-case-apm-disabled": "features.apm.enabled must be true or unset"},
+			assertSSI:           assertSSIEnabled(false),
+		},
+		{
+			name:        "base admission controller disabled with profile SSI enabled",
+			description: "Expect the DAP to be rejected because base admission controller is required for SSI.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				spec := testAPMMatrixBaseSpec()
+				spec.Features.AdmissionController.Enabled = ptr.To(false)
+				return spec
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-no-admission", baseTime, noMatchProfileRequirement("dap-case-no-admission"), testAPMMatrixHappyConfig()),
+			},
+			wantProfileApplied:  map[string]metav1.ConditionStatus{"dap-case-no-admission": metav1.ConditionFalse},
+			wantProfileMessages: map[string]string{"dap-case-no-admission": "features.admissionController.enabled must be true"},
+			assertSSI:           assertSSIEnabled(false),
+		},
+		{
+			name:        "base admission controller disabled with profile APM enabled only",
+			description: "Expect the DAP to apply because plain profile APM config stays profile-local and does not need shared SSI admission config.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				spec := testAPMMatrixBaseSpec()
+				spec.Features.AdmissionController.Enabled = ptr.To(false)
+				return spec
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-no-admission-apm-only", baseTime, noMatchProfileRequirement("dap-case-no-admission-apm-only"), &v2alpha1.APMFeatureConfig{
+					Enabled: ptr.To(true),
+				}),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-no-admission-apm-only": metav1.ConditionTrue},
+			assertSSI:          assertSSIEnabled(false),
+		},
+		{
+			name:        "base clusterAgent disabled with profile SSI enabled",
+			description: "Expect the DAP to be rejected because shared SSI config requires the base Cluster Agent.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				spec := testAPMMatrixBaseSpec()
+				spec.Override[v2alpha1.ClusterAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{Disabled: ptr.To(true)}
+				return spec
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-no-dca", baseTime, noMatchProfileRequirement("dap-case-no-dca"), testAPMMatrixHappyConfig()),
+			},
+			wantProfileApplied:  map[string]metav1.ConditionStatus{"dap-case-no-dca": metav1.ConditionFalse},
+			wantProfileMessages: map[string]string{"dap-case-no-dca": "clusterAgent cannot be disabled"},
+			assertSSI:           assertSSIEnabled(false),
+		},
+		{
+			name:        "base clusterAgent disabled with profile APM enabled only",
+			description: "Expect the DAP to apply because plain profile APM config stays profile-local and does not need shared SSI Cluster Agent config.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				spec := testAPMMatrixBaseSpec()
+				spec.Override[v2alpha1.ClusterAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{Disabled: ptr.To(true)}
+				return spec
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-no-dca-apm-only", baseTime, noMatchProfileRequirement("dap-case-no-dca-apm-only"), &v2alpha1.APMFeatureConfig{
+					Enabled: ptr.To(true),
+				}),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-no-dca-apm-only": metav1.ConditionTrue},
+			assertSSI:          assertSSIEnabled(false),
+		},
+		{
+			name:        "enabledNamespaces on base conflicts with disabledNamespaces on DAP",
+			description: "Expect the DAP to be rejected and the base enabledNamespaces config to remain unchanged.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				spec := testAPMMatrixBaseSpec()
+				spec.Features.APM.SingleStepInstrumentation.Enabled = ptr.To(true)
+				spec.Features.APM.SingleStepInstrumentation.EnabledNamespaces = []string{"default"}
+				return spec
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-ns-conflict", baseTime, noMatchProfileRequirement("dap-case-ns-conflict"), &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:            ptr.To(true),
+						DisabledNamespaces: []string{"kube-system"},
+					},
+				}),
+			},
+			wantProfileApplied:  map[string]metav1.ConditionStatus{"dap-case-ns-conflict": metav1.ConditionFalse},
+			wantProfileMessages: map[string]string{"dap-case-ns-conflict": "enabledNamespaces and features.apm.instrumentation.disabledNamespaces cannot both be set"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.True(t, ptr.Deref(ssi.Enabled, false))
+				assert.Equal(t, []string{"default"}, ssi.EnabledNamespaces)
+				assert.Empty(t, ssi.DisabledNamespaces)
+			},
+		},
+		{
+			name:        "multiple DAPs merge distinct libVersions",
+			description: "Expect both DAPs to apply and merge distinct tracer library versions into default DDAI SSI.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-lib-java", baseTime, noMatchProfileRequirement("dap-case-lib-java"), testAPMMatrixLibVersionConfig("java", "1.43.0")),
+				testAPMMatrixProfile(namespace, "dap-case-lib-python", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-lib-python"), testAPMMatrixLibVersionConfig("python", "2.14.0")),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-lib-java":   metav1.ConditionTrue,
+				"dap-case-lib-python": metav1.ConditionTrue,
+			},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.True(t, ptr.Deref(ssi.Enabled, false))
+				assert.Equal(t, map[string]string{"java": "1.43.0", "python": "2.14.0"}, ssi.LibVersions)
+			},
+		},
+		{
+			name:        "libVersions conflict rejects second profile",
+			description: "Expect the first DAP to apply, the conflicting second DAP to be rejected, and the first libVersion to remain.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-lib-conflict-a", baseTime, noMatchProfileRequirement("dap-case-lib-conflict-a"), testAPMMatrixLibVersionConfig("java", "1.43.0")),
+				testAPMMatrixProfile(namespace, "dap-case-lib-conflict-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-lib-conflict-b"), testAPMMatrixLibVersionConfig("java", "1.44.0")),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-lib-conflict-a": metav1.ConditionTrue,
+				"dap-case-lib-conflict-b": metav1.ConditionFalse,
+			},
+			wantProfileMessages: map[string]string{"dap-case-lib-conflict-b": `libVersions["java"] has conflicting values`},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.Equal(t, map[string]string{"java": "1.43.0"}, ssi.LibVersions)
+			},
+		},
+		{
+			name:        "injector tag conflict rejects second profile",
+			description: "Expect the first injector tag to apply and the second DAP to be rejected for changing that singleton value.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-injector-a", baseTime, noMatchProfileRequirement("dap-case-injector-a"), testAPMMatrixInjectorConfig("7.66.0")),
+				testAPMMatrixProfile(namespace, "dap-case-injector-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-injector-b"), testAPMMatrixInjectorConfig("7.67.0")),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-injector-a": metav1.ConditionTrue,
+				"dap-case-injector-b": metav1.ConditionFalse,
+			},
+			wantProfileMessages: map[string]string{"dap-case-injector-b": "injector.imageTag has conflicting values"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				require.NotNil(t, ssi.Injector)
+				assert.Equal(t, "7.66.0", ssi.Injector.ImageTag)
+			},
+		},
+		{
+			name:        "injectionMode conflict rejects second profile",
+			description: "Expect the first injection mode to apply and the second DAP to be rejected for changing that singleton value.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-mode-a", baseTime, noMatchProfileRequirement("dap-case-mode-a"), testAPMMatrixInjectionModeConfig(v2alpha1.InjectionModeInitContainer)),
+				testAPMMatrixProfile(namespace, "dap-case-mode-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-mode-b"), testAPMMatrixInjectionModeConfig(v2alpha1.InjectionModeCSI)),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-mode-a": metav1.ConditionTrue,
+				"dap-case-mode-b": metav1.ConditionFalse,
+			},
+			wantProfileMessages: map[string]string{"dap-case-mode-b": "injectionMode has conflicting values"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.Equal(t, v2alpha1.InjectionModeInitContainer, ssi.InjectionMode)
+			},
+		},
+		{
+			name:        "target-based SSI on supported Cluster Agent",
+			description: "Expect target-based SSI to apply when the base Cluster Agent image is at or above the required version.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				return testAPMMatrixBaseSpecWithClusterAgentImage("gcr.io/datadoghq/cluster-agent:7.64.0")
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-target-supported", baseTime, noMatchProfileRequirement("dap-case-target-supported"), testAPMMatrixTargetConfig("api", "api", map[string]string{"java": "1.43.0"}, []corev1.EnvVar{{Name: "DD_TRACE_DEBUG", Value: "true"}})),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-target-supported": metav1.ConditionTrue},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				require.Len(t, ssi.Targets, 1)
+				assert.Equal(t, "api", ssi.Targets[0].Name)
+				assert.Equal(t, "1.43.0", ssi.Targets[0].TracerVersions["java"])
+			},
+		},
+		{
+			name:        "target-based SSI on unsupported Cluster Agent",
+			description: "Expect target-based SSI to be rejected when the base Cluster Agent image is below the required version.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				return testAPMMatrixBaseSpecWithClusterAgentImage("gcr.io/datadoghq/cluster-agent:7.63.0")
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-target-unsupported", baseTime, noMatchProfileRequirement("dap-case-target-unsupported"), testAPMMatrixTargetConfig("api", "api", nil, nil)),
+			},
+			wantProfileApplied:  map[string]metav1.ConditionStatus{"dap-case-target-unsupported": metav1.ConditionFalse},
+			wantProfileMessages: map[string]string{"dap-case-target-unsupported": "targets requires Cluster Agent version"},
+			assertSSI:           assertSSIEnabled(false),
+		},
+		{
+			name:        "target overlays append in deterministic profile order",
+			description: "Expect all target overlays to apply and append in sorted profile order; targets remain an ordered first-match-wins list, even when names match.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				return testAPMMatrixBaseSpecWithClusterAgentImage("gcr.io/datadoghq/cluster-agent:7.64.0")
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-target-a", baseTime, noMatchProfileRequirement("dap-case-target-a"), testAPMMatrixTargetConfig("api", "api", map[string]string{"java": "1.43.0"}, nil)),
+				testAPMMatrixProfile(namespace, "dap-case-target-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-target-b"), testAPMMatrixTargetConfig("api", "api", map[string]string{"python": "2.14.0"}, nil)),
+				testAPMMatrixProfile(namespace, "dap-case-target-c", metav1.NewTime(baseTime.Add(2*time.Second)), noMatchProfileRequirement("dap-case-target-c"), testAPMMatrixTargetConfig("api", "api-v2", nil, nil)),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-target-a": metav1.ConditionTrue,
+				"dap-case-target-b": metav1.ConditionTrue,
+				"dap-case-target-c": metav1.ConditionTrue,
+			},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				require.Len(t, ssi.Targets, 3)
+				assert.Equal(t, map[string]string{"java": "1.43.0"}, ssi.Targets[0].TracerVersions)
+				assert.Equal(t, map[string]string{"python": "2.14.0"}, ssi.Targets[1].TracerVersions)
+				assert.Equal(t, map[string]string{"app": "api-v2"}, ssi.Targets[2].PodSelector.MatchLabels)
+			},
+		},
+		{
+			name:        "unnamed target-only overlay is preserved",
+			description: "Expect the DAP to apply and preserve the unnamed target as an ordered target entry because target.name is optional; unnamed targets are appended, not name-merged.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				return testAPMMatrixBaseSpecWithClusterAgentImage("gcr.io/datadoghq/cluster-agent:7.64.0")
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-unnamed-target", baseTime, noMatchProfileRequirement("dap-case-unnamed-target"), &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled: ptr.To(true),
+						Targets: []v2alpha1.SSITarget{
+							{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}}},
+						},
+					},
+				}),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-unnamed-target": metav1.ConditionTrue},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.True(t, ptr.Deref(ssi.Enabled, false))
+				require.Len(t, ssi.Targets, 1)
+				assert.Empty(t, ssi.Targets[0].Name)
+				assert.Equal(t, map[string]string{"app": "api"}, ssi.Targets[0].PodSelector.MatchLabels)
+			},
+		},
+		{
+			name:        "instrumentation enabled false with enabledNamespaces is skipped",
+			description: "Expect the DAP to apply but skip shared SSI overlay because instrumentation is explicitly disabled.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-enabled-false-ns", baseTime, noMatchProfileRequirement("dap-case-enabled-false-ns"), &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:           ptr.To(false),
+						EnabledNamespaces: []string{"payments"},
+					},
+				}),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-enabled-false-ns": metav1.ConditionTrue},
+			assertSSI:          assertSSIEnabled(false),
+		},
+		{
+			name:        "two profiles match the same real node and second does not contribute overlay",
+			description: "Expect node assignment conflict to reject the second DAP before it can contribute shared SSI config.",
+			nodes:       []corev1.Node{workerNode},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-node-conflict-a", baseTime, workerProfileRequirement(), testAPMMatrixLibVersionConfig("java", "1.43.0")),
+				testAPMMatrixProfile(namespace, "dap-case-node-conflict-b", metav1.NewTime(baseTime.Add(time.Second)), workerProfileRequirement(), testAPMMatrixLibVersionConfig("python", "2.14.0")),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-node-conflict-a": metav1.ConditionTrue,
+				"dap-case-node-conflict-b": metav1.ConditionFalse,
+			},
+			wantProfileMessages: map[string]string{"dap-case-node-conflict-b": "Conflict with existing profile"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.Equal(t, map[string]string{"java": "1.43.0"}, ssi.LibVersions)
+			},
+		},
+		{
+			name:        "first profile fails overlay and second profile matching same node succeeds",
+			description: "Expect a failed overlay to roll back node assignment and shared config so the next same-node DAP can apply.",
+			nodes:       []corev1.Node{workerNode},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-rollback-a", baseTime, workerProfileRequirement(), &v2alpha1.APMFeatureConfig{
+					Enabled:                   ptr.To(false),
+					SingleStepInstrumentation: testAPMMatrixLibVersionConfig("java", "1.43.0").SingleStepInstrumentation,
+				}),
+				testAPMMatrixProfile(namespace, "dap-case-rollback-b", metav1.NewTime(baseTime.Add(time.Second)), workerProfileRequirement(), testAPMMatrixLibVersionConfig("python", "2.14.0")),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-rollback-a": metav1.ConditionFalse,
+				"dap-case-rollback-b": metav1.ConditionTrue,
+			},
+			wantProfileMessages: map[string]string{"dap-case-rollback-a": "features.apm.enabled must be true or unset"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.Equal(t, map[string]string{"python": "2.14.0"}, ssi.LibVersions)
+			},
+		},
+		{
+			name:        "disjoint profiles with one failed overlay and one successful overlay",
+			description: "Expect a failed DAP overlay not to poison later valid shared SSI overlays from other profiles.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-disjoint-fail", baseTime, noMatchProfileRequirement("dap-case-disjoint-fail"), &v2alpha1.APMFeatureConfig{
+					Enabled:                   ptr.To(false),
+					SingleStepInstrumentation: testAPMMatrixLibVersionConfig("java", "1.43.0").SingleStepInstrumentation,
+				}),
+				testAPMMatrixProfile(namespace, "dap-case-disjoint-ok", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-disjoint-ok"), testAPMMatrixLibVersionConfig("python", "2.14.0")),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-disjoint-fail": metav1.ConditionFalse,
+				"dap-case-disjoint-ok":   metav1.ConditionTrue,
+			},
+			wantProfileMessages: map[string]string{"dap-case-disjoint-fail": "features.apm.enabled must be true or unset"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.Equal(t, map[string]string{"python": "2.14.0"}, ssi.LibVersions)
+			},
+		},
+		{
+			name:        "languageDetection singleton bool conflict",
+			description: "Expect the first language detection value to apply and the conflicting second value to be rejected.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-lang-a", baseTime, noMatchProfileRequirement("dap-case-lang-a"), testAPMMatrixLanguageDetectionConfig(true)),
+				testAPMMatrixProfile(namespace, "dap-case-lang-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-lang-b"), testAPMMatrixLanguageDetectionConfig(false)),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-lang-a": metav1.ConditionTrue,
+				"dap-case-lang-b": metav1.ConditionFalse,
+			},
+			wantProfileMessages: map[string]string{"dap-case-lang-b": "languageDetection.enabled has conflicting values"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.True(t, ptr.Deref(ssi.LanguageDetection.Enabled, false))
+			},
+		},
+		{
+			name:        "DAP enabledNamespaces conflicts with later DAP disabledNamespaces",
+			description: "Expect enabledNamespaces from the first DAP to remain and disabledNamespaces from the later DAP to be rejected.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-ns-a", baseTime, noMatchProfileRequirement("dap-case-ns-a"), &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:           ptr.To(true),
+						EnabledNamespaces: []string{"payments"},
+					},
+				}),
+				testAPMMatrixProfile(namespace, "dap-case-ns-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-ns-b"), &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:            ptr.To(true),
+						DisabledNamespaces: []string{"kube-system"},
+					},
+				}),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-ns-a": metav1.ConditionTrue,
+				"dap-case-ns-b": metav1.ConditionFalse,
+			},
+			wantProfileMessages: map[string]string{"dap-case-ns-b": "enabledNamespaces and features.apm.instrumentation.disabledNamespaces cannot both be set"},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.Equal(t, []string{"payments"}, ssi.EnabledNamespaces)
+				assert.Empty(t, ssi.DisabledNamespaces)
+			},
+		},
+		{
+			name:        "same target and env var name with different ddTraceConfigs appends",
+			description: "Expect both target entries to apply in order; if both match the same pod, the Cluster Agent uses the first matching target.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				return testAPMMatrixBaseSpecWithClusterAgentImage("gcr.io/datadoghq/cluster-agent:7.64.0")
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-target-env-a", baseTime, noMatchProfileRequirement("dap-case-target-env-a"), testAPMMatrixTargetConfig("api", "api", nil, []corev1.EnvVar{{Name: "DD_TRACE_DEBUG", Value: "true"}})),
+				testAPMMatrixProfile(namespace, "dap-case-target-env-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-target-env-b"), testAPMMatrixTargetConfig("api", "api", nil, []corev1.EnvVar{{Name: "DD_TRACE_DEBUG", Value: "false"}})),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-target-env-a": metav1.ConditionTrue,
+				"dap-case-target-env-b": metav1.ConditionTrue,
+			},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				require.Len(t, ssi.Targets, 2)
+				require.Len(t, ssi.Targets[0].TracerConfigs, 1)
+				require.Len(t, ssi.Targets[1].TracerConfigs, 1)
+				assert.Equal(t, "true", ssi.Targets[0].TracerConfigs[0].Value)
+				assert.Equal(t, "false", ssi.Targets[1].TracerConfigs[0].Value)
+			},
+		},
+		{
+			name:        "same target and identical ddTraceConfigs appends",
+			description: "Expect duplicate identical target entries to apply and remain as separate ordered target rules.",
+			baseSpec: func() *v2alpha1.DatadogAgentSpec {
+				return testAPMMatrixBaseSpecWithClusterAgentImage("gcr.io/datadoghq/cluster-agent:7.64.0")
+			},
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-target-env-same-a", baseTime, noMatchProfileRequirement("dap-case-target-env-same-a"), testAPMMatrixTargetConfig("api", "api", nil, []corev1.EnvVar{{Name: "DD_TRACE_DEBUG", Value: "true"}})),
+				testAPMMatrixProfile(namespace, "dap-case-target-env-same-b", metav1.NewTime(baseTime.Add(time.Second)), noMatchProfileRequirement("dap-case-target-env-same-b"), testAPMMatrixTargetConfig("api", "api", nil, []corev1.EnvVar{{Name: "DD_TRACE_DEBUG", Value: "true"}})),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{
+				"dap-case-target-env-same-a": metav1.ConditionTrue,
+				"dap-case-target-env-same-b": metav1.ConditionTrue,
+			},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				require.Len(t, ssi.Targets, 2)
+				require.Len(t, ssi.Targets[0].TracerConfigs, 1)
+				require.Len(t, ssi.Targets[1].TracerConfigs, 1)
+				assert.Equal(t, "true", ssi.Targets[0].TracerConfigs[0].Value)
+				assert.Equal(t, "true", ssi.Targets[1].TracerConfigs[0].Value)
+			},
+		},
+		{
+			name:        "no matching nodes still contributes shared SSI config",
+			description: "Expect a DAP with no matching nodes to still contribute shared SSI config to the default DDAI.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-no-match-contributes", baseTime, noMatchProfileRequirement("dap-case-no-match-contributes"), testAPMMatrixLibVersionConfig("ruby", "2.0.0")),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-no-match-contributes": metav1.ConditionTrue},
+			assertSSI: func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+				require.NotNil(t, ssi)
+				assert.Equal(t, map[string]string{"ruby": "2.0.0"}, ssi.LibVersions)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.description)
+			objects := make([]k8sruntime.Object, 0, len(tt.profiles)+len(tt.nodes))
+			for _, profile := range tt.profiles {
+				objects = append(objects, profile.DeepCopy())
+			}
+			for _, node := range tt.nodes {
+				nodeCopy := node.DeepCopy()
+				objects = append(objects, nodeCopy)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(sch).
+				WithRuntimeObjects(objects...).
+				WithStatusSubresource(&v1alpha1.DatadogAgentProfile{}).
+				Build()
+			logger := logf.Log.WithName("Test_reconcileProfiles_APMSharedOverlayMatrix")
+			eventBroadcaster := record.NewBroadcaster()
+			recorder := eventBroadcaster.NewRecorder(sch, corev1.EventSource{Component: "Test_reconcileProfiles_APMSharedOverlayMatrix"})
+
+			r := &Reconciler{
+				client:   fakeClient,
+				log:      logger,
+				scheme:   sch,
+				recorder: recorder,
+				options:  ReconcilerOptions{},
+			}
+
+			baseSpec := testAPMMatrixBaseSpec()
+			if tt.baseSpec != nil {
+				baseSpec = tt.baseSpec()
+			}
+			defaultDDAI := &v1alpha1.DatadogAgentInternal{Spec: *baseSpec}
+			appliedProfiles, err := r.reconcileProfiles(ctx, types.NamespacedName{Namespace: namespace, Name: "datadog-agent"}, intstr.FromInt(1), defaultDDAI)
+			require.NoError(t, err)
+
+			wantAppliedCount := 1
+			for _, status := range tt.wantProfileApplied {
+				if status == metav1.ConditionTrue {
+					wantAppliedCount++
+				}
+			}
+			assert.Len(t, appliedProfiles, wantAppliedCount)
+
+			for profileName, wantApplied := range tt.wantProfileApplied {
+				profile := &v1alpha1.DatadogAgentProfile{}
+				err := fakeClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: profileName}, profile)
+				require.NoError(t, err)
+				assert.Equal(t, metav1.ConditionTrue, profile.Status.Valid, "profile %s valid status", profileName)
+				assert.Equal(t, wantApplied, profile.Status.Applied, "profile %s applied status", profileName)
+				if wantMessage := tt.wantProfileMessages[profileName]; wantMessage != "" {
+					assert.Contains(t, testAPMMatrixConditionMessage(profile.Status.Conditions, agentprofile.AppliedConditionType), wantMessage)
+				}
+			}
+
+			require.NotNil(t, defaultDDAI.Spec.Features)
+			require.NotNil(t, defaultDDAI.Spec.Features.APM)
+			if tt.assertAPM != nil {
+				tt.assertAPM(t, defaultDDAI.Spec.Features.APM)
+			}
+			if tt.assertSSI != nil {
+				tt.assertSSI(t, defaultDDAI.Spec.Features.APM.SingleStepInstrumentation)
+			}
+		})
+	}
+}
+
+func testAPMMatrixBaseSpec() *v2alpha1.DatadogAgentSpec {
+	return &v2alpha1.DatadogAgentSpec{
+		Features: &v2alpha1.DatadogFeatures{
+			AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{Enabled: ptr.To(true)},
+			APM: &v2alpha1.APMFeatureConfig{
+				Enabled: ptr.To(false),
+				SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+					Enabled:           ptr.To(false),
+					LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+					Injector:          &v2alpha1.InjectorConfig{},
+				},
+			},
+		},
+		Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{},
+	}
+}
+
+func testAPMMatrixBaseSpecWithClusterAgentImage(imageName string) *v2alpha1.DatadogAgentSpec {
+	spec := testAPMMatrixBaseSpec()
+	spec.Override[v2alpha1.ClusterAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{
+		Image: &v2alpha1.AgentImageConfig{Name: imageName},
+	}
+	return spec
+}
+
+func testAPMMatrixProfile(namespace, name string, creationTimestamp metav1.Time, requirement corev1.NodeSelectorRequirement, apm *v2alpha1.APMFeatureConfig) *v1alpha1.DatadogAgentProfile {
+	return &v1alpha1.DatadogAgentProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			CreationTimestamp: creationTimestamp,
+		},
+		Spec: v1alpha1.DatadogAgentProfileSpec{
+			ProfileAffinity: &v1alpha1.ProfileAffinity{
+				ProfileNodeAffinity: []corev1.NodeSelectorRequirement{requirement},
+			},
+			Config: &v2alpha1.DatadogAgentSpec{
+				Features: &v2alpha1.DatadogFeatures{APM: apm},
+			},
+		},
+	}
+}
+
+func noMatchProfileRequirement(value string) corev1.NodeSelectorRequirement {
+	return corev1.NodeSelectorRequirement{
+		Key:      "profile",
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   []string{value},
+	}
+}
+
+func workerProfileRequirement() corev1.NodeSelectorRequirement {
+	return noMatchProfileRequirement("worker")
+}
+
+func testAPMMatrixHappyConfig() *v2alpha1.APMFeatureConfig {
+	return &v2alpha1.APMFeatureConfig{
+		SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+			Enabled:           ptr.To(true),
+			EnabledNamespaces: []string{"payments"},
+			LibVersions:       map[string]string{"java": "1.43.0"},
+			LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+		},
+	}
+}
+
+func testAPMMatrixLibVersionConfig(language, version string) *v2alpha1.APMFeatureConfig {
+	return &v2alpha1.APMFeatureConfig{
+		SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+			Enabled:     ptr.To(true),
+			LibVersions: map[string]string{language: version},
+		},
+	}
+}
+
+func testAPMMatrixInjectorConfig(imageTag string) *v2alpha1.APMFeatureConfig {
+	return &v2alpha1.APMFeatureConfig{
+		SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+			Enabled:  ptr.To(true),
+			Injector: &v2alpha1.InjectorConfig{ImageTag: imageTag},
+		},
+	}
+}
+
+func testAPMMatrixInjectionModeConfig(mode v2alpha1.InjectionModeType) *v2alpha1.APMFeatureConfig {
+	return &v2alpha1.APMFeatureConfig{
+		SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+			Enabled:       ptr.To(true),
+			InjectionMode: mode,
+		},
+	}
+}
+
+func testAPMMatrixLanguageDetectionConfig(enabled bool) *v2alpha1.APMFeatureConfig {
+	return &v2alpha1.APMFeatureConfig{
+		SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+			Enabled:           ptr.To(true),
+			LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(enabled)},
+		},
+	}
+}
+
+func testAPMMatrixTargetConfig(name, app string, tracerVersions map[string]string, tracerConfigs []corev1.EnvVar) *v2alpha1.APMFeatureConfig {
+	return &v2alpha1.APMFeatureConfig{
+		SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+			Enabled: ptr.To(true),
+			Targets: []v2alpha1.SSITarget{
+				{
+					Name: name,
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": app},
+					},
+					TracerVersions: tracerVersions,
+					TracerConfigs:  tracerConfigs,
+				},
+			},
+		},
+	}
+}
+
+func assertSSIEnabled(want bool) func(*testing.T, *v2alpha1.SingleStepInstrumentation) {
+	return func(t *testing.T, ssi *v2alpha1.SingleStepInstrumentation) {
+		require.NotNil(t, ssi)
+		assert.Equal(t, want, ptr.Deref(ssi.Enabled, false))
+	}
+}
+
+func testAPMMatrixConditionMessage(conditions []metav1.Condition, conditionType string) string {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Message
+		}
+	}
+	return ""
 }

--- a/internal/controller/datadogagent_controller_profiles_test.go
+++ b/internal/controller/datadogagent_controller_profiles_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 // This file contains integration tests for Datadog Agent Profiles. They define
@@ -1091,6 +1092,68 @@ var _ = Describe("V2 Controller - DatadogAgentProfile", func() {
 
 		testProfilesFunc(testScenario)()
 	})
+
+	Context("with APM shared profile overlays", func() {
+		It("should merge accepted profile instrumentation into the default DDAI", func() {
+			agent := newAPMSharedOverlayAgent(namespace, randomKubernetesObjectName())
+			profiles := []*v1alpha1.DatadogAgentProfile{
+				newAPMSharedOverlayProfile(namespace, "a-"+randomKubernetesObjectName(), "a", &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:     ptr.To(true),
+						LibVersions: map[string]string{"java": "1.43.0"},
+					},
+				}),
+				newAPMSharedOverlayProfile(namespace, "b-"+randomKubernetesObjectName(), "b", &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:     ptr.To(true),
+						LibVersions: map[string]string{"python": "2.14.0"},
+					},
+				}),
+			}
+
+			createAPMSharedOverlayObjects(agent, profiles)
+			DeferCleanup(cleanupAPMSharedOverlayObjects, agent, profiles)
+
+			for _, profile := range profiles {
+				checkProfileAppliedStatus(profile.Namespace, profile.Name, metav1.ConditionTrue, "")
+			}
+			checkDefaultDDAIInstrumentation(agent.Namespace, agent.Name, func(ssi *v2alpha1.SingleStepInstrumentation) bool {
+				return ptr.Deref(ssi.Enabled, false) &&
+					len(ssi.LibVersions) == 2 &&
+					ssi.LibVersions["java"] == "1.43.0" &&
+					ssi.LibVersions["python"] == "2.14.0"
+			})
+		})
+
+		It("should reject conflicting profile instrumentation without mutating the accepted config", func() {
+			agent := newAPMSharedOverlayAgent(namespace, randomKubernetesObjectName())
+			profiles := []*v1alpha1.DatadogAgentProfile{
+				newAPMSharedOverlayProfile(namespace, "a-"+randomKubernetesObjectName(), "a", &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:     ptr.To(true),
+						LibVersions: map[string]string{"java": "1.43.0"},
+					},
+				}),
+				newAPMSharedOverlayProfile(namespace, "b-"+randomKubernetesObjectName(), "b", &v2alpha1.APMFeatureConfig{
+					SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+						Enabled:     ptr.To(true),
+						LibVersions: map[string]string{"java": "1.44.0"},
+					},
+				}),
+			}
+
+			createAPMSharedOverlayObjects(agent, profiles)
+			DeferCleanup(cleanupAPMSharedOverlayObjects, agent, profiles)
+
+			checkProfileAppliedStatus(profiles[0].Namespace, profiles[0].Name, metav1.ConditionTrue, "")
+			checkProfileAppliedStatus(profiles[1].Namespace, profiles[1].Name, metav1.ConditionFalse, `libVersions["java"] has conflicting values`)
+			checkDefaultDDAIInstrumentation(agent.Namespace, agent.Name, func(ssi *v2alpha1.SingleStepInstrumentation) bool {
+				return ptr.Deref(ssi.Enabled, false) &&
+					len(ssi.LibVersions) == 1 &&
+					ssi.LibVersions["java"] == "1.43.0"
+			})
+		})
+	})
 })
 
 func testProfilesFunc(testScenario profilesTestScenario) func() {
@@ -1189,6 +1252,91 @@ func testProfilesFunc(testScenario profilesTestScenario) func() {
 
 func randomKubernetesObjectName() string {
 	return strings.ToLower(utils.GenerateRandomString(10))
+}
+
+func newAPMSharedOverlayAgent(namespace, name string) *v2alpha1.DatadogAgent {
+	agent := testutils.NewDatadogAgentWithoutFeatures(namespace, name)
+	agent.Spec.Features = &v2alpha1.DatadogFeatures{
+		AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{Enabled: ptr.To(true)},
+		APM: &v2alpha1.APMFeatureConfig{
+			Enabled: ptr.To(false),
+			SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
+				Enabled:           ptr.To(false),
+				LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(true)},
+				Injector:          &v2alpha1.InjectorConfig{},
+			},
+		},
+	}
+	return &agent
+}
+
+func newAPMSharedOverlayProfile(namespace, name, profileValue string, apm *v2alpha1.APMFeatureConfig) *v1alpha1.DatadogAgentProfile {
+	return &v1alpha1.DatadogAgentProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.DatadogAgentProfileSpec{
+			ProfileAffinity: &v1alpha1.ProfileAffinity{
+				ProfileNodeAffinity: []v1.NodeSelectorRequirement{
+					{
+						Key:      "profile",
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{profileValue},
+					},
+				},
+			},
+			Config: &v2alpha1.DatadogAgentSpec{
+				Features: &v2alpha1.DatadogFeatures{
+					APM: apm,
+				},
+			},
+		},
+	}
+}
+
+func createAPMSharedOverlayObjects(agent *v2alpha1.DatadogAgent, profiles []*v1alpha1.DatadogAgentProfile) {
+	for _, profile := range profiles {
+		createKubernetesObject(k8sClient, profile)
+	}
+	createKubernetesObject(k8sClient, agent)
+}
+
+func cleanupAPMSharedOverlayObjects(agent *v2alpha1.DatadogAgent, profiles []*v1alpha1.DatadogAgentProfile) {
+	for _, profile := range profiles {
+		deleteKubernetesObject(k8sClient, profile)
+	}
+	deleteKubernetesObject(k8sClient, agent)
+}
+
+func checkDefaultDDAIInstrumentation(namespace, ddaName string, check func(*v2alpha1.SingleStepInstrumentation) bool) {
+	ddai := &v1alpha1.DatadogAgentInternal{}
+	getObjectAndCheck(ddai, types.NamespacedName{Namespace: namespace, Name: ddaName}, func() bool {
+		if ddai.Spec.Features == nil ||
+			ddai.Spec.Features.APM == nil ||
+			ddai.Spec.Features.APM.SingleStepInstrumentation == nil {
+			return false
+		}
+		return check(ddai.Spec.Features.APM.SingleStepInstrumentation)
+	})
+}
+
+func checkProfileAppliedStatus(namespace, name string, status metav1.ConditionStatus, messageSubstring string) {
+	profile := &v1alpha1.DatadogAgentProfile{}
+	getObjectAndCheck(profile, types.NamespacedName{Namespace: namespace, Name: name}, func() bool {
+		if profile.Status.Applied != status {
+			return false
+		}
+		if messageSubstring == "" {
+			return true
+		}
+		for _, condition := range profile.Status.Conditions {
+			if condition.Type == agentprofile.AppliedConditionType {
+				return strings.Contains(condition.Message, messageSubstring)
+			}
+		}
+		return false
+	})
 }
 
 func defaultDaemonSetNamespacedName(namespace string, agent *v2alpha1.DatadogAgent) types.NamespacedName {

--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -49,6 +49,24 @@ type CreateStrategyInfo struct {
 	nodesAlreadyLabeled int32    // number of nodes with the correct label
 }
 
+// CloneCreateStrategyInfoMap returns a deep copy of create strategy state.
+// The map stores pointers containing slices, so maps.Clone would still share
+// mutable CreateStrategyInfo values between the committed and staged state.
+func CloneCreateStrategyInfoMap(src map[types.NamespacedName]*CreateStrategyInfo) map[types.NamespacedName]*CreateStrategyInfo {
+	dst := make(map[types.NamespacedName]*CreateStrategyInfo, len(src))
+	for profile, info := range src {
+		if info == nil {
+			dst[profile] = nil
+			continue
+		}
+		dst[profile] = &CreateStrategyInfo{
+			nodesNeedingLabel:   slices.Clone(info.nodesNeedingLabel),
+			nodesAlreadyLabeled: info.nodesAlreadyLabeled,
+		}
+	}
+	return dst
+}
+
 // ApplyProfileToNodes applies a profile to nodes based on its label requirements
 // If there is a conflict with an existing profile, it returns an error
 func ApplyProfileToNodes(profile metav1.ObjectMeta, profileRequirements []*labels.Requirement, nodes []v1.Node, profileAppliedByNode map[string]types.NamespacedName, csInfo map[types.NamespacedName]*CreateStrategyInfo) error {


### PR DESCRIPTION
### What does this PR do?

Add APM feature overrides for profiles

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Enable profiles in the operator by setting `datadogAgentProfile.enabled=true` and `datadogCRDs.crds.datadogAgentProfiles=true` in the operator helm chart

1. SSI profile on base APM disabled

Base DDA
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: qa-dda
spec:
  features:
    admissionController:
      enabled: true
    apm:
      enabled: false
```
DAP
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: qa-ssi-profile
spec:
  profileAffinity:
    profileNodeAffinity:
      - key: dap-qa
        operator: In
        values: ["enabled"]
  config:
    features:
      apm:
        instrumentation:
          enabled: true
```
Apply both and check:

```bash
kubectl describe datadogagentprofile qa-ssi-profile
```

Expected describe output should include:

```text
Status:
  Applied:  True
  Conditions:
    Message:  DatadogAgentProfile applied
    Reason:   Applied
    Status:   True
    Type:     Applied
```

Also check rendered config:

```bash
kubectl get deploy -o yaml | grep DD_APM_INSTRUMENTATION_ENABLED -A2
kubectl get ds -o yaml | grep DD_APM_ENABLED -A2
```

Expected: Cluster Agent has SSI enabled, default node Agent does not enable node APM.

2. APM-Only Profile Does Not Need SSI Prereqs

Disable admission on the base DDA:

```bash
kubectl patch datadogagent qa-dda --type merge \
  -p '{"spec":{"features":{"admissionController":{"enabled":false},"apm":{"enabled":false}}}}'
```

DAP:

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: qa-apm-only-profile
spec:
  profileAffinity:
    profileNodeAffinity:
      - key: dap-qa
        operator: In
        values: ["enabled"]
  config:
    features:
      apm:
        enabled: true
```

Check:

```bash
kubectl describe datadogagentprofile qa-apm-only-profile
```

Expected describe output should include:

```text
Status:
  Applied:  True
  Conditions:
    Message:  DatadogAgentProfile applied
    Reason:   Applied
    Status:   True
    Type:     Applied
```

Also check rendered config:

```bash
kubectl get ds -o yaml | grep DD_APM_ENABLED -A2
```

Expected: profile DaemonSet has node APM config.

3. SSI Profile Rejects When Shared Path Is Unavailable

Keep admission disabled, then apply:

```yaml
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: qa-ssi-reject-profile
spec:
  profileAffinity:
    profileNodeAffinity:
      - key: dap-qa
        operator: In
        values: ["enabled"]
  config:
    features:
      apm:
        instrumentation:
          enabled: true
```

Check:

```bash
kubectl describe datadogagentprofile qa-ssi-reject-profile
```

Expected describe output should include:

```text
Status:
  Applied:  False
  Conditions:
    Message:  features.admissionController.enabled must be true on the base DatadogAgent when APM instrumentation is configured
    Reason:   Conflict
    Status:   False
    Type:     Applied
```

Optional Cluster Agent variant:

```bash
kubectl patch datadogagent qa-dda --type merge \
  -p '{"spec":{"features":{"admissionController":{"enabled":true}},"override":{"clusterAgent":{"disabled":true}}}}'
```

Expected describe output should include:

```text
Status:
  Applied:  False
  Conditions:
    Message:  clusterAgent cannot be disabled on the base DatadogAgent when APM instrumentation is configured
    Reason:   Conflict
    Status:   False
    Type:     Applied
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits