### PR TITLE
Align host profiler seccomp image overrides

### DIFF
--- a/internal/controller/datadogagent/experimental/image.go
+++ b/internal/controller/datadogagent/experimental/image.go
@@ -59,6 +59,25 @@ func overrideImage(currentImg string, overrideImg imageOverride) string {
 	return images.OverrideAgentImage(currentImg, overrideImgConfig)
 }
 
+// ResolveImageOverride returns the effective image for a container after applying the experimental image override
+// annotation. If no override is configured, or if the annotation is malformed, it returns currentImg.
+func ResolveImageOverride(dda metav1.Object, containerName, currentImg string) (string, error) {
+	if dda == nil {
+		return currentImg, nil
+	}
+
+	imageOverrides, err := getImageOverrideConfig(dda)
+	if err != nil {
+		return currentImg, err
+	}
+
+	if imageOverride, ok := imageOverrides[containerName]; ok {
+		return overrideImage(currentImg, imageOverride), nil
+	}
+
+	return currentImg, nil
+}
+
 func applyExperimentalImageOverrides(logger logr.Logger, dda metav1.Object, manager feature.PodTemplateManagers) {
 	// We support overriding the image used for any non-init container in the Agent's pod spec.
 	//

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -1,10 +1,8 @@
 package hostprofiler
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +12,7 @@ import (
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 )
@@ -23,7 +22,6 @@ var errHostPIDDisabledManually = errors.New("Host PID is required for host profi
 type hostProfilerFeature struct {
 	owner                   metav1.Object
 	hostPIDDisabledManually bool
-	hostProfilerImage       string
 
 	logger logr.Logger
 }
@@ -49,18 +47,12 @@ func (o *hostProfilerFeature) ID() feature.IDType {
 	return feature.HostProfilerIDType
 }
 
-func (o *hostProfilerFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) feature.RequiredComponents {
+func (o *hostProfilerFeature) Configure(dda metav1.Object, _ *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) feature.RequiredComponents {
 	o.owner = dda
 
 	if !featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnableHostProfilerAnnotation) {
 		return feature.RequiredComponents{}
 	}
-
-	// Resolve the host-profiler image now, during Configure, so ManageNodeAgent can use
-	// the correct image for the seccomp init container and profile name. Both the
-	// experimental annotation and spec.override.nodeAgent.image are applied after
-	// ManageNodeAgent runs, so we must read them here.
-	o.hostProfilerImage = resolveHostProfilerImage(dda, ddaSpec)
 
 	return feature.RequiredComponents{
 		Agent: feature.RequiredComponent{
@@ -111,13 +103,10 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 		hostProfilerContainer.SecurityContext = &corev1.SecurityContext{}
 	}
 
-	// Use the pre-resolved image (set in Configure) so that experimental image overrides,
-	// which are applied after ManageNodeAgent, are correctly reflected in the seccomp profile
-	// name and the init container image.
-	hostProfilerImage := o.hostProfilerImage
-	if hostProfilerImage == "" {
-		hostProfilerImage = hostProfilerContainer.Image
-	}
+	// Experimental image overrides are applied after ManageNodeAgent, so mirror their image
+	// resolution here to keep the seccomp profile and init container aligned with the final
+	// host-profiler container image.
+	hostProfilerImage := resolveHostProfilerImage(o.owner, hostProfilerContainer.Image)
 
 	sc := hostProfilerContainer.SecurityContext
 	sc.AllowPrivilegeEscalation = ptr.To(false)
@@ -192,26 +181,12 @@ func (o *hostProfilerFeature) ManageOtelAgentGateway(managers feature.PodTemplat
 }
 
 // resolveHostProfilerImage returns the host-profiler image to use for the seccomp init container
-// and profile name when a host-profiler-specific image override is set via the experimental
-// per-container annotation. Returns "" otherwise, causing ManageNodeAgent to fall back to the
-// host-profiler container's own image.
-func resolveHostProfilerImage(dda metav1.Object, _ *v2alpha1.DatadogAgentSpec) string {
-	if annotations := dda.GetAnnotations(); annotations != nil {
-		if raw := annotations["experimental.agent.datadoghq.com/image-override-config"]; raw != "" {
-			var overrides map[string]struct {
-				Name string `json:"name,omitempty"`
-				Tag  string `json:"tag,omitempty"`
-			}
-			if err := json.Unmarshal([]byte(raw), &overrides); err == nil {
-				if o, ok := overrides[string(apicommon.HostProfiler)]; ok && o.Name != "" {
-					if o.Tag != "" && !strings.Contains(o.Name, ":") {
-						return o.Name + ":" + o.Tag
-					}
-					return o.Name
-				}
-			}
-		}
+// and profile name. It uses the same experimental image override semantics as the final pod
+// mutation so the seccomp init image cannot drift from the host-profiler container image.
+func resolveHostProfilerImage(dda metav1.Object, baseImage string) string {
+	hostProfilerImage, err := experimental.ResolveImageOverride(dda, string(apicommon.HostProfiler), baseImage)
+	if err != nil {
+		return baseImage
 	}
-
-	return ""
+	return hostProfilerImage
 }

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -4,15 +4,19 @@ import (
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -155,19 +159,20 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 }
 
 func TestResolveHostProfilerImage(t *testing.T) {
+	baseImage := "docker.io/datadog/agent:7.63.0"
 	tests := []struct {
 		name        string
 		annotations map[string]string
 		want        string
 	}{
 		{
-			name: "no annotations, no spec override",
-			want: "",
+			name: "no annotations",
+			want: baseImage,
 		},
 		{
 			name:        "annotation absent",
 			annotations: map[string]string{"some.other/annotation": "value"},
-			want:        "",
+			want:        baseImage,
 		},
 		{
 			name: "experimental annotation — full ref in name",
@@ -177,38 +182,142 @@ func TestResolveHostProfilerImage(t *testing.T) {
 			want: "gcr.io/x/host-profiler:v2",
 		},
 		{
-			name: "experimental annotation — name and tag fields",
+			name: "experimental annotation — tagged name preserves registry",
 			annotations: map[string]string{
-				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler","tag":"v2"}}`,
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"host-profiler:v2"}}`,
 			},
-			want: "gcr.io/x/host-profiler:v2",
+			want: "docker.io/datadog/host-profiler:v2",
+		},
+		{
+			name: "experimental annotation — name and tag fields preserve registry",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"host-profiler","tag":"v2"}}`,
+			},
+			want: "docker.io/datadog/host-profiler:v2",
 		},
 		{
 			name: "experimental annotation — name with tag takes precedence over tag field",
 			annotations: map[string]string{
-				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"gcr.io/x/host-profiler:v1","tag":"v2"}}`,
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"host-profiler:v1","tag":"v2"}}`,
 			},
-			want: "gcr.io/x/host-profiler:v1",
+			want: "docker.io/datadog/host-profiler:v1",
 		},
 		{
 			name: "experimental annotation — different container, ignored",
 			annotations: map[string]string{
 				"experimental.agent.datadoghq.com/image-override-config": `{"agent":{"name":"gcr.io/x/agent:v2"}}`,
 			},
-			want: "",
+			want: baseImage,
 		},
 		{
 			name: "experimental annotation — malformed json",
 			annotations: map[string]string{
 				"experimental.agent.datadoghq.com/image-override-config": `not-json`,
 			},
-			want: "",
+			want: baseImage,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dda := &metav1.ObjectMeta{Annotations: tt.annotations}
-			assert.Equal(t, tt.want, resolveHostProfilerImage(dda, nil))
+			assert.Equal(t, tt.want, resolveHostProfilerImage(dda, baseImage))
+		})
+	}
+}
+
+func TestHostProfilerSeccompImageStaysAlignedThroughOverrides(t *testing.T) {
+	ifNotPresent := corev1.PullIfNotPresent
+	tests := []struct {
+		name              string
+		annotations       map[string]string
+		baseImage         string
+		componentOverride *v2alpha1.DatadogAgentComponentOverride
+		wantImage         string
+	}{
+		{
+			name:      "node agent image override does not rewrite host-profiler seccomp image",
+			baseImage: "gcr.io/datadoghq/agent:7.80.1",
+			componentOverride: &v2alpha1.DatadogAgentComponentOverride{
+				Image: &v2alpha1.AgentImageConfig{Name: "agent", Tag: "nightly", PullPolicy: &ifNotPresent},
+			},
+			wantImage: "gcr.io/datadoghq/agent:7.80.1",
+		},
+		// Tag-only experimental overrides are intentionally omitted here: host-profiler must select
+		// an image name that contains the profiler, while tag-only would keep the agent image name.
+		{
+			name: "experimental name and tag preserves registry after node agent override",
+			annotations: map[string]string{
+				"experimental.agent.datadoghq.com/image-override-config": `{"host-profiler":{"name":"host-profiler","tag":"v2"}}`,
+			},
+			baseImage: "custom.registry/agent:7.80.1-fips",
+			componentOverride: &v2alpha1.DatadogAgentComponentOverride{
+				Image: &v2alpha1.AgentImageConfig{Name: "agent", Tag: "nightly", PullPolicy: &ifNotPresent},
+			},
+			wantImage: "custom.registry/host-profiler:v2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{"agent.datadoghq.com/host-profiler-enabled": "true"}
+			for k, v := range tt.annotations {
+				annotations[k] = v
+			}
+			dda := testutils.NewDatadogAgentBuilder().
+				WithName("datadog-agent").
+				WithAnnotations(annotations).
+				Build()
+			dda.Spec.Override[v2alpha1.NodeAgentComponentName] = tt.componentOverride
+
+			manager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: string(apicommon.CoreAgentContainerName), Image: "gcr.io/datadoghq/agent:7.80.1"},
+						{
+							Name:  string(apicommon.HostProfiler),
+							Image: tt.baseImage,
+							SecurityContext: &corev1.SecurityContext{
+								ReadOnlyRootFilesystem: ptr.To(true),
+							},
+						},
+					},
+				},
+			})
+
+			hostProfilerFeat := buildHostProfilerFeature(nil).(*hostProfilerFeature)
+			hostProfilerFeat.Configure(dda, &dda.Spec, nil)
+			assert.NoError(t, hostProfilerFeat.ManageNodeAgent(manager))
+
+			override.PodTemplateSpec(logr.Discard(), manager, tt.componentOverride, v2alpha1.NodeAgentComponentName, dda.Name)
+			experimental.ApplyExperimentalOverrides(logr.Discard(), dda, manager)
+
+			var hostProfilerContainer *corev1.Container
+			for i := range manager.PodTemplateSpec().Spec.Containers {
+				if manager.PodTemplateSpec().Spec.Containers[i].Name == string(apicommon.HostProfiler) {
+					hostProfilerContainer = &manager.PodTemplateSpec().Spec.Containers[i]
+					break
+				}
+			}
+			assert.NotNil(t, hostProfilerContainer)
+			if hostProfilerContainer != nil {
+				assert.Equal(t, tt.wantImage, hostProfilerContainer.Image)
+				assert.Equal(t, ifNotPresent, hostProfilerContainer.ImagePullPolicy)
+				assert.Equal(t, seccompProfileName(tt.wantImage), *hostProfilerContainer.SecurityContext.SeccompProfile.LocalhostProfile)
+			}
+
+			var setupContainer *corev1.Container
+			for i := range manager.PodTemplateSpec().Spec.InitContainers {
+				if manager.PodTemplateSpec().Spec.InitContainers[i].Name == string(apicommon.HostProfilerSeccompSetupContainerName) {
+					setupContainer = &manager.PodTemplateSpec().Spec.InitContainers[i]
+					break
+				}
+			}
+			assert.NotNil(t, setupContainer)
+			if setupContainer != nil {
+				assert.Equal(t, tt.wantImage, setupContainer.Image)
+				assert.Equal(t, ifNotPresent, setupContainer.ImagePullPolicy)
+				assert.Contains(t, setupContainer.Command, common.SeccompRootVolumePath+"/"+seccompProfileName(tt.wantImage))
+			}
 		})
 	}
 }

