### PR TITLE
Fix digest-pinned image references being truncated by FromString

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -75,6 +75,7 @@ type Image struct {
 	registry string
 	name     string
 	tag      string
+	digest   string
 	isJMX    bool
 	isFIPS   bool
 	isFull   bool
@@ -114,6 +115,14 @@ func (i *Image) WithName(name string) *Image {
 		return i
 	}
 	i.name = name
+	return i
+}
+
+func (i *Image) WithDigest(digest string) *Image {
+	if digest == "" {
+		return i
+	}
+	i.digest = digest
 	return i
 }
 
@@ -206,6 +215,12 @@ func OverrideAgentImage(currentImage string, overrideImageSpec *v2alpha1.AgentIm
 			WithFull(overrideImage.isFull)
 	}
 
+	// A digest only pins the exact reference it was computed for, so any override of the
+	// image identity replaces the current digest rather than carrying it over
+	if overrideImage.name != "" || overrideImage.tag != "" || overrideImage.digest != "" {
+		image.digest = overrideImage.digest
+	}
+
 	return image.ToString()
 }
 
@@ -234,6 +249,13 @@ func (i *Image) ToString() string {
 		suffix = FullTagSuffix
 	}
 
+	if i.digest != "" {
+		if i.tag == "" && suffix == "" {
+			return fmt.Sprintf("%s/%s@%s", i.registry, i.name, i.digest)
+		}
+		return fmt.Sprintf("%s/%s:%s%s@%s", i.registry, i.name, i.tag, suffix, i.digest)
+	}
+
 	return fmt.Sprintf("%s/%s:%s%s", i.registry, i.name, i.tag, suffix)
 }
 
@@ -255,17 +277,26 @@ func parseTagSuffixes(tag string) (baseTag string, isJMX, isFIPS, isFull bool) {
 	return tag, isJMX, isFIPS, isFull
 }
 
-// FromString translates a string Image in the format registry/name:tag to an Image object
+// FromString translates a string Image in the format registry/name:tag, optionally pinned
+// by digest (registry/name:tag@sha256:digest or registry/name@sha256:digest), to an Image object
 func FromString(stringImage string) *Image {
-	splitImg := strings.Split(stringImage, "/")
+	// A digest contains ":" itself (e.g. "@sha256:abc..."), so it must be split off before
+	// the name is parsed for a tag
+	imageRef, digest, _ := strings.Cut(stringImage, "@")
+
+	splitImg := strings.Split(imageRef, "/")
 	registry := strings.Join(splitImg[:len(splitImg)-1], "/")
 
 	splitName := strings.Split(splitImg[len(splitImg)-1], ":")
 
 	name := splitName[0]
-	tag, isJMX, isFIPS, isFull := parseTagSuffixes(splitName[1])
+	var tag string
+	var isJMX, isFIPS, isFull bool
+	if len(splitName) > 1 {
+		tag, isJMX, isFIPS, isFull = parseTagSuffixes(splitName[1])
+	}
 
-	return newImage(registry, name, tag, isJMX, isFIPS, isFull)
+	return newImage(registry, name, tag, isJMX, isFIPS, isFull).WithDigest(digest)
 }
 
 // fromImageConfig creates an Image instance from the AgentImageConfig spec object
@@ -273,8 +304,9 @@ func FromString(stringImage string) *Image {
 // - name
 // - name:tag
 // - registry/name:tag
+// each optionally pinned by digest, e.g. registry/name:tag@sha256:digest or registry/name@sha256:digest
 // (Notably, we do not accept "registry/name".)
-// Note that if the name includes a tag, then we ignore imageConfig.tag and imageConfig.JMXEnabled
+// Note that if the name includes a tag or a digest, then we ignore imageConfig.tag and imageConfig.JMXEnabled
 func fromImageConfig(imageConfig *v2alpha1.AgentImageConfig) *Image {
 	if strings.Contains(imageConfig.Name, ":") {
 		return FromString(imageConfig.Name)

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -227,6 +227,13 @@ func Test_AssembleImage(t *testing.T) {
 			},
 			want: "gcr.io/datadoghq/agent:latest-jmx",
 		},
+		{
+			name: "full path with digest passes through",
+			imageSpec: &v2alpha1.AgentImageConfig{
+				Name: "gcr.io/datadoghq/agent:7.64.0@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			},
+			want: "gcr.io/datadoghq/agent:7.64.0@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -330,6 +337,36 @@ func Test_ToString(t *testing.T) {
 			},
 			want: "gcr.io/datadoghq/agent:7.64.0-fips-full",
 		},
+		{
+			name: "with digest",
+			image: &Image{
+				registry: "gcr.io/datadoghq",
+				name:     "cluster-agent",
+				tag:      "7.64.0",
+				digest:   "sha256:55504934ebb295875d09c551e9f4e9f0e8540d1c274cde643a04c26dcb3b1a8a",
+			},
+			want: "gcr.io/datadoghq/cluster-agent:7.64.0@sha256:55504934ebb295875d09c551e9f4e9f0e8540d1c274cde643a04c26dcb3b1a8a",
+		},
+		{
+			name: "with jmx and digest",
+			image: &Image{
+				registry: "gcr.io/datadoghq",
+				name:     "agent",
+				tag:      "7.64.0",
+				digest:   "sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+				isJMX:    true,
+			},
+			want: "gcr.io/datadoghq/agent:7.64.0-jmx@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+		},
+		{
+			name: "with digest and no tag",
+			image: &Image{
+				registry: "gcr.io/datadoghq",
+				name:     "agent",
+				digest:   "sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			},
+			want: "gcr.io/datadoghq/agent@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -404,6 +441,36 @@ func Test_FromString(t *testing.T) {
 				tag:      "7.64.0",
 				isFIPS:   true,
 				isFull:   true,
+			},
+		},
+		{
+			name:        "with digest",
+			imageString: "gcr.io/datadoghq/cluster-agent:7.64.0@sha256:55504934ebb295875d09c551e9f4e9f0e8540d1c274cde643a04c26dcb3b1a8a",
+			want: &Image{
+				registry: "gcr.io/datadoghq",
+				name:     "cluster-agent",
+				tag:      "7.64.0",
+				digest:   "sha256:55504934ebb295875d09c551e9f4e9f0e8540d1c274cde643a04c26dcb3b1a8a",
+			},
+		},
+		{
+			name:        "with jmx and digest",
+			imageString: "gcr.io/datadoghq/agent:7.64.0-jmx@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			want: &Image{
+				registry: "gcr.io/datadoghq",
+				name:     "agent",
+				tag:      "7.64.0",
+				digest:   "sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+				isJMX:    true,
+			},
+		},
+		{
+			name:        "with digest and no tag",
+			imageString: "gcr.io/datadoghq/agent@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			want: &Image{
+				registry: "gcr.io/datadoghq",
+				name:     "agent",
+				digest:   "sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
 			},
 		},
 	}
@@ -638,6 +705,38 @@ func Test_OverrideAgentImage(t *testing.T) {
 				Tag: "7.65.0-fips-full",
 			},
 			want: "gcr.io/datadoghq/agent:7.65.0-fips-full",
+		},
+		{
+			name:         "override image name is full name with digest",
+			currentImage: "gcr.io/datadoghq/cluster-agent:7.64.0",
+			overrideImageSpec: &v2alpha1.AgentImageConfig{
+				Name: "eu.gcr.io/datadoghq/cluster-agent:7.65.0@sha256:55504934ebb295875d09c551e9f4e9f0e8540d1c274cde643a04c26dcb3b1a8a",
+			},
+			want: "eu.gcr.io/datadoghq/cluster-agent:7.65.0@sha256:55504934ebb295875d09c551e9f4e9f0e8540d1c274cde643a04c26dcb3b1a8a",
+		},
+		{
+			name:         "override image name is full name with jmx tag suffix and digest",
+			currentImage: "gcr.io/datadoghq/agent:7.64.0",
+			overrideImageSpec: &v2alpha1.AgentImageConfig{
+				Name: "docker.io/datadog/agent:7.65.0-jmx@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			},
+			want: "docker.io/datadog/agent:7.65.0-jmx@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+		},
+		{
+			name:         "override image name is full name with digest and no tag",
+			currentImage: "gcr.io/datadoghq/agent:7.64.0",
+			overrideImageSpec: &v2alpha1.AgentImageConfig{
+				Name: "eu.gcr.io/datadoghq/agent@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			},
+			want: "eu.gcr.io/datadoghq/agent:7.64.0@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+		},
+		{
+			name:         "current image includes digest and override tag does not",
+			currentImage: "gcr.io/datadoghq/agent:7.64.0@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			overrideImageSpec: &v2alpha1.AgentImageConfig{
+				Tag: "7.65.0",
+			},
+			want: "gcr.io/datadoghq/agent:7.65.0",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,10 @@ func GetMax(val1, val2 int64) int64 {
 // GetTagFromImageName returns a tag from a full image name
 // it should cover most cases
 func GetTagFromImageName(imageName string) string {
+	// A digest suffix (e.g. "@sha256:...") contains a colon and would otherwise be
+	// mistaken for the tag, so strip it before splitting
+	imageName, _, _ = strings.Cut(imageName, "@")
+
 	parts := strings.Split(imageName, ":")
 	if len(parts) <= 1 {
 		return "latest"

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -46,3 +46,47 @@ func TestGetMax(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTagFromImageName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		imageName string
+		want      string
+	}{
+		{
+			name:      "registry, name and tag",
+			imageName: "gcr.io/datadoghq/agent:7.64.0",
+			want:      "7.64.0",
+		},
+		{
+			name:      "name and tag",
+			imageName: "agent:7.64.0",
+			want:      "7.64.0",
+		},
+		{
+			name:      "no tag",
+			imageName: "gcr.io/datadoghq/agent",
+			want:      "latest",
+		},
+		{
+			name:      "registry with port and no tag",
+			imageName: "localhost:5000/agent",
+			want:      "latest",
+		},
+		{
+			name:      "tag and digest",
+			imageName: "gcr.io/datadoghq/agent:7.64.0@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			want:      "7.64.0",
+		},
+		{
+			name:      "digest only",
+			imageName: "gcr.io/datadoghq/agent@sha256:e8370b31d516e2c878bc4af696d6d06484465e6311d506ecd2b5ebb42c1ec8a1",
+			want:      "latest",
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, GetTagFromImageName(test.imageName))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes parsing of digest-pinned image references in `pkg/images`. Since v1.26.0, `FromString` splits the last image path component on every colon and keeps only the first two parts, so an override such as

```yaml
override:
  clusterAgent:
    image:
      name: "eu.gcr.io/datadoghq/cluster-agent:7.80.0@sha256:55504934ebb295875d09c551e9f4e9f0e8540d1c274cde643a04c26dcb3b1a8a"
```

loses the digest hex and is rendered into pods as `eu.gcr.io/datadoghq/cluster-agent:7.80.0@sha256`, which is not a valid image reference. The cluster agent, cluster checks runners, and any rescheduled node agent pods then fail with `InvalidImageName`.

This change splits the digest off before the tag is parsed, carries it through `Image` and `ToString`, and makes an override of the image identity (name or tag) replace any previous digest instead of carrying a stale one over. Digest-only references (`registry/name@sha256:...`) now parse correctly too.

### Motivation

We pin agent images by digest. Upgrading the operator from 1.23.1 to 1.27.1 broke every cluster that applied the upgrade: the regression came in with the tag suffix parsing rewrite in #2605 (first released in v1.26.0). Before that, the parser split on the first colon only, so tag plus digest references survived. Backports to v1.27 and v1.28 would be appreciated.

### Additional Notes

None.

### Minimum Agent Versions

No minimum Agent or Cluster Agent version changes.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Added unit tests covering digest parsing in `Test_FromString`, `Test_ToString`, `Test_OverrideAgentImage` (including the production repro and digest clearing on tag override) and `Test_AssembleImage`.

- `go test ./pkg/images/...`
- `go test ./internal/controller/datadogagent/override/... ./internal/controller/datadogagent/global/...`

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
