### PR TITLE
No-op: Remove unnecessary nil check

### DIFF
--- a/internal/controller/datadogagent/override/podtemplatespec.go
+++ b/internal/controller/datadogagent/override/podtemplatespec.go
@@ -104,7 +104,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		manager.EnvFromVar().AddEnvFromVar(&e)
 	}
 
-	if override.CELWorkloadExclude != nil && len(override.CELWorkloadExclude) > 0 {
+	if len(override.CELWorkloadExclude) > 0 {
 		jsonConfig, err := json.Marshal(override.CELWorkloadExclude)
 		if err != nil {
 			logger.Error(err, "failed to convert to JSON")


### PR DESCRIPTION
### What does this PR do?

Remove nil check for `override.CELWorkloadExclude`, len(nil slice) is 0, so it includes the first condition: https://go.dev/play/p/GA7rz1txEMw
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits