### PR TITLE
fix(rbac): remove stale gateways entry from generated RBAC role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -442,7 +442,6 @@ rules:
   - networking.istio.io
   resources:
   - destinationrules
-  - gateways
   - serviceentries
   - sidecars
   - virtualservices


### PR DESCRIPTION
### What does this PR do?

Removes a stale `networking.istio.io/gateways` entry from the orchestrator explorer RBAC block in `config/rbac/role.yaml`. This entry was manually added and has no corresponding `+kubebuilder:rbac:` marker — running `make generate` removes it.

The permission is already granted by the AppSec marker (`get;list;watch`) which subsumes the orchestrator `list;watch`, so this is a no-op from a runtime perspective.

### Motivation

Flagged by @tbavelier after merging #3053. The generated `role.yaml` should match what `make generate` produces.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

`make generate && git diff --stat` produces zero diff after this change.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed