### PR TITLE
E2E improvements: remove gotoolchain hack, share go cache, stream test output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 /bin
 /chart
+/.cache
+/.go
 /vendor
 /hack

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,14 +27,6 @@ variables:
   GOMODCACHE: "$CI_PROJECT_DIR/.go/pkg/mod"
   GOCACHE: "$CI_PROJECT_DIR/.cache/go-build"
 
-cache: &global_cache
-  key: go-${CI_COMMIT_REF_SLUG}
-  fallback_keys:
-    - go-${CI_DEFAULT_BRANCH}
-  paths:
-    - .go/pkg/mod
-    - .cache/go-build
-
 .resource_variables: &resource_variables
   KUBERNETES_MEMORY_REQUEST: 16Gi
   KUBERNETES_MEMORY_LIMIT: 16Gi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -264,6 +264,11 @@ go_e2e_deps:
   tags: ["arch:amd64"]
   variables:
     KUBERNETES_CPU_REQUEST: 16
+    KUBERNETES_CPU_LIMIT: 16
+    KUBERNETES_MEMORY_REQUEST: 16Gi
+    KUBERNETES_MEMORY_LIMIT: 16Gi
+    GOMEMLIMIT: 15GiB
+    GOMAXPROCS: 4
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       variables:
@@ -282,7 +287,7 @@ go_e2e_deps:
       # Pre-warm Go module and build caches before the e2e matrix starts.
       pushd test/e2e
       GOWORK=off go mod download
-      GOWORK=off go test ./... -count=1 --tags=e2e -run '^$'
+      GOWORK=off go test -p 4 ./... -count=1 --tags=e2e -run '^$'
       popd
     - |
       if [ ! -f pulumi_plugins.tar.xz ]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,11 +23,17 @@ variables:
     description: "Set PUSH_IMAGE_TO_STAGING to 'true' if you want to push the operator to internal staging registry."
   FIPS_ENABLED: false
   FF_TIMESTAMPS: true
+  GOPATH: "$CI_PROJECT_DIR/.go"
+  GOMODCACHE: "$CI_PROJECT_DIR/.go/pkg/mod"
+  GOCACHE: "$CI_PROJECT_DIR/.cache/go-build"
 
 cache: &global_cache
-  key: ${CI_COMMIT_REF_SLUG}
+  key: go-${CI_COMMIT_REF_SLUG}
+  fallback_keys:
+    - go-${CI_DEFAULT_BRANCH}
   paths:
-    - /go/pkg/mod
+    - .go/pkg/mod
+    - .cache/go-build
 
 .resource_variables: &resource_variables
   KUBERNETES_MEMORY_REQUEST: 16Gi
@@ -273,6 +279,12 @@ go_e2e_deps:
     - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-operator --policy self.gitlab.deps-fetch)
   script:
     - |
+      # Pre-warm Go module and build caches before the e2e matrix starts.
+      pushd test/e2e
+      GOWORK=off go mod download
+      GOWORK=off go test ./... -count=1 --tags=e2e -run '^$'
+      popd
+    - |
       if [ ! -f pulumi_plugins.tar.xz ]; then
         # Pre-download Pulumi plugins used by e2e scenarios and components
         pushd test/e2e
@@ -285,6 +297,13 @@ go_e2e_deps:
     paths:
       - $CI_PROJECT_DIR/pulumi_plugins.tar.xz
   cache:
+    - key: e2e-go-${CI_COMMIT_REF_SLUG}
+      fallback_keys:
+        - e2e-go-${CI_DEFAULT_BRANCH}
+      paths:
+        - .go/pkg/mod
+        - .cache/go-build
+      policy: pull-push
     - key:
         files:
           - ./test/e2e/go.mod
@@ -348,9 +367,15 @@ go_e2e_deps:
     E2E_AWS_PUBLIC_KEY_PATH: /tmp/agent-qa-ssh-key.pub
     E2E_AWS_PRIVATE_KEY_PATH: /tmp/agent-qa-ssh-key
     E2E_KEY_PAIR_NAME: ci.datadog-operator
-    # Temporary workaround from https://github.com/golang/go/issues/75031
-    GOTOOLCHAIN: go1.25.0+auto
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  cache:
+    - key: e2e-go-${CI_COMMIT_REF_SLUG}
+      fallback_keys:
+        - e2e-go-${CI_DEFAULT_BRANCH}
+      paths:
+        - .go/pkg/mod
+        - .cache/go-build
+      policy: pull
   before_script:
     # Extract cached Pulumi plugins
     - mkdir -p ~/.pulumi && tar xJf pulumi_plugins.tar.xz -C ~/.pulumi

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ ENVTEST_K8S_VERSION = 1.30
 # instead of the CI job timing out with no actionable logs.)
 E2E_GO_TEST_TIMEOUT ?= 55m
 E2E_AUTOSCALING_GO_TEST_TIMEOUT ?= 140m
+E2E_GO_TEST_OUTPUT ?= go run ./hack/e2e-test-output
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -215,15 +216,15 @@ integration-tests: $(ENVTEST) ## Run integration tests with reconciler
 .PHONY: e2e-tests
 e2e-tests: ## Run E2E tests and destroy environment stacks after tests complete. To run locally, complete pre-reqs (see docs/how-to-contribute.md) and prepend command with `aws-vault exec sso-agent-sandbox-account-admin --`. E.g. `aws-vault exec sso-agent-sandbox-account-admin -- make e2e-tests`.
 	@if [ -z "$(E2E_RUN_REGEX)" ]; then \
-		GOWORK=off KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test -C test/e2e/ ./... -count=1 --tags=e2e -v -run TestAWSKindSuite -timeout $(E2E_GO_TEST_TIMEOUT) -coverprofile cover_e2e.out; \
+		GOWORK=off KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test -C test/e2e/ ./... -count=1 --tags=e2e -json -run TestAWSKindSuite -timeout $(E2E_GO_TEST_TIMEOUT) -coverprofile cover_e2e.out | $(E2E_GO_TEST_OUTPUT); \
 	else \
 	    echo "Running e2e test: $(E2E_RUN_REGEX)"; \
-		GOWORK=off KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test -C test/e2e/ ./... -count=1 --tags=e2e -v -run $(E2E_RUN_REGEX) -timeout $(E2E_GO_TEST_TIMEOUT) -coverprofile cover_e2e.out; \
+		GOWORK=off KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test -C test/e2e/ ./... -count=1 --tags=e2e -json -run $(E2E_RUN_REGEX) -timeout $(E2E_GO_TEST_TIMEOUT) -coverprofile cover_e2e.out | $(E2E_GO_TEST_OUTPUT); \
 	fi
 
 .PHONY: e2e-autoscaling-tests
 e2e-autoscaling-tests: kubectl-datadog ## Run autoscaling E2E tests on EKS. To run locally, complete pre-reqs (see docs/how-to-contribute.md) and prepend command with `aws-vault exec sso-agent-sandbox-account-admin --`.
-	GOWORK=off KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test -C test/e2e/ ./tests/autoscaling_suite/... -count=1 --tags=e2e -v -timeout $(E2E_AUTOSCALING_GO_TEST_TIMEOUT) -coverprofile cover_e2e_autoscaling.out
+	GOWORK=off KUBEBUILDER_ASSETS="$(ROOT)/bin/$(PLATFORM)/" go test -C test/e2e/ ./tests/autoscaling_suite/... -count=1 --tags=e2e -json -timeout $(E2E_AUTOSCALING_GO_TEST_TIMEOUT) -coverprofile cover_e2e_autoscaling.out | $(E2E_GO_TEST_OUTPUT)
 
 .PHONY: yaml-mapper-tests
 yaml-mapper-tests: fmt yaml-mapper-unit-tests

