### PR TITLE
[CONTP-1610][CONTP-1611] Wait for CSI driver node server pod readiness in untaint controller if csi feature is enabled

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,6 +148,7 @@ type options struct {
 	datadogGenericResourceEnabled          bool
 	datadogCSIDriverEnabled                bool
 	untaintControllerEnabled               bool
+	untaintControllerWaitForCSIDriver      bool
 
 	// Secret Backend options
 	secretBackendCommand  string
@@ -188,6 +189,8 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.datadogGenericResourceEnabled, "datadogGenericResourceEnabled", false, "Enable the DatadogGenericResource controller")
 	flag.BoolVar(&opts.datadogCSIDriverEnabled, "datadogCSIDriverEnabled", false, "Enable the DatadogCSIDriver controller")
 	flag.BoolVar(&opts.untaintControllerEnabled, "untaintControllerEnabled", false, "Enable the Untaint controller")
+	flag.BoolVar(&opts.untaintControllerWaitForCSIDriver, "untaintControllerWaitForCSIDriver", false,
+		"When true (requires --untaintControllerEnabled), the Untaint controller removes the startup taint only after both the node Agent and Datadog CSI node-server pods are Ready. Requires Pod watch coverage of CSI namespaces (DD_CSIDRIVER_WATCH_NAMESPACE).")
 
 	// DatadogAgentInternal
 	flag.BoolVar(&opts.createControllerRevisions, "createControllerRevisions", false, "Enable creation of ControllerRevision snapshots on each DDA spec change")
@@ -234,6 +237,10 @@ func run(opts *options) error {
 		return nil
 	}
 	version.PrintVersionLogs(setupLog)
+
+	if opts.untaintControllerWaitForCSIDriver && !opts.untaintControllerEnabled {
+		return setupErrorf(setupLog, fmt.Errorf("invalid flags"), "--untaintControllerWaitForCSIDriver requires --untaintControllerEnabled=true")
+	}
 
 	// submits the maximum go routine setting as a metric
 	metrics.MaxGoroutines.Set(float64(opts.maximumGoroutines))
@@ -287,15 +294,16 @@ func run(opts *options) error {
 		RenewDeadline:              &renewDeadline,
 		RetryPeriod:                &retryPeriod,
 		Cache: config.CacheOptions(setupLog, config.WatchOptions{
-			DatadogAgentEnabled:           opts.datadogAgentEnabled,
-			DatadogMonitorEnabled:         opts.datadogMonitorEnabled,
-			DatadogSLOEnabled:             opts.datadogSLOEnabled,
-			DatadogAgentProfileEnabled:    opts.datadogAgentProfileEnabled,
-			IntrospectionEnabled:          opts.introspectionEnabled,
-			DatadogDashboardEnabled:       opts.datadogDashboardEnabled,
-			DatadogGenericResourceEnabled: opts.datadogGenericResourceEnabled,
-			DatadogCSIDriverEnabled:       opts.datadogCSIDriverEnabled,
-			UntaintControllerEnabled:      opts.untaintControllerEnabled,
+			DatadogAgentEnabled:               opts.datadogAgentEnabled,
+			DatadogMonitorEnabled:             opts.datadogMonitorEnabled,
+			DatadogSLOEnabled:                 opts.datadogSLOEnabled,
+			DatadogAgentProfileEnabled:        opts.datadogAgentProfileEnabled,
+			IntrospectionEnabled:              opts.introspectionEnabled,
+			DatadogDashboardEnabled:           opts.datadogDashboardEnabled,
+			DatadogGenericResourceEnabled:     opts.datadogGenericResourceEnabled,
+			DatadogCSIDriverEnabled:           opts.datadogCSIDriverEnabled,
+			UntaintControllerEnabled:          opts.untaintControllerEnabled,
+			UntaintControllerWaitForCSIDriver: opts.untaintControllerWaitForCSIDriver,
 		}),
 		// UsePriorityQueue makes all controllers use the priority queue, which
 		// directly registers workqueue metrics into controller-runtime's metrics
@@ -366,20 +374,21 @@ func run(opts *options) error {
 			CanaryAutoPauseMaxSlowStartDuration: opts.edsCanaryAutoPauseMaxSlowStartDuration,
 			MaxPodSchedulerFailure:              opts.edsMaxPodSchedulerFailure,
 		},
-		SupportCilium:                 opts.supportCilium,
-		CredsManager:                  credsManager,
-		DatadogAgentEnabled:           opts.datadogAgentEnabled,
-		CreateControllerRevisions:     opts.createControllerRevisions && opts.datadogAgentEnabled,
-		DatadogMonitorEnabled:         opts.datadogMonitorEnabled,
-		DatadogSLOEnabled:             opts.datadogSLOEnabled,
-		OperatorMetricsEnabled:        opts.operatorMetricsEnabled,
-		V2APIEnabled:                  true,
-		IntrospectionEnabled:          opts.introspectionEnabled,
-		DatadogAgentProfileEnabled:    opts.datadogAgentProfileEnabled,
-		DatadogDashboardEnabled:       opts.datadogDashboardEnabled,
-		DatadogGenericResourceEnabled: opts.datadogGenericResourceEnabled,
-		DatadogCSIDriverEnabled:       opts.datadogCSIDriverEnabled,
-		UntaintControllerEnabled:      opts.untaintControllerEnabled,
+		SupportCilium:                     opts.supportCilium,
+		CredsManager:                      credsManager,
+		DatadogAgentEnabled:               opts.datadogAgentEnabled,
+		CreateControllerRevisions:         opts.createControllerRevisions && opts.datadogAgentEnabled,
+		DatadogMonitorEnabled:             opts.datadogMonitorEnabled,
+		DatadogSLOEnabled:                 opts.datadogSLOEnabled,
+		OperatorMetricsEnabled:            opts.operatorMetricsEnabled,
+		V2APIEnabled:                      true,
+		IntrospectionEnabled:              opts.introspectionEnabled,
+		DatadogAgentProfileEnabled:        opts.datadogAgentProfileEnabled,
+		DatadogDashboardEnabled:           opts.datadogDashboardEnabled,
+		DatadogGenericResourceEnabled:     opts.datadogGenericResourceEnabled,
+		DatadogCSIDriverEnabled:           opts.datadogCSIDriverEnabled,
+		UntaintControllerEnabled:          opts.untaintControllerEnabled,
+		UntaintControllerWaitForCSIDriver: opts.untaintControllerWaitForCSIDriver,
 	}
 
 	versionInfo, platformInfo, err := getVersionAndPlatformInfo(rest.CopyConfig(mgr.GetConfig()))

--- a/docs/untaint_controller.md
+++ b/docs/untaint_controller.md
@@ -10,13 +10,13 @@ readiness criteria are met (see below), or after a configurable timeout. It is
 intended to run alongside a separate mechanism (cluster-autoscaler hook, CCM,
 admission webhook, etc.) that adds the taint to new nodes.
 
-**With `--untaintControllerEnabled` only** (or with `--datadogCSIDriverEnabled=false`):
+**With `--untaintControllerEnabled=true` only** (and without `--untaintControllerWaitForCSIDriver`):
 the controller removes the taint once the **node Agent** pod
 (`agent.datadoghq.com/component=agent`) on that node is `Ready`. Agent pods are
 listed in the operator's agent watch namespaces (`WATCH_NAMESPACE` /
 `DD_AGENT_WATCH_NAMESPACE`).
 
-**With both `--untaintControllerEnabled=true` and `--datadogCSIDriverEnabled=true`:**
+**With `--untaintControllerEnabled=true` and `--untaintControllerWaitForCSIDriver=true`:**
 the controller waits until **both** the node Agent and **CSI
 node-server** pod (`app=datadog-csi-driver-node-server`) on the node are
 `Ready` before removing the taint. The taint stays until both are
@@ -25,19 +25,26 @@ satisfied or a timeout fires. The operator's Pod informer then watches the
 pods in those namespaces—keep namespaces tight). Ensure CSI namespaces are
 covered so the controller can list CSI pod status.
 
+**`--datadogCSIDriverEnabled`** only controls whether the **DatadogCSIDriver**
+controller runs; it does **not** by itself turn on dual-readiness untaint.
+Enable `--untaintControllerWaitForCSIDriver` only when you actually deploy CSI
+node-server pods on tainted nodes (for example via a `DatadogCSIDriver` CR with
+the operator's CSI controller enabled, or another install path that produces
+the same pod labels).
+
 If a required pod never reaches Ready on a tainted node, a configurable timeout
 policy ensures the node is never permanently unschedulable. Two clocks cover
 the main failure modes:
 
 - **Readiness timeout** — at least one Agent pod is on the node but the Agent
-  is not Ready yet, **or** (with CSI enabled) the Agent is Ready but a CSI
+  is not Ready yet, **or** (with `--untaintControllerWaitForCSIDriver`) the Agent is Ready but a CSI
   node-server pod exists on the node and is not Ready. Clock: latest
   `pod.Status.StartTime` among **Agent** pods in the first case, and among **CSI
   node-server** pods only in the second (the Agent’s age does not shorten the
   wait for CSI). Pod recreation restarts the window; container restarts inside the
   same pod do not.
-- **Scheduling timeout** — no Agent pod is on the node, **or** (with CSI
-  enabled) the Agent is Ready but **no** CSI node-server pod is on the node
+- **Scheduling timeout** — no Agent pod is on the node, **or** (with wait-for-CSI)
+  the Agent is Ready but **no** CSI node-server pod is on the node
   yet. Clock: `node.metadata.creationTimestamp`. Covers DaemonSets that never
   schedule onto the node (taint not tolerated, missing labels, CSI still pulling,
   etc.).
@@ -62,18 +69,23 @@ manager:
 ```yaml
 args:
   - --untaintControllerEnabled=true
+  # Optional: require CSI node-server Ready before untainting (see Overview).
+  - --untaintControllerWaitForCSIDriver=true
 ```
 
-| `--untaintControllerEnabled` | `--datadogCSIDriverEnabled` | Behavior |
-| ----------------------------- | --------------------------- | -------- |
-| `false` | any | Untaint controller off; no startup toleration injection for this feature on Agent or CSI. |
-| `true` | `false` | Agent-only readiness and Agent DaemonSet toleration (default historical behavior). |
-| `true` | `true` | Wait for Agent **and** CSI node-server Ready; widened Pod cache (agent + `DD_CSIDRIVER_WATCH_NAMESPACE` namespaces); toleration on Agent and CSI DaemonSets. |
+| `--untaintControllerEnabled` | `--untaintControllerWaitForCSIDriver` | Behavior |
+| ----------------------------- | ------------------------------------- | -------- |
+| `false` | any | Untaint controller off; no Agent startup toleration for this feature. |
+| `true` | `false` | Agent-only readiness; Agent DaemonSet startup toleration injected. |
+| `true` | `true` | Wait for Agent **and** CSI node-server Ready; widened Pod cache (agent + `DD_CSIDRIVER_WATCH_NAMESPACE` namespaces); startup toleration on Agent and, when the DatadogCSIDriver controller is enabled, on the CSI node DaemonSet. |
 
-When this flag is enabled, the operator injects a toleration for
+`--untaintControllerWaitForCSIDriver` requires `--untaintControllerEnabled=true` (the operator exits on invalid combinations).
+
+When `--untaintControllerEnabled` is enabled, the operator injects a toleration for
 `agent.datadoghq.com/not-ready=presence:NoSchedule` into the node Agent
 DaemonSet (or ExtendedDaemonSet) pod template, unless an equivalent toleration
-is already present. When **`--datadogCSIDriverEnabled`** is also true, the same
+is already present. When **`--untaintControllerWaitForCSIDriver`** is also true **and**
+the DatadogCSIDriver controller is running (`--datadogCSIDriverEnabled=true`), the same
 toleration is injected into the **Datadog CSI node-server** DaemonSet pod
 template so the CSI workload can schedule on tainted nodes before the taint is
 removed.
@@ -104,7 +116,7 @@ Metrics, under the `untaint` Prometheus subsystem:
 Kubernetes Events (gated by `DD_UNTAINT_CONTROLLER_EVENTS_ENABLED=true`):
 
 - `TaintRemoved` (Normal) — taint removed after the Agent became Ready, or (when
-  the Datadog CSI driver controller is also enabled) after both the Agent and
+  `--untaintControllerWaitForCSIDriver` is enabled) after both the Agent and
   CSI node-server pods became Ready.
 - `UntaintTimeout` — a timeout fired. Normal under `remove`, Warning under `keep`. Message carries the reason, elapsed time, and policy.
 

--- a/docs/untaint_controller.md
+++ b/docs/untaint_controller.md
@@ -37,17 +37,19 @@ policy ensures the node is never permanently unschedulable. Two clocks cover
 the main failure modes:
 
 - **Readiness timeout** — at least one Agent pod is on the node but the Agent
-  is not Ready yet, **or** (with `--untaintControllerWaitForCSIDriver`) the Agent is Ready but a CSI
-  node-server pod exists on the node and is not Ready. Clock: latest
-  `pod.Status.StartTime` among **Agent** pods in the first case, and among **CSI
-  node-server** pods only in the second (the Agent’s age does not shorten the
-  wait for CSI). Pod recreation restarts the window; container restarts inside the
-  same pod do not.
+  is not Ready yet, **or** (with `--untaintControllerWaitForCSIDriver`) at least
+  one Agent and one CSI node-server pod are on the node, each has
+  `pod.Status.StartTime` set, and at least one of them is not Ready. Clock: the
+  **later** of the latest `StartTime` among Agent pods on the node and the latest
+  `StartTime` among CSI node-server pods on the node (so a recent restart on
+  either workload resets the window). Agent-only mode (no wait-for-CSI) still
+  uses only Agent `StartTime` for this clock.
 - **Scheduling timeout** — no Agent pod is on the node, **or** (with wait-for-CSI)
-  the Agent is Ready but **no** CSI node-server pod is on the node
-  yet. Clock: `node.metadata.creationTimestamp`. Covers DaemonSets that never
-  schedule onto the node (taint not tolerated, missing labels, CSI still pulling,
-  etc.).
+  no CSI node-server pod on the node yet, **or** (with wait-for-CSI) either side
+  is present but **any** required pod still lacks `StartTime`. Clock:
+  `node.metadata.creationTimestamp`. Covers DaemonSets that never schedule onto
+  the node (taint not tolerated, missing labels, CSI still pulling, kubelet has
+  not set `StartTime` yet, etc.).
 
 A pod-recreation crash-loop faster than the readiness window can hold a node
 tainted indefinitely; run with `policy=keep` and alert on

--- a/docs/untaint_controller.md
+++ b/docs/untaint_controller.md
@@ -45,11 +45,15 @@ the main failure modes:
   either workload resets the window). Agent-only mode (no wait-for-CSI) still
   uses only Agent `StartTime` for this clock.
 - **Scheduling timeout** — no Agent pod is on the node, **or** (with wait-for-CSI)
-  no CSI node-server pod on the node yet, **or** (with wait-for-CSI) either side
-  is present but **any** required pod still lacks `StartTime`. Clock:
-  `node.metadata.creationTimestamp`. Covers DaemonSets that never schedule onto
-  the node (taint not tolerated, missing labels, CSI still pulling, kubelet has
-  not set `StartTime` yet, etc.).
+  no CSI node-server pod on the node yet. Clock: `node.metadata.creationTimestamp`.
+  Covers DaemonSets that never schedule onto the node (taint not tolerated,
+  missing labels, CSI still pulling, etc.).
+- **(Wait-for-CSI only)** If **both** an Agent pod and a CSI node-server pod are on
+  the node but **either** still lacks `StartTime`, the controller **requeues**
+  after the readiness-timeout duration (coarse poll, same idea as agent-only when
+  `StartTime` is not populated yet)—it does **not** use the scheduling clock here,
+  so an old node does not instantly hit a scheduling timeout while waiting for
+  `StartTime` to appear.
 
 A pod-recreation crash-loop faster than the readiness window can hold a node
 tainted indefinitely; run with `policy=keep` and alert on

--- a/docs/untaint_controller.md
+++ b/docs/untaint_controller.md
@@ -5,27 +5,42 @@ This feature was introduced in Datadog Operator v1.28 and is currently in previe
 ## Overview
 
 The Untaint controller watches Kubernetes Nodes carrying the taint
-`agent.datadoghq.com/not-ready=presence:NoSchedule` and removes it once the
-Datadog Agent pod on that node is `Ready`. It is intended to run alongside a
-separate mechanism (cluster-autoscaler hook, CCM, admission webhook, etc.)
-that adds the taint to new nodes. The use case is keeping workloads off a
-node until the Datadog Agent is Ready, and recovering gracefully if the Agent never
-becomes Ready.
+`agent.datadoghq.com/not-ready=presence:NoSchedule` and removes it when
+readiness criteria are met (see below), or after a configurable timeout. It is
+intended to run alongside a separate mechanism (cluster-autoscaler hook, CCM,
+admission webhook, etc.) that adds the taint to new nodes.
 
-Agent pods are matched by the label `agent.datadoghq.com/component=agent` in
-the operator's watched namespaces (`WATCH_NAMESPACE` /
+**With `--untaintControllerEnabled` only** (or with `--datadogCSIDriverEnabled=false`):
+the controller removes the taint once the **node Agent** pod
+(`agent.datadoghq.com/component=agent`) on that node is `Ready`. Agent pods are
+listed in the operator's agent watch namespaces (`WATCH_NAMESPACE` /
 `DD_AGENT_WATCH_NAMESPACE`).
 
-If the Agent pod never reaches Ready on a tainted node, a configurable timeout
-policy ensures the node is never permanently unschedulable. Two clocks cover
-the two failure modes:
+**With both `--untaintControllerEnabled=true` and `--datadogCSIDriverEnabled=true`:**
+the controller waits until **both** the node Agent and **CSI
+node-server** pod (`app=datadog-csi-driver-node-server`) on the node are
+`Ready` before removing the taint. The taint stays until both are
+satisfied or a timeout fires. The operator's Pod informer then watches the
+**union** of `DD_AGENT_WATCH_NAMESPACE` and `DD_CSIDRIVER_WATCH_NAMESPACE` (all
+pods in those namespaces—keep namespaces tight). Ensure CSI namespaces are
+covered so the controller can list CSI pod status.
 
-- **Readiness timeout** — the Agent pod is on the node but not Ready. Clock:
-  `pod.Status.StartTime`. Pod recreation restarts the window; container
-  restarts inside the same pod do not.
-- **Scheduling timeout** — no Agent pod is on the node. Clock:
-  `node.metadata.creationTimestamp`. The expected path when a DaemonSet never
-  schedules a pod onto the node (taint not tolerated, missing labels, etc.).
+If a required pod never reaches Ready on a tainted node, a configurable timeout
+policy ensures the node is never permanently unschedulable. Two clocks cover
+the main failure modes:
+
+- **Readiness timeout** — at least one Agent pod is on the node but the Agent
+  is not Ready yet, **or** (with CSI enabled) the Agent is Ready but a CSI
+  node-server pod exists on the node and is not Ready. Clock: latest
+  `pod.Status.StartTime` among **Agent** pods in the first case, and among **CSI
+  node-server** pods only in the second (the Agent’s age does not shorten the
+  wait for CSI). Pod recreation restarts the window; container restarts inside the
+  same pod do not.
+- **Scheduling timeout** — no Agent pod is on the node, **or** (with CSI
+  enabled) the Agent is Ready but **no** CSI node-server pod is on the node
+  yet. Clock: `node.metadata.creationTimestamp`. Covers DaemonSets that never
+  schedule onto the node (taint not tolerated, missing labels, CSI still pulling,
+  etc.).
 
 A pod-recreation crash-loop faster than the readiness window can hold a node
 tainted indefinitely; run with `policy=keep` and alert on
@@ -49,12 +64,19 @@ args:
   - --untaintControllerEnabled=true
 ```
 
-When this flag is enabled, the operator also injects a toleration for
+| `--untaintControllerEnabled` | `--datadogCSIDriverEnabled` | Behavior |
+| ----------------------------- | --------------------------- | -------- |
+| `false` | any | Untaint controller off; no startup toleration injection for this feature on Agent or CSI. |
+| `true` | `false` | Agent-only readiness and Agent DaemonSet toleration (default historical behavior). |
+| `true` | `true` | Wait for Agent **and** CSI node-server Ready; widened Pod cache (agent + `DD_CSIDRIVER_WATCH_NAMESPACE` namespaces); toleration on Agent and CSI DaemonSets. |
+
+When this flag is enabled, the operator injects a toleration for
 `agent.datadoghq.com/not-ready=presence:NoSchedule` into the node Agent
 DaemonSet (or ExtendedDaemonSet) pod template, unless an equivalent toleration
-is already present. This avoids a deadlock where the node stays tainted because
-the Agent pod cannot schedule without the toleration, especially when admission
-webhook auto-injection is not in use.
+is already present. When **`--datadogCSIDriverEnabled`** is also true, the same
+toleration is injected into the **Datadog CSI node-server** DaemonSet pod
+template so the CSI workload can schedule on tainted nodes before the taint is
+removed.
 
 ## Configuration
 
@@ -81,6 +103,8 @@ Metrics, under the `untaint` Prometheus subsystem:
 
 Kubernetes Events (gated by `DD_UNTAINT_CONTROLLER_EVENTS_ENABLED=true`):
 
-- `TaintRemoved` (Normal) — taint removed because the Agent pod became Ready.
+- `TaintRemoved` (Normal) — taint removed after the Agent became Ready, or (when
+  the Datadog CSI driver controller is also enabled) after both the Agent and
+  CSI node-server pods became Ready.
 - `UntaintTimeout` — a timeout fired. Normal under `remove`, Warning under `keep`. Message carries the reason, elapsed time, and policy.
 

--- a/internal/controller/datadogcsidriver/const.go
+++ b/internal/controller/datadogcsidriver/const.go
@@ -6,8 +6,14 @@
 package datadogcsidriver
 
 const (
+	// AppLabelKey is the Kubernetes label key on CSI node-server pods.
+	AppLabelKey = "app"
+	// NodeServerDaemonSetAppValue is the label value identifying CSI node-server pods
+	// (and the default DaemonSet name).
+	NodeServerDaemonSetAppValue = "datadog-csi-driver-node-server"
+
 	// csiDsName is the default name of the CSI driver DaemonSet
-	csiDsName = "datadog-csi-driver-node-server"
+	csiDsName = NodeServerDaemonSetAppValue
 	// csiDriverName is the default name of the CSIDriver Kubernetes object
 	csiDriverName = "k8s.csi.datadoghq.com"
 	// defaultCSIDriverImageName is the default CSI driver container image name
@@ -51,7 +57,6 @@ const (
 	csiDriverPort = int32(5000)
 
 	// Pod labels
-	appLabelKey                     = "app"
 	admissionControllerEnabledLabel = "admission.datadoghq.com/enabled"
 
 	// finalizerName is the finalizer for CSIDriver object cleanup

--- a/internal/controller/datadogcsidriver/controller.go
+++ b/internal/controller/datadogcsidriver/controller.go
@@ -36,19 +36,19 @@ const (
 
 // Reconciler reconciles a DatadogCSIDriver object
 type Reconciler struct {
-	client                   client.Client
-	scheme                   *runtime.Scheme
-	recorder                 record.EventRecorder
-	untaintControllerEnabled bool
+	client                            client.Client
+	scheme                            *runtime.Scheme
+	recorder                          record.EventRecorder
+	untaintInjectCSIStartupToleration bool
 }
 
 // NewReconciler creates a new DatadogCSIDriver reconciler
-func NewReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, untaintControllerEnabled bool) *Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, untaintInjectCSIStartupToleration bool) *Reconciler {
 	return &Reconciler{
-		client:                   client,
-		scheme:                   scheme,
-		recorder:                 recorder,
-		untaintControllerEnabled: untaintControllerEnabled,
+		client:                            client,
+		scheme:                            scheme,
+		recorder:                          recorder,
+		untaintInjectCSIStartupToleration: untaintInjectCSIStartupToleration,
 	}
 }
 
@@ -203,7 +203,7 @@ func (r *Reconciler) reconcileCSIDriver(ctx context.Context, instance *v1alpha1.
 func (r *Reconciler) reconcileDaemonSet(ctx context.Context, instance *v1alpha1.DatadogCSIDriver) error {
 	logger := ctrl.LoggerFrom(ctx)
 	desired := buildDaemonSet(instance)
-	if r.untaintControllerEnabled {
+	if r.untaintInjectCSIStartupToleration {
 		componentagent.EnsureAgentNotReadyStartupToleration(logger, &desired.Spec.Template.Spec)
 	}
 

--- a/internal/controller/datadogcsidriver/controller.go
+++ b/internal/controller/datadogcsidriver/controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	componentagent "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 )
 
 const (
@@ -35,17 +36,19 @@ const (
 
 // Reconciler reconciles a DatadogCSIDriver object
 type Reconciler struct {
-	client   client.Client
-	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	client                   client.Client
+	scheme                   *runtime.Scheme
+	recorder                 record.EventRecorder
+	untaintControllerEnabled bool
 }
 
 // NewReconciler creates a new DatadogCSIDriver reconciler
-func NewReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) *Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, untaintControllerEnabled bool) *Reconciler {
 	return &Reconciler{
-		client:   client,
-		scheme:   scheme,
-		recorder: recorder,
+		client:                   client,
+		scheme:                   scheme,
+		recorder:                 recorder,
+		untaintControllerEnabled: untaintControllerEnabled,
 	}
 }
 
@@ -198,13 +201,16 @@ func (r *Reconciler) reconcileCSIDriver(ctx context.Context, instance *v1alpha1.
 }
 
 func (r *Reconciler) reconcileDaemonSet(ctx context.Context, instance *v1alpha1.DatadogCSIDriver) error {
+	logger := ctrl.LoggerFrom(ctx)
 	desired := buildDaemonSet(instance)
+	if r.untaintControllerEnabled {
+		componentagent.EnsureAgentNotReadyStartupToleration(logger, &desired.Spec.Template.Spec)
+	}
 
 	if err := controllerutil.SetControllerReference(instance, desired, r.scheme); err != nil {
 		return fmt.Errorf("setting owner reference: %w", err)
 	}
 
-	logger := ctrl.LoggerFrom(ctx)
 	nsName := types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}
 	current := &appsv1.DaemonSet{}
 	err := r.client.Get(ctx, nsName, current)

--- a/internal/controller/datadogcsidriver/controller_test.go
+++ b/internal/controller/datadogcsidriver/controller_test.go
@@ -37,7 +37,7 @@ const (
 	testName      = "datadog-csi"
 )
 
-func newTestReconciler(t *testing.T, untaintControllerEnabled bool, objects ...client.Object) (*Reconciler, client.Client) {
+func newTestReconciler(t *testing.T, injectCSIStartupToleration bool, objects ...client.Object) (*Reconciler, client.Client) {
 	t.Helper()
 	s := scheme.Scheme
 	s.AddKnownTypes(v1alpha1.GroupVersion,
@@ -54,7 +54,7 @@ func newTestReconciler(t *testing.T, untaintControllerEnabled bool, objects ...c
 	// Set the default controller-runtime logger so ctrl.LoggerFrom(ctx) works in tests
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	recorder := record.NewFakeRecorder(10)
-	r := NewReconciler(c, s, recorder, untaintControllerEnabled)
+	r := NewReconciler(c, s, recorder, injectCSIStartupToleration)
 
 	return r, c
 }
@@ -489,7 +489,7 @@ func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
 	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
 }
 
-func TestReconcile_DaemonSetIncludesStartupTolerationWhenUntaintEnabled(t *testing.T) {
+func TestReconcile_DaemonSetIncludesStartupTolerationWhenUntaintWaitForCSI(t *testing.T) {
 	instance := defaultCSIDriverCR()
 	r, c := newTestReconciler(t, true, instance)
 	ctx := context.Background()
@@ -508,7 +508,7 @@ func TestReconcile_DaemonSetIncludesStartupTolerationWhenUntaintEnabled(t *testi
 		"expected %+v in %+v", want, ds.Spec.Template.Spec.Tolerations)
 }
 
-func TestReconcile_DaemonSetOmitsStartupTolerationWhenUntaintDisabled(t *testing.T) {
+func TestReconcile_DaemonSetOmitsStartupTolerationWhenUntaintCoordinationOff(t *testing.T) {
 	instance := defaultCSIDriverCR()
 	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()

--- a/internal/controller/datadogcsidriver/controller_test.go
+++ b/internal/controller/datadogcsidriver/controller_test.go
@@ -8,6 +8,7 @@ package datadogcsidriver
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/DataDog/datadog-operator/pkg/untaint"
 )
 
 const (
@@ -35,7 +37,7 @@ const (
 	testName      = "datadog-csi"
 )
 
-func newTestReconciler(t *testing.T, objects ...client.Object) (*Reconciler, client.Client) {
+func newTestReconciler(t *testing.T, untaintControllerEnabled bool, objects ...client.Object) (*Reconciler, client.Client) {
 	t.Helper()
 	s := scheme.Scheme
 	s.AddKnownTypes(v1alpha1.GroupVersion,
@@ -52,7 +54,7 @@ func newTestReconciler(t *testing.T, objects ...client.Object) (*Reconciler, cli
 	// Set the default controller-runtime logger so ctrl.LoggerFrom(ctx) works in tests
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	recorder := record.NewFakeRecorder(10)
-	r := NewReconciler(c, s, recorder)
+	r := NewReconciler(c, s, recorder, untaintControllerEnabled)
 
 	return r, c
 }
@@ -73,7 +75,7 @@ func defaultCSIDriverCR() *v1alpha1.DatadogCSIDriver {
 
 func TestReconcile_CreatesResources(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// First reconcile: adds finalizer
@@ -150,7 +152,7 @@ func TestReconcile_CustomSocketPaths(t *testing.T) {
 	instance.Spec.APMSocketPath = &customAPM
 	instance.Spec.DSDSocketPath = &customDSD
 
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// Reconcile twice (finalizer + create)
@@ -181,7 +183,7 @@ func TestReconcile_CustomSocketPaths(t *testing.T) {
 
 func TestReconcile_Deletion(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// Reconcile to add finalizer + create resources
@@ -224,7 +226,7 @@ func TestReconcile_Deletion(t *testing.T) {
 
 func TestReconcile_UpdateDaemonSetOnSpecChange(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// Reconcile to create resources
@@ -266,7 +268,7 @@ func TestReconcile_UpdateDaemonSetOnSpecChange(t *testing.T) {
 
 func TestReconcile_IdempotentNoUpdate(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// Reconcile to create resources
@@ -316,7 +318,7 @@ func TestReconcile_CSIDriverLabelsAdoption(t *testing.T) {
 		},
 	}
 
-	r, c := newTestReconciler(t, instance, existingCSIDriver)
+	r, c := newTestReconciler(t, false, instance, existingCSIDriver)
 	ctx := context.Background()
 
 	// Reconcile: add finalizer
@@ -369,7 +371,7 @@ func TestReconcile_Overrides(t *testing.T) {
 		},
 	}
 
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// Reconcile twice (finalizer + create)
@@ -388,7 +390,7 @@ func TestReconcile_Overrides(t *testing.T) {
 	// Labels merged into pod template
 	assert.Equal(t, "containers", ds.Spec.Template.Labels["team"])
 	// Default labels still present
-	assert.Equal(t, csiDsName, ds.Spec.Template.Labels[appLabelKey])
+	assert.Equal(t, csiDsName, ds.Spec.Template.Labels[AppLabelKey])
 
 	// Tolerations applied
 	require.Len(t, ds.Spec.Template.Spec.Tolerations, 1)
@@ -423,7 +425,7 @@ func TestReconcile_StatusConditionOnCSIDriverError(t *testing.T) {
 	// Instead, we test that when the reconcile succeeds, the condition is Ready=True,
 	// and verify the status structure.
 	instance := defaultCSIDriverCR()
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// Reconcile to add finalizer
@@ -450,7 +452,7 @@ func TestReconcile_StatusConditionOnCSIDriverError(t *testing.T) {
 
 func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
 	instance := defaultCSIDriverCR()
-	r, c := newTestReconciler(t, instance)
+	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
 
 	// Reconcile to create resources.
@@ -485,6 +487,49 @@ func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
 	assert.True(t, *csiDriver.Spec.PodInfoOnMount)
 	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecyclePersistent)
 	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
+}
+
+func TestReconcile_DaemonSetIncludesStartupTolerationWhenUntaintEnabled(t *testing.T) {
+	instance := defaultCSIDriverCR()
+	r, c := newTestReconciler(t, true, instance)
+	ctx := context.Background()
+
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance))
+
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+
+	ds := &appsv1.DaemonSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds))
+	want := untaint.AgentNotReadyEqualToleration()
+	assert.True(t, tolerationListContains(ds.Spec.Template.Spec.Tolerations, want),
+		"expected %+v in %+v", want, ds.Spec.Template.Spec.Tolerations)
+}
+
+func TestReconcile_DaemonSetOmitsStartupTolerationWhenUntaintDisabled(t *testing.T) {
+	instance := defaultCSIDriverCR()
+	r, c := newTestReconciler(t, false, instance)
+	ctx := context.Background()
+	_, err := r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance))
+	_, err = r.Reconcile(ctx, instance)
+	require.NoError(t, err)
+	ds := &appsv1.DaemonSet{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: csiDsName, Namespace: testNamespace}, ds))
+	want := untaint.AgentNotReadyEqualToleration()
+	assert.False(t, tolerationListContains(ds.Spec.Template.Spec.Tolerations, want))
+}
+
+func tolerationListContains(tols []corev1.Toleration, want corev1.Toleration) bool {
+	for i := range tols {
+		if reflect.DeepEqual(tols[i], want) {
+			return true
+		}
+	}
+	return false
 }
 
 // findCondition returns the condition with the given type, or nil.

--- a/internal/controller/datadogcsidriver/daemonset.go
+++ b/internal/controller/datadogcsidriver/daemonset.go
@@ -29,10 +29,10 @@ func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.Daemon
 	dsdSocketDir := filepath.Dir(dsdSocketPath)
 
 	labels := map[string]string{
-		appLabelKey: csiDsName,
+		AppLabelKey: csiDsName,
 	}
 	podLabels := map[string]string{
-		appLabelKey:                     csiDsName,
+		AppLabelKey:                     csiDsName,
 		admissionControllerEnabledLabel: "false",
 	}
 
@@ -50,7 +50,7 @@ func buildDaemonSet(instance *datadoghqv1alpha1.DatadogCSIDriver) *appsv1.Daemon
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					appLabelKey: csiDsName,
+					AppLabelKey: csiDsName,
 				},
 			},
 			RevisionHistoryLimit: &revisionHistoryLimit,

--- a/internal/controller/datadogcsidriver_controller.go
+++ b/internal/controller/datadogcsidriver_controller.go
@@ -27,11 +27,11 @@ import (
 
 // DatadogCSIDriverReconciler reconciles a DatadogCSIDriver object.
 type DatadogCSIDriverReconciler struct {
-	Client                   client.Client
-	Scheme                   *runtime.Scheme
-	Recorder                 record.EventRecorder
-	UntaintControllerEnabled bool
-	internal                 *datadogcsidriver.Reconciler
+	Client                            client.Client
+	Scheme                            *runtime.Scheme
+	Recorder                          record.EventRecorder
+	UntaintInjectCSIStartupToleration bool
+	internal                          *datadogcsidriver.Reconciler
 }
 
 // RBACs for DatadogCSIDriver objects
@@ -61,7 +61,7 @@ func (r *DatadogCSIDriverReconciler) Reconcile(ctx context.Context, instance *da
 
 // SetupWithManager creates a new DatadogCSIDriver controller.
 func (r *DatadogCSIDriverReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.internal = datadogcsidriver.NewReconciler(r.Client, r.Scheme, r.Recorder, r.UntaintControllerEnabled)
+	r.internal = datadogcsidriver.NewReconciler(r.Client, r.Scheme, r.Recorder, r.UntaintInjectCSIStartupToleration)
 
 	or := reconcile.AsReconciler[*datadoghqv1alpha1.DatadogCSIDriver](r.Client, r)
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/datadogcsidriver_controller.go
+++ b/internal/controller/datadogcsidriver_controller.go
@@ -27,10 +27,11 @@ import (
 
 // DatadogCSIDriverReconciler reconciles a DatadogCSIDriver object.
 type DatadogCSIDriverReconciler struct {
-	Client   client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	internal *datadogcsidriver.Reconciler
+	Client                   client.Client
+	Scheme                   *runtime.Scheme
+	Recorder                 record.EventRecorder
+	UntaintControllerEnabled bool
+	internal                 *datadogcsidriver.Reconciler
 }
 
 // RBACs for DatadogCSIDriver objects
@@ -60,7 +61,7 @@ func (r *DatadogCSIDriverReconciler) Reconcile(ctx context.Context, instance *da
 
 // SetupWithManager creates a new DatadogCSIDriver controller.
 func (r *DatadogCSIDriverReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.internal = datadogcsidriver.NewReconciler(r.Client, r.Scheme, r.Recorder)
+	r.internal = datadogcsidriver.NewReconciler(r.Client, r.Scheme, r.Recorder, r.UntaintControllerEnabled)
 
 	or := reconcile.AsReconciler[*datadoghqv1alpha1.DatadogCSIDriver](r.Client, r)
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -34,22 +34,23 @@ const (
 
 // SetupOptions defines options for setting up controllers to ease testing
 type SetupOptions struct {
-	SupportExtendedDaemonset      ExtendedDaemonsetOptions
-	SupportCilium                 bool
-	CredsManager                  *config.CredentialManager
-	DatadogAgentEnabled           bool
-	DatadogMonitorEnabled         bool
-	DatadogSLOEnabled             bool
-	OperatorMetricsEnabled        bool
-	V2APIEnabled                  bool
-	IntrospectionEnabled          bool
-	DatadogAgentProfileEnabled    bool
-	OtelAgentEnabled              bool
-	DatadogDashboardEnabled       bool
-	DatadogGenericResourceEnabled bool
-	CreateControllerRevisions     bool
-	DatadogCSIDriverEnabled       bool
-	UntaintControllerEnabled      bool
+	SupportExtendedDaemonset          ExtendedDaemonsetOptions
+	SupportCilium                     bool
+	CredsManager                      *config.CredentialManager
+	DatadogAgentEnabled               bool
+	DatadogMonitorEnabled             bool
+	DatadogSLOEnabled                 bool
+	OperatorMetricsEnabled            bool
+	V2APIEnabled                      bool
+	IntrospectionEnabled              bool
+	DatadogAgentProfileEnabled        bool
+	OtelAgentEnabled                  bool
+	DatadogDashboardEnabled           bool
+	DatadogGenericResourceEnabled     bool
+	CreateControllerRevisions         bool
+	DatadogCSIDriverEnabled           bool
+	UntaintControllerEnabled          bool
+	UntaintControllerWaitForCSIDriver bool
 }
 
 // ExtendedDaemonsetOptions defines ExtendedDaemonset options
@@ -250,7 +251,7 @@ func startUntaint(logger logr.Logger, mgr manager.Manager, _ kubernetes.Platform
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(untaintControllerName),
 		mgr.GetEventRecorderFor(untaintControllerName),
-		options.DatadogCSIDriverEnabled,
+		options.UntaintControllerWaitForCSIDriver,
 	)
 	if err != nil {
 		return fmt.Errorf("untaint controller setup: %w", err)
@@ -279,9 +280,10 @@ func startDatadogCSIDriver(logger logr.Logger, mgr manager.Manager, pInfo kubern
 	}
 
 	return (&DatadogCSIDriverReconciler{
-		Client:                   mgr.GetClient(),
-		Scheme:                   mgr.GetScheme(),
-		Recorder:                 mgr.GetEventRecorderFor(csiDriverControllerName),
-		UntaintControllerEnabled: options.UntaintControllerEnabled,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor(csiDriverControllerName),
+		// Inject startup toleration on CSI node DaemonSet only when untaint coordinates with CSI.
+		UntaintInjectCSIStartupToleration: options.UntaintControllerEnabled && options.UntaintControllerWaitForCSIDriver,
 	}).SetupWithManager(mgr)
 }

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -250,6 +250,7 @@ func startUntaint(logger logr.Logger, mgr manager.Manager, _ kubernetes.Platform
 		mgr.GetClient(),
 		ctrl.Log.WithName("controllers").WithName(untaintControllerName),
 		mgr.GetEventRecorderFor(untaintControllerName),
+		options.DatadogCSIDriverEnabled,
 	)
 	if err != nil {
 		return fmt.Errorf("untaint controller setup: %w", err)
@@ -278,8 +279,9 @@ func startDatadogCSIDriver(logger logr.Logger, mgr manager.Manager, pInfo kubern
 	}
 
 	return (&DatadogCSIDriverReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(csiDriverControllerName),
+		Client:                   mgr.GetClient(),
+		Scheme:                   mgr.GetScheme(),
+		Recorder:                 mgr.GetEventRecorderFor(csiDriverControllerName),
+		UntaintControllerEnabled: options.UntaintControllerEnabled,
 	}).SetupWithManager(mgr)
 }

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -10,7 +10,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent"
@@ -273,17 +276,28 @@ func startDatadogAgentProfiles(logger logr.Logger, mgr manager.Manager, pInfo ku
 	}).SetupWithManager(mgr)
 }
 
+// csiDriverManagerDeps is the subset of manager.Manager required to construct DatadogCSIDriverReconciler.
+type csiDriverManagerDeps interface {
+	GetClient() client.Client
+	GetScheme() *runtime.Scheme
+	GetEventRecorderFor(name string) record.EventRecorder
+}
+
+func newDatadogCSIDriverReconciler(mgr csiDriverManagerDeps, options SetupOptions) *DatadogCSIDriverReconciler {
+	return &DatadogCSIDriverReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor(csiDriverControllerName),
+		// Inject startup toleration on CSI node DaemonSet only when untaint coordinates with CSI.
+		UntaintInjectCSIStartupToleration: options.UntaintControllerEnabled && options.UntaintControllerWaitForCSIDriver,
+	}
+}
+
 func startDatadogCSIDriver(logger logr.Logger, mgr manager.Manager, pInfo kubernetes.PlatformInfo, options SetupOptions, metricForwardersMgr datadog.MetricsForwardersManager) error {
 	if !options.DatadogCSIDriverEnabled {
 		logger.Info("Feature disabled, not starting the controller", "controller", csiDriverControllerName)
 		return nil
 	}
 
-	return (&DatadogCSIDriverReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor(csiDriverControllerName),
-		// Inject startup toleration on CSI node DaemonSet only when untaint coordinates with CSI.
-		UntaintInjectCSIStartupToleration: options.UntaintControllerEnabled && options.UntaintControllerWaitForCSIDriver,
-	}).SetupWithManager(mgr)
+	return newDatadogCSIDriverReconciler(mgr, options).SetupWithManager(mgr)
 }

--- a/internal/controller/setup_test.go
+++ b/internal/controller/setup_test.go
@@ -7,10 +7,19 @@ package controller
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -41,4 +50,58 @@ func TestSetupControllers_StarterErrorsAreBestEffort(t *testing.T) {
 		kubernetes.PlatformInfo{},
 		SetupOptions{UntaintControllerEnabled: true},
 	))
+}
+
+type csiMgrStub struct {
+	cli client.Client
+	sch *runtime.Scheme
+	rec record.EventRecorder
+}
+
+func (s *csiMgrStub) GetClient() client.Client { return s.cli }
+
+func (s *csiMgrStub) GetScheme() *runtime.Scheme { return s.sch }
+
+func (s *csiMgrStub) GetEventRecorderFor(string) record.EventRecorder { return s.rec }
+
+func TestNewDatadogCSIDriverReconciler_UntaintInjectCSIStartupToleration(t *testing.T) {
+	s := runtime.NewScheme()
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+	rec := record.NewFakeRecorder(1)
+	stub := &csiMgrStub{cli: cli, sch: s, rec: rec}
+
+	for _, tc := range []struct {
+		name    string
+		untaint bool
+		waitCSI bool
+		want    bool
+	}{
+		{"both true", true, true, true},
+		{"untaint off", false, true, false},
+		{"wait CSI off", true, false, false},
+		{"both off", false, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newDatadogCSIDriverReconciler(stub, SetupOptions{
+				UntaintControllerEnabled:          tc.untaint,
+				UntaintControllerWaitForCSIDriver: tc.waitCSI,
+			})
+			assert.Equal(t, tc.want, r.UntaintInjectCSIStartupToleration)
+		})
+	}
+}
+
+func TestStartUntaint_NewUntaintReconcilerErrorIsWrapped(t *testing.T) {
+	ctrl.SetLogger(logr.Discard())
+	t.Setenv(EnvTimeoutPolicy, "unknown")
+	t.Cleanup(func() { _ = os.Unsetenv(EnvTimeoutPolicy) })
+
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	mgr, err := ctrl.NewManager(&rest.Config{}, manager.Options{Scheme: s, LeaderElection: false})
+	require.NoError(t, err)
+
+	err = startUntaint(logr.Discard(), mgr, kubernetes.PlatformInfo{}, SetupOptions{UntaintControllerEnabled: true}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "untaint controller setup")
 }

--- a/internal/controller/untaint_controller.go
+++ b/internal/controller/untaint_controller.go
@@ -191,8 +191,10 @@ func durationFromEnv(envVar string, def time.Duration) (time.Duration, error) {
 //     apply the timeout policy
 //   - with --untaintControllerWaitForCSIDriver: readiness timeout uses the
 //     later of max(agent StartTime) and max(CSI StartTime) when both workloads
-//     have a pod on the node with Status.StartTime set; otherwise the
-//     scheduling timeout (node creation) applies until both have StartTimes
+//     have a pod on the node with Status.StartTime set; if either workload is
+//     missing on the node use the scheduling timeout (node creation); if both
+//     are on the node but either side still lacks StartTime, requeue with
+//     readinessTimeout (same coarse poll as agent-only) until StartTime appears
 //   - otherwise, requeue after the remaining timeout window so we re-evaluate.
 func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithValues("node", req.Name)
@@ -245,29 +247,14 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if agentReady && csiReady {
 			combined := append(append([]corev1.Pod{}, podList.Items...), csiPodList.Items...)
 			readyAt, _ := maxReadyTransitionTime(combined)
-			result, err := r.removeTaint(ctx, node)
-			if err != nil {
-				return result, err
-			}
-			if result.RequeueAfter > 0 {
-				return result, nil
-			}
-			log.Info(fmt.Sprintf("Removed agent-not-ready taint from node %s after node agent and CSI driver pods became ready", node.Name))
-			metrics.TaintRemovalsTotal.Inc()
-			if !readyAt.IsZero() {
-				metrics.TaintRemovalLatency.Observe(r.clock.Since(readyAt).Seconds())
-			}
-			if r.eventsEnabled {
-				r.recorder.Eventf(node, corev1.EventTypeNormal, "TaintRemoved",
-					"Removed taint %s from node %s after node agent and CSI node-server pods became ready", untaint.AgentNotReadyTaintKey, node.Name)
-			}
-			return ctrl.Result{}, nil
+			return r.completeUntaintFromReadiness(ctx, node, log, readyAt,
+				fmt.Sprintf("Removed agent-not-ready taint from node %s after node agent and CSI driver pods became ready", node.Name),
+				"Removed taint %s from node %s after node agent and CSI node-server pods became ready",
+			)
 		}
 		return r.reconcileTaintedNodeTimeouts(ctx, node, log, podList, csiPodList)
 	} else {
-		// No need to wait for CSI
-
-		// Happy path: any ready agent pod → untaint immediately and record latency.
+		// Agent-only mode: untaint when any node-agent pod is Ready; otherwise timeouts below.
 		var readyAt time.Time
 		var anyReady bool
 		for i := range podList.Items {
@@ -277,36 +264,47 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}
 		if anyReady {
-			result, err := r.removeTaint(ctx, node)
-			if err != nil {
-				return result, err
-			}
-			if result.RequeueAfter > 0 {
-				return result, nil
-			}
-			log.Info(fmt.Sprintf("Removed agent-not-ready taint from node %s", node.Name))
-			metrics.TaintRemovalsTotal.Inc()
-			if !readyAt.IsZero() {
-				metrics.TaintRemovalLatency.Observe(r.clock.Since(readyAt).Seconds())
-			}
-			if r.eventsEnabled {
-				r.recorder.Eventf(node, corev1.EventTypeNormal, "TaintRemoved",
-					"Removed taint %s from node %s after agent became ready", untaint.AgentNotReadyTaintKey, node.Name)
-			}
-			return ctrl.Result{}, nil
+			return r.completeUntaintFromReadiness(ctx, node, log, readyAt,
+				fmt.Sprintf("Removed agent-not-ready taint from node %s", node.Name),
+				"Removed taint %s from node %s after agent became ready",
+			)
 		}
 	}
 
 	return r.reconcileTaintedNodeTimeouts(ctx, node, log, podList, nil)
 }
 
+// completeUntaintFromReadiness runs removeTaint after readiness gates passed, then
+// records removal metrics, optional Node event, and latency from readyAt.
+func (r *UntaintReconciler) completeUntaintFromReadiness(ctx context.Context, node *corev1.Node, log logr.Logger, readyAt time.Time, infoLog, eventFmt string) (ctrl.Result, error) {
+	result, err := r.removeTaint(ctx, node)
+	if err != nil {
+		return result, err
+	}
+	if result.RequeueAfter > 0 {
+		return result, nil
+	}
+	log.Info(infoLog)
+	metrics.TaintRemovalsTotal.Inc()
+	if !readyAt.IsZero() {
+		metrics.TaintRemovalLatency.Observe(r.clock.Since(readyAt).Seconds())
+	}
+	if r.eventsEnabled {
+		r.recorder.Eventf(node, corev1.EventTypeNormal, "TaintRemoved", eventFmt, untaint.AgentNotReadyTaintKey, node.Name)
+	}
+	return ctrl.Result{}, nil
+}
+
 // reconcileTaintedNodeTimeouts evaluates scheduling vs readiness timeouts.
 // When waitForCSIDriver is false, only agent pods are considered (csiPods is ignored).
 // When waitForCSIDriver is true, both the node agent and CSI node-server must
 // have at least one pod on the node with Status.StartTime before the readiness
-// clock runs; the clock is the later of the two sides' max(StartTime). If any
-// required pod is missing on the node or any side lacks StartTime, the
-// scheduling timeout anchored on node creation applies.
+// clock runs; the clock is the later of the two sides' max(StartTime). If a
+// required workload is missing on the node (no agent pod or no CSI pod), the
+// scheduling timeout anchored on node creation applies. If both workloads have
+// pods on the node but either side still lacks StartTime, requeue after
+// readinessTimeout (same coarse behavior as agent-only when StartTime is not set
+// yet) so an old node CreationTimestamp does not instantly trip scheduling.
 func (r *UntaintReconciler) reconcileTaintedNodeTimeouts(ctx context.Context, node *corev1.Node, log logr.Logger, agentPods *corev1.PodList, csiPods *corev1.PodList) (ctrl.Result, error) {
 	now := r.clock.Now()
 	agents := agentPods.Items
@@ -332,7 +330,9 @@ func (r *UntaintReconciler) reconcileTaintedNodeTimeouts(ctx context.Context, no
 	agentLatest, agentOK := latestPodStartTime(agents)
 	csiLatest, csiOK := latestPodStartTime(csis)
 	if !agentOK || !csiOK {
-		return r.schedulingTimeoutResult(ctx, node, log, now)
+		// Match agent-only: pods exist but StartTime not populated yet — coarse
+		// requeue, not node-age scheduling (avoids instant timeout on old nodes).
+		return ctrl.Result{RequeueAfter: r.readinessTimeout}, nil
 	}
 	latestStart := agentLatest
 	if csiLatest.After(latestStart) {

--- a/internal/controller/untaint_controller.go
+++ b/internal/controller/untaint_controller.go
@@ -188,8 +188,11 @@ func durationFromEnv(envVar string, def time.Duration) (time.Duration, error) {
 //   - if pods exist but readiness criteria are not met and the readiness timeout
 //     has elapsed, apply the timeout policy (remove or keep)
 //   - if no agent pod is scheduled and the scheduling timeout has elapsed,
-//     apply the timeout policy; with CSI coordination, if the agent is Ready
-//     but no CSI pod is on the node yet, the scheduling timeout also applies
+//     apply the timeout policy
+//   - with --untaintControllerWaitForCSIDriver: readiness timeout uses the
+//     later of max(agent StartTime) and max(CSI StartTime) when both workloads
+//     have a pod on the node with Status.StartTime set; otherwise the
+//     scheduling timeout (node creation) applies until both have StartTimes
 //   - otherwise, requeue after the remaining timeout window so we re-evaluate.
 func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithValues("node", req.Name)
@@ -238,8 +241,7 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ok
 		})
 
-		// Both Ready → untaint. Otherwise keep the taint and evaluate timeouts
-		// (CSI-specific clocks apply only while the agent is already Ready but CSI is not).
+		// Both Ready → untaint. Otherwise keep the taint and evaluate timeouts.
 		if agentReady && csiReady {
 			combined := append(append([]corev1.Pod{}, podList.Items...), csiPodList.Items...)
 			readyAt, _ := maxReadyTransitionTime(combined)
@@ -261,11 +263,10 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			return ctrl.Result{}, nil
 		}
-		if agentReady && !csiReady {
-			return r.reconcileAgentReadyWaitForCSI(ctx, node, csiPodList)
-		}
-		return r.reconcileTaintedNodeAgentTimeouts(ctx, node, log, podList)
+		return r.reconcileTaintedNodeTimeouts(ctx, node, log, podList, csiPodList)
 	} else {
+		// No need to wait for CSI
+
 		// Happy path: any ready agent pod → untaint immediately and record latency.
 		var readyAt time.Time
 		var anyReady bool
@@ -296,74 +297,54 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	return r.reconcileTaintedNodeAgentTimeouts(ctx, node, log, podList)
+	return r.reconcileTaintedNodeTimeouts(ctx, node, log, podList, nil)
 }
 
-// reconcileAgentReadyWaitForCSI applies timeouts while the node agent is Ready
-// but the CSI node-server requirement is not met (no pod on node yet, or pod
-// not Ready). RequeueAfter matches reconcileTaintedNodeAgentTimeouts: full
-// remaining scheduling or readiness window (watch-driven reconciles still apply).
-func (r *UntaintReconciler) reconcileAgentReadyWaitForCSI(ctx context.Context, node *corev1.Node, csiPodList *corev1.PodList) (ctrl.Result, error) {
+// reconcileTaintedNodeTimeouts evaluates scheduling vs readiness timeouts.
+// When waitForCSIDriver is false, only agent pods are considered (csiPods is ignored).
+// When waitForCSIDriver is true, both the node agent and CSI node-server must
+// have at least one pod on the node with Status.StartTime before the readiness
+// clock runs; the clock is the later of the two sides' max(StartTime). If any
+// required pod is missing on the node or any side lacks StartTime, the
+// scheduling timeout anchored on node creation applies.
+func (r *UntaintReconciler) reconcileTaintedNodeTimeouts(ctx context.Context, node *corev1.Node, log logr.Logger, agentPods *corev1.PodList, csiPods *corev1.PodList) (ctrl.Result, error) {
 	now := r.clock.Now()
-	if len(csiPodList.Items) == 0 {
-		// Agent is Ready but CSI has not landed on the node yet. Do not use
-		// the agent pod's StartTime for readiness timeout (it can be much
-		// older than the wait-for-CSI phase). Use scheduling timeout from
-		// node creation until a CSI pod appears or the window elapses.
-		created := node.CreationTimestamp.Time
-		if created.IsZero() {
-			r.log.V(1).Info("Node has no CreationTimestamp; requeueing", "node", node.Name)
-			return ctrl.Result{RequeueAfter: r.schedulingTimeout}, nil
-		}
-		elapsed := now.Sub(created)
-		if elapsed >= r.schedulingTimeout {
-			return r.applyTimeoutPolicy(ctx, node, metrics.UntaintTimeoutReasonScheduling, elapsed)
-		}
-		return ctrl.Result{RequeueAfter: r.schedulingTimeout - elapsed}, nil
-	}
-	// CSI pod(s) on the node but not Ready: readiness clock from CSI pods only.
-	latestStart, ok := latestPodStartTime(csiPodList.Items)
-	if !ok {
-		return ctrl.Result{RequeueAfter: r.readinessTimeout}, nil
-	}
-	elapsed := now.Sub(latestStart)
-	if elapsed >= r.readinessTimeout {
-		return r.applyTimeoutPolicy(ctx, node, metrics.UntaintTimeoutReasonReadiness, elapsed)
-	}
-	return ctrl.Result{RequeueAfter: r.readinessTimeout - elapsed}, nil
-}
+	agents := agentPods.Items
 
-// reconcileTaintedNodeAgentTimeouts is the readiness vs scheduling timeout path
-// driven by agent pods on the node (agent-only mode, or CSI mode while the
-// agent is not Ready yet).
-func (r *UntaintReconciler) reconcileTaintedNodeAgentTimeouts(ctx context.Context, node *corev1.Node, log logr.Logger, podList *corev1.PodList) (ctrl.Result, error) {
-	// Timeout-evaluation path.
-	//   1. Agent pod present - readiness timeout. Clock: max(pod.Status.StartTime),
-	//      so a fresh restart resets the window. If StartTime is unset (very
-	//      early lifecycle), requeue without falling through to scheduling timeout check
-	//      since pod is scheduled.
-	//   2. Agent pod not present - scheduling timeout. Clock: node.CreationTimestamp.
-	now := r.clock.Now()
-
-	if len(podList.Items) > 0 {
-		latestStart, ok := latestPodStartTime(podList.Items)
+	if !r.waitForCSIDriver {
+		if len(agents) == 0 {
+			return r.schedulingTimeoutResult(ctx, node, log, now)
+		}
+		latestStart, ok := latestPodStartTime(agents)
 		if !ok {
-			// Pods scheduled but no StartTime yet. Re-check shortly.
 			return ctrl.Result{RequeueAfter: r.readinessTimeout}, nil
 		}
-		elapsed := now.Sub(latestStart)
-		if elapsed >= r.readinessTimeout {
-			return r.applyTimeoutPolicy(ctx, node, metrics.UntaintTimeoutReasonReadiness, elapsed)
-		}
-		return ctrl.Result{RequeueAfter: r.readinessTimeout - elapsed}, nil
+		return r.readinessTimeoutResult(ctx, node, now, latestStart)
 	}
 
+	csis := []corev1.Pod(nil)
+	if csiPods != nil {
+		csis = csiPods.Items
+	}
+	if len(agents) == 0 || len(csis) == 0 {
+		return r.schedulingTimeoutResult(ctx, node, log, now)
+	}
+	agentLatest, agentOK := latestPodStartTime(agents)
+	csiLatest, csiOK := latestPodStartTime(csis)
+	if !agentOK || !csiOK {
+		return r.schedulingTimeoutResult(ctx, node, log, now)
+	}
+	latestStart := agentLatest
+	if csiLatest.After(latestStart) {
+		latestStart = csiLatest
+	}
+	return r.readinessTimeoutResult(ctx, node, now, latestStart)
+}
+
+func (r *UntaintReconciler) schedulingTimeoutResult(ctx context.Context, node *corev1.Node, log logr.Logger, now time.Time) (ctrl.Result, error) {
 	created := node.CreationTimestamp.Time
 	if created.IsZero() {
-		// Defensive: without a CreationTimestamp we cannot compute scheduling
-		// elapsed. Requeue after the scheduling timeout so we re-evaluate once
-		// the cache catches up.
-		log.V(1).Info("Node has no CreationTimestamp; requeueing")
+		log.V(1).Info("Node has no CreationTimestamp; requeueing", "node", node.Name)
 		return ctrl.Result{RequeueAfter: r.schedulingTimeout}, nil
 	}
 	elapsed := now.Sub(created)
@@ -371,6 +352,14 @@ func (r *UntaintReconciler) reconcileTaintedNodeAgentTimeouts(ctx context.Contex
 		return r.applyTimeoutPolicy(ctx, node, metrics.UntaintTimeoutReasonScheduling, elapsed)
 	}
 	return ctrl.Result{RequeueAfter: r.schedulingTimeout - elapsed}, nil
+}
+
+func (r *UntaintReconciler) readinessTimeoutResult(ctx context.Context, node *corev1.Node, now, latestStart time.Time) (ctrl.Result, error) {
+	elapsed := now.Sub(latestStart)
+	if elapsed >= r.readinessTimeout {
+		return r.applyTimeoutPolicy(ctx, node, metrics.UntaintTimeoutReasonReadiness, elapsed)
+	}
+	return ctrl.Result{RequeueAfter: r.readinessTimeout - elapsed}, nil
 }
 
 // applyTimeoutPolicy is invoked when a readiness or scheduling timeout has
@@ -570,9 +559,9 @@ func nodeToRequest(_ context.Context, obj client.Object) []reconcile.Request {
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: node.Name}}}
 }
 
-// agentPodPredicate enqueues an agent pod's node for any Create/Update/Delete
-// event on an agent pod. We deliberately do NOT filter to "ready transition"
-// here because:
+// podWatchPredicate enqueues a node's reconcile for pod Create/Update/Delete
+// events on agent pods, and on CSI node-server pods when waitForCSIDriver is set.
+// We deliberately do NOT filter to "ready transition" here because:
 //   - a NotReady pod creation starts the readiness clock for that node, so the
 //     reconciler needs to schedule a RequeueAfter against pod.Status.StartTime
 //     (filtering out Create-as-NotReady would silently miss this clock until
@@ -582,29 +571,10 @@ func nodeToRequest(_ context.Context, obj client.Object) []reconcile.Request {
 //   - Reconcile itself is idempotent and quick (cache list + early-return on
 //     !hasTaint), and bounds re-evaluation via RequeueAfter, so the extra
 //     reconciles are cheap.
-func agentPodPredicate() predicate.Predicate {
-	isAgentPodEvent := func(o client.Object) bool {
-		p, ok := o.(*corev1.Pod)
-		return ok && isAgentPod(p)
-	}
-	return predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return isAgentPodEvent(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return isAgentPodEvent(e.ObjectNew) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return isAgentPodEvent(e.Object) },
-		GenericFunc: func(event.GenericEvent) bool { return false },
-	}
-}
-
-// podWatchPredicate selects pod events that should enqueue a node reconcile.
-// When waitForCSIDriver is set, CSI node-server pods are included in addition
-// to agent pods.
 func (r *UntaintReconciler) podWatchPredicate() predicate.Predicate {
-	if !r.waitForCSIDriver {
-		return agentPodPredicate()
-	}
 	isRelevant := func(o client.Object) bool {
 		p, ok := o.(*corev1.Pod)
-		return ok && (isAgentPod(p) || isCSINodeServerPod(p))
+		return ok && (isAgentPod(p) || (r.waitForCSIDriver && isCSINodeServerPod(p)))
 	}
 	return predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return isRelevant(e.Object) },

--- a/internal/controller/untaint_controller.go
+++ b/internal/controller/untaint_controller.go
@@ -94,20 +94,19 @@ func ParseTimeoutPolicy(s string) (TimeoutPolicy, error) {
 // UntaintReconciler watches agent pods and nodes and removes the taint
 // agent.datadoghq.com/not-ready=presence:NoSchedule once readiness criteria
 // are met, or after a configurable timeout depending on the policy.
-// When datadogCSIDriverEnabled is true (same meaning as the manager's
-// --datadogCSIDriverEnabled), the node agent and CSI node-server pods must both
-// be Ready before untainting.
+// When waitForCSIDriver is true (--untaintControllerWaitForCSIDriver), the node
+// agent and CSI node-server pods must both be Ready before untainting.
 type UntaintReconciler struct {
 	client   client.Client
 	log      logr.Logger
 	recorder record.EventRecorder
 	clock    clock.PassiveClock
 
-	datadogCSIDriverEnabled bool
-	eventsEnabled           bool
-	readinessTimeout        time.Duration
-	schedulingTimeout       time.Duration
-	timeoutPolicy           TimeoutPolicy
+	waitForCSIDriver  bool
+	eventsEnabled     bool
+	readinessTimeout  time.Duration
+	schedulingTimeout time.Duration
+	timeoutPolicy     TimeoutPolicy
 }
 
 // NewUntaintReconciler builds an UntaintReconciler. All tuning knobs are
@@ -121,9 +120,9 @@ type UntaintReconciler struct {
 // The effective configuration is logged once at INFO so the operator can
 // confirm what was actually applied.
 //
-// datadogCSIDriverEnabled should match SetupOptions.DatadogCSIDriverEnabled.
+// waitForCSIDriver should match SetupOptions.UntaintControllerWaitForCSIDriver.
 // It is only consulted when the untaint controller is running (--untaintControllerEnabled).
-func NewUntaintReconciler(c client.Client, log logr.Logger, rec record.EventRecorder, datadogCSIDriverEnabled bool) (*UntaintReconciler, error) {
+func NewUntaintReconciler(c client.Client, log logr.Logger, rec record.EventRecorder, waitForCSIDriver bool) (*UntaintReconciler, error) {
 	policy, err := ParseTimeoutPolicy(os.Getenv(EnvTimeoutPolicy))
 	if err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", EnvTimeoutPolicy, err)
@@ -138,19 +137,19 @@ func NewUntaintReconciler(c client.Client, log logr.Logger, rec record.EventReco
 	}
 
 	r := &UntaintReconciler{
-		client:                  c,
-		log:                     log,
-		recorder:                rec,
-		clock:                   clock.RealClock{},
-		datadogCSIDriverEnabled: datadogCSIDriverEnabled,
-		eventsEnabled:           os.Getenv(EnvEventsEnabled) == "true",
-		readinessTimeout:        readiness,
-		schedulingTimeout:       scheduling,
-		timeoutPolicy:           policy,
+		client:            c,
+		log:               log,
+		recorder:          rec,
+		clock:             clock.RealClock{},
+		waitForCSIDriver:  waitForCSIDriver,
+		eventsEnabled:     os.Getenv(EnvEventsEnabled) == "true",
+		readinessTimeout:  readiness,
+		schedulingTimeout: scheduling,
+		timeoutPolicy:     policy,
 	}
 
 	log.Info("untaint controller configured",
-		"datadogCSIDriverEnabled", r.datadogCSIDriverEnabled,
+		"waitForCSIDriver", r.waitForCSIDriver,
 		"eventsEnabled", r.eventsEnabled,
 		"readinessTimeout", r.readinessTimeout,
 		"schedulingTimeout", r.schedulingTimeout,
@@ -184,7 +183,7 @@ func durationFromEnv(envVar string, def time.Duration) (time.Duration, error) {
 
 // Reconcile decides what to do with a tainted node:
 //   - by default: if any agent pod on the node is Ready, untaint
-//   - with CSI driver controller also enabled: agent and CSI node-server pods
+//   - with --untaintControllerWaitForCSIDriver: agent and CSI node-server pods
 //     must both be Ready before untaint
 //   - if pods exist but readiness criteria are not met and the readiness timeout
 //     has elapsed, apply the timeout policy (remove or keep)
@@ -218,7 +217,7 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("failed to list pods on node %s: %w", req.Name, err)
 	}
 
-	if r.datadogCSIDriverEnabled {
+	if r.waitForCSIDriver {
 		csiPodList := &corev1.PodList{}
 		csiLabel := labels.SelectorFromSet(map[string]string{
 			datadogcsidriver.AppLabelKey: datadogcsidriver.NodeServerDaemonSetAppValue,
@@ -597,10 +596,10 @@ func agentPodPredicate() predicate.Predicate {
 }
 
 // podWatchPredicate selects pod events that should enqueue a node reconcile.
-// When datadogCSIDriverEnabled is set, CSI node-server pods are included in addition
+// When waitForCSIDriver is set, CSI node-server pods are included in addition
 // to agent pods.
 func (r *UntaintReconciler) podWatchPredicate() predicate.Predicate {
-	if !r.datadogCSIDriverEnabled {
+	if !r.waitForCSIDriver {
 		return agentPodPredicate()
 	}
 	isRelevant := func(o client.Object) bool {

--- a/internal/controller/untaint_controller.go
+++ b/internal/controller/untaint_controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogcsidriver"
 	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/untaint"
@@ -91,18 +92,22 @@ func ParseTimeoutPolicy(s string) (TimeoutPolicy, error) {
 }
 
 // UntaintReconciler watches agent pods and nodes and removes the taint
-// agent.datadoghq.com/not-ready=presence:NoSchedule once the agent pod is
-// Ready, or after a configurable timeout depending on the policy.
+// agent.datadoghq.com/not-ready=presence:NoSchedule once readiness criteria
+// are met, or after a configurable timeout depending on the policy.
+// When datadogCSIDriverEnabled is true (same meaning as the manager's
+// --datadogCSIDriverEnabled), the node agent and CSI node-server pods must both
+// be Ready before untainting.
 type UntaintReconciler struct {
 	client   client.Client
 	log      logr.Logger
 	recorder record.EventRecorder
 	clock    clock.PassiveClock
 
-	eventsEnabled     bool
-	readinessTimeout  time.Duration
-	schedulingTimeout time.Duration
-	timeoutPolicy     TimeoutPolicy
+	datadogCSIDriverEnabled bool
+	eventsEnabled           bool
+	readinessTimeout        time.Duration
+	schedulingTimeout       time.Duration
+	timeoutPolicy           TimeoutPolicy
 }
 
 // NewUntaintReconciler builds an UntaintReconciler. All tuning knobs are
@@ -115,7 +120,10 @@ type UntaintReconciler struct {
 //
 // The effective configuration is logged once at INFO so the operator can
 // confirm what was actually applied.
-func NewUntaintReconciler(c client.Client, log logr.Logger, rec record.EventRecorder) (*UntaintReconciler, error) {
+//
+// datadogCSIDriverEnabled should match SetupOptions.DatadogCSIDriverEnabled.
+// It is only consulted when the untaint controller is running (--untaintControllerEnabled).
+func NewUntaintReconciler(c client.Client, log logr.Logger, rec record.EventRecorder, datadogCSIDriverEnabled bool) (*UntaintReconciler, error) {
 	policy, err := ParseTimeoutPolicy(os.Getenv(EnvTimeoutPolicy))
 	if err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", EnvTimeoutPolicy, err)
@@ -130,17 +138,19 @@ func NewUntaintReconciler(c client.Client, log logr.Logger, rec record.EventReco
 	}
 
 	r := &UntaintReconciler{
-		client:            c,
-		log:               log,
-		recorder:          rec,
-		clock:             clock.RealClock{},
-		eventsEnabled:     os.Getenv(EnvEventsEnabled) == "true",
-		readinessTimeout:  readiness,
-		schedulingTimeout: scheduling,
-		timeoutPolicy:     policy,
+		client:                  c,
+		log:                     log,
+		recorder:                rec,
+		clock:                   clock.RealClock{},
+		datadogCSIDriverEnabled: datadogCSIDriverEnabled,
+		eventsEnabled:           os.Getenv(EnvEventsEnabled) == "true",
+		readinessTimeout:        readiness,
+		schedulingTimeout:       scheduling,
+		timeoutPolicy:           policy,
 	}
 
 	log.Info("untaint controller configured",
+		"datadogCSIDriverEnabled", r.datadogCSIDriverEnabled,
 		"eventsEnabled", r.eventsEnabled,
 		"readinessTimeout", r.readinessTimeout,
 		"schedulingTimeout", r.schedulingTimeout,
@@ -173,11 +183,14 @@ func durationFromEnv(envVar string, def time.Duration) (time.Duration, error) {
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile decides what to do with a tainted node:
-//   - if any agent pod on the node is Ready, untaint
-//   - if an agent pod exists but is not Ready and the readiness timeout has
-//     elapsed, apply the timeout policy (remove or keep)
+//   - by default: if any agent pod on the node is Ready, untaint
+//   - with CSI driver controller also enabled: agent and CSI node-server pods
+//     must both be Ready before untaint
+//   - if pods exist but readiness criteria are not met and the readiness timeout
+//     has elapsed, apply the timeout policy (remove or keep)
 //   - if no agent pod is scheduled and the scheduling timeout has elapsed,
-//     apply the timeout policy
+//     apply the timeout policy; with CSI coordination, if the agent is Ready
+//     but no CSI pod is on the node yet, the scheduling timeout also applies
 //   - otherwise, requeue after the remaining timeout window so we re-evaluate.
 func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.log.WithValues("node", req.Name)
@@ -205,35 +218,126 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("failed to list pods on node %s: %w", req.Name, err)
 	}
 
-	// Happy path: any ready agent pod → untaint immediately and record latency.
-	var readyAt time.Time
-	var anyReady bool
-	for i := range podList.Items {
-		if ts, ok := podReadyTransition(&podList.Items[i]); ok {
-			readyAt, anyReady = ts, true
-			break
+	if r.datadogCSIDriverEnabled {
+		csiPodList := &corev1.PodList{}
+		csiLabel := labels.SelectorFromSet(map[string]string{
+			datadogcsidriver.AppLabelKey: datadogcsidriver.NodeServerDaemonSetAppValue,
+		})
+		if err := r.client.List(ctx, csiPodList,
+			client.MatchingLabelsSelector{Selector: csiLabel},
+			client.MatchingFields{untaintPodNodeIndex: req.Name},
+		); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to list CSI driver pods on node %s: %w", req.Name, err)
 		}
-	}
-	if anyReady {
-		result, err := r.removeTaint(ctx, node)
-		if err != nil {
-			return result, err
+
+		agentReady := slices.ContainsFunc(podList.Items, func(p corev1.Pod) bool {
+			_, ok := podReadyTransition(&p)
+			return ok
+		})
+		csiReady := len(csiPodList.Items) > 0 && slices.ContainsFunc(csiPodList.Items, func(p corev1.Pod) bool {
+			_, ok := podReadyTransition(&p)
+			return ok
+		})
+
+		// Both Ready → untaint. Otherwise keep the taint and evaluate timeouts
+		// (CSI-specific clocks apply only while the agent is already Ready but CSI is not).
+		if agentReady && csiReady {
+			combined := append(append([]corev1.Pod{}, podList.Items...), csiPodList.Items...)
+			readyAt, _ := maxReadyTransitionTime(combined)
+			result, err := r.removeTaint(ctx, node)
+			if err != nil {
+				return result, err
+			}
+			if result.RequeueAfter > 0 {
+				return result, nil
+			}
+			log.Info(fmt.Sprintf("Removed agent-not-ready taint from node %s after node agent and CSI driver pods became ready", node.Name))
+			metrics.TaintRemovalsTotal.Inc()
+			if !readyAt.IsZero() {
+				metrics.TaintRemovalLatency.Observe(r.clock.Since(readyAt).Seconds())
+			}
+			if r.eventsEnabled {
+				r.recorder.Eventf(node, corev1.EventTypeNormal, "TaintRemoved",
+					"Removed taint %s from node %s after node agent and CSI node-server pods became ready", untaint.AgentNotReadyTaintKey, node.Name)
+			}
+			return ctrl.Result{}, nil
 		}
-		if result.RequeueAfter > 0 {
-			return result, nil
+		if agentReady && !csiReady {
+			return r.reconcileAgentReadyWaitForCSI(ctx, node, csiPodList)
 		}
-		log.Info(fmt.Sprintf("Removed agent-not-ready taint from node %s", node.Name))
-		metrics.TaintRemovalsTotal.Inc()
-		if !readyAt.IsZero() {
-			metrics.TaintRemovalLatency.Observe(r.clock.Since(readyAt).Seconds())
+		return r.reconcileTaintedNodeAgentTimeouts(ctx, node, log, podList)
+	} else {
+		// Happy path: any ready agent pod → untaint immediately and record latency.
+		var readyAt time.Time
+		var anyReady bool
+		for i := range podList.Items {
+			if ts, ok := podReadyTransition(&podList.Items[i]); ok {
+				readyAt, anyReady = ts, true
+				break
+			}
 		}
-		if r.eventsEnabled {
-			r.recorder.Eventf(node, corev1.EventTypeNormal, "TaintRemoved",
-				"Removed taint %s from node %s after agent became ready", untaint.AgentNotReadyTaintKey, node.Name)
+		if anyReady {
+			result, err := r.removeTaint(ctx, node)
+			if err != nil {
+				return result, err
+			}
+			if result.RequeueAfter > 0 {
+				return result, nil
+			}
+			log.Info(fmt.Sprintf("Removed agent-not-ready taint from node %s", node.Name))
+			metrics.TaintRemovalsTotal.Inc()
+			if !readyAt.IsZero() {
+				metrics.TaintRemovalLatency.Observe(r.clock.Since(readyAt).Seconds())
+			}
+			if r.eventsEnabled {
+				r.recorder.Eventf(node, corev1.EventTypeNormal, "TaintRemoved",
+					"Removed taint %s from node %s after agent became ready", untaint.AgentNotReadyTaintKey, node.Name)
+			}
+			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, nil
 	}
 
+	return r.reconcileTaintedNodeAgentTimeouts(ctx, node, log, podList)
+}
+
+// reconcileAgentReadyWaitForCSI applies timeouts while the node agent is Ready
+// but the CSI node-server requirement is not met (no pod on node yet, or pod
+// not Ready). RequeueAfter matches reconcileTaintedNodeAgentTimeouts: full
+// remaining scheduling or readiness window (watch-driven reconciles still apply).
+func (r *UntaintReconciler) reconcileAgentReadyWaitForCSI(ctx context.Context, node *corev1.Node, csiPodList *corev1.PodList) (ctrl.Result, error) {
+	now := r.clock.Now()
+	if len(csiPodList.Items) == 0 {
+		// Agent is Ready but CSI has not landed on the node yet. Do not use
+		// the agent pod's StartTime for readiness timeout (it can be much
+		// older than the wait-for-CSI phase). Use scheduling timeout from
+		// node creation until a CSI pod appears or the window elapses.
+		created := node.CreationTimestamp.Time
+		if created.IsZero() {
+			r.log.V(1).Info("Node has no CreationTimestamp; requeueing", "node", node.Name)
+			return ctrl.Result{RequeueAfter: r.schedulingTimeout}, nil
+		}
+		elapsed := now.Sub(created)
+		if elapsed >= r.schedulingTimeout {
+			return r.applyTimeoutPolicy(ctx, node, metrics.UntaintTimeoutReasonScheduling, elapsed)
+		}
+		return ctrl.Result{RequeueAfter: r.schedulingTimeout - elapsed}, nil
+	}
+	// CSI pod(s) on the node but not Ready: readiness clock from CSI pods only.
+	latestStart, ok := latestPodStartTime(csiPodList.Items)
+	if !ok {
+		return ctrl.Result{RequeueAfter: r.readinessTimeout}, nil
+	}
+	elapsed := now.Sub(latestStart)
+	if elapsed >= r.readinessTimeout {
+		return r.applyTimeoutPolicy(ctx, node, metrics.UntaintTimeoutReasonReadiness, elapsed)
+	}
+	return ctrl.Result{RequeueAfter: r.readinessTimeout - elapsed}, nil
+}
+
+// reconcileTaintedNodeAgentTimeouts is the readiness vs scheduling timeout path
+// driven by agent pods on the node (agent-only mode, or CSI mode while the
+// agent is not Ready yet).
+func (r *UntaintReconciler) reconcileTaintedNodeAgentTimeouts(ctx context.Context, node *corev1.Node, log logr.Logger, podList *corev1.PodList) (ctrl.Result, error) {
 	// Timeout-evaluation path.
 	//   1. Agent pod present - readiness timeout. Clock: max(pod.Status.StartTime),
 	//      so a fresh restart resets the window. If StartTime is unset (very
@@ -325,6 +429,22 @@ func podReadyTransition(pod *corev1.Pod) (time.Time, bool) {
 		}
 	}
 	return time.Time{}, false
+}
+
+// maxReadyTransitionTime returns the latest PodReady LastTransitionTime among
+// pods that are currently Ready (used for removal latency when multiple pods
+// must be ready).
+func maxReadyTransitionTime(pods []corev1.Pod) (time.Time, bool) {
+	var latest time.Time
+	found := false
+	for i := range pods {
+		if ts, ok := podReadyTransition(&pods[i]); ok {
+			if !found || ts.After(latest) {
+				latest, found = ts, true
+			}
+		}
+	}
+	return latest, found
 }
 
 // latestPodStartTime returns the most recent non-nil Status.StartTime across
@@ -423,7 +543,7 @@ func (r *UntaintReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.podToNodeRequest),
-			builder.WithPredicates(agentPodPredicate()),
+			builder.WithPredicates(r.podWatchPredicate()),
 		).
 		Watches(
 			&corev1.Node{},
@@ -474,6 +594,30 @@ func agentPodPredicate() predicate.Predicate {
 		DeleteFunc:  func(e event.DeleteEvent) bool { return isAgentPodEvent(e.Object) },
 		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
+}
+
+// podWatchPredicate selects pod events that should enqueue a node reconcile.
+// When datadogCSIDriverEnabled is set, CSI node-server pods are included in addition
+// to agent pods.
+func (r *UntaintReconciler) podWatchPredicate() predicate.Predicate {
+	if !r.datadogCSIDriverEnabled {
+		return agentPodPredicate()
+	}
+	isRelevant := func(o client.Object) bool {
+		p, ok := o.(*corev1.Pod)
+		return ok && (isAgentPod(p) || isCSINodeServerPod(p))
+	}
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isRelevant(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return isRelevant(e.ObjectNew) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isRelevant(e.Object) },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+// isCSINodeServerPod reports whether the pod is a Datadog CSI node-server workload.
+func isCSINodeServerPod(pod *corev1.Pod) bool {
+	return pod.Labels[datadogcsidriver.AppLabelKey] == datadogcsidriver.NodeServerDaemonSetAppValue
 }
 
 // taintedNodePredicate enqueues a node when it carries the target taint on

--- a/internal/controller/untaint_controller_test.go
+++ b/internal/controller/untaint_controller_test.go
@@ -145,19 +145,19 @@ func newFakeClient(t *testing.T, objs ...client.Object) client.WithWatch {
 		Build()
 }
 
-func newReconciler(t *testing.T, c client.Client, now time.Time, policy TimeoutPolicy, readiness, scheduling time.Duration, datadogCSIDriverEnabled bool) (*UntaintReconciler, *record.FakeRecorder) {
+func newReconciler(t *testing.T, c client.Client, now time.Time, policy TimeoutPolicy, readiness, scheduling time.Duration, waitForCSIDriver bool) (*UntaintReconciler, *record.FakeRecorder) {
 	t.Helper()
 	rec := record.NewFakeRecorder(16)
 	r := &UntaintReconciler{
-		client:                  c,
-		log:                     log.Log.WithName("test"),
-		recorder:                rec,
-		clock:                   clocktesting.NewFakePassiveClock(now),
-		datadogCSIDriverEnabled: datadogCSIDriverEnabled,
-		eventsEnabled:           true,
-		readinessTimeout:        readiness,
-		schedulingTimeout:       scheduling,
-		timeoutPolicy:           policy,
+		client:            c,
+		log:               log.Log.WithName("test"),
+		recorder:          rec,
+		clock:             clocktesting.NewFakePassiveClock(now),
+		waitForCSIDriver:  waitForCSIDriver,
+		eventsEnabled:     true,
+		readinessTimeout:  readiness,
+		schedulingTimeout: scheduling,
+		timeoutPolicy:     policy,
 	}
 	return r, rec
 }

--- a/internal/controller/untaint_controller_test.go
+++ b/internal/controller/untaint_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogcsidriver"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/untaint"
 )
@@ -94,6 +95,32 @@ func agentPod(name, ns, nodeName string, ready bool, startedAgo time.Duration, n
 	return pod
 }
 
+func csiNodeServerPod(name, ns, nodeName string, ready bool, startedAgo time.Duration, now time.Time) *corev1.Pod {
+	cond := corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionFalse}
+	if ready {
+		cond.Status = corev1.ConditionTrue
+		cond.LastTransitionTime = metav1.NewTime(now.Add(-time.Second))
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				datadogcsidriver.AppLabelKey: datadogcsidriver.NodeServerDaemonSetAppValue,
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{cond},
+		},
+	}
+	if startedAgo > 0 {
+		start := metav1.NewTime(now.Add(-startedAgo))
+		pod.Status.StartTime = &start
+	}
+	return pod
+}
+
 func nonAgentPod(name, ns, nodeName string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: map[string]string{"app": "other"}},
@@ -118,18 +145,19 @@ func newFakeClient(t *testing.T, objs ...client.Object) client.WithWatch {
 		Build()
 }
 
-func newReconciler(t *testing.T, c client.Client, now time.Time, policy TimeoutPolicy, readiness, scheduling time.Duration) (*UntaintReconciler, *record.FakeRecorder) {
+func newReconciler(t *testing.T, c client.Client, now time.Time, policy TimeoutPolicy, readiness, scheduling time.Duration, datadogCSIDriverEnabled bool) (*UntaintReconciler, *record.FakeRecorder) {
 	t.Helper()
 	rec := record.NewFakeRecorder(16)
 	r := &UntaintReconciler{
-		client:            c,
-		log:               log.Log.WithName("test"),
-		recorder:          rec,
-		clock:             clocktesting.NewFakePassiveClock(now),
-		eventsEnabled:     true,
-		readinessTimeout:  readiness,
-		schedulingTimeout: scheduling,
-		timeoutPolicy:     policy,
+		client:                  c,
+		log:                     log.Log.WithName("test"),
+		recorder:                rec,
+		clock:                   clocktesting.NewFakePassiveClock(now),
+		datadogCSIDriverEnabled: datadogCSIDriverEnabled,
+		eventsEnabled:           true,
+		readinessTimeout:        readiness,
+		schedulingTimeout:       scheduling,
+		timeoutPolicy:           policy,
 	}
 	return r, rec
 }
@@ -196,7 +224,7 @@ func TestNewUntaintReconciler_ConfigErrors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(tc.envKey, tc.envVal)
-			_, err := NewUntaintReconciler(newFakeClient(t), log.Log, record.NewFakeRecorder(1))
+			_, err := NewUntaintReconciler(newFakeClient(t), log.Log, record.NewFakeRecorder(1), false)
 			assert.Error(t, err, "expected NewUntaintReconciler to fail on %s=%q", tc.envKey, tc.envVal)
 		})
 	}
@@ -321,7 +349,7 @@ func TestRemoveTaint_PatchContents(t *testing.T) {
 		},
 	})
 
-	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 	result, err := r.removeTaint(context.Background(), node)
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
@@ -360,7 +388,7 @@ func TestRemoveTaint_NilTaintsDefensive(t *testing.T) {
 			return nil
 		},
 	})
-	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 	result, err := r.removeTaint(context.Background(), node)
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
@@ -386,7 +414,7 @@ func TestRemoveTaint_ConflictRequeues(t *testing.T) {
 					return tc.err
 				},
 			})
-			r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+			r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 			result, err := r.removeTaint(context.Background(), node.DeepCopy())
 			assert.NoError(t, err, "race must not surface as error")
 			assert.Equal(t, conflictRequeueDelay, result.RequeueAfter, "race should requeue with conflictRequeueDelay")
@@ -402,7 +430,7 @@ func TestRemoveTaint_OtherErrorPropagates(t *testing.T) {
 			return errors.New("boom")
 		},
 	})
-	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 	_, err := r.removeTaint(context.Background(), node.DeepCopy())
 	assert.Error(t, err)
 }
@@ -413,7 +441,7 @@ func TestRemoveTaint_OtherErrorPropagates(t *testing.T) {
 
 func TestReconcile_NodeNotFound(t *testing.T) {
 	now := testNow()
-	r, _ := newReconciler(t, newFakeClient(t), now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, newFakeClient(t), now, PolicyRemove, time.Minute, time.Minute, false)
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "missing"}})
 	assert.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
@@ -422,7 +450,7 @@ func TestReconcile_NodeNotFound(t *testing.T) {
 func TestReconcile_NoTaint(t *testing.T) {
 	now := testNow()
 	node := untaintedNode(testNodeName)
-	r, _ := newReconciler(t, newFakeClient(t, node), now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, newFakeClient(t, node), now, PolicyRemove, time.Minute, time.Minute, false)
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	assert.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, result)
@@ -434,7 +462,7 @@ func TestReconcile_PodReady_RemovesTaint(t *testing.T) {
 	pod := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
 
 	c := newFakeClient(t, node, pod)
-	r, rec := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+	r, rec := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	require.NoError(t, err)
@@ -461,7 +489,7 @@ func TestReconcile_TerminatingReadyPod_RemovesTaint(t *testing.T) {
 	pod.Finalizers = []string{"test/finalizer"}
 
 	c := newFakeClient(t, node, pod)
-	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	require.NoError(t, err)
@@ -510,7 +538,7 @@ func TestReconcile_ReadinessTimeout(t *testing.T) {
 			node := taintedNode(testNodeName, 30*time.Minute, now)
 			pod := agentPod(testPodName, testPodNS, testNodeName, false, tc.startedAgo, now)
 			c := newFakeClient(t, node, pod)
-			r, _ := newReconciler(t, c, now, tc.policy, readiness, scheduling)
+			r, _ := newReconciler(t, c, now, tc.policy, readiness, scheduling, false)
 
 			result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 			require.NoError(t, err)
@@ -565,7 +593,7 @@ func TestReconcile_SchedulingTimeout(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node := taintedNode(testNodeName, tc.nodeAge, now)
 			c := newFakeClient(t, node)
-			r, _ := newReconciler(t, c, now, tc.policy, readiness, scheduling)
+			r, _ := newReconciler(t, c, now, tc.policy, readiness, scheduling, false)
 
 			result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 			require.NoError(t, err)
@@ -595,7 +623,7 @@ func TestReconcile_PodExistsWithoutStartTime_DoesNotFireSchedulingTimeout(t *tes
 	node := taintedNode(testNodeName, 1*time.Hour, now)                  // node old enough to trip scheduling
 	pod := agentPod(testPodName, testPodNS, testNodeName, false, 0, now) // no StartTime
 	c := newFakeClient(t, node, pod)
-	r, _ := newReconciler(t, c, now, PolicyRemove, 10*time.Minute, 5*time.Minute)
+	r, _ := newReconciler(t, c, now, PolicyRemove, 10*time.Minute, 5*time.Minute, false)
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	require.NoError(t, err)
@@ -617,7 +645,7 @@ func TestReconcile_ConflictReturnsRequeue(t *testing.T) {
 			return apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, testNodeName, errors.New("race"))
 		},
 	})
-	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	assert.NoError(t, err, "conflict must not be returned as an error")
@@ -635,8 +663,72 @@ func TestReconcile_GenericPatchErrorBubbles(t *testing.T) {
 			return errors.New("boom")
 		},
 	})
-	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
 
 	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	assert.Error(t, err)
+}
+
+func TestReconcile_CSI_enforceBothReadyRemovesTaint(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, true, 1*time.Minute, now)
+	c := newFakeClient(t, node, agent, csi)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	assert.False(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_agentReadyCsiNotReadyKeepsTaint(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	// CSI readiness clock follows CSI StartTime only; keep it inside readinessTimeout
+	// so we requeue instead of immediately applying timeout policy.
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 30*time.Second, now)
+	c := newFakeClient(t, node, agent, csi)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Greater(t, result.RequeueAfter, time.Duration(0))
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	assert.True(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_agentReadyNoCsiPodKeepsTaint(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	c := newFakeClient(t, node, agent)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Greater(t, result.RequeueAfter, time.Duration(0))
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	assert.True(t, hasTaint(fresh))
+}
+
+func TestPodWatchPredicate_withCSI(t *testing.T) {
+	now := testNow()
+	r, _ := newReconciler(t, newFakeClient(t), now, PolicyRemove, time.Minute, time.Minute, true)
+	p := r.podWatchPredicate()
+	readyAgent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 1*time.Minute, now)
+	other := nonAgentPod("x", testPodNS, testNodeName)
+	assert.True(t, p.Create(event.CreateEvent{Object: csi}))
+	assert.True(t, p.Create(event.CreateEvent{Object: readyAgent}))
+	assert.False(t, p.Create(event.CreateEvent{Object: other}))
 }

--- a/internal/controller/untaint_controller_test.go
+++ b/internal/controller/untaint_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -719,6 +720,139 @@ func TestReconcile_CSI_agentReadyNoCsiPodKeepsTaint(t *testing.T) {
 	fresh := &corev1.Node{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
 	assert.True(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_agentReadyNoCsiPod_zeroCreationTimestampRequeuesSchedulingTimeout(t *testing.T) {
+	now := testNow()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testNodeName,
+			CreationTimestamp: metav1.Time{}, // zero — defensive branch in reconcileAgentReadyWaitForCSI
+		},
+		Spec: corev1.NodeSpec{Taints: []corev1.Taint{untaint.AgentNotReadyTaint()}},
+	}
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	c := newFakeClient(t, node, agent)
+	const scheduling = 7 * time.Minute
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, scheduling, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Equal(t, scheduling, result.RequeueAfter)
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	require.True(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_agentReadyNoCsiPod_schedulingTimeoutRemovesTaint(t *testing.T) {
+	now := testNow()
+	const scheduling = 5 * time.Minute
+	node := taintedNode(testNodeName, scheduling+time.Minute, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	c := newFakeClient(t, node, agent)
+	r, _ := newReconciler(t, c, now, PolicyRemove, 10*time.Minute, scheduling, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	assert.False(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_agentReadyCsiNotReady_noStartTimeRequeuesReadinessTimeout(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	// not Ready, startedAgo 0 → no Status.StartTime → latestPodStartTime !ok branch
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 0, now)
+	c := newFakeClient(t, node, agent, csi)
+	const readiness = 9 * time.Minute
+	r, _ := newReconciler(t, c, now, PolicyRemove, readiness, time.Minute, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Equal(t, readiness, result.RequeueAfter)
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	assert.True(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_agentReadyCsiNotReady_readinessTimeoutRemovesTaint(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	const readiness = time.Minute
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 2*readiness, now)
+	c := newFakeClient(t, node, agent, csi)
+	r, _ := newReconciler(t, c, now, PolicyRemove, readiness, 5*time.Minute, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	assert.False(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_listDriverPodsError(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	base := newFakeClient(t, node, agent)
+	var listCalls atomic.Int32
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if listCalls.Add(1) == 2 {
+				return errors.New("simulated CSI pod list failure")
+			}
+			return base.List(ctx, list, opts...)
+		},
+	})
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, true)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list CSI driver pods")
+}
+
+func TestReconcile_CSI_bothReadyConflictReturnsRequeue(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, true, 1*time.Minute, now)
+	base := newFakeClient(t, node, agent, csi)
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Patch: func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+			return apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, testNodeName, errors.New("race"))
+		},
+	})
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Equal(t, conflictRequeueDelay, result.RequeueAfter)
+}
+
+func TestReconcile_CSI_bothReadyPatchErrorBubbles(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, true, 1*time.Minute, now)
+	base := newFakeClient(t, node, agent, csi)
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Patch: func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+			return errors.New("boom")
+		},
+	})
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, true)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.Error(t, err)
 }
 
 func TestPodWatchPredicate_withCSI(t *testing.T) {

--- a/internal/controller/untaint_controller_test.go
+++ b/internal/controller/untaint_controller_test.go
@@ -783,12 +783,13 @@ func TestReconcile_CSI_agentReadyNoCsiPod_schedulingTimeoutRemovesTaint(t *testi
 	assert.False(t, hasTaint(fresh))
 }
 
-func TestReconcile_CSI_agentReadyCsiNotReady_noStartTimeUsesSchedulingRequeue(t *testing.T) {
+func TestReconcile_CSI_agentReadyCsiNotReady_noStartTimeCoarseReadinessRequeue(t *testing.T) {
 	now := testNow()
 	node := taintedNode(testNodeName, 0, now)
 	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
-	// CSI not Ready, startedAgo 0 → no Status.StartTime → wait-for-CSI path uses
-	// scheduling timeout (one side lacks StartTime) until kubelet sets StartTime.
+	// CSI not Ready, startedAgo 0 → no Status.StartTime: both workloads are on
+	// the node, so use the same coarse readiness requeue as agent-only (not
+	// node-age scheduling), avoiding instant timeout on an old node.
 	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 0, now)
 	c := newFakeClient(t, node, agent, csi)
 	const readiness = 9 * time.Minute
@@ -797,7 +798,7 @@ func TestReconcile_CSI_agentReadyCsiNotReady_noStartTimeUsesSchedulingRequeue(t 
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	require.NoError(t, err)
-	assert.Equal(t, scheduling, result.RequeueAfter)
+	assert.Equal(t, readiness, result.RequeueAfter)
 
 	fresh := &corev1.Node{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))

--- a/internal/controller/untaint_controller_test.go
+++ b/internal/controller/untaint_controller_test.go
@@ -273,7 +273,8 @@ func TestLatestPodStartTime(t *testing.T) {
 
 func TestAgentPodPredicate(t *testing.T) {
 	now := testNow()
-	p := agentPodPredicate()
+	r, _ := newReconciler(t, newFakeClient(t), now, PolicyRemove, time.Minute, time.Minute, false)
+	p := r.podWatchPredicate()
 
 	readyAgent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
 	notReadyAgent := agentPod(testPodName, testPodNS, testNodeName, false, 1*time.Minute, now)
@@ -691,8 +692,8 @@ func TestReconcile_CSI_agentReadyCsiNotReadyKeepsTaint(t *testing.T) {
 	now := testNow()
 	node := taintedNode(testNodeName, 0, now)
 	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
-	// CSI readiness clock follows CSI StartTime only; keep it inside readinessTimeout
-	// so we requeue instead of immediately applying timeout policy.
+	// Readiness clock uses the later of agent and CSI max(StartTime); CSI started
+	// 30s ago stays inside readinessTimeout so we requeue instead of timing out.
 	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 30*time.Second, now)
 	c := newFakeClient(t, node, agent, csi)
 	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, true)
@@ -700,6 +701,26 @@ func TestReconcile_CSI_agentReadyCsiNotReadyKeepsTaint(t *testing.T) {
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	require.NoError(t, err)
 	assert.Greater(t, result.RequeueAfter, time.Duration(0))
+
+	fresh := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
+	assert.True(t, hasTaint(fresh))
+}
+
+func TestReconcile_CSI_bothPodsNotReady_readinessUsesLaterStartTime(t *testing.T) {
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	// Agent started more recently than CSI; readiness clock must use the later
+	// max(StartTime), not CSI-only.
+	agent := agentPod(testPodName, testPodNS, testNodeName, false, 10*time.Second, now)
+	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 40*time.Second, now)
+	c := newFakeClient(t, node, agent, csi)
+	const readiness = time.Minute
+	r, _ := newReconciler(t, c, now, PolicyRemove, readiness, 5*time.Minute, true)
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+	assert.Equal(t, 50*time.Second, result.RequeueAfter)
 
 	fresh := &corev1.Node{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))
@@ -727,7 +748,7 @@ func TestReconcile_CSI_agentReadyNoCsiPod_zeroCreationTimestampRequeuesSchedulin
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              testNodeName,
-			CreationTimestamp: metav1.Time{}, // zero — defensive branch in reconcileAgentReadyWaitForCSI
+			CreationTimestamp: metav1.Time{}, // zero — defensive branch in schedulingTimeoutResult
 		},
 		Spec: corev1.NodeSpec{Taints: []corev1.Taint{untaint.AgentNotReadyTaint()}},
 	}
@@ -762,19 +783,21 @@ func TestReconcile_CSI_agentReadyNoCsiPod_schedulingTimeoutRemovesTaint(t *testi
 	assert.False(t, hasTaint(fresh))
 }
 
-func TestReconcile_CSI_agentReadyCsiNotReady_noStartTimeRequeuesReadinessTimeout(t *testing.T) {
+func TestReconcile_CSI_agentReadyCsiNotReady_noStartTimeUsesSchedulingRequeue(t *testing.T) {
 	now := testNow()
 	node := taintedNode(testNodeName, 0, now)
 	agent := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
-	// not Ready, startedAgo 0 → no Status.StartTime → latestPodStartTime !ok branch
+	// CSI not Ready, startedAgo 0 → no Status.StartTime → wait-for-CSI path uses
+	// scheduling timeout (one side lacks StartTime) until kubelet sets StartTime.
 	csi := csiNodeServerPod("csi-1", testPodNS, testNodeName, false, 0, now)
 	c := newFakeClient(t, node, agent, csi)
 	const readiness = 9 * time.Minute
-	r, _ := newReconciler(t, c, now, PolicyRemove, readiness, time.Minute, true)
+	const scheduling = time.Minute
+	r, _ := newReconciler(t, c, now, PolicyRemove, readiness, scheduling, true)
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
 	require.NoError(t, err)
-	assert.Equal(t, readiness, result.RequeueAfter)
+	assert.Equal(t, scheduling, result.RequeueAfter)
 
 	fresh := &corev1.Node{}
 	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNodeName}, fresh))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,14 +133,26 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 		// For the profiles feature and untaint controller we need to list agent pods.
 		// The profiles feature needs node name and labels; the untaint controller also needs
 		// Status.Conditions to check readiness. Pods are watched in DatadogAgent namespace(s).
+		// When both untaint and DatadogCSIDriver are enabled, widen to merged agent+CSI
+		// namespaces and drop the pod informer label filter so CSI node-server pods
+		// (app=datadog-csi-driver-node-server) are cached for dual-readiness untaint.
 		agentNamespaces := GetWatchNamespacesFromEnv(logger, AgentWatchNamespaceEnvVar)
-		logger.Info("Pod cache enabled", "watching Pods in namespaces", slices.Collect(maps.Keys(agentNamespaces)))
-		byObject[podObj] = cache.ByObject{
-			Namespaces: agentNamespaces,
-
-			Label: labels.SelectorFromSet(map[string]string{
+		podNamespaces := agentNamespaces
+		var podLabel labels.Selector
+		if opts.UntaintControllerEnabled && opts.DatadogCSIDriverEnabled {
+			csiDriverNamespaces := GetWatchNamespacesFromEnv(logger, csiDriverWatchNamespaceEnvVar)
+			podNamespaces = maps.Clone(agentNamespaces)
+			maps.Copy(podNamespaces, csiDriverNamespaces)
+			logger.Info("Pod cache enabled for untaint with CSI driver",
+				"watching Pods in namespaces", slices.Collect(maps.Keys(podNamespaces)))
+		} else {
+			podLabel = labels.SelectorFromSet(map[string]string{
 				common.AgentDeploymentComponentLabelKey: constants.DefaultAgentResourceSuffix,
-			}),
+			})
+			logger.Info("Pod cache enabled", "watching Pods in namespaces", slices.Collect(maps.Keys(agentNamespaces)))
+		}
+		podByObject := cache.ByObject{
+			Namespaces: podNamespaces,
 
 			Transform: func(obj any) (any, error) {
 				pod := obj.(*corev1.Pod)
@@ -167,6 +179,10 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 				return newPod, nil
 			},
 		}
+		if podLabel != nil {
+			podByObject.Label = podLabel
+		}
+		byObject[podObj] = podByObject
 	}
 
 	if opts.DatadogAgentProfileEnabled || opts.IntrospectionEnabled || opts.UntaintControllerEnabled {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,15 +65,16 @@ var (
 )
 
 type WatchOptions struct {
-	DatadogAgentEnabled           bool
-	DatadogMonitorEnabled         bool
-	DatadogSLOEnabled             bool
-	DatadogAgentProfileEnabled    bool
-	IntrospectionEnabled          bool
-	DatadogDashboardEnabled       bool
-	DatadogGenericResourceEnabled bool
-	DatadogCSIDriverEnabled       bool
-	UntaintControllerEnabled      bool
+	DatadogAgentEnabled               bool
+	DatadogMonitorEnabled             bool
+	DatadogSLOEnabled                 bool
+	DatadogAgentProfileEnabled        bool
+	IntrospectionEnabled              bool
+	DatadogDashboardEnabled           bool
+	DatadogGenericResourceEnabled     bool
+	DatadogCSIDriverEnabled           bool
+	UntaintControllerEnabled          bool
+	UntaintControllerWaitForCSIDriver bool
 }
 
 // CacheOptions function configures Controller Runtime cache options on a resource level (supported in v0.16+).
@@ -133,17 +134,17 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 		// For the profiles feature and untaint controller we need to list agent pods.
 		// The profiles feature needs node name and labels; the untaint controller also needs
 		// Status.Conditions to check readiness. Pods are watched in DatadogAgent namespace(s).
-		// When both untaint and DatadogCSIDriver are enabled, widen to merged agent+CSI
+		// When untaint is configured to wait for CSI, widen to merged agent+CSI
 		// namespaces and drop the pod informer label filter so CSI node-server pods
 		// (app=datadog-csi-driver-node-server) are cached for dual-readiness untaint.
 		agentNamespaces := GetWatchNamespacesFromEnv(logger, AgentWatchNamespaceEnvVar)
 		podNamespaces := agentNamespaces
 		var podLabel labels.Selector
-		if opts.UntaintControllerEnabled && opts.DatadogCSIDriverEnabled {
+		if opts.UntaintControllerEnabled && opts.UntaintControllerWaitForCSIDriver {
 			csiDriverNamespaces := GetWatchNamespacesFromEnv(logger, csiDriverWatchNamespaceEnvVar)
 			podNamespaces = maps.Clone(agentNamespaces)
 			maps.Copy(podNamespaces, csiDriverNamespaces)
-			logger.Info("Pod cache enabled for untaint with CSI driver",
+			logger.Info("Pod cache enabled for untaint with wait-for-CSI",
 				"watching Pods in namespaces", slices.Collect(maps.Keys(podNamespaces)))
 		} else {
 			podLabel = labels.SelectorFromSet(map[string]string{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -237,11 +237,11 @@ func Test_CacheConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "Untaint and CSI enabled; Pod cache merges agent and CSI namespaces and omits label selector",
+			name: "Untaint wait-for-CSI; Pod cache merges agent and CSI namespaces and omits label selector",
 
 			watchOptions: WatchOptions{
-				UntaintControllerEnabled: true,
-				DatadogCSIDriverEnabled:  true,
+				UntaintControllerEnabled:          true,
+				UntaintControllerWaitForCSIDriver: true,
 			},
 
 			envConfig: map[string]string{
@@ -254,7 +254,7 @@ func Test_CacheConfig(t *testing.T) {
 			wantObjectConfig: map[client.Object]objectConfig{
 				podObj:       {configured: true, namespaces: []string{"agentNs", "csiNs1", "csiNs2"}, noPodLabel: true},
 				nodeObj:      {configured: true, namespaces: nil},
-				csiDriverObj: {configured: true, namespaces: []string{"csiNs1", "csiNs2"}},
+				csiDriverObj: {configured: false},
 			},
 		},
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,6 +16,8 @@ import (
 type objectConfig struct {
 	configured bool
 	namespaces []string
+	// noPodLabel, when true, asserts Pod ByObject has no label selector (widened informer).
+	noPodLabel bool
 }
 
 func Test_CacheConfig(t *testing.T) {
@@ -234,6 +236,27 @@ func Test_CacheConfig(t *testing.T) {
 				csiDriverObj:       {configured: false},
 			},
 		},
+		{
+			name: "Untaint and CSI enabled; Pod cache merges agent and CSI namespaces and omits label selector",
+
+			watchOptions: WatchOptions{
+				UntaintControllerEnabled: true,
+				DatadogCSIDriverEnabled:  true,
+			},
+
+			envConfig: map[string]string{
+				WatchNamespaceEnvVar:          "commonNs",
+				AgentWatchNamespaceEnvVar:     "agentNs",
+				csiDriverWatchNamespaceEnvVar: "csiNs1,csiNs2",
+			},
+
+			wantDefaultNamepsace: objectConfig{configured: true, namespaces: []string{"agentNs"}},
+			wantObjectConfig: map[client.Object]objectConfig{
+				podObj:       {configured: true, namespaces: []string{"agentNs", "csiNs1", "csiNs2"}, noPodLabel: true},
+				nodeObj:      {configured: true, namespaces: nil},
+				csiDriverObj: {configured: true, namespaces: []string{"csiNs1", "csiNs2"}},
+			},
+		},
 	}
 
 	logger := logf.Log.WithName(t.Name())
@@ -262,6 +285,9 @@ func verifyResourceNamespace(t *testing.T, resource client.Object, wantConfig ob
 			assert.Nil(t, byObjectOptions.Namespaces, "Namespaces should be nil for", reflect.TypeOf(resource).Elem())
 		} else {
 			assert.ElementsMatch(t, wantConfig.namespaces, maps.Keys(byObjectOptions.Namespaces), "Namespaces don't match for", reflect.TypeOf(resource).Elem())
+		}
+		if wantConfig.noPodLabel {
+			assert.Nil(t, byObjectOptions.Label)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds **`--untaintControllerWaitForCSIDriver`** (default `false`). When **`--untaintControllerEnabled=true`** and this flag is **`true`**, the Untaint controller removes `agent.datadoghq.com/not-ready=presence:NoSchedule` only after **both**:

- the **node Agent** pod (`agent.datadoghq.com/component=agent`) is `Ready`, and  
- at least one **CSI node-server** pod (`app=datadog-csi-driver-node-server`) on that node is **Ready** (strict: no untaint while `len(csiPods)==0`).

**`--datadogCSIDriverEnabled`** is **not** used to decide dual-readiness; it only controls whether the **DatadogCSIDriver** controller runs. Operators who enable “wait for CSI” must actually run CSI node-server pods (or they will hit scheduling/readiness timeouts per existing env vars).

Startup validation: **`--untaintControllerWaitForCSIDriver` requires `--untaintControllerEnabled=true`** (invalid combination fails fast at process start).

This is a continuation of [previous PR](https://github.com/DataDog/datadog-operator/pull/2753) that added untaint controller 

### Additional Notes

- Helm / chart authors: expose **`--untaintControllerWaitForCSIDriver`** next to **`--untaintControllerEnabled`** where appropriate.  
- Manual test: enable untaint + wait-for-CSI + deploy CSI in watched namespaces; confirm taint clears only after both Ready.

### Minimum Agent Versions

* Agent: vX.Y.Z  
* Cluster Agent: vX.Y.Z  

*(Fill if applicable.)*

### Describe your test plan

#### Create Kind cluster
Create a kind cluster with 3 nodes:

kind create cluster --config ./kind.yaml

kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
  - role: control-plane
  - role: worker
  - role: worker

#### Deploy datadog operator

Deploy the datadog operator with the following settings:
```
- --untaintControllerEnabled=true
- --datadogCSIDriverEnabled=false # (csi will not be created).
- --untaintControllerWaitForCSIDriver=true
```

Apply `datadog.yaml` with csi enabled

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: system
spec:
  features:
    autoscaling:
      workload:
        enabled: true
      cluster:
        enabled: true
  global:
    clusterName: <your cluster name>
    kubelet:
      tlsVerify: false
    csi:
      enabled: true
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
```

This will run the agent, but not the csi driver, because csi controller is disabled.

#### Taint worker

Taint one of the worker nodes to block scheduling:
`kubectl taint node kind-worker  agent.datadoghq.com/not-ready=presence:NoSchedule`

#### Create a sample deployment

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-test
spec:
  replicas: 2
  selector:
    matchLabels:
      app: nginx-test
  template:
    metadata:
      labels:
        app: nginx-test
    spec:
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: app
                operator: In
                values:
                - nginx-test
            topologyKey: kubernetes.io/hostname
      containers:
      - name: nginx
        image: nginx
```

Only one of the pods is scheduled on the untainted node, and the second pod is blocked at `Pending` because CSI pods are not running:

```
adel.hajhassan@COMP-QH9XH7D725 datadog-operator % kubectl get pods -o wide
NAME                                        READY   STATUS    RESTARTS   AGE     IP            NODE          NOMINATED NODE   READINESS GATES
datadog-agent-j7ldw                         3/3     Running   0          2m6s    10.244.1.11   kind-worker   <none>           <none>
datadog-cluster-agent-5ddcf7dc78-7tnrl      1/1     Running   0          5m30s   10.244.1.8    kind-worker   <none>           <none>
datadog-operator-manager-86b86d5d4b-vh54c   1/1     Running   0          6m52s   10.244.1.7    kind-worker   <none>           <none>
nginx-test-7f85bdc6d-4867m                  1/1     Running   0          74s     10.244.1.12   kind-worker   <none>           <none>
nginx-test-7f85bdc6d-xm6fn                  0/1     Pending   0          74s     <none>        <none>        <none>           <none>
```

#### Activate CSI controller

Activate CSI controller by setting `--datadogCSIDriverEnabled=true` on the operator deployment.

After the operator rolls out, CSI pods should spin up, and nginx pod should transition from Pending to Running.

```
adel.hajhassan@COMP-QH9XH7D725 datadog-operator % kubectl get pods
NAME                                        READY   STATUS    RESTARTS   AGE
datadog-agent-lhvt2                         3/3     Running   0          22h
datadog-agent-qh5jr                         3/3     Running   0          22h
datadog-cluster-agent-5ddcf7dc78-q5f29      1/1     Running   0          22h
datadog-csi-driver-node-server-ml7k6        2/2     Running   0          22h
datadog-csi-driver-node-server-tf44g        2/2     Running   0          22h
datadog-operator-manager-74d7f5dc6c-6dsgq   1/1     Running   0          22h
nginx-test-7f85bdc6d-5j4fz                  1/1     Running   0          22h
nginx-test-7f85bdc6d-csm2n                  1/1     Running   0          22
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`  
- [x] PR has a milestone or the `qa/skip-qa` label  
- [x] All commits are signed (see: [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))
