### PR TITLE
[codex] Use reachable git tag for build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ SHELL = /usr/bin/env bash -o pipefail
 # Datadog custom variables
 #
 BUILDINFOPKG=github.com/DataDog/datadog-operator/pkg/version
-GIT_TAG?=$(shell git tag | tr - \~ | sort -V | tr \~ - | tail -1)
-TAG_HASH=$(shell git tag | tr - \~ | sort -V | tr \~ - | tail -1)_$(shell git rev-parse --short HEAD)
+GIT_TAG?=$(shell git describe --tags --exact-match --match 'v[0-9]*' 2>/dev/null)
+LATEST_REACHABLE_TAG?=$(shell git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null)
+TAG_HASH=$(if $(LATEST_REACHABLE_TAG),$(LATEST_REACHABLE_TAG)_$(shell git rev-parse --short HEAD),$(shell git rev-parse --short HEAD))
 IMG_VERSION?=$(if $(VERSION),$(VERSION),latest)
 VERSION?=$(if $(GIT_TAG),$(GIT_TAG),$(TAG_HASH))
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ SHELL = /usr/bin/env bash -o pipefail
 #
 BUILDINFOPKG=github.com/DataDog/datadog-operator/pkg/version
 GIT_TAG?=$(shell git describe --tags --exact-match --match 'v[0-9]*' 2>/dev/null)
-LATEST_REACHABLE_TAG?=$(shell git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null)
-TAG_HASH=$(if $(LATEST_REACHABLE_TAG),$(LATEST_REACHABLE_TAG)_$(shell git rev-parse --short HEAD),$(shell git rev-parse --short HEAD))
+TAG_HASH=$(shell git rev-parse --short HEAD)
 IMG_VERSION?=$(if $(VERSION),$(VERSION),latest)
 VERSION?=$(if $(GIT_TAG),$(GIT_TAG),$(TAG_HASH))
 GIT_COMMIT?=$(shell git rev-parse HEAD)


### PR DESCRIPTION
## What changed

Update the Makefile version discovery used by build ldflags so the default embedded operator version only uses an explicit release tag when `HEAD` is exactly on that tag. Untagged builds now fall back to the current short commit SHA.

## Why

The previous default selected the highest version tag present in the local clone:

```make
git tag | sort -V | tail -1
```

That made CI sensitive to unrelated fetched tags. A v1.27 release-branch image build could embed `v1.28.0-rc.1` if that tag existed in the checkout, even though the image was built from the correct v1.27 commit.

## Impact

- Tagged release builds embed the exact release tag, for example `v1.27.1-rc.1`.
- Untagged builds from `main`, release branches, or custom branches embed only the short SHA.
- Explicit `make VERSION=...` usage still takes precedence, preserving the bundle/release workflow.

## Validation

- `make -n docker-build-push-ci GOARCH=amd64 IMG=test/operator:test`
- `make -n VERSION=1.27.1-rc.1 LATEST_VERSION=1.27.0 bundle`