--- a/hack/e2e-test-output/main.go
+++ b/hack/e2e-test-output/main.go
@@ -12,24 +12,30 @@ type testEvent struct {
 }
 
 func main() {
-	scanner := bufio.NewScanner(os.Stdin)
+	os.Exit(run(os.Stdin, os.Stdout, os.Stderr))
+}
+
+func run(input io.Reader, output, errorOutput io.Writer) int {
+	scanner := bufio.NewScanner(input)
 	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
 
 	for scanner.Scan() {
 		var event testEvent
 		line := scanner.Bytes()
 		if err := json.Unmarshal(line, &event); err != nil {
-			_, _ = os.Stdout.Write(line)
-			_, _ = os.Stdout.Write([]byte("\n"))
+			_, _ = output.Write(line)
+			_, _ = output.Write([]byte("\n"))
 			continue
 		}
 		if event.Output != "" {
-			_, _ = io.WriteString(os.Stdout, event.Output)
+			_, _ = io.WriteString(output, event.Output)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		_, _ = io.WriteString(os.Stderr, "reading go test output: "+err.Error()+"\n")
-		os.Exit(1)
+		_, _ = io.WriteString(errorOutput, "reading go test output: "+err.Error()+"\n")
+		return 1
 	}
+
+	return 0
 }

--- a/hack/e2e-test-output/main.go
+++ b/hack/e2e-test-output/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
+	"io"
 	"os"
 )
 
@@ -19,16 +19,17 @@ func main() {
 		var event testEvent
 		line := scanner.Bytes()
 		if err := json.Unmarshal(line, &event); err != nil {
-			fmt.Println(string(line))
+			_, _ = os.Stdout.Write(line)
+			_, _ = os.Stdout.Write([]byte("\n"))
 			continue
 		}
 		if event.Output != "" {
-			fmt.Print(event.Output)
+			_, _ = io.WriteString(os.Stdout, event.Output)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "reading go test output: %v\n", err)
+		_, _ = io.WriteString(os.Stderr, "reading go test output: "+err.Error()+"\n")
 		os.Exit(1)
 	}
 }

--- a/hack/e2e-test-output/main.go
+++ b/hack/e2e-test-output/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type testEvent struct {
+	Output string
+}
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		var event testEvent
+		line := scanner.Bytes()
+		if err := json.Unmarshal(line, &event); err != nil {
+			fmt.Println(string(line))
+			continue
+		}
+		if event.Output != "" {
+			fmt.Print(event.Output)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "reading go test output: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/e2e-test-output/main_test.go
+++ b/hack/e2e-test-output/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunPrintsGoTestOutputEvents(t *testing.T) {
+	input := strings.Join([]string{
+		`{"Action":"run","Package":"pkg","Test":"TestExample"}`,
+		`{"Action":"output","Package":"pkg","Output":"=== RUN   TestExample\n"}`,
+		`{"Action":"output","Package":"pkg","Output":"--- PASS: TestExample (0.00s)\n"}`,
+		`{"Action":"pass","Package":"pkg","Test":"TestExample"}`,
+	}, "\n")
+	var output bytes.Buffer
+	var errorOutput bytes.Buffer
+
+	exitCode := run(strings.NewReader(input), &output, &errorOutput)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if got, want := output.String(), "=== RUN   TestExample\n--- PASS: TestExample (0.00s)\n"; got != want {
+		t.Fatalf("unexpected output:\ngot:  %q\nwant: %q", got, want)
+	}
+	if got := errorOutput.String(); got != "" {
+		t.Fatalf("expected no stderr, got %q", got)
+	}
+}
+
+func TestRunPrintsInvalidJSONLines(t *testing.T) {
+	var output bytes.Buffer
+	var errorOutput bytes.Buffer
+
+	exitCode := run(strings.NewReader("not json\n"), &output, &errorOutput)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if got, want := output.String(), "not json\n"; got != want {
+		t.Fatalf("unexpected output:\ngot:  %q\nwant: %q", got, want)
+	}
+	if got := errorOutput.String(); got != "" {
+		t.Fatalf("expected no stderr, got %q", got)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Improves the operator e2e CI pipeline by:
- removing the obsolete `GOTOOLCHAIN` workaround
- pre-warming shared e2e Go module/build caches in `go_e2e_deps`
- streaming `go test` output live in GitLab logs
<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/d0ca6b2d-64e3-4123-ad68-a47a21fc8d56" />


### Motivation

Reduce duplicated Go dependency work across the Kubernetes-version e2e matrix and make long e2e runs easier to debug while they are running.

### Additional Notes

The e2e Go cache is scoped to e2e jobs only, and `.go`/`.cache` are ignored from Docker build contexts.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- DDCI/GitLab pipeline `116706367`
- Verified `go_e2e_deps` creates the e2e Go cache and matrix jobs restore it
- `go test ./hack/e2e-test-output -cover`
- `golangci-lint run ./hack/e2e-test-output`

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
