### PR TITLE
Enforce DDI validation at spec level

### DIFF
--- a/api/datadoghq/v1alpha1/datadoginstrumentation_types.go
+++ b/api/datadoghq/v1alpha1/datadoginstrumentation_types.go
@@ -14,6 +14,7 @@ import (
 // DatadogInstrumentationSpec defines the desired state of DatadogInstrumentation.
 type DatadogInstrumentationSpec struct {
 	// TargetRef is the reference to the workload resource to instrument.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="targetRef is immutable"
 	TargetRef autoscalingv2.CrossVersionObjectReference `json:"targetRef"`
 
 	// Config defines the Datadog instrumentation configuration to apply to the target workload.

--- a/api/datadoghq/v1alpha1/datadoginstrumentation_types.go
+++ b/api/datadoghq/v1alpha1/datadoginstrumentation_types.go
@@ -12,9 +12,11 @@ import (
 )
 
 // DatadogInstrumentationSpec defines the desired state of DatadogInstrumentation.
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind == 'Service' || !has(self.config.checks) || self.config.checks.all(c, has(c.containerImage) && c.containerImage.size() > 0)",message="a container image is required for all checks"
 type DatadogInstrumentationSpec struct {
 	// TargetRef is the reference to the workload resource to instrument.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="targetRef is immutable"
+	// +kubebuilder:validation:XValidation:rule="self.kind in ['Deployment', 'DaemonSet', 'StatefulSet', 'CronJob', 'Job', 'Service']",message="targetRef.kind must be one of Deployment, DaemonSet, StatefulSet, CronJob, Job, or Service"
 	TargetRef autoscalingv2.CrossVersionObjectReference `json:"targetRef"`
 
 	// Config defines the Datadog instrumentation configuration to apply to the target workload.
@@ -30,8 +32,11 @@ type DatadogInstrumentationConfig struct {
 }
 
 // DatadogInstrumentationCheckConfig defines an Autodiscovery check configuration.
+// +kubebuilder:validation:XValidation:rule="(has(self.instances) && self.instances.size() > 0) || (has(self.logs) && self.logs.size() > 0)",message="at least one instance or log config is required"
 type DatadogInstrumentationCheckConfig struct {
 	// Integration is the Datadog integration name, for example redisdb.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^\S.*`
 	Integration string `json:"integration"`
 
 	// ContainerImage identifies container image names this check applies to.

--- a/config/crd/bases/v1/datadoghq.com_datadoginstrumentations.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadoginstrumentations.yaml
@@ -81,6 +81,8 @@ spec:
                             x-kubernetes-list-type: atomic
                           integration:
                             description: Integration is the Datadog integration name, for example redisdb.
+                            minLength: 1
+                            pattern: ^\S.*
                             type: string
                           logs:
                             description: Logs contains log collection configuration payloads for this integration.
@@ -157,6 +159,9 @@ spec:
                         required:
                           - integration
                         type: object
+                        x-kubernetes-validations:
+                          - message: at least one instance or log config is required
+                            rule: (has(self.instances) && self.instances.size() > 0) || (has(self.logs) && self.logs.size() > 0)
                       type: array
                       x-kubernetes-list-type: atomic
                   type: object
@@ -179,10 +184,15 @@ spec:
                   x-kubernetes-validations:
                     - message: targetRef is immutable
                       rule: self == oldSelf
+                    - message: targetRef.kind must be one of Deployment, DaemonSet, StatefulSet, CronJob, Job, or Service
+                      rule: self.kind in ['Deployment', 'DaemonSet', 'StatefulSet', 'CronJob', 'Job', 'Service']
               required:
                 - config
                 - targetRef
               type: object
+              x-kubernetes-validations:
+                - message: a container image is required for all checks
+                  rule: self.targetRef.kind == 'Service' || !has(self.config.checks) || self.config.checks.all(c, has(c.containerImage) && c.containerImage.size() > 0)
             status:
               description: DatadogInstrumentationStatus defines the observed state of DatadogInstrumentation.
               properties:

--- a/config/crd/bases/v1/datadoghq.com_datadoginstrumentations.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadoginstrumentations.yaml
@@ -176,6 +176,9 @@ spec:
                     - kind
                     - name
                   type: object
+                  x-kubernetes-validations:
+                    - message: targetRef is immutable
+                      rule: self == oldSelf
               required:
                 - config
                 - targetRef

--- a/config/crd/bases/v1/datadoghq.com_datadoginstrumentations_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadoginstrumentations_v1alpha1.json
@@ -177,7 +177,13 @@
             "kind",
             "name"
           ],
-          "type": "object"
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "targetRef is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
         }
       },
       "required": [

--- a/config/crd/bases/v1/datadoghq.com_datadoginstrumentations_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadoginstrumentations_v1alpha1.json
@@ -51,6 +51,8 @@
                   },
                   "integration": {
                     "description": "Integration is the Datadog integration name, for example redisdb.",
+                    "minLength": 1,
+                    "pattern": "^\\S.*",
                     "type": "string"
                   },
                   "logs": {
@@ -148,7 +150,13 @@
                 "required": [
                   "integration"
                 ],
-                "type": "object"
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "at least one instance or log config is required",
+                    "rule": "(has(self.instances) \u0026\u0026 self.instances.size() \u003e 0) || (has(self.logs) \u0026\u0026 self.logs.size() \u003e 0)"
+                  }
+                ]
               },
               "type": "array",
               "x-kubernetes-list-type": "atomic"
@@ -182,6 +190,10 @@
             {
               "message": "targetRef is immutable",
               "rule": "self == oldSelf"
+            },
+            {
+              "message": "targetRef.kind must be one of Deployment, DaemonSet, StatefulSet, CronJob, Job, or Service",
+              "rule": "self.kind in ['Deployment', 'DaemonSet', 'StatefulSet', 'CronJob', 'Job', 'Service']"
             }
           ]
         }
@@ -190,7 +202,13 @@
         "config",
         "targetRef"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "a container image is required for all checks",
+          "rule": "self.targetRef.kind == 'Service' || !has(self.config.checks) || self.config.checks.all(c, has(c.containerImage) \u0026\u0026 c.containerImage.size() \u003e 0)"
+        }
+      ]
     },
     "status": {
       "additionalProperties": false,


### PR DESCRIPTION
### What does this PR do?

Adds `DatadogInstrumentation` CRD validation on the spec layer using [Kubernetes CEL validation rules](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules). All these validations are already enforced by a [validation webhook](https://github.com/DataDog/datadog-agent/pull/50428), so this is added as an extra layer of validation.

Added validations:
* `targetRef` is immutable after creation.
* `targetRef.kind` must be one of `Deployment`, `DaemonSet`, `StatefulSet`, `CronJob`, `Job`, or `Service`.
* `integration` must not be blank.
* Each check must define at least one `instances` or `logs` entry.
* A container image is required for all checks on non-`Service` targets.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.81.x
* Cluster Agent: v7.81.x

### Describe your test plan

Tested apply of `DatadogInstrumentation` CRD with invalid specs, confirming each validation

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits