### PR TITLE
Include api module in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ ci-test: gotest integration-tests ## Run tests only (for CI, where build/generat
 
 .PHONY: gotest
 gotest:
-	go test ./... -coverprofile cover.out
+	go test ./... ./api/... -coverprofile cover.out
 
 .PHONY: integration-tests
 integration-tests: $(ENVTEST) ## Run integration tests with reconciler


### PR DESCRIPTION
### What does this PR do?

Updates the `gotest` Makefile target to run unit tests for both the root module and the separate `api` module.

### Motivation

`go test ./...` from the repository root does not include packages under `api/` because `api` is a separate Go module. This lets API test assertion failures pass `make ci-test` unnoticed.

### Additional Notes

None.

### Minimum Agent Versions

No minimum Agent or Cluster Agent version changes.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- `make -n gotest`
- `go test ./api/...`
- `go test ./... ./api/... -run '^$' -coverprofile /tmp/datadog-operator-api-gotest-cover.out`

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits