### PR TITLE
docs: recommend explicit cpu limits on high-core-count nodes

### DIFF
--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -642,6 +642,7 @@ spec:
 
 Use an integer value for `limits.cpu` so the runtime can read it directly. If your cluster has node shapes with widely varying core counts, apply different limits per shape with [DatadogAgentProfiles][10] rather than setting a single global value that may be too low for small nodes or too high for large ones.
 
+
 {{% collapse-content title="Parameters" level="h4" expanded=true id="override-options-list" %}}
 `[component].affinity`
 : If specified, the pod's scheduling constraints. See [link](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) for more information.

--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -615,6 +615,32 @@ spec:
 {{< /highlight >}}
 In the table, `spec.override.nodeAgent.image.name` and `spec.override.nodeAgent.containers.system-probe.resources.limits` appear as `[component].image.name` and `[component].containers.[container].resources.limits`, respectively.
 
+### Resource limits on high-core-count nodes
+
+On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This can drive memory usage proportionally and cause the Agent container to be OOM-killed even with otherwise modest workloads.
+
+Setting an explicit CPU limit on the `agent` container constrains the runtime to that value:
+
+{{< highlight yaml "hl_lines=6-14" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    nodeAgent:
+      containers:
+        agent:
+          resources:
+            requests:
+              cpu: "2"
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+{{< /highlight >}}
+
+Use an integer value for `limits.cpu` so the runtime can read it directly. If your cluster has node shapes with widely varying core counts, apply different limits per shape with [DatadogAgentProfiles][10] rather than setting a single global value that may be too low for small nodes or too high for large ones.
 
 {{% collapse-content title="Parameters" level="h4" expanded=true id="override-options-list" %}}
 `[component].affinity`
@@ -804,3 +830,4 @@ For a complete list of parameters, see the [Operator configuration spec][9].
 [7]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-tolerations.yaml
 [8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#all-configuration-options
 [9]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#override
+[10]: https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md

--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -617,7 +617,7 @@ In the table, `spec.override.nodeAgent.image.name` and `spec.override.nodeAgent.
 
 ### Resource limits on high-core-count nodes
 
-On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This can drive memory usage proportionally and cause the Agent container to be OOM-killed even with otherwise modest workloads.
+On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This scales memory usage proportionally with the CPU count and can cause the Agent container to be OOM-killed even with otherwise modest workloads.
 
 Setting an explicit CPU limit on the `agent` container constrains the runtime to that value:
 

--- a/docs/datadog_agent_profiles.md
+++ b/docs/datadog_agent_profiles.md
@@ -50,7 +50,7 @@ datadogagentprofile-sample                                      1         1     
 
 Common scenarios:
 
-* **Heterogeneous clusters with varying CPU core counts.** A single global resource limit set on the `DatadogAgent` is either too low for small control-plane nodes or too high for large GPU/bare-metal nodes. Use one DAP per node shape (selected via `profileAffinity` on a label such as `node.kubernetes.io/instance-type` or a custom node-role label) to apply appropriate `resources.limits.cpu` and `resources.limits.memory` to each group. On nodes with a high logical CPU count, an explicit CPU limit also prevents the Agent's Go runtime from sizing its scheduler to the host CPU count, which can otherwise lead to OOM kills.
+* **Heterogeneous clusters with varying CPU core counts.** A single global resource limit set on the `DatadogAgent` is either too low for small control-plane nodes or too high for large GPU/bare-metal nodes. Use one DatadogAgentProfile (DAP) per node shape (selected via `profileAffinity` on a label such as `node.kubernetes.io/instance-type` or a custom node-role label) to apply appropriate `resources.limits.cpu` and `resources.limits.memory` to each group. On nodes with a high logical CPU count, an explicit CPU limit also prevents the Agent's Go runtime from sizing its scheduler to the host CPU count, which can otherwise lead to OOM kills.
 * **Targeting specific node roles.** Run a different Agent configuration (for example, additional checks or a higher log level) on nodes labeled for a particular workload.
 
 ## Prerequisites

--- a/docs/datadog_agent_profiles.md
+++ b/docs/datadog_agent_profiles.md
@@ -46,6 +46,13 @@ datadogagentprofile-sample                                      1         1     
 * `datadog-agent` is the DaemonSet created by the default profile
 * `datadogagentprofile-sample` is the DaemonSet created by the profile `datadogagentprofile-sample`
 
+## When to use DatadogAgentProfiles
+
+Common scenarios:
+
+* **Heterogeneous clusters with varying CPU core counts.** A single global resource limit set on the `DatadogAgent` is either too low for small control-plane nodes or too high for large GPU/bare-metal nodes. Use one DAP per node shape (selected via `profileAffinity` on a label such as `node.kubernetes.io/instance-type` or a custom node-role label) to apply appropriate `resources.limits.cpu` and `resources.limits.memory` to each group. On nodes with a high logical CPU count, an explicit CPU limit also prevents the Agent's Go runtime from sizing its scheduler to the host CPU count, which can otherwise lead to OOM kills.
+* **Targeting specific node roles.** Run a different Agent configuration (for example, additional checks or a higher log level) on nodes labeled for a particular workload.
+
 ## Prerequisites
 
 * Operator v1.5.0+

--- a/hack/generate-docs/public_footer.markdown
+++ b/hack/generate-docs/public_footer.markdown
@@ -9,3 +9,4 @@ For a complete list of parameters, see the [Operator configuration spec][9].
 [7]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-tolerations.yaml
 [8]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#all-configuration-options
 [9]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#override
+[10]: https://github.com/DataDog/datadog-operator/blob/main/docs/datadog_agent_profiles.md

--- a/hack/generate-docs/public_overrides.markdown
+++ b/hack/generate-docs/public_overrides.markdown
@@ -23,3 +23,30 @@ spec:
               memory: 1Gi
 {{< /highlight >}}
 In the table, `spec.override.nodeAgent.image.name` and `spec.override.nodeAgent.containers.system-probe.resources.limits` appear as `[component].image.name` and `[component].containers.[container].resources.limits`, respectively.
+
+### Resource limits on high-core-count nodes
+
+On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This can drive memory usage proportionally and cause the Agent container to be OOM-killed even with otherwise modest workloads.
+
+Setting an explicit CPU limit on the `agent` container constrains the runtime to that value:
+
+{{< highlight yaml "hl_lines=6-14" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    nodeAgent:
+      containers:
+        agent:
+          resources:
+            requests:
+              cpu: "2"
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+{{< /highlight >}}
+
+Use an integer value for `limits.cpu` so the runtime can read it directly. If your cluster has node shapes with widely varying core counts, apply different limits per shape with [DatadogAgentProfiles][10] rather than setting a single global value that may be too low for small nodes or too high for large ones.

--- a/hack/generate-docs/public_overrides.markdown
+++ b/hack/generate-docs/public_overrides.markdown
@@ -26,7 +26,7 @@ In the table, `spec.override.nodeAgent.image.name` and `spec.override.nodeAgent.
 
 ### Resource limits on high-core-count nodes
 
-On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This can drive memory usage proportionally and cause the Agent container to be OOM-killed even with otherwise modest workloads.
+On nodes with a high logical CPU count (for example, large GPU or bare-metal hosts), the Agent's Go runtime sizes its scheduler to the host CPU count by default. This scales memory usage proportionally with the CPU count and can cause the Agent container to be OOM-killed even with otherwise modest workloads.
 
 Setting an explicit CPU limit on the `agent` container constrains the runtime to that value:
 


### PR DESCRIPTION
## Motivation

A customer (customer case reference #2907822) hit OOM kills on a 384-logical-CPU node. The Agent's Go runtime sizes its scheduler to `runtime.NumCPU()` by default, which drove memory usage proportionally on the high-core host. Setting `GOMAXPROCS=8` resolved it.

The customer has widely varying core counts across their fleet and cannot set a single global value. The working fix is to set per-node-group CPU limits, but this trade-off is not currently documented in the operator docs. The customer asked us to document this, and this PR addresses that request for the operator. A parallel PR ([DataDog/helm-charts#2718](https://github.com/DataDog/helm-charts/pull/2718)) covers the Helm chart.

## Approach

A new "Resource limits on high-core-count nodes" section in `docs/configuration_public.md` sits right after the existing override example. It explains the runtime behavior and shows an `override.nodeAgent.containers.agent` snippet with an integer `limits.cpu`. It also points users with heterogeneous node shapes at `DatadogAgentProfiles` as a way to apply different limits per shape from a single `DatadogAgent`.

The actual source files for the regenerated public docs are `hack/generate-docs/public_overrides.markdown` for the section body and `hack/generate-docs/public_footer.markdown` for the link reference. `docs/configuration_public.md` is regenerated from those sources by `make generate manifests`.

A new "When to use DatadogAgentProfiles" section in `docs/datadog_agent_profiles.md` leads with the heterogeneous-core-count scenario so users land in the right place from the DAP page too.

## Verification

- [x] Ran `make generate manifests` locally. The regenerated `docs/configuration_public.md` contains the callout in the override section.
- [x] Confirmed idempotency. A second `make generate manifests` run produces no diff.
- [ ] Reviewer: skim the new callout for clarity and the example for correctness against current API types.
- [ ] Reviewer: confirm the cross-link to DAPs lands users on the right page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)