--- a/internal/controller/datadogagent/global/global.go
+++ b/internal/controller/datadogagent/global/global.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
@@ -313,10 +312,6 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 func updateContainerImages(config *v2alpha1.GlobalConfig, podTemplateManager feature.PodTemplateManagers) {
 	image := &images.Image{}
 	for i, container := range podTemplateManager.PodTemplateSpec().Spec.Containers {
-		if apicommon.AgentContainerName(container.Name) == apicommon.HostProfiler {
-			// do not override host-profiler image
-			continue
-		}
 		image = images.FromString(container.Image).
 			WithRegistry(*config.Registry).
 			WithFIPS(*config.UseFIPSAgent)
@@ -325,10 +320,6 @@ func updateContainerImages(config *v2alpha1.GlobalConfig, podTemplateManager fea
 	}
 
 	for i, container := range podTemplateManager.PodTemplateSpec().Spec.InitContainers {
-		if apicommon.AgentContainerName(container.Name) == apicommon.HostProfilerSeccompSetupContainerName {
-			// do not override host-profiler-seccomp-setup initContainer image
-			continue
-		}
 		image = images.FromString(container.Image).
 			WithRegistry(*config.Registry).
 			WithFIPS(*config.UseFIPSAgent)

--- a/internal/controller/datadogagent/override/podtemplatespec.go
+++ b/internal/controller/datadogagent/override/podtemplatespec.go
@@ -73,10 +73,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 						JMXEnabled: false,
 					}
 					manager.PodTemplateSpec().Spec.Containers[i].Image = images.OverrideAgentImage(container.Image, otelOverride)
-				} else if containerName == apicommon.HostProfiler {
-					// The Host Profiler only relies on its override annotation image
-					continue
-				} else {
+				} else if containerName != apicommon.HostProfiler {
 					manager.PodTemplateSpec().Spec.Containers[i].Image = images.OverrideAgentImage(container.Image, override.Image)
 				}
 				if override.Image.PullPolicy != nil {
@@ -87,10 +84,9 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 
 		for i, initContainer := range manager.PodTemplateSpec().Spec.InitContainers {
 			// host-profiler-seccomp-setup copies a seccomp profile JSON baked into the profiler image, not the agent image.
-			if apicommon.AgentContainerName(initContainer.Name) == apicommon.HostProfilerSeccompSetupContainerName {
-				continue
+			if apicommon.AgentContainerName(initContainer.Name) != apicommon.HostProfilerSeccompSetupContainerName {
+				manager.PodTemplateSpec().Spec.InitContainers[i].Image = images.OverrideAgentImage(initContainer.Image, override.Image)
 			}
-			manager.PodTemplateSpec().Spec.InitContainers[i].Image = images.OverrideAgentImage(initContainer.Image, override.Image)
 			if override.Image.PullPolicy != nil {
 				manager.PodTemplateSpec().Spec.InitContainers[i].ImagePullPolicy = *override.Image.PullPolicy
 			}

--- a/internal/controller/datadogagent/override/podtemplatespec_test.go
+++ b/internal/controller/datadogagent/override/podtemplatespec_test.go
@@ -344,7 +344,7 @@ func TestPodTemplateSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "image override does not rewrite host-profiler or host-profiler-seccomp-setup images",
+			name: "image override does not rewrite host-profiler images but applies pull policy",
 			existingManager: func() *fake.PodTemplateManagers {
 				manager := fake.NewPodTemplateManagers(t, v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
@@ -370,15 +370,15 @@ func TestPodTemplateSpec(t *testing.T) {
 					} else {
 						assert.NotEqual(t, "profiler:old", c.Image, "container %s image should have been overridden", c.Name)
 					}
+					assert.Equal(t, v1.PullIfNotPresent, c.ImagePullPolicy, "container %s pull policy should have been overridden", c.Name)
 				}
 				for _, c := range manager.PodTemplateSpec().Spec.InitContainers {
 					if c.Name == string(apicommon.HostProfilerSeccompSetupContainerName) {
 						assert.Equal(t, "profiler:old", c.Image, "host-profiler-seccomp-setup image must not be overridden")
-						assert.Equal(t, v1.PullPolicy(""), c.ImagePullPolicy, "host-profiler-seccomp-setup pull policy must not be overridden")
 					} else {
 						assert.NotEqual(t, "profiler:old", c.Image, "init container %s image should have been overridden", c.Name)
-						assert.Equal(t, v1.PullIfNotPresent, c.ImagePullPolicy, "init container %s pull policy should have been overridden", c.Name)
 					}
+					assert.Equal(t, v1.PullIfNotPresent, c.ImagePullPolicy, "init container %s pull policy should have been overridden", c.Name)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

Stacked on #3135. This follows up on the host-profiler seccomp image override review feedback:

- use the same experimental image override semantics when selecting the host-profiler seccomp init image/profile
- keep `host-profiler` and `host-profiler-seccomp-setup` images from being rewritten by `spec.override.nodeAgent.image`
- still apply `spec.override.nodeAgent.image.pullPolicy` to those containers
- keep global registry/FIPS image handling for host-profiler so short-form experimental overrides preserve the expected base registry/tag
- add focused coverage for image alignment through the real mutation order

## Validation

```bash
GOMODCACHE=/tmp/datadog-operator-gomodcache \
GOCACHE=/tmp/datadog-operator-gocache \
go test ./internal/controller/datadogagent/feature/hostprofiler \
        ./internal/controller/datadogagent/override \
        ./internal/controller/datadogagent/global \
        ./internal/controller/datadogagent/experimental
```
