### PR TITLE
[docs] Add GKE Autopilot operator support documentation

### DIFF
--- a/docs/gke_autopilot/README.md
+++ b/docs/gke_autopilot/README.md
@@ -1,0 +1,6 @@
+# GKE Autopilot
+
+This directory documents the Datadog Operator support for Google Kubernetes Engine Autopilot clusters.
+
+- [External guide](external.md): how to install and configure a `DatadogAgent` for GKE Autopilot.
+- [Internal technical dive](internal.md): how the Autopilot support is wired into reconciliation and which code paths own each behavior.

--- a/docs/gke_autopilot/external.md
+++ b/docs/gke_autopilot/external.md
@@ -26,7 +26,7 @@ helm install datadog-operator datadog/datadog-operator
 
 ## Create the Datadog credentials Secret
 
-Create a Secret in the namespace where you will create the `DatadogAgent`:
+Create a Secret in the namespace where you plan to create the `DatadogAgent`:
 
 ```shell
 kubectl create secret generic datadog-secret \

--- a/docs/gke_autopilot/external.md
+++ b/docs/gke_autopilot/external.md
@@ -33,7 +33,7 @@ kubectl create secret generic datadog-secret \
   --from-literal api-key=<DATADOG_API_KEY>
 ```
 
-Add `app-key` as well if you enable features that require a Datadog application key.
+Add `app-key` if you enable features that require a Datadog application key.
 
 ## Enable Autopilot mode
 

--- a/docs/gke_autopilot/external.md
+++ b/docs/gke_autopilot/external.md
@@ -79,7 +79,7 @@ The value must use the `vX.Y.Z` format. Malformed values are ignored and the def
 
 ## Customize resources
 
-Use the normal `spec.override.nodeAgent.containers` override to set container resources. For example, this sets resources on the core Agent container:
+Use the `spec.override.nodeAgent.containers` override to set container resources. For example, the following configuration sets resources on the core Agent container:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/docs/gke_autopilot/external.md
+++ b/docs/gke_autopilot/external.md
@@ -1,0 +1,210 @@
+# Datadog Operator on GKE Autopilot
+
+This guide explains how to deploy the Datadog Operator and a `DatadogAgent` on a GKE Autopilot cluster.
+
+GKE Autopilot applies stricter workload restrictions than standard GKE clusters. The Operator's Autopilot mode adjusts the generated Agent workload so it can run within those restrictions.
+
+## Prerequisites
+
+- A GKE Autopilot cluster.
+- `kubectl` configured for the cluster.
+- `helm` for installing the Operator.
+- A Datadog API key stored in a Kubernetes Secret.
+
+See [Installing the Datadog Operator](../installation.md) for the general installation flow.
+
+## Install the Operator
+
+Add the Datadog Helm repository and install the Operator:
+
+```shell
+helm repo add datadog https://helm.datadoghq.com
+helm install datadog-operator datadog/datadog-operator
+```
+
+*Note: GKE Autopilot is supported with the Operator version `1.27.0+`.*
+
+## Create the Datadog credentials Secret
+
+Create a Secret in the namespace where you will create the `DatadogAgent`:
+
+```shell
+kubectl create secret generic datadog-secret \
+  --from-literal api-key=<DATADOG_API_KEY>
+```
+
+Add `app-key` as well if you enable features that require a Datadog application key.
+
+## Enable Autopilot mode
+
+Enable Autopilot mode by adding the experimental annotation to the `DatadogAgent` metadata:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  annotations:
+    experimental.agent.datadoghq.com/autopilot: "true"
+spec:
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+```
+
+Apply the manifest:
+
+```shell
+kubectl apply -f datadog-agent.yaml
+```
+
+The annotation is case-insensitive for the value `true`, but use the quoted string `"true"` in manifests.
+
+## Optional: select the WorkloadAllowlist version
+
+When Autopilot mode is enabled, the Operator applies a GKE `AllowlistSynchronizer` named `datadog-synchronizer` that points GKE to the Datadog WorkloadAllowlist.
+
+By default, the Operator uses the built-in default allowlist version. To pin another allowlist version, set:
+
+```yaml
+metadata:
+  annotations:
+    experimental.agent.datadoghq.com/autopilot: "true"
+    experimental.agent.datadoghq.com/autopilot-allowlist-version: "v1.0.5"
+```
+
+The value must use the `vX.Y.Z` format. Malformed values are ignored and the default version is used.
+
+## Customize resources
+
+Use the normal `spec.override.nodeAgent.containers` override to set container resources. For example, this sets resources on the core Agent container:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  annotations:
+    experimental.agent.datadoghq.com/autopilot: "true"
+spec:
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+  override:
+    nodeAgent:
+      containers:
+        agent:
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+```
+
+Add entries for other enabled Node Agent containers as needed. For example, if APM is enabled, you can also set resources for `trace-agent`:
+
+```yaml
+spec:
+  override:
+    nodeAgent:
+      containers:
+        trace-agent:
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "300m"
+              memory: "256Mi"
+```
+
+Common Node Agent container names include:
+
+| Container | Purpose |
+|-----------|---------|
+| `agent` | Core Agent container |
+| `trace-agent` | APM trace intake |
+| `process-agent` | Process and live process collection |
+| `system-probe` | System Probe, NPM, and related features |
+| `init-config` | Agent configuration init container |
+| `init-volume` | Agent volume init container |
+| `seccomp-setup` | Seccomp setup init container |
+
+Only override containers that are enabled by your feature configuration.
+
+## Set a PriorityClass
+
+Create a `PriorityClass` if you do not want to use a built-in Kubernetes priority class:
+
+```yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: datadog-agent-priority
+value: 1000000
+globalDefault: false
+description: "Priority class for Datadog Agent pods."
+```
+
+Then reference it from the Node Agent override:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  annotations:
+    experimental.agent.datadoghq.com/autopilot: "true"
+spec:
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+  override:
+    nodeAgent:
+      priorityClassName: datadog-agent-priority
+```
+
+You can also set `priorityClassName` on `clusterAgent`, `clusterChecksRunner`, or `otelAgentGateway` if those components are enabled.
+
+## Enable APM or DogStatsD
+
+On Autopilot, the Operator uses host ports for APM and DogStatsD instead of Unix domain sockets because host socket paths are not available in the same way as on standard clusters.
+
+Example:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  annotations:
+    experimental.agent.datadoghq.com/autopilot: "true"
+spec:
+  global:
+    credentials:
+      apiSecret:
+        secretName: datadog-secret
+        keyName: api-key
+  features:
+    apm:
+      enabled: true
+    dogstatsd:
+      originDetectionEnabled: true
+```
+
+The Operator keeps the configured host port values if you set them in the feature configuration.
+
+## Operational notes
+
+- Do not use overrides to re-add host paths, auth-token mounts, CRI socket mounts, DogStatsD socket mounts, or APM socket mounts that Autopilot mode removes.
+- Autopilot mode rewrites the `trace-agent` and `process-agent` commands; avoid overriding those commands unless the Autopilot implementation is updated to support the change.
+- If log collection uses a hostPath-backed run path, Autopilot mode rewrites it to `/var/autopilot/addon/datadog/logs`, the path allowed by the Datadog WorkloadAllowlist.
+- For the full override schema, see [configuration.v2alpha1.md](../configuration.v2alpha1.md).

--- a/docs/gke_autopilot/internal.md
+++ b/docs/gke_autopilot/internal.md
@@ -1,0 +1,175 @@
+# GKE Autopilot Technical Dive
+
+This document describes how GKE Autopilot support is implemented in the Datadog Operator.
+
+## Entry point
+
+Autopilot mode is enabled through a `DatadogAgent` annotation:
+
+```yaml
+metadata:
+  annotations:
+    experimental.agent.datadoghq.com/autopilot: "true"
+```
+
+The constants live in `internal/controller/datadogagent/experimental/const.go`:
+
+- `ExperimentalAnnotationPrefix = "experimental.agent.datadoghq.com"`
+- `ExperimentalAutopilotSubkey = "autopilot"`
+- `ExperimentalAutopilotAllowlistVersionSubkey = "autopilot-allowlist-version"`
+
+`experimental.IsAutopilotEnabled(obj)` reads the annotation and returns true when its value equals `true`, case-insensitively.
+
+## Reconcile flow
+
+The public `DatadogAgent` controller does not build the final Agent DaemonSet directly. Its flow is:
+
+```text
+DatadogAgent
+  -> validate and default spec
+  -> manage DatadogAgent-owned dependencies
+  -> generate DatadogAgentInternal
+  -> copy annotations from DatadogAgent to DatadogAgentInternal
+  -> create or update DatadogAgentInternal
+```
+
+Relevant code:
+
+- `internal/controller/datadogagent/controller_reconcile_v2.go`
+- `internal/controller/datadogagent/ddai.go`
+
+`generateObjMetaFromDDA` copies annotations from the `DatadogAgent` to the generated `DatadogAgentInternal`, excluding only `kubectl.kubernetes.io/last-applied-configuration`. This is what carries the Autopilot annotation into the internal reconciler.
+
+The `DatadogAgentInternal` controller then builds the actual workloads:
+
+```text
+DatadogAgentInternal
+  -> default spec
+  -> build configured/enabled features and required components
+  -> manage global and feature dependencies
+  -> reconcile Deployment-backed components
+  -> reconcile Node Agent DaemonSet or ExtendedDaemonSet
+  -> cleanup stale resources
+```
+
+Relevant code:
+
+- `internal/controller/datadogagentinternal/controller_reconcile_v2.go`
+- `internal/controller/datadogagentinternal/controller_reconcile_agent.go`
+- `internal/controller/datadogagentinternal/component_reconciler.go`
+
+## Where Autopilot mutates the Node Agent
+
+The Node Agent path in `reconcileV2Agent` is the main pod-template integration point.
+
+For a DaemonSet, the order is:
+
+```text
+NewDefaultAgentDaemonset
+  -> global provider capabilities
+  -> global Node Agent settings
+  -> feature ManageNodeAgent or ManageSingleContainerNodeAgent
+  -> feature provider capabilities
+  -> spec.override.nodeAgent
+  -> experimental.ApplyExperimentalOverrides
+  -> untaint startup toleration
+  -> create or update DaemonSet
+```
+
+`experimental.ApplyExperimentalOverrides` calls:
+
+1. `applyExperimentalImageOverrides`
+2. `applyExperimentalAutopilotOverrides`
+
+The Autopilot mutation therefore runs after `spec.override.nodeAgent` for the Node Agent workload. User overrides still apply to fields that Autopilot does not subsequently rewrite or remove, such as container resource requirements and `priorityClassName`. Overrides that re-add blocked volumes or mounts are stripped again by the Autopilot pass.
+
+Deployment-backed components (`clusterAgent`, `clusterChecksRunner`, `otelAgentGateway`) go through `datadogagentinternal/component_reconciler.go`. That path applies global settings, features, and component overrides, but it does not call `experimental.ApplyExperimentalOverrides`.
+
+## Autopilot pod-template changes
+
+The implementation is in `internal/controller/datadogagent/experimental/autopilot.go`.
+
+When enabled, it applies these Node Agent changes:
+
+- Creates or updates the GKE `AllowlistSynchronizer`.
+- Adds `DD_KUBELET_USE_API_SERVER=true` to use the API server instead of the kubelet for pod discovery.
+- Adds `DD_CLOUD_PROVIDER_METADATA=["gcp"]`.
+- Adds pod label `admission.datadoghq.com/enabled: "false"` so the Datadog admission controller does not mutate the Agent.
+- Changes the `init-volume` container args to `cp -r /etc/datadog-agent /opt`.
+- Removes disallowed Agent volumes, including auth, CRI socket, DogStatsD socket, and APM socket volumes.
+- Rewrites the run path hostPath to `/var/autopilot/addon/datadog/logs` when the run path is hostPath-backed.
+- Removes `DD_AUTH_TOKEN_FILE_PATH` from init containers and containers.
+- Removes disallowed volume mounts per container.
+- Marks the seccomp security mount read-only on init containers.
+- Replaces the `trace-agent` command with `trace-agent -config=/etc/datadog-agent/datadog.yaml`.
+- Replaces the `process-agent` command with `process-agent -config=/etc/datadog-agent/datadog.yaml`.
+
+The forbidden mount lists are container-specific. For example, `trace-agent` drops auth, CRI socket, DogStatsD socket, proc, cgroups, and APM socket mounts, while `system-probe` drops auth, CRI socket, and DogStatsD socket mounts.
+
+NPM-related volumes and mounts on `system-probe` are intentionally preserved. The tests assert that `proc`, `cgroups`, `debugfs`, `system-probe-socket`, and `HostPID` survive the Autopilot pass because the WorkloadAllowlist grants the required exemptions.
+
+## AllowlistSynchronizer
+
+The GKE `AllowlistSynchronizer` integration lives in `pkg/allowlistsynchronizer`.
+
+`CreateAllowlistSynchronizer(version, partOfLabel)`:
+
+- Resolves the requested WorkloadAllowlist version.
+- Falls back to `DefaultWorkloadAllowlistVersion` when the annotation is empty or malformed.
+- Builds a direct controller-runtime client from the current kubeconfig.
+- Server-side applies an `auto.gke.io/v1` `AllowlistSynchronizer` named `datadog-synchronizer`.
+
+The generated object points at:
+
+```text
+Datadog/datadog/datadog-datadog-daemonset-exemption-<version>.yaml
+```
+
+The default version is defined by `DefaultWorkloadAllowlistVersion` in `pkg/allowlistsynchronizer/allowlistsynchronizer.go`.
+
+## Feature-specific Autopilot behavior
+
+Several features check `experimental.IsAutopilotEnabled` during `Configure`.
+
+APM, in `internal/controller/datadogagent/feature/apm/feature.go`:
+
+- Enables host port mode.
+- Disables Unix domain socket mode.
+
+DogStatsD, in `internal/controller/datadogagent/feature/dogstatsd/feature.go`:
+
+- Enables host port mode.
+- Uses the configured host port when present, otherwise the default DogStatsD port.
+- Disables Unix domain socket mode.
+
+Admission Controller, in `internal/controller/datadogagent/feature/admissioncontroller/feature.go`:
+
+- Defaults Agent communication mode to `hostip` when the user has not set `agentCommunicationMode`.
+
+These feature defaults happen before Node Agent pod-template overrides and before the final Autopilot mutation pass.
+
+## RBAC behavior
+
+Node Agent RBAC is adjusted in `internal/controller/datadogagent/global/dependencies.go`.
+
+When Autopilot is enabled:
+
+- Fine-grained kubelet authorization is enabled by default.
+- The Agent ClusterRole includes the API-server pod permissions required by `DD_KUBELET_USE_API_SERVER=true`.
+
+The lower-level rule construction is in `internal/controller/datadogagent/component/agent/rbac.go`.
+
+## Testing
+
+Focused tests:
+
+- `internal/controller/datadogagent/experimental/autopilot_test.go`
+- `internal/controller/datadogagent/controller_v2_test.go`, `Test_AutopilotOverrides`
+
+Add tests when changing:
+
+- Annotation parsing or constants.
+- The WorkloadAllowlist version resolver.
+- Any forbidden volume or mount list.
+- The relative ordering of overrides and Autopilot mutations.
+- Feature defaults that branch on `IsAutopilotEnabled`.


### PR DESCRIPTION
### What does this PR do?

Title now that 1.27.0 is released

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Doc PR https://github.com/DataDog/documentation/pull/37329

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits