### PR TITLE
Use registry.datadoghq.com for Agent image defaults

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -1801,13 +1801,14 @@ type GlobalConfig struct {
 	Endpoint *Endpoint `json:"endpoint,omitempty"`
 
 	// Registry is the image registry to use for all Agent images.
+	// Use 'registry.datadoghq.com' for Datadog Container Registry.
 	// Use 'public.ecr.aws/datadog' for AWS ECR.
 	// Use 'datadoghq.azurecr.io' for Azure Container Registry.
 	// Use 'gcr.io/datadoghq' for Google Container Registry.
 	// Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
 	// Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
 	// Use 'docker.io/datadog' for DockerHub.
-	// Default: 'gcr.io/datadoghq'
+	// Default: 'registry.datadoghq.com'
 	// +optional
 	Registry *string `json:"registry,omitempty"`
 

--- a/bundle/manifests/datadoghq.com_datadogagentinternals.yaml
+++ b/bundle/manifests/datadoghq.com_datadogagentinternals.yaml
@@ -3808,13 +3808,14 @@ spec:
                   registry:
                     description: |-
                       Registry is the image registry to use for all Agent images.
+                      Use 'registry.datadoghq.com' for Datadog Container Registry.
                       Use 'public.ecr.aws/datadog' for AWS ECR.
                       Use 'datadoghq.azurecr.io' for Azure Container Registry.
                       Use 'gcr.io/datadoghq' for Google Container Registry.
                       Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
                       Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
                       Use 'docker.io/datadog' for DockerHub.
-                      Default: 'gcr.io/datadoghq'
+                      Default: 'registry.datadoghq.com'
                     type: string
                   secretBackend:
                     description: |-

--- a/bundle/manifests/datadoghq.com_datadogagentprofiles.yaml
+++ b/bundle/manifests/datadoghq.com_datadogagentprofiles.yaml
@@ -3840,13 +3840,14 @@ spec:
                       registry:
                         description: |-
                           Registry is the image registry to use for all Agent images.
+                          Use 'registry.datadoghq.com' for Datadog Container Registry.
                           Use 'public.ecr.aws/datadog' for AWS ECR.
                           Use 'datadoghq.azurecr.io' for Azure Container Registry.
                           Use 'gcr.io/datadoghq' for Google Container Registry.
                           Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
                           Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
                           Use 'docker.io/datadog' for DockerHub.
-                          Default: 'gcr.io/datadoghq'
+                          Default: 'registry.datadoghq.com'
                         type: string
                       secretBackend:
                         description: |-

--- a/bundle/manifests/datadoghq.com_datadogagents.yaml
+++ b/bundle/manifests/datadoghq.com_datadogagents.yaml
@@ -3811,13 +3811,14 @@ spec:
                   registry:
                     description: |-
                       Registry is the image registry to use for all Agent images.
+                      Use 'registry.datadoghq.com' for Datadog Container Registry.
                       Use 'public.ecr.aws/datadog' for AWS ECR.
                       Use 'datadoghq.azurecr.io' for Azure Container Registry.
                       Use 'gcr.io/datadoghq' for Google Container Registry.
                       Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
                       Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
                       Use 'docker.io/datadog' for DockerHub.
-                      Default: 'gcr.io/datadoghq'
+                      Default: 'registry.datadoghq.com'
                     type: string
                   secretBackend:
                     description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -3599,13 +3599,14 @@ spec:
                     registry:
                       description: |-
                         Registry is the image registry to use for all Agent images.
+                        Use 'registry.datadoghq.com' for Datadog Container Registry.
                         Use 'public.ecr.aws/datadog' for AWS ECR.
                         Use 'datadoghq.azurecr.io' for Azure Container Registry.
                         Use 'gcr.io/datadoghq' for Google Container Registry.
                         Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
                         Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
                         Use 'docker.io/datadog' for DockerHub.
-                        Default: 'gcr.io/datadoghq'
+                        Default: 'registry.datadoghq.com'
                       type: string
                     secretBackend:
                       description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -3750,7 +3750,7 @@
               "type": "object"
             },
             "registry": {
-              "description": "Registry is the image registry to use for all Agent images.\nUse 'public.ecr.aws/datadog' for AWS ECR.\nUse 'datadoghq.azurecr.io' for Azure Container Registry.\nUse 'gcr.io/datadoghq' for Google Container Registry.\nUse 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.\nUse 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.\nUse 'docker.io/datadog' for DockerHub.\nDefault: 'gcr.io/datadoghq'",
+              "description": "Registry is the image registry to use for all Agent images.\nUse 'registry.datadoghq.com' for Datadog Container Registry.\nUse 'public.ecr.aws/datadog' for AWS ECR.\nUse 'datadoghq.azurecr.io' for Azure Container Registry.\nUse 'gcr.io/datadoghq' for Google Container Registry.\nUse 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.\nUse 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.\nUse 'docker.io/datadog' for DockerHub.\nDefault: 'registry.datadoghq.com'",
               "type": "string"
             },
             "secretBackend": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -3599,13 +3599,14 @@ spec:
                         registry:
                           description: |-
                             Registry is the image registry to use for all Agent images.
