### PR TITLE
No-op: make e2e job timeout 60mn to allow e2e tests to completion

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -438,7 +438,7 @@ e2e:
 
 e2e_mq:
   extends: e2e
-  timeout: 40m
+  timeout: 60m
   retry: 0
   rules:
     # Skip if only .md files are changed


### PR DESCRIPTION
### What does this PR do?

Title

### Motivation


https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/1773927448
```
ERROR: Job failed: execution took longer than 40m0s seconds
```

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits