### PR TITLE
Reduce operator image chmod layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,15 +58,12 @@ COPY --from=certs /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
-COPY --from=builder /workspace/helpers .
-COPY scripts/readsecret.sh .
-RUN chmod 550 readsecret.sh && chmod 550 helpers
+COPY --from=builder --chmod=550 /workspace/helpers .
+COPY --chmod=550 scripts/readsecret.sh .
 
-COPY --from=builder /workspace/yaml-mapper .
-RUN chmod 550 yaml-mapper
+COPY --from=builder --chmod=550 /workspace/yaml-mapper .
 
-COPY ./LICENSE ./LICENSE-3rdparty.csv /licenses/
-RUN chmod -R 755 /licenses
+COPY --chmod=755 ./LICENSE ./LICENSE-3rdparty.csv /licenses/
 
 USER 1001
 


### PR DESCRIPTION
## What

Use `COPY --chmod` in the operator image runtime stage instead of copying files and changing permissions in separate `RUN chmod` layers.

## Why

The separate chmod commands rewrote large files into new layers, duplicating `/helpers`, `/yaml-mapper`, `/readsecret.sh`, and license files in the final image.

## Validation

- `make docker-build-ci IMG=tbdatadog/operator:main-chmod-test GOARCH=arm64`
- `dive --ci tbdatadog/operator:main-chmod-test`

Result:

```console
╰─❯ docker images tbdatadog/operator
                                                                                                                                                      i Info →   U  In Use
IMAGE                                ID             DISK USAGE   CONTENT SIZE   EXTRA
tbdatadog/operator:main              40dacd9fcc78        221MB         52.3MB
tbdatadog/operator:main-chmod-test   63cb8e21465a        170MB         39.5MB
```
- `dive` efficiency improved from `0.7699` to `1.0`:

```console
╰─❯ CI=true dive tbdatadog/operator:main
  Using default CI config
Image Source: docker://tbdatadog/operator:main
Extracting image from docker-engine... (this can take a while for large images)
Analyzing image...
  efficiency: 76.9862 %
  wastedBytes: 76596908 bytes (77 MB)
  userWastedPercent: 54.0052 %
Inefficient Files:
Count  Wasted Space  File Path
    2         52 MB  /yaml-mapper
    2         24 MB  /helpers
    2         27 kB  /licenses/LICENSE-3rdparty.csv
    2         23 kB  /licenses/LICENSE
    2         560 B  /readsecret.sh
Results:
  FAIL: highestUserWastedPercent: too many bytes wasted, relative to the user bytes added (%-user-wasted-bytes=0.5400516648659988 > threshold=0.1)
  SKIP: highestWastedBytes: rule disabled
  FAIL: lowestEfficiency: image efficiency is too low (efficiency=0.769861641423005 < threshold=0.9)
Result:FAIL [Total:3] [Passed:0] [Failed:2] [Warn:0] [Skipped:1]

╭─ ~/dd/datadog-operator tbavelier/re…r-image-size                                                                                                         3.12  16:13:36
╰─❯ CI=true dive tbdatadog/operator:main-chmod-test
  Using default CI config
Image Source: docker://tbdatadog/operator:main-chmod-test
Extracting image from docker-engine... (this can take a while for large images)
Analyzing image...
  efficiency: 100.0000 %
  wastedBytes: 0 bytes (0 B)
  userWastedPercent: 0.0000 %
Inefficient Files:
Count  Wasted Space  File Path
None
Results:
  PASS: highestUserWastedPercent
  SKIP: highestWastedBytes: rule disabled
  PASS: lowestEfficiency
Result:PASS [Total:3] [Passed:2] [Failed:0] [Warn:0] [Skipped:1]
```