+                            Use 'registry.datadoghq.com' for Datadog Container Registry.
                             Use 'public.ecr.aws/datadog' for AWS ECR.
                             Use 'datadoghq.azurecr.io' for Azure Container Registry.
                             Use 'gcr.io/datadoghq' for Google Container Registry.
                             Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
                             Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
                             Use 'docker.io/datadog' for DockerHub.
-                            Default: 'gcr.io/datadoghq'
+                            Default: 'registry.datadoghq.com'
                           type: string
                         secretBackend:
                           description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -3754,7 +3754,7 @@
                   "type": "object"
                 },
                 "registry": {
-                  "description": "Registry is the image registry to use for all Agent images.\nUse 'public.ecr.aws/datadog' for AWS ECR.\nUse 'datadoghq.azurecr.io' for Azure Container Registry.\nUse 'gcr.io/datadoghq' for Google Container Registry.\nUse 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.\nUse 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.\nUse 'docker.io/datadog' for DockerHub.\nDefault: 'gcr.io/datadoghq'",
+                  "description": "Registry is the image registry to use for all Agent images.\nUse 'registry.datadoghq.com' for Datadog Container Registry.\nUse 'public.ecr.aws/datadog' for AWS ECR.\nUse 'datadoghq.azurecr.io' for Azure Container Registry.\nUse 'gcr.io/datadoghq' for Google Container Registry.\nUse 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.\nUse 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.\nUse 'docker.io/datadog' for DockerHub.\nDefault: 'registry.datadoghq.com'",
                   "type": "string"
                 },
                 "secretBackend": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -3603,13 +3603,14 @@ spec:
                     registry:
                       description: |-
                         Registry is the image registry to use for all Agent images.
+                        Use 'registry.datadoghq.com' for Datadog Container Registry.
                         Use 'public.ecr.aws/datadog' for AWS ECR.
                         Use 'datadoghq.azurecr.io' for Azure Container Registry.
                         Use 'gcr.io/datadoghq' for Google Container Registry.
                         Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
                         Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
                         Use 'docker.io/datadog' for DockerHub.
-                        Default: 'gcr.io/datadoghq'
+                        Default: 'registry.datadoghq.com'
                       type: string
                     secretBackend:
                       description: |-

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v1alpha1.json
@@ -11136,7 +11136,7 @@
           "type": "object"
         },
         "registry": {
-          "description": "Registry to use for all Agent images (default gcr.io/datadoghq). Use public.ecr.aws/datadog for AWS Use docker.io/datadog for DockerHub",
+          "description": "Registry to use for all Agent images (default registry.datadoghq.com). Use public.ecr.aws/datadog for AWS. Use gcr.io/datadoghq for Google Container Registry. Use docker.io/datadog for DockerHub.",
           "type": "string"
         },
         "site": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -3750,7 +3750,7 @@
               "type": "object"
             },
             "registry": {
-              "description": "Registry is the image registry to use for all Agent images.\nUse 'public.ecr.aws/datadog' for AWS ECR.\nUse 'datadoghq.azurecr.io' for Azure Container Registry.\nUse 'gcr.io/datadoghq' for Google Container Registry.\nUse 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.\nUse 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.\nUse 'docker.io/datadog' for DockerHub.\nDefault: 'gcr.io/datadoghq'",
+              "description": "Registry is the image registry to use for all Agent images.\nUse 'registry.datadoghq.com' for Datadog Container Registry.\nUse 'public.ecr.aws/datadog' for AWS ECR.\nUse 'datadoghq.azurecr.io' for Azure Container Registry.\nUse 'gcr.io/datadoghq' for Google Container Registry.\nUse 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.\nUse 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.\nUse 'docker.io/datadog' for DockerHub.\nDefault: 'registry.datadoghq.com'",
               "type": "string"
             },
             "secretBackend": {

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1091,9 +1091,9 @@ func Test_otelImageTags(t *testing.T) {
 				verifyDaemonsetContainers(t, c, resourcesNamespace, dsName, expectedContainers)
 				agentContainer := getDsContainers(c, resourcesNamespace, dsName)
 
-				assert.Equal(t, fmt.Sprintf("gcr.io/datadoghq/agent:%s", images.AgentLatestVersion), agentContainer[apicommon.CoreAgentContainerName].Image)
-				assert.Equal(t, fmt.Sprintf("gcr.io/datadoghq/agent:%s", images.AgentLatestVersion), agentContainer[apicommon.TraceAgentContainerName].Image)
-				assert.Equal(t, fmt.Sprintf("gcr.io/datadoghq/ddot-collector:%s", images.AgentLatestVersion), agentContainer[apicommon.OtelAgent].Image)
+				assert.Equal(t, fmt.Sprintf("registry.datadoghq.com/agent:%s", images.AgentLatestVersion), agentContainer[apicommon.CoreAgentContainerName].Image)
+				assert.Equal(t, fmt.Sprintf("registry.datadoghq.com/agent:%s", images.AgentLatestVersion), agentContainer[apicommon.TraceAgentContainerName].Image)
+				assert.Equal(t, fmt.Sprintf("registry.datadoghq.com/ddot-collector:%s", images.AgentLatestVersion), agentContainer[apicommon.OtelAgent].Image)
 
 			},
 		},
@@ -1117,9 +1117,9 @@ func Test_otelImageTags(t *testing.T) {
 				verifyDaemonsetContainers(t, c, resourcesNamespace, dsName, expectedContainers)
 				agentContainer := getDsContainers(c, resourcesNamespace, dsName)
 
-				assert.Equal(t, "gcr.io/datadoghq/agent:7.71.0", agentContainer[apicommon.CoreAgentContainerName].Image)
-				assert.Equal(t, "gcr.io/datadoghq/agent:7.71.0", agentContainer[apicommon.TraceAgentContainerName].Image)
-				assert.Equal(t, "gcr.io/datadoghq/ddot-collector:7.71.0", agentContainer[apicommon.OtelAgent].Image)
+				assert.Equal(t, "registry.datadoghq.com/agent:7.71.0", agentContainer[apicommon.CoreAgentContainerName].Image)
+				assert.Equal(t, "registry.datadoghq.com/agent:7.71.0", agentContainer[apicommon.TraceAgentContainerName].Image)
+				assert.Equal(t, "registry.datadoghq.com/ddot-collector:7.71.0", agentContainer[apicommon.OtelAgent].Image)
 
 			},
 		},
@@ -1179,9 +1179,9 @@ func Test_otelImageTags(t *testing.T) {
 				verifyDaemonsetContainers(t, c, resourcesNamespace, dsName, expectedContainers)
 				agentContainer := getDsContainers(c, resourcesNamespace, dsName)
 
-				assert.Equal(t, "gcr.io/datadoghq/testagent:7.65.0-full", agentContainer[apicommon.CoreAgentContainerName].Image)
-				assert.Equal(t, "gcr.io/datadoghq/testagent:7.65.0-full", agentContainer[apicommon.TraceAgentContainerName].Image)
-				assert.Equal(t, "gcr.io/datadoghq/testagent:7.65.0-full", agentContainer[apicommon.OtelAgent].Image)
+				assert.Equal(t, "registry.datadoghq.com/testagent:7.65.0-full", agentContainer[apicommon.CoreAgentContainerName].Image)
+				assert.Equal(t, "registry.datadoghq.com/testagent:7.65.0-full", agentContainer[apicommon.TraceAgentContainerName].Image)
+				assert.Equal(t, "registry.datadoghq.com/testagent:7.65.0-full", agentContainer[apicommon.OtelAgent].Image)
 
 			},
 		},
@@ -1204,9 +1204,9 @@ func Test_otelImageTags(t *testing.T) {
 				verifyDaemonsetContainers(t, c, resourcesNamespace, dsName, expectedContainers)
 				agentContainer := getDsContainers(c, resourcesNamespace, dsName)
 
-				assert.Equal(t, "gcr.io/datadoghq/testagent:7.65.0-full", agentContainer[apicommon.CoreAgentContainerName].Image)
-				assert.Equal(t, "gcr.io/datadoghq/testagent:7.65.0-full", agentContainer[apicommon.TraceAgentContainerName].Image)
-				assert.Equal(t, "gcr.io/datadoghq/testagent:7.65.0-full", agentContainer[apicommon.OtelAgent].Image)
+				assert.Equal(t, "registry.datadoghq.com/testagent:7.65.0-full", agentContainer[apicommon.CoreAgentContainerName].Image)
+				assert.Equal(t, "registry.datadoghq.com/testagent:7.65.0-full", agentContainer[apicommon.TraceAgentContainerName].Image)
+				assert.Equal(t, "registry.datadoghq.com/testagent:7.65.0-full", agentContainer[apicommon.OtelAgent].Image)
 
 			},
 		},

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -40,7 +40,7 @@ const (
 	// PublicECSContainerRegistry corresponds to the datadoghq PublicECSContainerRegistry registry
 	PublicECSContainerRegistry = "public.ecr.aws/datadog"
 	// DefaultImageRegistry corresponds to the datadoghq containers registry
-	DefaultImageRegistry = "gcr.io/datadoghq"
+	DefaultImageRegistry = DatadogContainerRegistry
 	// Default Image Registries
 	DefaultAzureImageRegistry  string = "datadoghq.azurecr.io"
 	DefaultEuropeImageRegistry string = "eu.gcr.io/datadoghq"

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -22,7 +22,7 @@ func TestGetLatestAgentImage(t *testing.T) {
 	}{
 		{
 			name: "default registry",
-			want: fmt.Sprintf("gcr.io/datadoghq/agent:%s", AgentLatestVersion),
+			want: fmt.Sprintf("registry.datadoghq.com/agent:%s", AgentLatestVersion),
 		},
 	}
 	for _, tt := range tests {
@@ -41,7 +41,7 @@ func TestGetLatestClusterAgentImage(t *testing.T) {
 	}{
 		{
 			name: "default registry",
-			want: fmt.Sprintf("gcr.io/datadoghq/cluster-agent:%s", ClusterAgentLatestVersion),
+			want: fmt.Sprintf("registry.datadoghq.com/cluster-agent:%s", ClusterAgentLatestVersion),
 		},
 	}
 	for _, tt := range tests {
@@ -207,7 +207,7 @@ func Test_AssembleImage(t *testing.T) {
 				Name: "agent",
 				Tag:  "latest",
 			},
-			want: "gcr.io/datadoghq/agent:latest",
+			want: "registry.datadoghq.com/agent:latest",
 		},
 		{
 			name: "cluster-agent",
@@ -225,7 +225,7 @@ func Test_AssembleImage(t *testing.T) {
 				Tag:        "latest-jmx",
 				JMXEnabled: true,
 			},
-			want: "gcr.io/datadoghq/agent:latest-jmx",
+			want: "registry.datadoghq.com/agent:latest-jmx",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Change the Operator Agent image default registry from `gcr.io/datadoghq` to `registry.datadoghq.com` by pointing `DefaultImageRegistry` at the existing `DatadogContainerRegistry` constant.

This also updates generated DatadogAgent registry descriptions in CRD and bundle artifacts so the documented default matches the runtime default. GCR remains listed as the Google Container Registry option for explicit overrides.

## Why

The public container registry guidance recommends `registry.datadoghq.com` as the simple/default Datadog registry while preserving cloud-provider registries for users who explicitly choose them. The Operator should generate default Agent, Cluster Agent, and DDOT image references from the same default registry.

## Validation

- `make manifests`
- `make bundle VERSION=1.27.0` refreshed the bundle registry descriptions before `hack/patch-bundle.sh` exited locally on an unbound `LATEST_VERSION`; unrelated generated bundle churn was pruned from the final diff.
- `go test ./internal/controller/datadogagent ./internal/controller/datadogagent/defaults ./pkg/images`
