### PR TITLE
support nested SGC config options

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -7,6 +7,7 @@ package v2alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -1997,7 +1998,7 @@ type SecretBackendConfig struct {
 
 	// Additional configuration for the secret backend type.
 	// +optional
-	Config map[string]string `json:"config,omitempty"`
+	Config map[string]apiextensionsv1.JSON `json:"config,omitempty"`
 
 	// Roles for Datadog to read the specified secrets, replacing `enableGlobalPermissions`.
 	// They are defined as a list of namespace/secrets.

--- a/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
+++ b/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
@@ -12,6 +12,7 @@ package v2alpha1
 import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -3495,9 +3496,9 @@ func (in *SecretBackendConfig) DeepCopyInto(out *SecretBackendConfig) {
 	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]apiextensionsv1.JSON, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 	if in.Roles != nil {

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -1914,9 +1914,7 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_SecretBackendConfig(ref comm
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Ref: ref("k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON"),
 									},
 								},
 							},
@@ -1944,7 +1942,7 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_SecretBackendConfig(ref comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.SecretBackendRolesConfig"},
+			"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.SecretBackendRolesConfig", "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.JSON"},
 	}
 }
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.35.3
+	k8s.io/apiextensions-apiserver v0.35.1
 	k8s.io/apimachinery v0.35.3
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e
 	k8s.io/utils v0.0.0-20251222233032-718f0e51e6d2

--- a/api/go.sum
+++ b/api/go.sum
@@ -119,6 +119,7 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 k8s.io/api v0.35.3 h1:pA2fiBc6+N9PDf7SAiluKGEBuScsTzd2uYBkA5RzNWQ=
 k8s.io/api v0.35.3/go.mod h1:9Y9tkBcFwKNq2sxwZTQh1Njh9qHl81D0As56tu42GA4=
+k8s.io/apiextensions-apiserver v0.35.1 h1:p5vvALkknlOcAqARwjS20kJffgzHqwyQRM8vHLwgU7w=
 k8s.io/apimachinery v0.35.3 h1:MeaUwQCV3tjKP4bcwWGgZ/cp/vpsRnQzqO6J6tJyoF8=
 k8s.io/apimachinery v0.35.3/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -3617,7 +3617,7 @@ spec:
                           type: string
                         config:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           description: Additional configuration for the secret backend type.
                           type: object
                         enableGlobalPermissions:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -3763,7 +3763,7 @@
                 },
                 "config": {
                   "additionalProperties": {
-                    "type": "string"
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
                   "description": "Additional configuration for the secret backend type.",
                   "type": "object"

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -3617,7 +3617,7 @@ spec:
                               type: string
                             config:
                               additionalProperties:
-                                type: string
+                                x-kubernetes-preserve-unknown-fields: true
                               description: Additional configuration for the secret backend type.
                               type: object
                             enableGlobalPermissions:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -3767,7 +3767,7 @@
                     },
                     "config": {
                       "additionalProperties": {
-                        "type": "string"
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "description": "Additional configuration for the secret backend type.",
                       "type": "object"

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -3621,7 +3621,7 @@ spec:
                           type: string
                         config:
                           additionalProperties:
-                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           description: Additional configuration for the secret backend type.
                           type: object
                         enableGlobalPermissions:

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -3763,7 +3763,7 @@
                 },
                 "config": {
                   "additionalProperties": {
-                    "type": "string"
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
                   "description": "Additional configuration for the secret backend type.",
                   "type": "object"

--- a/internal/controller/datadogagent/global/global_test.go
+++ b/internal/controller/datadogagent/global/global_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -493,7 +495,7 @@ func TestNodeAgentComponenGlobalSettings(t *testing.T) {
 				ddaName,
 				ddaNamespace,
 				testutils.NewDatadogAgentBuilder().
-					WithGlobalSecretBackendType("k8s.secrets", map[string]string{"token_path": "/custom/token"}).
+					WithGlobalSecretBackendType("k8s.secrets", map[string]apiextensionsv1.JSON{"token_path": {Raw: []byte(`"/custom/token"`)}}).
 					WithCredentials("apiKey", "appKey").
 					BuildWithDefaults(),
 			),
@@ -547,6 +549,74 @@ func TestNodeAgentComponenGlobalSettings(t *testing.T) {
 				{
 					Name:  DDSecretBackendConfig,
 					Value: `{"token_path":"/custom/token"}`,
+				},
+			}...),
+			wantCoreAgentVolumeMounts: getExpectedVolumeMounts(),
+			wantVolumeMounts:          getExpectedVolumeMounts(),
+			wantVolumes:               getExpectedVolumes(),
+			want:                      assertAll,
+		},
+		{
+			name:                           "Secret backend - type-based config with nested object value",
+			singleContainerStrategyEnabled: false,
+			dda: addNameNamespaceToDDA(
+				ddaName,
+				ddaNamespace,
+				testutils.NewDatadogAgentBuilder().
+					WithGlobalSecretBackendType("gcp.secretmanager", map[string]apiextensionsv1.JSON{"gcp_session": {Raw: []byte(`{"project_id":"my-project"}`)}}).
+					WithCredentials("apiKey", "appKey").
+					BuildWithDefaults(),
+			),
+			wantCoreAgentEnvVars: nil,
+			wantEnvVars: getExpectedEnvVars([]*corev1.EnvVar{
+				{
+					Name: constants.DDAPIKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "datadog-secret",
+							},
+							Key: v2alpha1.DefaultAPIKeyKey,
+						},
+					},
+				},
+				{
+					Name: constants.DDAppKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "datadog-secret",
+							},
+							Key: v2alpha1.DefaultAPPKeyKey,
+						},
+					},
+				},
+				{
+					Name: DDClusterAgentAuthToken,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "datadog-token",
+							},
+							Key: common.DefaultTokenKey,
+						},
+					},
+				},
+				{
+					Name:  DDSecretBackendCommand,
+					Value: "",
+				},
+				{
+					Name:  DDSecretBackendArguments,
+					Value: "",
+				},
+				{
+					Name:  DDSecretBackendType,
+					Value: "gcp.secretmanager",
+				},
+				{
+					Name:  DDSecretBackendConfig,
+					Value: `{"gcp_session":{"project_id":"my-project"}}`,
 				},
 			}...),
 			wantCoreAgentVolumeMounts: getExpectedVolumeMounts(),
@@ -1392,4 +1462,34 @@ func Test_ValidateFIPSVersions(t *testing.T) {
 			assert.Len(t, errs, tt.wantErrors)
 		})
 	}
+}
+
+// TestSecretBackendConfigNestedDecode decodes secretBackend.config the way the API
+// server does. It is a regression test for the bug where the field was map[string]string
+// and could not represent the nested objects (e.g. gcp_session) the Agent requires.
+func TestSecretBackendConfigNestedDecode(t *testing.T) {
+	manifest := []byte(`
+type: gcp.secretmanager
+config:
+  gcp_session:
+    project_id: my-project
+  token_path: /custom/token
+`)
+
+	var cfg v2alpha1.SecretBackendConfig
+	if err := yaml.Unmarshal(manifest, &cfg); err != nil {
+		t.Fatalf("decoding nested secretBackend.config failed (the map[string]string regression): %v", err)
+	}
+
+	if assert.NotNil(t, cfg.Type) {
+		assert.Equal(t, "gcp.secretmanager", *cfg.Type)
+	}
+
+	gcpSession, ok := cfg.Config["gcp_session"]
+	assert.True(t, ok, "gcp_session key should be present")
+	assert.JSONEq(t, `{"project_id":"my-project"}`, string(gcpSession.Raw))
+
+	tokenPath, ok := cfg.Config["token_path"]
+	assert.True(t, ok, "token_path key should be present")
+	assert.JSONEq(t, `"/custom/token"`, string(tokenPath.Raw))
 }

--- a/pkg/testutils/builder.go
+++ b/pkg/testutils/builder.go
@@ -7,6 +7,7 @@ package testutils
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -1126,7 +1127,7 @@ func (builder *DatadogAgentBuilder) WithGlobalSecretBackendGlobalPerms(command s
 	return builder
 }
 
-func (builder *DatadogAgentBuilder) WithGlobalSecretBackendType(backendType string, config map[string]string) *DatadogAgentBuilder {
+func (builder *DatadogAgentBuilder) WithGlobalSecretBackendType(backendType string, config map[string]apiextensionsv1.JSON) *DatadogAgentBuilder {
 	if builder.datadogAgent.Spec.Global.SecretBackend == nil {
 		builder.datadogAgent.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{}
 	}

--- a/pkg/testutils/ddai_builder.go
+++ b/pkg/testutils/ddai_builder.go
@@ -7,6 +7,7 @@ package testutils
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -1001,7 +1002,7 @@ func (builder *DatadogAgentInternalBuilder) WithGlobalSecretBackendGlobalPerms(c
 	return builder
 }
 
-func (builder *DatadogAgentInternalBuilder) WithGlobalSecretBackendType(backendType string, config map[string]string) *DatadogAgentInternalBuilder {
+func (builder *DatadogAgentInternalBuilder) WithGlobalSecretBackendType(backendType string, config map[string]apiextensionsv1.JSON) *DatadogAgentInternalBuilder {
 	if builder.datadogAgentInternal.Spec.Global.SecretBackend == nil {
 		builder.datadogAgentInternal.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{}
 	}


### PR DESCRIPTION
### What does this PR do?
Changes spec.global.secretBackend.config from `map[string]string` to `map[string]apiextensionsv1.JSON`, so it can hold the nested config that built-in secret backends require

### Motivation
https://datadoghq.atlassian.net/browse/AGENT-16274

### Additional Notes
`map[string]interface{}` as a solution doesn't work, `make generate manifests` can't build a schema or correct deepcopy for bare `interface{}`

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

- Agent: v7.70.0+
- Cluster Agent: v7.70.0+

### Describe your test plan
Unit Tests:
- `TestSecretBackendConfigNestedDecode`
- `TestNodeAgentComponenGlobalSettings`
Manual:
- use the operator with sgc secrets that has a nested config and ensure secrets load

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits