### PR TITLE
Add env var overrides for controller enable flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	goruntime "runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -205,8 +206,40 @@ func (opts *options) Parse() {
 	flag.IntVar(&opts.edsCanaryAutoFailMaxRestarts, "edsCanaryAutoFailMaxRestarts", defaultCanaryAutoFailMaxRestarts, "ExtendedDaemonset canary auto fail max restart count")
 	flag.DurationVar(&opts.edsCanaryAutoPauseMaxSlowStartDuration, "edsCanaryAutoPauseMaxSlowStartDuration", defaultCanaryAutoPauseMaxSlowStartDuration*time.Minute, "ExtendedDaemonset canary max slow start duration")
 
+	// Environment variable overrides applied before flag.Parse() so that
+	// explicit CLI flags take precedence (default < env < CLI).
+	boolFromEnv(&opts.datadogAgentEnabled, "DD_AGENT_CONTROLLER_ENABLED")
+	boolFromEnv(&opts.datadogMonitorEnabled, "DD_MONITOR_CONTROLLER_ENABLED")
+	boolFromEnv(&opts.datadogSLOEnabled, "DD_SLO_CONTROLLER_ENABLED")
+	boolFromEnv(&opts.datadogDashboardEnabled, "DD_DASHBOARD_CONTROLLER_ENABLED")
+	boolFromEnv(&opts.datadogGenericResourceEnabled, "DD_GENERIC_RESOURCE_CONTROLLER_ENABLED")
+	boolFromEnv(&opts.datadogCSIDriverEnabled, "DD_CSI_DRIVER_CONTROLLER_ENABLED")
+	boolFromEnv(&opts.datadogAgentProfileEnabled, "DD_AGENT_PROFILE_CONTROLLER_ENABLED")
+	boolFromEnv(&opts.introspectionEnabled, "DD_INTROSPECTION_ENABLED")
+	boolFromEnv(&opts.remoteConfigEnabled, "DD_REMOTE_CONFIG_ENABLED")
+	boolFromEnv(&opts.remoteUpdatesEnabled, "DD_REMOTE_UPDATES_ENABLED")
+	boolFromEnv(&opts.operatorMetricsEnabled, "DD_OPERATOR_METRICS_ENABLED")
+	boolFromEnv(&opts.untaintControllerEnabled, "DD_UNTAINT_CONTROLLER_ENABLED")
+
 	// Parsing flags
 	flag.Parse()
+}
+
+// boolFromEnv parses a boolean environment variable and writes the result into
+// dst. Accepted values follow strconv.ParseBool: 1/0, t/f, T/F, TRUE/FALSE,
+// true/false, True/False. "yes"/"no" are NOT accepted.
+// If the variable is unset, dst is left unchanged.
+func boolFromEnv(dst *bool, envVar string) {
+	val, found := os.LookupEnv(envVar)
+	if !found {
+		return
+	}
+	parsed, err := strconv.ParseBool(val)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ignoring invalid boolean env var %s=%q: %v\n", envVar, val, err)
+		return
+	}
+	*dst = parsed
 }
 
 func main() {

--- a/docs/control_plane_monitoring.md
+++ b/docs/control_plane_monitoring.md
@@ -40,7 +40,22 @@ Using the command line:
 helm install datadog-operator datadog/datadog-operator --set introspection.enabled=true
 ```
 
-Or, for **OpenShift users** who installed the operator via OperatorHub/Marketplace (the [recommended method](install-openshift.md)), by patching the operator cluster service version:
+Or, for **OpenShift users** who installed the operator via OperatorHub/Marketplace (the [recommended method](install-openshift.md)), set the environment variable in the `Subscription`:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: datadog-operator
+spec:
+  # ... channel, source, etc.
+  config:
+    env:
+      - name: DD_INTROSPECTION_ENABLED
+        value: "true"
+```
+
+Alternatively, you can patch the CSV directly (the env var approach above is preferred as it survives operator upgrades):
 
 ```bash
 oc patch csv <datadog-operator.VERSION> -n <datadog-operator-namespace> \

--- a/docs/datadog_agent_profiles.md
+++ b/docs/datadog_agent_profiles.md
@@ -57,6 +57,15 @@ DAP is disabled by default. To enable DAP using the [datadog-operator helm chart
 * `datadogAgentProfile.enabled=true`: this instructs the Operator deployment to start the `DatadogAgentProfile` controller.
 * `datadogCRDs.crds.datadogAgentProfiles=true`: this installs the `DatadogAgentProfile` CRD.
 
+For **OLM deployments** where container args cannot be set, enable the controller
+via environment variable in the `Subscription`:
+```yaml
+config:
+  env:
+    - name: DD_AGENT_PROFILE_CONTROLLER_ENABLED
+      value: "true"
+```
+
 > [!CAUTION]
 > Enabling DAP will increase the resource usage of the Operator. Please ensure the operator pod has enough resources allocated to it prior to enabling DAP.
 

--- a/docs/datadog_dashboard.md
+++ b/docs/datadog_dashboard.md
@@ -20,6 +20,14 @@ To deploy a `DatadogDashboard` with the Datadog Operator, use the [`datadog-oper
     helm repo add datadog https://helm.datadoghq.com
     ```
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_DASHBOARD_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 1. Choose one of the following options:
 
     * Run the install command, substituting your [Datadog API and application keys][6]:

--- a/docs/datadog_generic_resource.md
+++ b/docs/datadog_generic_resource.md
@@ -68,6 +68,14 @@ To deploy a `DatadogGenericResource` with the Datadog Operator, follow the steps
     helm repo add datadog https://helm.datadoghq.com
     ```
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_GENERIC_RESOURCE_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 2. The DDGR controller and its CRD are both disabled by default. The controller also requires an API and an application key. Choose one of the following options:
     * Override the default values by providing your [API and application keys][2], installing the CRD, and enabling the controller:
       ```shell

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -13,6 +13,14 @@ This page describes the simplest and fastest way to deploy a [Datadog monitor](h
 
 To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operator` Helm chart][3].
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_MONITOR_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 1. Install the [Datadog Operator][4]:
 
    First, add the Datadog Helm chart with

--- a/docs/datadog_slo.md
+++ b/docs/datadog_slo.md
@@ -21,6 +21,14 @@ To deploy a `DatadogSLO` with the Datadog Operator, use the [`datadog-operator` 
     helm repo add datadog https://helm.datadoghq.com
     ```
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_SLO_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 1. Choose one of the following options:
 
     * Run the install command, substituting your [Datadog API and application keys][6]:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,6 +154,54 @@ spec:
    ```
 
 
+### Enable optional controllers with OLM
+
+Each optional controller can be toggled via a CLI flag (highest precedence) or
+an environment variable (middle precedence). If neither is set, the compiled
+default applies.
+
+| Controller              | CLI flag                          | Env var                                  | Default |
+|-------------------------|-----------------------------------|------------------------------------------|---------|
+| DatadogAgent            | `--datadogAgentEnabled`           | `DD_AGENT_CONTROLLER_ENABLED`            | `true`  |
+| DatadogMonitor          | `--datadogMonitorEnabled`         | `DD_MONITOR_CONTROLLER_ENABLED`          | `false` |
+| DatadogSLO              | `--datadogSLOEnabled`             | `DD_SLO_CONTROLLER_ENABLED`              | `false` |
+| DatadogDashboard        | `--datadogDashboardEnabled`       | `DD_DASHBOARD_CONTROLLER_ENABLED`        | `false` |
+| DatadogGenericResource  | `--datadogGenericResourceEnabled` | `DD_GENERIC_RESOURCE_CONTROLLER_ENABLED` | `false` |
+| DatadogCSIDriver        | `--datadogCSIDriverEnabled`       | `DD_CSI_DRIVER_CONTROLLER_ENABLED`       | `false` |
+| DatadogAgentProfile     | `--datadogAgentProfileEnabled`    | `DD_AGENT_PROFILE_CONTROLLER_ENABLED`    | `false` |
+| Introspection           | `--introspectionEnabled`          | `DD_INTROSPECTION_ENABLED`               | `false` |
+| RemoteConfig            | `--remoteConfigEnabled`           | `DD_REMOTE_CONFIG_ENABLED`               | `false` |
+| RemoteUpdates           | `--remoteUpdatesEnabled`          | `DD_REMOTE_UPDATES_ENABLED`              | `false` |
+| OperatorMetrics         | `--operatorMetricsEnabled`        | `DD_OPERATOR_METRICS_ENABLED`            | `true`  |
+| UntaintController       | `--untaintControllerEnabled`      | `DD_UNTAINT_CONTROLLER_ENABLED`          | `false` |
+
+Other flags (leader election, profiling, TLS, EDS tuning) are only configurable
+via CLI flag.
+
+Boolean values follow Go's [`strconv.ParseBool`](https://pkg.go.dev/strconv#ParseBool):
+`true`, `True`, `TRUE`, `1` or `false`, `False`, `FALSE`, `0`. The strings
+`yes` and `no` are **not** accepted and will be logged as an error, leaving the
+default in effect.
+
+For example, to enable the DatadogMonitor controller in an OLM deployment:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-datadog-operator
+  namespace: operators
+spec:
+  channel: stable
+  name: datadog-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  config:
+    env:
+      - name: DD_MONITOR_CONTROLLER_ENABLED
+        value: "true"
+```
+
 ## Deploy the DatadogAgent custom resource managed by the Operator
 
 After deploying the Datadog Operator, create the `DatadogAgent` resource that triggers the deployment of the Datadog Agent, Cluster Agent, and Cluster Checks Runners (if used) in your Kubernetes cluster. The Datadog Agent is deployed as a DaemonSet, running a pod on every node of your cluster.

--- a/docs/introspection.md
+++ b/docs/introspection.md
@@ -28,6 +28,15 @@ datadog-agent-gke-cos   2         2         2       2            2           <no
 
 Introspection is disabled by default. To enable introspection using the [datadog-operator helm chart](https://github.com/DataDog/helm-charts/tree/main/charts/datadog-operator), set `introspection.enabled=true` in your `values.yaml` file or as a flag in the command line arguments `--set introspection.enabled=true`.
 
+For **OLM deployments** where container args cannot be set, enable introspection
+via environment variable in the `Subscription`:
+```yaml
+config:
+  env:
+    - name: DD_INTROSPECTION_ENABLED
+      value: "true"
+```
+
 ## Migration from Operator Version < 1.4.0
 
 ### Operator v1.4.0 <= x < v1.6.0

--- a/docs/untaint_controller.md
+++ b/docs/untaint_controller.md
@@ -41,20 +41,22 @@ timeouts are global and cannot be tuned per Node (Group), DDA, or DAP.
 
 ## Enable the Untaint controller
 
-The Untaint controller is disabled by default. Enable it on the operator
-manager:
+The Untaint controller is disabled by default. Enable it via CLI flag or
+environment variable:
 
+**CLI flag:**
 ```yaml
 args:
   - --untaintControllerEnabled=true
 ```
 
-When this flag is enabled, the operator also injects a toleration for
-`agent.datadoghq.com/not-ready=presence:NoSchedule` into the node Agent
-DaemonSet (or ExtendedDaemonSet) pod template, unless an equivalent toleration
-is already present. This avoids a deadlock where the node stays tainted because
-the Agent pod cannot schedule without the toleration, especially when admission
-webhook auto-injection is not in use.
+**Environment variable** (useful for OLM / GitOps deployments where container
+args cannot be set):
+```yaml
+env:
+  - name: DD_UNTAINT_CONTROLLER_ENABLED
+    value: "true"
+```
 
 ## Configuration
 


### PR DESCRIPTION
   ## Changes

   ### `cmd/main.go`
   - Added `boolFromEnv` helper using `os.LookupEnv` + `strconv.ParseBool`
   - 12 env var overrides applied before `flag.Parse()` so CLI flags take precedence
   - Invalid values logged to stderr (logger is not initialized at parse time)

   ### Documentation
   | Doc | Env var documented |
   |-----|--------------------|
   | `docs/installation.md` | Full reference table with all 12 flags |
   | `docs/untaint_controller.md` | `DD_UNTAINT_CONTROLLER_ENABLED` |
   | `docs/datadog_agent_profiles.md` | `DD_AGENT_PROFILE_CONTROLLER_ENABLED` |
   | `docs/introspection.md` | `DD_INTROSPECTION_ENABLED` |
   | `docs/control_plane_monitoring.md` | `DD_INTROSPECTION_ENABLED` (OLM alternative to CSV patch) |
   | `docs/datadog_dashboard.md` | `DD_DASHBOARD_CONTROLLER_ENABLED` |
   | `docs/datadog_monitor.md` | `DD_MONITOR_CONTROLLER_ENABLED` |
   | `docs/datadog_slo.md` | `DD_SLO_CONTROLLER_ENABLED` |
   | `docs/datadog_generic_resource.md` | `DD_GENERIC_RESOURCE_CONTROLLER_ENABLED` |

   ## Test plan
   - [x] `go build ./cmd/main.go` passes
   - [x] `go test ./cmd/...` passes
   - [x] `go vet ./cmd/...` clean
   - [ ] Set `DD_DASHBOARD_CONTROLLER_ENABLED=true` on operator pod, verify controller starts
   - [ ] Set invalid value (e.g. `yes`), verify stderr error message
   - [ ] Set env var + CLI flag, verify CLI flag wins