### PR TITLE
aks provider support

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1592,6 +1592,7 @@ golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJ
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc h1:bH6xUXay0AIFMElXG2rQ4uiE+7ncwtiOdPfYK1NK2XA=
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
+golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
@@ -1646,6 +1647,8 @@ golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 google.golang.org/api v0.152.0/go.mod h1:3qNJX5eOmhiWYc67jRA/3GsDw97UFb5ivv7Y2PrriAY=
 google.golang.org/api v0.169.0 h1:QwWPy71FgMWqJN/l6jVlFHUa29a7dcUy02I8o799nPY=

--- a/internal/controller/datadogagent/feature/admissioncontroller/envvar.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/envvar.go
@@ -34,4 +34,5 @@ const (
 	DDAdmissionControllerProbeEnabled                                           = "DD_ADMISSION_CONTROLLER_PROBE_ENABLED"
 	DDAdmissionControllerProbeInterval                                          = "DD_ADMISSION_CONTROLLER_PROBE_INTERVAL"
 	DDAdmissionControllerProbeGracePeriod                                       = "DD_ADMISSION_CONTROLLER_PROBE_GRACE_PERIOD"
+	DDAdmissionControllerAddAKSSelectors                                        = "DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS"
 )

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -22,9 +22,11 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/objects"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/providercaps"
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/images"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 func init() {
@@ -558,4 +560,22 @@ func (f *admissionControllerFeature) ManageClusterChecksRunner(managers feature.
 
 func (f *admissionControllerFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers) error {
 	return nil
+}
+
+func (f *admissionControllerFeature) ClusterAgentProviderCapabilities() providercaps.ProviderCapabilityMap {
+	return providercaps.ProviderCapabilityMap{
+		kubernetes.AKSProvider: {
+			EnvVars: []providercaps.EnvVarSet{
+				{
+					EnvVar: corev1.EnvVar{
+						Name:  DDAdmissionControllerAddAKSSelectors,
+						Value: "true",
+					},
+					Containers: []apicommon.AgentContainerName{
+						apicommon.ClusterAgentContainerName,
+					},
+				},
+			},
+		},
+	}
 }

--- a/internal/controller/datadogagent/feature/oomkill/feature.go
+++ b/internal/controller/datadogagent/feature/oomkill/feature.go
@@ -39,8 +39,8 @@ type oomKillFeature struct{}
 // NodeAgentProviderCapabilities returns provider-conditional pod-template
 // mutations for the node agent. On GKE COS, /usr/src does not exist on host
 // nodes; strip the src volume + mounts so the pod schedules successfully.
-func (f *oomKillFeature) NodeAgentProviderCapabilities() providercaps.NodeAgentProviderCapabilities {
-	return providercaps.NodeAgentProviderCapabilities{
+func (f *oomKillFeature) NodeAgentProviderCapabilities() providercaps.ProviderCapabilityMap {
+	return providercaps.ProviderCapabilityMap{
 		kubernetes.GKECosProvider: {
 			RemoveVolumes: []string{common.SrcVolumeName},
 		},

--- a/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
+++ b/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
@@ -39,8 +39,8 @@ type tcpQueueLengthFeature struct{}
 // NodeAgentProviderCapabilities returns provider-conditional pod-template
 // mutations for the node agent. On GKE COS, /usr/src does not exist on host
 // nodes; strip the src volume + mounts so the pod schedules successfully.
-func (f *tcpQueueLengthFeature) NodeAgentProviderCapabilities() providercaps.NodeAgentProviderCapabilities {
-	return providercaps.NodeAgentProviderCapabilities{
+func (f *tcpQueueLengthFeature) NodeAgentProviderCapabilities() providercaps.ProviderCapabilityMap {
+	return providercaps.ProviderCapabilityMap{
 		kubernetes.GKECosProvider: {
 			RemoveVolumes: []string{common.SrcVolumeName},
 		},

--- a/internal/controller/datadogagent/feature/types.go
+++ b/internal/controller/datadogagent/feature/types.go
@@ -161,11 +161,11 @@ type Feature interface {
 // ProviderAwareFeature is an optional interface for features that vary behaviour
 // by provider. Features that have no provider-specific variation do not need
 // to implement it. The reconciler applies the returned capabilities by calling
-// providercaps.ApplyNodeAgentProviderCapabilities after the feature's
+// providercaps.ApplyProviderCapabilities after the feature's
 // ManageNodeAgent runs.
 type ProviderAwareFeature interface {
 	Feature
-	NodeAgentProviderCapabilities() providercaps.NodeAgentProviderCapabilities
+	NodeAgentProviderCapabilities() providercaps.ProviderCapabilityMap
 }
 
 // Options option that can be pass to the Interface.Configure function

--- a/internal/controller/datadogagent/feature/types.go
+++ b/internal/controller/datadogagent/feature/types.go
@@ -168,6 +168,15 @@ type ProviderAwareFeature interface {
 	NodeAgentProviderCapabilities() providercaps.ProviderCapabilityMap
 }
 
+// ClusterAgentProviderAwareFeature is an optional interface for features that vary
+// cluster agent behaviour by provider. The reconciler applies the returned
+// capabilities by calling providercaps.ApplyProviderCapabilities after
+// the feature's ManageClusterAgent runs.
+type ClusterAgentProviderAwareFeature interface {
+	Feature
+	ClusterAgentProviderCapabilities() providercaps.ProviderCapabilityMap
+}
+
 // Options option that can be pass to the Interface.Configure function
 type Options struct {
 	Logger logr.Logger

--- a/internal/controller/datadogagent/global/provider_spec.go
+++ b/internal/controller/datadogagent/global/provider_spec.go
@@ -34,7 +34,7 @@ const cloudInitInstanceIDVolumeName = "cloudinit-instance-id-file"
 // Mirrors the Helm chart's _provider-specific_ pod-template additions (see
 // charts/datadog/templates/_containers-common-env.yaml and
 // _container-cloudinit-volumemounts.yaml).
-var NodeAgentProviderSpec = providercaps.NodeAgentProviderCapabilities{
+var NodeAgentProviderSpec = providercaps.ProviderCapabilityMap{
 	kubernetes.EKSEC2UseHostnameFromFileProvider: {
 		// DD_HOSTNAME_FILE points the agent at the EC2 instance-id so it
 		// derives a stable hostname even when the kubelet hostname differs.

--- a/internal/controller/datadogagent/global/provider_spec_test.go
+++ b/internal/controller/datadogagent/global/provider_spec_test.go
@@ -37,7 +37,7 @@ func TestNodeAgentProviderSpec_EKS(t *testing.T) {
 	}
 	mgr := feature.NewPodTemplateManagers(tmpl)
 
-	providercaps.ApplyNodeAgentProviderCapabilities(mgr, kubernetes.EKSEC2UseHostnameFromFileProvider, NodeAgentProviderSpec)
+	providercaps.ApplyProviderCapabilities(mgr, kubernetes.EKSEC2UseHostnameFromFileProvider, NodeAgentProviderSpec)
 
 	wantEnv := corev1.EnvVar{Name: "DD_HOSTNAME_FILE", Value: "/var/lib/cloud/data/instance-id"}
 	for _, c := range tmpl.Spec.Containers {
@@ -87,7 +87,7 @@ func TestNodeAgentProviderSpec_NoProvider(t *testing.T) {
 	}
 	mgr := feature.NewPodTemplateManagers(tmpl)
 
-	providercaps.ApplyNodeAgentProviderCapabilities(mgr, "", NodeAgentProviderSpec)
+	providercaps.ApplyProviderCapabilities(mgr, "", NodeAgentProviderSpec)
 
 	assert.Empty(t, tmpl.Spec.Containers[0].Env)
 	assert.Empty(t, tmpl.Spec.Containers[0].VolumeMounts)

--- a/internal/controller/datadogagent/providercaps/provider_capabilities.go
+++ b/internal/controller/datadogagent/providercaps/provider_capabilities.go
@@ -5,9 +5,8 @@
 
 // Package providercaps holds the provider-conditional pod-template mutation
 // framework. Both per-feature (feature.ProviderAwareFeature) and global
-// (global.ApplyGlobalNodeAgentSpec) consumers declare their mutations as a
-// NodeAgentProviderCapabilities map and apply them via
-// ApplyNodeAgentProviderCapabilities.
+// (global.NodeAgentProviderSpec) consumers declare their mutations as a
+// ProviderCapabilityMap and apply them via ApplyProviderCapabilities.
 package providercaps
 
 import (
@@ -17,8 +16,8 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
 )
 
-// PodTemplateManager is the minimal interface ApplyNodeAgentProviderCapabilities
-// needs from a pod-template manager. feature.PodTemplateManagers satisfies it
+// PodTemplateManager is the minimal interface ApplyProviderCapabilities needs
+// from a pod-template manager. feature.PodTemplateManagers satisfies it
 // structurally, so callers pass their existing manager unchanged.
 type PodTemplateManager interface {
 	PodTemplateSpec() *corev1.PodTemplateSpec
@@ -53,7 +52,7 @@ type ContainerMountRef struct {
 }
 
 // ProviderCapabilities holds the volumes, env vars, and removals for a
-// specific provider entry in a NodeAgentProviderCapabilities map.
+// specific provider entry in a ProviderCapabilityMap.
 type ProviderCapabilities struct {
 	Volumes []VolumeAndMount
 	EnvVars []EnvVarSet
@@ -65,16 +64,16 @@ type ProviderCapabilities struct {
 	RemoveEnvVars []string
 }
 
-// NodeAgentProviderCapabilities maps a provider string to its capabilities.
+// ProviderCapabilityMap maps a provider string to its capabilities.
 // The empty string key "" is the baseline applied to all providers first.
 // Provider-specific entries are then applied on top: removals first, additions second.
-type NodeAgentProviderCapabilities = map[string]ProviderCapabilities
+type ProviderCapabilityMap = map[string]ProviderCapabilities
 
-// ApplyNodeAgentProviderCapabilities applies all provider-conditional mutations.
+// ApplyProviderCapabilities applies all provider-conditional mutations.
 // The baseline ("") entry is applied first. The provider-specific entry is then
 // applied: removals run before additions so a provider can replace a baseline item
 // by removing it and re-adding a modified version.
-func ApplyNodeAgentProviderCapabilities(mgr PodTemplateManager, provider string, caps NodeAgentProviderCapabilities) {
+func ApplyProviderCapabilities(mgr PodTemplateManager, provider string, caps ProviderCapabilityMap) {
 	if len(caps) == 0 {
 		return
 	}

--- a/internal/controller/datadogagentinternal/component_clusteragent.go
+++ b/internal/controller/datadogagentinternal/component_clusteragent.go
@@ -20,6 +20,7 @@ import (
 	componentdca "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/providercaps"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 )
 
@@ -58,9 +59,15 @@ func (c *ClusterAgentComponent) GetNewDeploymentFunc() func(ddai metav1.Object, 
 	return componentdca.NewDefaultClusterAgentDeployment
 }
 
-func (c *ClusterAgentComponent) GetManageFeatureFunc() func(feat feature.Feature, managers feature.PodTemplateManagers) error {
+func (c *ClusterAgentComponent) GetManageFeatureFunc(provider string) func(feat feature.Feature, managers feature.PodTemplateManagers) error {
 	return func(feat feature.Feature, managers feature.PodTemplateManagers) error {
-		return feat.ManageClusterAgent(managers)
+		if err := feat.ManageClusterAgent(managers); err != nil {
+			return err
+		}
+		if paf, ok := feat.(feature.ClusterAgentProviderAwareFeature); ok {
+			providercaps.ApplyProviderCapabilities(managers, provider, paf.ClusterAgentProviderCapabilities())
+		}
+		return nil
 	}
 }
 

--- a/internal/controller/datadogagentinternal/component_clusterchecksrunner.go
+++ b/internal/controller/datadogagentinternal/component_clusterchecksrunner.go
@@ -59,7 +59,7 @@ func (c *ClusterChecksRunnerComponent) GetNewDeploymentFunc() func(ddai metav1.O
 	return componentccr.NewDefaultClusterChecksRunnerDeployment
 }
 
-func (c *ClusterChecksRunnerComponent) GetManageFeatureFunc() func(feat feature.Feature, managers feature.PodTemplateManagers) error {
+func (c *ClusterChecksRunnerComponent) GetManageFeatureFunc(_ string) func(feat feature.Feature, managers feature.PodTemplateManagers) error {
 	return func(feat feature.Feature, managers feature.PodTemplateManagers) error {
 		return feat.ManageClusterChecksRunner(managers)
 	}

--- a/internal/controller/datadogagentinternal/component_otelagentgateway.go
+++ b/internal/controller/datadogagentinternal/component_otelagentgateway.go
@@ -57,7 +57,7 @@ func (c *OtelAgentGatewayComponent) GetNewDeploymentFunc() func(ddai metav1.Obje
 	return componentotelagentgateway.NewDefaultOtelAgentGatewayDeployment
 }
 
-func (c *OtelAgentGatewayComponent) GetManageFeatureFunc() func(feat feature.Feature, managers feature.PodTemplateManagers) error {
+func (c *OtelAgentGatewayComponent) GetManageFeatureFunc(_ string) func(feat feature.Feature, managers feature.PodTemplateManagers) error {
 	return func(feat feature.Feature, managers feature.PodTemplateManagers) error {
 		return feat.ManageOtelAgentGateway(managers)
 	}

--- a/internal/controller/datadogagentinternal/component_reconciler.go
+++ b/internal/controller/datadogagentinternal/component_reconciler.go
@@ -83,8 +83,10 @@ type ComponentReconciler interface {
 	// GetNewDeploymentFunc returns the function to create a new deployment for the component
 	GetNewDeploymentFunc() func(ddai metav1.Object, spec *datadoghqv2alpha1.DatadogAgentSpec) *appsv1.Deployment
 
-	// GetManageFeatureFunc returns the function to manage features for the component
-	GetManageFeatureFunc() func(feat feature.Feature, managers feature.PodTemplateManagers) error
+	// GetManageFeatureFunc returns the function to manage features for the component.
+	// provider is the current DDAI provider annotation value; components that apply
+	// provider-conditional mutations (e.g. ClusterAgent) use it in the returned closure.
+	GetManageFeatureFunc(provider string) func(feat feature.Feature, managers feature.PodTemplateManagers) error
 
 	// UpdateStatus updates the status of the component
 	UpdateStatus(deployment *appsv1.Deployment, newStatus *v1alpha1.DatadogAgentInternalStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string)
@@ -194,10 +196,12 @@ func (r *ComponentRegistry) reconcileComponent(ctx context.Context, params *Reco
 	// Set Global setting on the default deployment
 	component.GetGlobalSettingsFunc()(objLogger, podManagers, params.DDAI.GetObjectMeta(), &params.DDAI.Spec, params.ResourceManagers, params.RequiredComponents)
 
-	// Apply features changes on the Deployment.Spec.Template
+	// Apply features changes on the Deployment.Spec.Template.
+	// Each component's GetManageFeatureFunc owns any provider-conditional mutations it needs.
+	manageFeature := component.GetManageFeatureFunc(params.Provider)
 	var featErrors []error
 	for _, feat := range params.Features {
-		if errFeat := component.GetManageFeatureFunc()(feat, podManagers); errFeat != nil {
+		if errFeat := manageFeature(feat, podManagers); errFeat != nil {
 			featErrors = append(featErrors, errFeat)
 		}
 	}

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -62,7 +62,7 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 		podManagers = feature.NewPodTemplateManagers(&eds.Spec.Template)
 
 		// Apply provider-conditional global mutations to the pod template — pre-feature.
-		providercaps.ApplyNodeAgentProviderCapabilities(podManagers, provider, global.NodeAgentProviderSpec)
+		providercaps.ApplyProviderCapabilities(podManagers, provider, global.NodeAgentProviderSpec)
 
 		// Set Global setting on the default extendeddaemonset
 		global.ApplyGlobalSettingsNodeAgent(objLogger, podManagers, ddai.GetObjectMeta(), &ddai.Spec, resourcesManager, singleContainerStrategyEnabled, requiredComponents)
@@ -75,7 +75,7 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 				return result, errFeat
 			}
 			if paf, ok := feat.(feature.ProviderAwareFeature); ok {
-				providercaps.ApplyNodeAgentProviderCapabilities(podManagers, provider, paf.NodeAgentProviderCapabilities())
+				providercaps.ApplyProviderCapabilities(podManagers, provider, paf.NodeAgentProviderCapabilities())
 			}
 		}
 
@@ -127,7 +127,7 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 	podManagers = feature.NewPodTemplateManagers(&daemonset.Spec.Template)
 
 	// Apply provider-conditional global mutations to the pod template — pre-feature.
-	providercaps.ApplyNodeAgentProviderCapabilities(podManagers, provider, global.NodeAgentProviderSpec)
+	providercaps.ApplyProviderCapabilities(podManagers, provider, global.NodeAgentProviderSpec)
 
 	// Set Global setting on the default daemonset
 	global.ApplyGlobalSettingsNodeAgent(objLogger, podManagers, ddai.GetObjectMeta(), &ddai.Spec, resourcesManager, singleContainerStrategyEnabled, requiredComponents)
@@ -145,7 +145,7 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 				return result, errFeat
 			}
 			if paf, ok := feat.(feature.ProviderAwareFeature); ok {
-				providercaps.ApplyNodeAgentProviderCapabilities(podManagers, provider, paf.NodeAgentProviderCapabilities())
+				providercaps.ApplyProviderCapabilities(podManagers, provider, paf.NodeAgentProviderCapabilities())
 			}
 		}
 	}

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -82,6 +82,8 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 		}
 	}
 
+	provider := instance.GetAnnotations()[kubernetes.ProviderAnnotationKey]
+
 	// 2. Reconcile each component (DCA, CCR, OTel Gateway) using the component registry.
 	// Profile DDAIs only manage the Node Agent DaemonSet, so skip components to avoid cleanup of un-related components / running un-necessary operations.
 	if !isDDAILabeledWithProfile(instance) {
@@ -91,7 +93,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 			Features:           append(configuredFeatures, enabledFeatures...),
 			ResourceManagers:   resourceManagers,
 			Status:             newStatus,
-			Provider:           "",
+			Provider:           provider,
 		}
 
 		result, err = r.componentRegistry.ReconcileComponents(ctx, params)
@@ -101,7 +103,6 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	}
 
 	// 2.b. Node Agent
-	provider := instance.GetAnnotations()[kubernetes.ProviderAnnotationKey]
 	result, err = r.reconcileV2Agent(ctx, requiredComponents, append(configuredFeatures, enabledFeatures...), instance, resourceManagers, newStatus, provider)
 	if utils.ShouldReturn(result, err) {
 		return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -46,6 +46,9 @@ const (
 	// OpenShiftProviderLabel is the OpenShift node label used to determine the node's provider
 	OpenShiftProviderLabel = "node.openshift.io/os_id"
 
+	// AKSProvider is the Azure Kubernetes Service provider name (mirrors helm's providers.aks).
+	AKSProvider = "aks"
+
 	// EKSCloudProvider is the Amazon EKS CloudProvider name
 	EKSCloudProvider = "eks"
 

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -34,7 +34,7 @@ const (
 
 	// GKECosProvider is the full provider string for GKE on Container-Optimized OS
 	// nodes (matches the `{cloudProvider}-{value}` convention from
-	// generateValidProviderName). Used as a NodeAgentProviderCapabilities map key.
+	// generateValidProviderName). Used as a ProviderCapabilityMap key.
 	GKECosProvider = "gke-cos"
 
 	// GKEProviderLabel is the GKE node label used to determine the node's provider


### PR DESCRIPTION
### What does this PR do?

CONTP-1567

Adds support for `aks` provider supported in [helm](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L3171-L3173).

Easiest to review commit-by-commit:
228abde2802227fb4b415741f35b35793690b970 refactor provider capabilities to drop `NodeAgent` for naming.
711d01b610079c8de6b17eb708ba42c10c95eb77 support `aks` provider to customize DCA config.

### Motivation

Related issue https://github.com/DataDog/datadog-operator/issues/2746. 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan
user operator renderer or kind cluster to generate DCA Deployment manifest
1. Apply
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: datadog
  annotations:
    datadoghq.com/provider: aks
spec:
  global:
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
```
verify DCA container has env var
```
        - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
          value: "true"
```
2. Remove provider or disable DCA (`spec.features.admissionController.enabled: false`)
`DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS` shouldn't be added

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits