### PR TITLE
fix(appsec): correct envoyproxy RBAC resource typo backend -> backends

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -368,7 +368,7 @@ rules:
 - apiGroups:
   - gateway.envoyproxy.io
   resources:
-  - backend
+  - backends
   - envoyextensionpolicies
   - envoypatchpolicies
   verbs:

--- a/internal/controller/datadogagent/feature/appsec/rbac.go
+++ b/internal/controller/datadogagent/feature/appsec/rbac.go
@@ -78,7 +78,7 @@ func getRBACPolicyRules() []rbacv1.PolicyRule {
 		},
 		{
 			APIGroups: []string{rbac.EnvoyGatewayAPIGroup},
-			Resources: []string{"envoyextensionpolicies", "envoypatchpolicies", "backend"},
+			Resources: []string{"envoyextensionpolicies", "envoypatchpolicies", "backends"},
 			Verbs: []string{
 				rbac.GetVerb,
 				rbac.DeleteVerb,

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -123,7 +123,7 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways;gatewayclasses;httproutes,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;delete;create;patch
-// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoyextensionpolicies;envoypatchpolicies;backend,verbs=get;delete;create
+// +kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoyextensionpolicies;envoypatchpolicies;backends,verbs=get;delete;create
 // +kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;create;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=gateways,verbs=get;list;watch
 


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the Envoy Gateway RBAC resource name: `backend` -> `backends` (the Envoy Gateway API resource is plural).

The fix touches all three places the name appears:
- `internal/controller/datadogagent_controller.go` — the `+kubebuilder:rbac` marker for `gateway.envoyproxy.io`
- `internal/controller/datadogagent/feature/appsec/rbac.go` — the appsec runtime `PolicyRule`
- `config/rbac/role.yaml` — regenerated via `make manifests`

### Motivation

The operator's AppSec feature requested RBAC permissions for a resource named `backend`, which does not exist in the Envoy Gateway API (the correct resource is `backends`). As a result the granted permission never matched the real CRD.

### Additional Notes

- `config/rbac/role.yaml` was regenerated with `make manifests` (controller-gen v0.17.3); the only resulting change is `backend` -> `backends`.
- No API type changes, so no CRD regeneration was needed.

### Minimum Agent Versions

Not applicable.

### Describe your test plan

- `make manifests` produces only the `backend` -> `backends` change in `config/rbac/role.yaml`.
- `go build ./internal/controller/...` succeeds.
- `go test ./internal/controller/datadogagent/feature/appsec/...` passes.

### Checklist

- [x] PR has at least one valid label: `bug`
- [x] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed