### PR TITLE
Copy OpenShift etcd metric secret

### DIFF
--- a/internal/controller/datadogagent/feature/controlplanemonitoring/const.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/const.go
@@ -23,6 +23,7 @@ const (
 	etcdCertsVolumeName      = "etcd-client-certs"
 	etcdCertsVolumeMountPath = "/etc/etcd-certs"
 	etcdCertsSecretName      = "etcd-metric-client"
+	etcdCertsSourceNamespace = "openshift-etcd-operator"
 
 	disableEtcdAutoconfVolumeName      = "disable-etcd-autoconf"
 	disableEtcdAutoconfVolumeMountPath = "/etc/datadog-agent/conf.d/etcd.d"

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -136,7 +136,7 @@ func (f *controlPlaneMonitoringFeature) copyOpenShiftEtcdSecret(managers feature
 	defer cancel()
 	if err := f.client.Get(ctx, sourceKey, source); err != nil {
 		f.logger.Info("Unable to copy OpenShift etcd metric client secret automatically", "namespace", sourceKey.Namespace, "name", sourceKey.Name, "error", err)
-		return false
+		return f.keepExistingOpenShiftEtcdSecret(managers)
 	}
 
 	target := &corev1.Secret{
@@ -153,6 +153,29 @@ func (f *controlPlaneMonitoringFeature) copyOpenShiftEtcdSecret(managers feature
 	}
 
 	f.logger.V(1).Info("Copied OpenShift etcd metric client secret", "sourceNamespace", sourceKey.Namespace, "targetNamespace", target.Namespace, "name", target.Name)
+	return true
+}
+
+func (f *controlPlaneMonitoringFeature) keepExistingOpenShiftEtcdSecret(managers feature.ResourceManagers) bool {
+	target := &corev1.Secret{}
+	targetKey := types.NamespacedName{
+		Namespace: f.owner.GetNamespace(),
+		Name:      etcdCertsSecretName,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := f.client.Get(ctx, targetKey, target); err != nil {
+		f.logger.Info("Unable to keep existing OpenShift etcd metric client secret", "namespace", targetKey.Namespace, "name", targetKey.Name, "error", err)
+		return false
+	}
+
+	if err := managers.Store().AddOrUpdate(kubernetes.SecretsKind, target); err != nil {
+		f.logger.Info("Unable to add existing OpenShift etcd metric client secret to dependency store", "namespace", target.Namespace, "name", target.Name, "error", err)
+		return false
+	}
+
+	f.logger.V(1).Info("Keeping existing OpenShift etcd metric client secret after source read failure", "namespace", target.Namespace, "name", target.Name)
 	return true
 }
 

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -131,7 +132,9 @@ func (f *controlPlaneMonitoringFeature) copyOpenShiftEtcdSecret(managers feature
 		Namespace: etcdCertsSourceNamespace,
 		Name:      etcdCertsSecretName,
 	}
-	if err := f.client.Get(context.TODO(), sourceKey, source); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := f.client.Get(ctx, sourceKey, source); err != nil {
 		f.logger.Info("Unable to copy OpenShift etcd metric client secret automatically", "namespace", sourceKey.Namespace, "name", sourceKey.Name, "error", err)
 		return false
 	}

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -6,12 +6,16 @@
 package controlplanemonitoring
 
 import (
+	"context"
 	"fmt"
+	"maps"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -29,6 +33,7 @@ func init() {
 func buildControlPlaneMonitoringFeature(options *feature.Options) feature.Feature {
 	controlplaneFeat := &controlPlaneMonitoringFeature{
 		logger: options.Logger,
+		client: options.Client,
 	}
 	return controlplaneFeat
 }
@@ -41,6 +46,7 @@ type controlPlaneMonitoringFeature struct {
 	defaultConfigMapName   string
 	openshiftConfigMapName string
 	eksConfigMapName       string
+	client                 client.Reader
 }
 
 // ID returns the ID of the Feature
@@ -86,13 +92,14 @@ func (f *controlPlaneMonitoringFeature) ManageDependencies(managers feature.Reso
 			return fmt.Errorf("failed to add openshift configmap to store: %w", err)
 		}
 
-		// For OpenShift, etcd monitoring requires manual secret copying
-		targetNamespace := f.owner.GetNamespace()
-		copyCommand := fmt.Sprintf("oc get secret etcd-metric-client -n openshift-etcd-operator -o yaml | sed 's/namespace: openshift-etcd-operator/namespace: %s/' | oc apply -f -", targetNamespace)
+		if copied := f.copyOpenShiftEtcdSecret(managers); !copied {
+			targetNamespace := f.owner.GetNamespace()
+			copyCommand := fmt.Sprintf("oc get secret %s -n %s -o yaml | sed 's/namespace: %s/namespace: %s/' | oc apply -f -", etcdCertsSecretName, etcdCertsSourceNamespace, etcdCertsSourceNamespace, targetNamespace)
 
-		f.logger.Info("OpenShift control plane monitoring requires manual etcd secret copy",
-			"command", copyCommand,
-			"note", "Run this command if cluster-checks-runner and node-agent pods fail to start due to missing etcd-metric-cert secret")
+			f.logger.Info("OpenShift control plane monitoring requires manual etcd secret copy",
+				"command", copyCommand,
+				"note", "Run this command if cluster-checks-runner and node-agent pods fail to start due to missing etcd-metric-cert secret")
+		}
 	} else if f.provider == kubernetes.EKSCloudProvider {
 		// EKS ConfigMap
 		eksConfigMap, err2 := f.buildControlPlaneMonitoringConfigMap(kubernetes.EKSProviderLabel, f.eksConfigMapName)
@@ -107,6 +114,43 @@ func (f *controlPlaneMonitoringFeature) ManageDependencies(managers feature.Reso
 	}
 
 	return nil
+}
+
+func (f *controlPlaneMonitoringFeature) copyOpenShiftEtcdSecret(managers feature.ResourceManagers) bool {
+	if f.client == nil {
+		f.logger.V(1).Info("Skipping OpenShift etcd metric client secret copy: Kubernetes reader is not configured")
+		return false
+	}
+
+	// Read the source Secret directly from the API server instead of relying on
+	// the controller cache: default operator installs do not watch the
+	// openshift-etcd-operator namespace, and broadening the cache would keep
+	// sensitive platform Secrets in memory just for this one copy.
+	source := &corev1.Secret{}
+	sourceKey := types.NamespacedName{
+		Namespace: etcdCertsSourceNamespace,
+		Name:      etcdCertsSecretName,
+	}
+	if err := f.client.Get(context.TODO(), sourceKey, source); err != nil {
+		f.logger.Info("Unable to copy OpenShift etcd metric client secret automatically", "namespace", sourceKey.Namespace, "name", sourceKey.Name, "error", err)
+		return false
+	}
+
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      etcdCertsSecretName,
+			Namespace: f.owner.GetNamespace(),
+		},
+		Type: source.Type,
+		Data: maps.Clone(source.Data),
+	}
+	if err := managers.Store().AddOrUpdate(kubernetes.SecretsKind, target); err != nil {
+		f.logger.Info("Unable to add copied OpenShift etcd metric client secret to dependency store", "namespace", target.Namespace, "name", target.Name, "error", err)
+		return false
+	}
+
+	f.logger.V(1).Info("Copied OpenShift etcd metric client secret", "sourceNamespace", sourceKey.Namespace, "targetNamespace", target.Namespace, "name", target.Name)
+	return true
 }
 
 // ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
@@ -54,7 +54,7 @@ func Test_controlPlaneMonitoringFeature_Configure(t *testing.T) {
 				WithControlPlaneMonitoring(true).
 				Build(),
 			FeatureOptions: &feature.Options{
-				Client: fakeClientWithSecret(t, &corev1.Secret{
+				Client: fakeClientWithSecrets(t, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      etcdCertsSecretName,
 						Namespace: etcdCertsSourceNamespace,
@@ -69,16 +69,42 @@ func Test_controlPlaneMonitoringFeature_Configure(t *testing.T) {
 			WantConfigure:        true,
 			WantDependenciesFunc: openShiftControlPlaneWantDepsFunc(),
 		},
+		{
+			Name: "Control Plane Monitoring enabled with OpenShift provider keeps existing target secret when source read fails",
+			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+				WithAnnotations(map[string]string{kubernetes.ProviderAnnotationKey: "openshift-rhcos"}).
+				WithControlPlaneMonitoring(true).
+				Build(),
+			FeatureOptions: &feature.Options{
+				Client: fakeClientWithSecrets(t, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdCertsSecretName,
+						Namespace: resourcesNamespace,
+					},
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						"tls.crt": []byte("existing-cert"),
+						"tls.key": []byte("existing-key"),
+					},
+				}),
+			},
+			WantConfigure:        true,
+			WantDependenciesFunc: openShiftControlPlaneWantExistingSecretDepsFunc(),
+		},
 	}
 
 	tests.Run(t, buildControlPlaneMonitoringFeature)
 }
 
-func fakeClientWithSecret(t testing.TB, secret *corev1.Secret) client.Client {
+func fakeClientWithSecrets(t testing.TB, secrets ...*corev1.Secret) client.Client {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	assert.NoError(t, corev1.AddToScheme(scheme))
-	return ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	objs := make([]client.Object, 0, len(secrets))
+	for _, secret := range secrets {
+		objs = append(objs, secret)
+	}
+	return ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 }
 
 func controlPlaneWantDepsFunc() func(t testing.TB, store store.StoreClient) {
@@ -102,6 +128,19 @@ func openShiftControlPlaneWantDepsFunc() func(t testing.TB, store store.StoreCli
 		assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
 		assert.Equal(t, []byte("cert"), secret.Data["tls.crt"])
 		assert.Equal(t, []byte("key"), secret.Data["tls.key"])
+	}
+}
+
+func openShiftControlPlaneWantExistingSecretDepsFunc() func(t testing.TB, store store.StoreClient) {
+	return func(t testing.TB, store store.StoreClient) {
+		obj, found := store.Get(kubernetes.SecretsKind, resourcesNamespace, etcdCertsSecretName)
+		assert.True(t, found, "Should have kept the existing OpenShift etcd metric client Secret")
+
+		secret, ok := obj.(*corev1.Secret)
+		assert.True(t, ok)
+		assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
+		assert.Equal(t, []byte("existing-cert"), secret.Data["tls.crt"])
+		assert.Equal(t, []byte("existing-key"), secret.Data["tls.key"])
 	}
 }
 

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
@@ -43,9 +47,38 @@ func Test_controlPlaneMonitoringFeature_Configure(t *testing.T) {
 			WantDependenciesFunc: controlPlaneWantDepsFunc(),
 			ClusterAgent:         controlPlaneWantResourcesFunc(),
 		},
+		{
+			Name: "Control Plane Monitoring enabled with OpenShift provider copies etcd metric client secret",
+			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+				WithAnnotations(map[string]string{kubernetes.ProviderAnnotationKey: "openshift-rhcos"}).
+				WithControlPlaneMonitoring(true).
+				Build(),
+			FeatureOptions: &feature.Options{
+				Client: fakeClientWithSecret(t, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      etcdCertsSecretName,
+						Namespace: etcdCertsSourceNamespace,
+					},
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						"tls.crt": []byte("cert"),
+						"tls.key": []byte("key"),
+					},
+				}),
+			},
+			WantConfigure:        true,
+			WantDependenciesFunc: openShiftControlPlaneWantDepsFunc(),
+		},
 	}
 
 	tests.Run(t, buildControlPlaneMonitoringFeature)
+}
+
+func fakeClientWithSecret(t testing.TB, secret *corev1.Secret) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	return ctrlfake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
 }
 
 func controlPlaneWantDepsFunc() func(t testing.TB, store store.StoreClient) {
@@ -56,6 +89,19 @@ func controlPlaneWantDepsFunc() func(t testing.TB, store store.StoreClient) {
 
 		_, found2 := store.Get(kubernetes.ConfigMapKind, resourcesNamespace, eksConfigMapName)
 		assert.False(t, found2, "Should not have created an EKS ConfigMap")
+	}
+}
+
+func openShiftControlPlaneWantDepsFunc() func(t testing.TB, store store.StoreClient) {
+	return func(t testing.TB, store store.StoreClient) {
+		obj, found := store.Get(kubernetes.SecretsKind, resourcesNamespace, etcdCertsSecretName)
+		assert.True(t, found, "Should have copied the OpenShift etcd metric client Secret")
+
+		secret, ok := obj.(*corev1.Secret)
+		assert.True(t, ok)
+		assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
+		assert.Equal(t, []byte("cert"), secret.Data["tls.crt"])
+		assert.Equal(t, []byte("key"), secret.Data["tls.key"])
 	}
 }
 

--- a/internal/controller/datadogagent/feature/types.go
+++ b/internal/controller/datadogagent/feature/types.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -171,6 +172,10 @@ type ProviderAwareFeature interface {
 // Options option that can be pass to the Interface.Configure function
 type Options struct {
 	Logger logr.Logger
+	// Client is a read-only Kubernetes client for feature code that needs live
+	// cluster state while building dependencies. Callers should pass an uncached
+	// reader when the feature may read outside the controller cache scope.
+	Client client.Reader
 }
 
 // BuildFunc function type used by each Feature during its factory registration.

--- a/internal/controller/datadogagentinternal/controller.go
+++ b/internal/controller/datadogagentinternal/controller.go
@@ -68,16 +68,21 @@ type ReconcilerOptions struct {
 	SupportCilium            bool
 	OperatorMetricsEnabled   bool
 	UntaintControllerEnabled bool
+	APIReader                client.Reader
 }
 
 // Reconciler is the internal reconciler for Datadog Agent
 type Reconciler struct {
-	options           ReconcilerOptions
-	client            client.Client
-	platformInfo      kubernetes.PlatformInfo
-	scheme            *runtime.Scheme
-	recorder          record.EventRecorder
-	forwarders        datadog.MetricsForwardersManager
+	options      ReconcilerOptions
+	client       client.Client
+	platformInfo kubernetes.PlatformInfo
+	scheme       *runtime.Scheme
+	recorder     record.EventRecorder
+	forwarders   datadog.MetricsForwardersManager
+	// apiReader bypasses the controller cache for feature-owned reads outside
+	// the watched namespace set, for example OpenShift control-plane source
+	// secrets. Writes still go through the normal dependency store and client.
+	apiReader         client.Reader
 	componentRegistry *ComponentRegistry
 }
 
@@ -98,6 +103,10 @@ func NewReconciler(options ReconcilerOptions, client client.Client, platformInfo
 		scheme:       scheme,
 		recorder:     recorder,
 		forwarders:   metricForwardersMgr,
+		apiReader:    options.APIReader,
+	}
+	if r.apiReader == nil {
+		r.apiReader = client
 	}
 
 	// Initialize component registry
@@ -117,9 +126,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, ddai *v1alpha1.DatadogAgentI
 	return resp, err
 }
 
-func reconcilerOptionsToFeatureOptions(opts *ReconcilerOptions, ctx context.Context) *feature.Options {
+func reconcilerOptionsToFeatureOptions(ctx context.Context, reader client.Reader) *feature.Options {
 	return &feature.Options{
 		Logger: ctrl.LoggerFrom(ctx),
+		Client: reader,
 	}
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -56,7 +56,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	newStatus := instance.Status.DeepCopy()
 	now := metav1.NewTime(time.Now())
 
-	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instance, &instance.Spec, instance.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(&r.options, ctx))
+	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instance, &instance.Spec, instance.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(ctx, r.apiReader))
 	// update list of enabled features for metrics forwarder
 	r.updateMetricsForwardersFeatures(instance, enabledFeatures)
 

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -169,6 +169,7 @@ func startDatadogAgentInternal(logger logr.Logger, mgr manager.Manager, pInfo ku
 			SupportCilium:            options.SupportCilium,
 			OperatorMetricsEnabled:   options.OperatorMetricsEnabled,
 			UntaintControllerEnabled: options.UntaintControllerEnabled,
+			APIReader:                mgr.GetAPIReader(),
 		},
 	}).SetupWithManager(mgr, metricForwardersMgr)
 }


### PR DESCRIPTION
## What

PoC for automatically copying the OpenShift etcd metric client Secret when OpenShift control plane monitoring is enabled.

- Pass an uncached API reader into feature construction from the DatadogAgentInternal reconciler.
- Read `openshift-etcd-operator/etcd-metric-client` directly from the API server.
- Add a managed `etcd-metric-client` Secret in the DatadogAgent namespace through the existing dependency store.
- Keep the manual-copy log fallback when the source Secret cannot be read.

## Why

OpenShift etcd monitoring mounts `etcd-metric-client` in the DatadogAgent namespace. Previously the operator only logged an `oc get ... | oc apply ...` command for users to copy it manually. This secret is necessary otherwise the pod fails to initialize. Now that introspection is enabled by default through target PR, it would "break" users that do not expect/use control-plane monitoring.

The operator ClusterRole already allows core Secret `get/list/watch/create/update/patch/delete`, so it has the required RBAC to perform this copy.

## Alternatives considered

- Watch `openshift-etcd-operator` by default: rejected for this PoC because it broadens the controller cache to a sensitive platform namespace, keeps platform Secrets in memory, and ties this behavior to bundle/install packaging.
- Use the cached client: rejected because default installs do not watch `openshift-etcd-operator`, producing `unknown namespace for the cache`.
- Use a direct API server read: chosen for the source Secret because this is a narrow one-off read outside the watched namespace set. The copied target Secret still uses the normal dependency store for ownership, apply, and cleanup.

## Follow-ups before productionizing

This PoC performs the direct source Secret read during each relevant DDAI reconciliation. Better production options include:

- Read only when the target Secret is missing or differs.
- Add a small TTL/cache around the source Secret content.
- Move copying into a dedicated helper/reconciler with status/error reporting.
- Consider a narrow watch only if it can target the exact source object without broadly caching the namespace.

## Validation

- Tested on my OpenShift cluster
