### PR TITLE
chore(deps): Bump go directive to 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/DataDog/datadog-operator
 
-go 1.25.7
-
-toolchain go1.25.11
+go 1.25.11
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.63.0-rc.1 // indirect

--- a/hack/update-golang.sh
+++ b/hack/update-golang.sh
@@ -100,17 +100,32 @@ else
     echo "Warning: $actions_directory not found, skipping."
 fi
 
-# Update go.mod files
-go_mod_files="$ROOT/go.mod $ROOT/test/e2e/go.mod $ROOT/api/go.mod"
+# Update non-api go.mod files with the full Go patch version so static SCA
+# scanners don't flag patch-level stdlib CVEs that are already cleared by the
+# toolchain directive.
+go_mod_files="$ROOT/go.mod $ROOT/test/e2e/go.mod"
 for file in $go_mod_files; do
     if [[ -f $file ]]; then
         echo "Processing $file..."
-        go mod edit -go $new_minor_version $file
+        go mod edit -go $GOVERSION $file
         go mod edit -toolchain go$GOVERSION $file
     else
         echo "Warning: $file not found, skipping."
     fi
 done
+
+# api/go.mod stays minor-only: it is a types-only CRD module imported by
+# external projects (Agent, EDS, dd-source autoscaling, ...). A stricter `go`
+# directive would force consumers off Go n-1 for no real benefit since the
+# module ships no runtime code that could trigger stdlib CVEs.
+api_go_mod="$ROOT/api/go.mod"
+if [[ -f $api_go_mod ]]; then
+    echo "Processing $api_go_mod..."
+    go mod edit -go $new_minor_version $api_go_mod
+    go mod edit -toolchain go$GOVERSION $api_go_mod
+else
+    echo "Warning: $api_go_mod not found, skipping."
+fi
 
 # Run go work sync
 echo "Running go work sync..."

--- a/hack/update-golang.sh
+++ b/hack/update-golang.sh
@@ -108,7 +108,6 @@ for file in $go_mod_files; do
     if [[ -f $file ]]; then
         echo "Processing $file..."
         go mod edit -go $GOVERSION $file
-        go mod edit -toolchain go$GOVERSION $file
     else
         echo "Warning: $file not found, skipping."
     fi

--- a/hack/update-golang.sh
+++ b/hack/update-golang.sh
@@ -120,7 +120,7 @@ done
 api_go_mod="$ROOT/api/go.mod"
 if [[ -f $api_go_mod ]]; then
     echo "Processing $api_go_mod..."
-    go mod edit -go $new_minor_version $api_go_mod
+    go mod edit -go ${new_minor_version}.0 $api_go_mod
     go mod edit -toolchain go$GOVERSION $api_go_mod
 else
     echo "Warning: $api_go_mod not found, skipping."

--- a/hack/update-golang.sh
+++ b/hack/update-golang.sh
@@ -113,7 +113,7 @@ for file in $go_mod_files; do
     fi
 done
 
-# api/go.mod stays minor-only: it is a types-only CRD module imported by
+# api/go.mod stays at initial patch release for the minor Go version: it is a types-only CRD module imported by
 # external projects (Agent, EDS, dd-source autoscaling, ...). A stricter `go`
 # directive would force consumers off Go n-1 for no real benefit since the
 # module ships no runtime code that could trigger stdlib CVEs.

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,8 +1,6 @@
 module github.com/DataDog/datadog-operator/test/e2e
 
-go 1.25.8
-
-toolchain go1.25.11
+go 1.25.11
 
 require (
 	github.com/DataDog/datadog-agent/test/e2e-framework v0.78.0-devel


### PR DESCRIPTION
### What does this PR do?

Two related changes

1. **[`hack/update-golang.sh`](hack/update-golang.sh) split logic**: writes the full Go patch version (`$GOVERSION`) to `go.mod` and `test/e2e/go.mod`, but keeps `api/go.mod` at the minor-only form (`$new_minor_version`). This eliminates spurious patch-level CVE findings on non-api modules without forcing a stricter `go` directive on the public `api/` submodule.
2. **Resulting bumps from running the updated script**: `go.mod` `go 1.25.7` → `1.25.11` and `test/e2e/go.mod` `go 1.25.8` → `1.25.11`. `api/go.mod` stays at `go 1.25.0`.

### Motivation

The SCA scanner flagged the operator repo for **CVE-2025-68121 / GO-2026-4337** (a `crypto/tls` session-resumption bug in stdlib < `go1.25.7`). Looking at it:

- The `toolchain` directive was already pinned to `go1.25.11` repo-wide, so built binaries are clean (`go version -m ./manager` → `go1.25.11`). The runtime was never exposed.
- Static scanners read the `go` directive literally as "minimum stdlib version" and flag every patch CVE fixed between that value and the running toolchain, even though the actual build is unaffected.
- The existing `update-golang.sh` convention of writing minor-only (`go 1.X`) to all go.mod files made this worse: every script run normalized e.g. `go 1.25.0` for `api/go.mod`, keeping the scanner noise alive across patch versions.

The fix is to split the convention along module-purpose lines:

- **`go.mod` and `test/e2e/go.mod`** are internal to this repo (not imported by external projects), so writing the full patch version is safe and silences SCA noise without breaking anyone.
- **`api/go.mod`** is a types-only CRD module imported by other projects (Agent, EDS, dd-source autoscaling, ...). A stricter `go` directive would force consumers off Go n-1 for no real benefit: the module ships no runtime code, so stdlib CVEs cannot trigger from it. Keeping it minor-only preserves Go's standard n-1/n compatibility guarantee for consumers. The api/-specific scanner finding will be handled via SCA suppression separately.

### Additional Notes

- No behavior change at build/runtime — toolchain was already `go1.25.11`.
- Future `make update-golang` runs produce the same asymmetric output deterministically, so CI's `check-golang-version` job stays green.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- `make managergobuild` — clean build
- `make lint` — `go vet` + `golangci-lint` both clean (0 issues)
- `make verify-licenses` — pass
- `make update-golang && git diff --exit-code` — reproduces clean (this is what the `check-golang-version` CI job runs)
- `api/go.mod` confirmed at `go 1.25.0` matching main; `go.mod` and `test/e2e/go.mod` at `go 1.25.11`

### Checklist

- [x] PR has at least one valid label — apply `dependencies` and `tooling`
- [x] PR has a milestone or the `qa/skip-qa` label — recommend `qa/skip-qa` (no runtime change)
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits