### PR TITLE
[CONTP-1448] Add Windows node support

### DIFF
--- a/api/datadoghq/v1alpha1/datadogagentinternal_types.go
+++ b/api/datadoghq/v1alpha1/datadogagentinternal_types.go
@@ -22,6 +22,9 @@ type DatadogAgentInternalStatus struct {
 	// The actual state of the Agent as a daemonset or an extended daemonset.
 	// +optional
 	Agent *v2alpha1.DaemonSetStatus `json:"agent,omitempty"`
+	// The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).
+	// +optional
+	AgentWindows *v2alpha1.DaemonSetStatus `json:"agentWindows,omitempty"`
 	// The actual state of the Cluster Agent as a deployment.
 	// +optional
 	ClusterAgent *v2alpha1.DeploymentStatus `json:"clusterAgent,omitempty"`
@@ -42,6 +45,7 @@ type DatadogAgentInternalStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="agent",type="string",JSONPath=".status.agent.status"
+// +kubebuilder:printcolumn:name="agent-windows",type="string",JSONPath=".status.agentWindows.status",priority=1
 // +kubebuilder:printcolumn:name="cluster-agent",type="string",JSONPath=".status.clusterAgent.status"
 // +kubebuilder:printcolumn:name="cluster-checks-runner",type="string",JSONPath=".status.clusterChecksRunner.status"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/datadoghq/v1alpha1/zz_generated.deepcopy.go
+++ b/api/datadoghq/v1alpha1/zz_generated.deepcopy.go
@@ -197,6 +197,11 @@ func (in *DatadogAgentInternalStatus) DeepCopyInto(out *DatadogAgentInternalStat
 		*out = new(v2alpha1.DaemonSetStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AgentWindows != nil {
+		in, out := &in.AgentWindows, &out.AgentWindows
+		*out = new(v2alpha1.DaemonSetStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ClusterAgent != nil {
 		in, out := &in.ClusterAgent, &out.ClusterAgent
 		*out = new(v2alpha1.DeploymentStatus)

--- a/api/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -346,6 +346,12 @@ func schema_datadog_operator_api_datadoghq_v1alpha1_DatadogAgentInternalStatus(r
 							Ref:         ref("github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.DaemonSetStatus"),
 						},
 					},
+					"agentWindows": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).",
+							Ref:         ref("github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.DaemonSetStatus"),
+						},
+					},
 					"clusterAgent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Cluster Agent as a deployment.",

--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -25,6 +25,10 @@ const (
 	ClusterChecksRunnerComponentName ComponentName = "clusterChecksRunner"
 	// OtelAgentGatewayComponentName is the name of the OTel Agent Gateway
 	OtelAgentGatewayComponentName ComponentName = "otelAgentGateway"
+	// WindowsNodeAgentComponentName is the name of the Windows Node Agent DaemonSet.
+	// When present in spec.override, the operator creates a Windows-targeted DaemonSet
+	// alongside the Linux one (prototype: CONTP-1448).
+	WindowsNodeAgentComponentName ComponentName = "windowsNodeAgent"
 )
 
 // DatadogAgentSpec defines the desired state of DatadogAgent
@@ -2496,6 +2500,9 @@ type DatadogAgentStatus struct {
 	// The combined actual state of all Agents as daemonsets or extended daemonsets.
 	// +optional
 	Agent *DaemonSetStatus `json:"agent,omitempty"`
+	// The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).
+	// +optional
+	AgentWindows *DaemonSetStatus `json:"agentWindows,omitempty"`
 	// The actual state of the Cluster Agent as a deployment.
 	// +optional
 	ClusterAgent *DeploymentStatus `json:"clusterAgent,omitempty"`
@@ -2519,6 +2526,7 @@ type DatadogAgentStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:resource:path=datadogagents,shortName=dd
 // +kubebuilder:printcolumn:name="agent",type="string",JSONPath=".status.agent.status"
+// +kubebuilder:printcolumn:name="agent-windows",type="string",JSONPath=".status.agentWindows.status",priority=1
 // +kubebuilder:printcolumn:name="cluster-agent",type="string",JSONPath=".status.clusterAgent.status"
 // +kubebuilder:printcolumn:name="cluster-checks-runner",type="string",JSONPath=".status.clusterChecksRunner.status"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
+++ b/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
@@ -1401,6 +1401,11 @@ func (in *DatadogAgentStatus) DeepCopyInto(out *DatadogAgentStatus) {
 		*out = new(DaemonSetStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AgentWindows != nil {
+		in, out := &in.AgentWindows, &out.AgentWindows
+		*out = new(DaemonSetStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ClusterAgent != nil {
 		in, out := &in.ClusterAgent, &out.ClusterAgent
 		*out = new(DeploymentStatus)

--- a/api/datadoghq/v2alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v2alpha1/zz_generated.openapi.go
@@ -622,6 +622,12 @@ func schema_datadog_operator_api_datadoghq_v2alpha1_DatadogAgentStatus(ref commo
 							Ref:         ref("github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.DaemonSetStatus"),
 						},
 					},
+					"agentWindows": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).",
+							Ref:         ref("github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1.DaemonSetStatus"),
+						},
+					},
 					"clusterAgent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The actual state of the Cluster Agent as a deployment.",

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -20,6 +20,10 @@ spec:
         - jsonPath: .status.agent.status
           name: agent
           type: string
+        - jsonPath: .status.agentWindows.status
+          name: agent-windows
+          priority: 1
+          type: string
         - jsonPath: .status.clusterAgent.status
           name: cluster-agent
           type: string
@@ -8511,6 +8515,52 @@ spec:
               properties:
                 agent:
                   description: The actual state of the Agent as a daemonset or an extended daemonset.
+                  properties:
+                    available:
+                      description: Number of available pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    current:
+                      description: Number of current pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    currentHash:
+                      description: CurrentHash is the stored hash of the DaemonSet.
+                      type: string
+                    daemonsetName:
+                      description: DaemonsetName corresponds to the name of the created DaemonSet.
+                      type: string
+                    desired:
+                      description: Number of desired pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      description: LastUpdate is the last time the status was updated.
+                      format: date-time
+                      type: string
+                    ready:
+                      description: Number of ready pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    state:
+                      description: State corresponds to the DaemonSet state.
+                      type: string
+                    status:
+                      description: Status corresponds to the DaemonSet computed status.
+                      type: string
+                    upToDate:
+                      description: Number of up to date pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
+                agentWindows:
+                  description: The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).
                   properties:
                     available:
                       description: Number of available pods in the DaemonSet.

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -8208,6 +8208,66 @@
           ],
           "type": "object"
         },
+        "agentWindows": {
+          "additionalProperties": false,
+          "description": "The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).",
+          "properties": {
+            "available": {
+              "description": "Number of available pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "current": {
+              "description": "Number of current pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "currentHash": {
+              "description": "CurrentHash is the stored hash of the DaemonSet.",
+              "type": "string"
+            },
+            "daemonsetName": {
+              "description": "DaemonsetName corresponds to the name of the created DaemonSet.",
+              "type": "string"
+            },
+            "desired": {
+              "description": "Number of desired pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "ready": {
+              "description": "Number of ready pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "state": {
+              "description": "State corresponds to the DaemonSet state.",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status corresponds to the DaemonSet computed status.",
+              "type": "string"
+            },
+            "upToDate": {
+              "description": "Number of up to date pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "available",
+            "current",
+            "desired",
+            "ready",
+            "upToDate"
+          ],
+          "type": "object"
+        },
         "clusterAgent": {
           "additionalProperties": false,
           "description": "The actual state of the Cluster Agent as a deployment.",

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -20,6 +20,10 @@ spec:
         - jsonPath: .status.agent.status
           name: agent
           type: string
+        - jsonPath: .status.agentWindows.status
+          name: agent-windows
+          priority: 1
+          type: string
         - jsonPath: .status.clusterAgent.status
           name: cluster-agent
           type: string
@@ -8609,6 +8613,52 @@ spec:
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic
+                agentWindows:
+                  description: The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).
+                  properties:
+                    available:
+                      description: Number of available pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    current:
+                      description: Number of current pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    currentHash:
+                      description: CurrentHash is the stored hash of the DaemonSet.
+                      type: string
+                    daemonsetName:
+                      description: DaemonsetName corresponds to the name of the created DaemonSet.
+                      type: string
+                    desired:
+                      description: Number of desired pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      description: LastUpdate is the last time the status was updated.
+                      format: date-time
+                      type: string
+                    ready:
+                      description: Number of ready pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    state:
+                      description: State corresponds to the DaemonSet state.
+                      type: string
+                    status:
+                      description: Status corresponds to the DaemonSet computed status.
+                      type: string
+                    upToDate:
+                      description: Number of up to date pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                  required:
+                    - available
+                    - current
+                    - desired
+                    - ready
+                    - upToDate
+                  type: object
                 clusterAgent:
                   description: The actual state of the Cluster Agent as a deployment.
                   properties:

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -8273,6 +8273,66 @@
           "type": "array",
           "x-kubernetes-list-type": "atomic"
         },
+        "agentWindows": {
+          "additionalProperties": false,
+          "description": "The actual state of the Windows Agent as a daemonset (when spec.override.windowsNodeAgent is set).",
+          "properties": {
+            "available": {
+              "description": "Number of available pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "current": {
+              "description": "Number of current pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "currentHash": {
+              "description": "CurrentHash is the stored hash of the DaemonSet.",
+              "type": "string"
+            },
+            "daemonsetName": {
+              "description": "DaemonsetName corresponds to the name of the created DaemonSet.",
+              "type": "string"
+            },
+            "desired": {
+              "description": "Number of desired pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "lastUpdate": {
+              "description": "LastUpdate is the last time the status was updated.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "ready": {
+              "description": "Number of ready pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "state": {
+              "description": "State corresponds to the DaemonSet state.",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status corresponds to the DaemonSet computed status.",
+              "type": "string"
+            },
+            "upToDate": {
+              "description": "Number of up to date pods in the DaemonSet.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "available",
+            "current",
+            "desired",
+            "ready",
+            "upToDate"
+          ],
+          "type": "object"
+        },
         "clusterAgent": {
           "additionalProperties": false,
           "description": "The actual state of the Cluster Agent as a deployment.",

--- a/examples/datadogagent/datadog-agent-with-windows-nodes.yaml
+++ b/examples/datadogagent/datadog-agent-with-windows-nodes.yaml
@@ -1,0 +1,43 @@
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    clusterName: my-example-cluster
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+  # The presence of the windowsNodeAgent override key tells the Operator to create a
+  # second DaemonSet (datadog-agent-windows) targeting Windows nodes, alongside the
+  # default Linux DaemonSet. Each DaemonSet targets only its own OS via nodeSelector
+  # and the node.kubernetes.io/os=windows:NoSchedule toleration, so in a mixed cluster
+  # every node gets exactly one agent pod of the correct type.
+  #
+  # If this key is omitted, behavior is unchanged (Linux-only) — the feature is opt-in.
+  #
+  # Notes / current limitations:
+  #   - Windows runs the core agent + trace agent only (system-probe / security-agent
+  #     are Linux/eBPF only and are excluded automatically).
+  #   - Not supported with ExtendedDaemonSet or global.useFIPSAgent (the Operator
+  #     surfaces a WindowsAgentReconcile condition explaining why).
+  #   - systemProbe / securityAgent containers set in this override are ignored.
+  #   - LogCollection works on Windows: the operator mounts C:\var\log, C:\var\log\pods,
+  #     and C:\ProgramData so the agent can tail Windows pod logs.
+  #   - APM/DogStatsD: Windows has no Unix socket, so the agents listen on non-local
+  #     TCP (8126) / UDP (8125). The default component=agent local service does NOT route
+  #     to Windows pods, so to send traces/metrics from Windows workloads, enable hostPort
+  #     (features.apm.hostPortConfig / features.dogstatsd.hostPortConfig) so workloads can
+  #     reach the agent via the host IP. A Windows-specific local service is future work.
+  override:
+    windowsNodeAgent:
+      # Optional: override the Windows agent image. Defaults to the latest agent
+      # "-servercore" variant. Use a tag matching your Windows Server version
+      # (e.g. ltsc2022 nodes need a 2022-compatible servercore tag).
+      image:
+        name: agent
+        tag: 7.80.2-servercore
+      # All standard DatadogAgentComponentOverride fields work here (env, resources,
+      # tolerations, nodeSelector, ...).
+      env:
+        - name: DD_LOGS_ENABLED
+          value: "true"

--- a/internal/controller/datadogagent/component/agent/windows.go
+++ b/internal/controller/datadogagent/component/agent/windows.go
@@ -1,0 +1,627 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Windows DaemonSet builder — prototype for CONTP-1448.
+// Creates a minimal Windows-compatible DaemonSet alongside the Linux one:
+//   - nodeSelector: kubernetes.io/os=windows
+//   - toleration for node.kubernetes.io/os=windows:NoSchedule
+//   - Windows agent image (servercore variant)
+//   - PowerShell init container creates an empty datadog.yaml + auth/ dir in a shared vol
+//   - Core agent + trace agent share config vol at C:/ProgramData/Datadog
+//     so the auth_token written by core agent is visible to trace agent
+//   - Core agent + trace agent only (no system-probe/security-agent — Linux/eBPF only)
+//   - No Linux capabilities, no seccomp, no readOnlyRootFilesystem
+//   - Only emptyDir/configMap volumes (no Linux hostPath mounts)
+//   - StripLinuxOnlySettings (allowlist) removes anything Linux-only that features inject
+
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/images"
+)
+
+const (
+	// WindowsAgentResourceSuffix is the suffix used to name Windows agent resources.
+	WindowsAgentResourceSuffix = "agent-windows"
+
+	// windowsInitContainerName is the name of the Windows config-bootstrap init container.
+	windowsInitContainerName = "init-config-windows"
+
+	// windowsConfigVolumeName is the emptyDir volume shared between the init container
+	// and the core/trace agent containers on Windows. The init container creates an empty
+	// datadog.yaml (and the auth/ dir) in this volume; both agent containers then mount it
+	// at windowsDatadogConfigPath so they share the same datadog.yaml and the auth_token
+	// the core agent writes is visible to the trace agent.
+	windowsConfigVolumeName = "win-datadog-config"
+
+	// windowsDatadogConfigPath is the Windows default config directory. Both the core
+	// agent and trace agent mount the shared config volume here.
+	windowsDatadogConfigPath = "C:/ProgramData/Datadog"
+
+	// windowsAuthTokenFilePath is the auth token path for Windows containers.
+	// This overrides the Linux default (DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth/token)
+	// that commonEnvVars injects, since both containers mount the shared vol at
+	// windowsDatadogConfigPath and the core agent writes auth_token there.
+	windowsAuthTokenFilePath = windowsDatadogConfigPath + "/auth/token"
+
+	// Windows log-collection host paths (mirrors the Helm chart's daemonset-volumes-windows).
+	// On Windows, pod log files under C:/var/log/pods are symlinks into C:/ProgramData
+	// (containerd/docker), so the agent needs C:/ProgramData mounted to follow them.
+	windowsVarLogPath      = "C:/var/log"      // pointer dir (RW: agent stores log tail offsets)
+	windowsPodLogsPath     = "C:/var/log/pods" // Kubernetes pod log files
+	windowsProgramDataPath = "C:/ProgramData"  // symlink targets for the pod log files
+
+	windowsPointerVolumeName      = "win-pointerdir"
+	windowsPodLogsVolumeName      = "win-logpodpath"
+	windowsContainerLogVolumeName = "win-logcontainerpath"
+)
+
+// GetWindowsAgentName returns the Windows DaemonSet name for a given DatadogAgent.
+func GetWindowsAgentName(dda metav1.Object) string {
+	return fmt.Sprintf("%s-%s", dda.GetName(), WindowsAgentResourceSuffix)
+}
+
+// EnsureWindowsIntakeReachable forces non-local-traffic on for APM (trace-agent) and
+// DogStatsD (core agent) so they bind reachable TCP/UDP listeners on Windows, where Unix
+// sockets are unavailable. It MUST run after the feature loop and overrides: the DogStatsD
+// feature writes DD_DOGSTATSD_NON_LOCAL_TRAFFIC unconditionally to the user's value
+// (default false) with last-writer-wins merge, so setting it earlier (in the builder) would
+// be clobbered. Applied only to containers that exist in the (already stripped) pod spec.
+func EnsureWindowsIntakeReachable(managers feature.PodTemplateManagers) {
+	for _, c := range managers.PodTemplateSpec().Spec.Containers {
+		switch c.Name {
+		case string(apicommon.CoreAgentContainerName):
+			managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, &corev1.EnvVar{
+				Name: "DD_DOGSTATSD_NON_LOCAL_TRAFFIC", Value: "true",
+			})
+		case string(apicommon.TraceAgentContainerName):
+			managers.EnvVar().AddEnvVarToContainer(apicommon.TraceAgentContainerName, &corev1.EnvVar{
+				Name: "DD_APM_NON_LOCAL_TRAFFIC", Value: "true",
+			})
+		}
+	}
+}
+
+// WindowsLogPaths holds the host log paths to mount on the Windows agent. Empty fields fall
+// back to the Windows defaults. These come from features.logCollection.{tempStoragePath,
+// podLogsPath,containerLogsPath} so custom Windows log paths take effect.
+type WindowsLogPaths struct {
+	TempStoragePath   string // pointer dir (RW); default C:/var/log
+	PodLogsPath       string // pod logs (RO);   default C:/var/log/pods
+	ContainerLogsPath string // symlink targets (RO); default C:/ProgramData
+}
+
+// AddWindowsLogCollectionVolumes adds the Windows host-log hostPath volumes + mounts to the
+// core agent so log collection actually works (the logcollection feature only injects the
+// Linux paths, which the strip removes). Mirrors the Helm chart's daemonset-volumes-windows,
+// but honors the configured logCollection paths (falling back to the Windows defaults):
+//   - tempStoragePath   (pointer dir, RW — agent persists tail offsets); default C:/var/log
+//   - podLogsPath       (RO — Kubernetes pod log files);                 default C:/var/log/pods
+//   - containerLogsPath (RO — symlink targets the pod logs point into);  default C:/ProgramData
+//
+// It is a no-op if there is no core agent container (e.g. it was stripped). Safe to call only
+// when log collection is enabled.
+//
+// Following the Linux logcollection feature model, the configured paths set the HOST path only;
+// the in-container mount path is always the Windows Agent's standard path (C:/var/log,
+// C:/var/log/pods, C:/ProgramData). The Agent reads logs from those fixed in-container paths, so
+// a custom host path (e.g. D:/logs/pods) is surfaced where the Agent expects it without extra
+// Agent config. Mounting a custom path at itself would instead leave the Agent reading an empty
+// default path and silently collecting nothing.
+func AddWindowsLogCollectionVolumes(spec *corev1.PodSpec, paths WindowsLogPaths) {
+	pointerHostPath := windowsPathOrDefault(paths.TempStoragePath, windowsVarLogPath)
+	podLogsHostPath := windowsPathOrDefault(paths.PodLogsPath, windowsPodLogsPath)
+	containerLogsHostPath := windowsPathOrDefault(paths.ContainerLogsPath, windowsProgramDataPath)
+
+	idx := -1
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == string(apicommon.CoreAgentContainerName) {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return
+	}
+
+	hostPathVol := func(name, path string) corev1.Volume {
+		hpType := corev1.HostPathDirectoryOrCreate
+		return corev1.Volume{
+			Name:         name,
+			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: path, Type: &hpType}},
+		}
+	}
+	spec.Volumes = append(spec.Volumes,
+		hostPathVol(windowsPointerVolumeName, pointerHostPath),
+		hostPathVol(windowsPodLogsVolumeName, podLogsHostPath),
+		hostPathVol(windowsContainerLogVolumeName, containerLogsHostPath),
+	)
+	// Mount paths are fixed to the Agent's standard Windows paths regardless of the host path.
+	spec.Containers[idx].VolumeMounts = append(spec.Containers[idx].VolumeMounts,
+		corev1.VolumeMount{Name: windowsPointerVolumeName, MountPath: windowsVarLogPath},
+		corev1.VolumeMount{Name: windowsPodLogsVolumeName, MountPath: windowsPodLogsPath, ReadOnly: true},
+		corev1.VolumeMount{Name: windowsContainerLogVolumeName, MountPath: windowsProgramDataPath, ReadOnly: true},
+	)
+
+	// Force file-based container log collection on Windows. The only Windows log source we
+	// mount is the file tree (C:/var/log/pods + C:/ProgramData); runtime/socket-based
+	// collection has no Windows container-runtime socket/pipe wired up, so if the user set
+	// containerCollectUsingFiles=false the agent would collect nothing. Override to file mode.
+	spec.Containers[idx].Env = setEnvVar(spec.Containers[idx].Env, "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE", "true")
+}
+
+// windowsPathOrDefault returns the Windows default when the configured path is empty OR is a
+// Linux absolute path (starts with "/"). The latter is essential: the logCollection feature
+// defaults these fields to Linux paths (/var/log/pods, /var/lib/docker/containers, …), so a
+// plain empty-check would let those defaults through and produce an invalid Windows DaemonSet.
+// Only genuinely Windows paths (e.g. C:/...) are honored as overrides.
+func windowsPathOrDefault(v, def string) string {
+	if v == "" || strings.HasPrefix(v, "/") {
+		return def
+	}
+	return v
+}
+
+// setEnvVar replaces the named env var (or appends it) and returns the slice.
+func setEnvVar(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			envs[i] = corev1.EnvVar{Name: name, Value: value}
+			return envs
+		}
+	}
+	return append(envs, corev1.EnvVar{Name: name, Value: value})
+}
+
+// EnsureWindowsServercoreImage makes sure the default Datadog Agent image on the Windows
+// pod spec carries the "-servercore" tag suffix. It MUST run after override.PodTemplateSpec
+// applies spec.override.windowsNodeAgent.image: the generic OverrideAgentImage path replaces
+// the whole tag (servercore is not modeled as a preserved suffix), so a user pinning
+// image.tag=7.81.0 on the default image would otherwise get the Linux agent image.
+//
+// Coercion is intentionally limited to the default Datadog Agent image name ("agent"): a
+// fully custom image (e.g. registry.local/custom-agent:win2022) is the user's responsibility
+// and must already be Windows-compatible — we must not mangle its tag. Images whose tag
+// already contains "servercore" are left unchanged.
+func EnsureWindowsServercoreImage(spec *corev1.PodSpec) {
+	for i := range spec.Containers {
+		spec.Containers[i].Image = ensureServercoreTag(spec.Containers[i].Image)
+	}
+	for i := range spec.InitContainers {
+		spec.InitContainers[i].Image = ensureServercoreTag(spec.InitContainers[i].Image)
+	}
+}
+
+func ensureServercoreTag(image string) string {
+	// The tag is the segment after the last ":" that follows the last "/" (so a registry
+	// port like localhost:5000/agent:7.81.0 isn't mistaken for the tag).
+	slash := strings.LastIndex(image, "/")
+	colon := strings.LastIndex(image, ":")
+	if colon <= slash {
+		return image // no tag present; nothing safe to do
+	}
+	// Only coerce the default Datadog Agent image ("<registry>/agent"); leave custom images alone.
+	name := image[slash+1 : colon]
+	if name != images.DefaultAgentImageName {
+		return image
+	}
+	if strings.Contains(image[colon+1:], "servercore") {
+		return image
+	}
+	return image + images.WindowsServerCoreTagSuffix
+}
+
+// NewDefaultWindowsAgentDaemonset returns a new Windows-targeted DaemonSet.
+// It is meant to run alongside the Linux DaemonSet when Windows nodes are present.
+func NewDefaultWindowsAgentDaemonset(dda metav1.Object, edsOptions *ExtendedDaemonsetOptions, agentComponent feature.RequiredComponent, instanceName string) *appsv1.DaemonSet {
+	daemonset := NewDaemonset(dda, edsOptions, WindowsAgentResourceSuffix, GetWindowsAgentName(dda), common.GetAgentVersion(dda), nil, instanceName)
+	podTemplate := NewDefaultWindowsAgentPodTemplateSpec(dda, agentComponent, daemonset.GetLabels())
+	daemonset.Spec.Template = *podTemplate
+	return daemonset
+}
+
+// NewDefaultWindowsAgentPodTemplateSpec returns a Windows-compatible PodTemplateSpec.
+func NewDefaultWindowsAgentPodTemplateSpec(dda metav1.Object, agentComponent feature.RequiredComponent, labels map[string]string) *corev1.PodTemplateSpec {
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:      labels,
+			Annotations: make(map[string]string),
+		},
+		Spec: corev1.PodSpec{
+			// Windows does not support RunAsUser — omit PodSecurityContext entirely.
+			SecurityContext:    nil,
+			ServiceAccountName: getDefaultServiceAccountName(dda),
+			InitContainers:     windowsInitContainers(images.GetLatestWindowsAgentImage()),
+			Containers:         windowsAgentContainers(dda, agentComponent.Containers),
+			Volumes:            volumesForWindowsAgent(dda),
+			NodeSelector: map[string]string{
+				"kubernetes.io/os": "windows",
+			},
+			Tolerations: []corev1.Toleration{
+				{
+					// All Kubernetes distributions automatically taint Windows nodes
+					// with node.kubernetes.io/os=windows:NoSchedule via kubelet.
+					Key:      "node.kubernetes.io/os",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "windows",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+}
+
+// windowsInitContainers returns a PowerShell init container that creates a minimal
+// datadog.yaml inside the shared win-datadog-config emptyDir volume, which is mounted
+// at windowsDatadogConfigPath. All meaningful configuration (API key, site, cluster-agent
+// token) is supplied via environment variables injected by global settings, so an empty
+// config file is sufficient to satisfy the agent's startup requirement.
+//
+// All three containers (init, core agent, trace agent) mount the same emptyDir at
+// C:/ProgramData/Datadog, so the auth_token written by the core agent is visible to
+// the trace agent without any additional path trickery.
+func windowsInitContainers(img string) []corev1.Container {
+	return []corev1.Container{
+		{
+			Name:    windowsInitContainerName,
+			Image:   img,
+			Command: []string{"powershell", "-command"},
+			// Create the auth/ subdirectory before datadog.yaml so the trace agent
+			// can read the token path (C:/ProgramData/Datadog/auth/token) immediately
+			// on startup without waiting for the core agent to create it.
+			Args: []string{
+				"New-Item -ItemType Directory -Force -Path C:/ProgramData/Datadog/auth; " +
+					"New-Item -ItemType File -Force -Path C:/ProgramData/Datadog/datadog.yaml",
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      windowsConfigVolumeName,
+					MountPath: windowsDatadogConfigPath,
+				},
+			},
+		},
+	}
+}
+
+// windowsAgentContainers returns the containers for the Windows DaemonSet.
+// Only core agent and trace agent are included; system-probe and security-agent are
+// Linux/eBPF only and have no Windows equivalent.
+func windowsAgentContainers(dda metav1.Object, requiredContainers []apicommon.AgentContainerName) []corev1.Container {
+	img := images.GetLatestWindowsAgentImage()
+
+	containers := []corev1.Container{windowsCoreAgentContainer(dda, img)}
+
+	for _, c := range requiredContainers {
+		switch c {
+		case apicommon.TraceAgentContainerName:
+			containers = append(containers, windowsTraceAgentContainer(dda, img))
+		case apicommon.ProcessAgentContainerName:
+			containers = append(containers, windowsProcessAgentContainer(dda, img))
+			// SystemProbe, SecurityAgent: skip — Linux/eBPF only.
+		}
+	}
+	return containers
+}
+
+func windowsCoreAgentContainer(dda metav1.Object, img string) corev1.Container {
+	return corev1.Container{
+		Name:  string(apicommon.CoreAgentContainerName),
+		Image: img,
+		// "agent run" uses windowsDatadogConfigPath as the default config directory
+		// on Windows (mounted from the shared init-populated volume).
+		Command:        []string{"agent", "run"},
+		Env:            windowsEnvVarsForCoreAgent(dda),
+		VolumeMounts:   volumeMountsForWindowsCoreAgent(),
+		LivenessProbe:  constants.GetDefaultLivenessProbe(),
+		ReadinessProbe: constants.GetDefaultReadinessProbe(),
+		// No security context: Linux capabilities, seccomp, and readOnlyRootFilesystem
+		// are not supported by the Windows container runtime.
+	}
+}
+
+func windowsTraceAgentContainer(dda metav1.Object, img string) corev1.Container {
+	return corev1.Container{
+		Name:  string(apicommon.TraceAgentContainerName),
+		Image: img,
+		// "trace-agent run --foreground": on the Windows servercore image, "run" IS the
+		// trace-agent's own foreground subcommand (validated live — the container serves
+		// :8126 and registers with the core agent). This differs from the Linux container,
+		// which invokes "trace-agent --config=...". Do not "simplify" to drop "run": without
+		// it the binary prints usage and exits. It reads config from windowsDatadogConfigPath
+		// (shared with the core agent) so it can reach the auth_token written there.
+		Command:      []string{"trace-agent", "run", "--foreground"},
+		Env:          windowsEnvVarsForTraceAgent(dda),
+		VolumeMounts: volumeMountsForWindowsTraceAgent(),
+		// No security context.
+	}
+}
+
+func windowsProcessAgentContainer(dda metav1.Object, img string) corev1.Container {
+	return corev1.Container{
+		Name:         string(apicommon.ProcessAgentContainerName),
+		Image:        img,
+		Command:      []string{"process-agent", "--foreground"},
+		Env:          windowsCommonEnvVars(dda),
+		VolumeMounts: volumeMountsForWindowsProcessAgent(),
+		// No security context.
+	}
+}
+
+// windowsCommonEnvVars returns commonEnvVars with DD_AUTH_TOKEN_FILE_PATH overridden
+// to the Windows path. commonEnvVars sets the Linux default (/etc/datadog-agent/auth/token);
+// on Windows both containers mount the shared vol at windowsDatadogConfigPath so the
+// auth token lives there instead.
+func windowsCommonEnvVars(dda metav1.Object) []corev1.EnvVar {
+	return overrideAuthTokenPath(commonEnvVars(dda))
+}
+
+func windowsEnvVarsForCoreAgent(dda metav1.Object) []corev1.EnvVar {
+	return overrideAuthTokenPath(envVarsForCoreAgent(dda))
+}
+
+func windowsEnvVarsForTraceAgent(dda metav1.Object) []corev1.EnvVar {
+	return overrideAuthTokenPath(envVarsForTraceAgent(dda))
+}
+
+// overrideAuthTokenPath returns a copy of envs with DD_AUTH_TOKEN_FILE_PATH set to the
+// Windows auth token path. It builds a new slice to avoid mutating the caller's backing array.
+func overrideAuthTokenPath(envs []corev1.EnvVar) []corev1.EnvVar {
+	out := make([]corev1.EnvVar, 0, len(envs)+1)
+	replaced := false
+	for _, e := range envs {
+		if e.Name == common.DDAuthTokenFilePath {
+			out = append(out, corev1.EnvVar{Name: common.DDAuthTokenFilePath, Value: windowsAuthTokenFilePath})
+			replaced = true
+			continue
+		}
+		out = append(out, e)
+	}
+	if !replaced {
+		out = append(out, corev1.EnvVar{Name: common.DDAuthTokenFilePath, Value: windowsAuthTokenFilePath})
+	}
+	return out
+}
+
+// volumesForWindowsAgent returns the volumes for the Windows DaemonSet.
+// Only the shared config volume is declared; Linux-only volumes (/proc, /sys/fs/cgroup,
+// /etc/passwd, seccomp, Unix sockets) are omitted. Additional volumes (log collection
+// paths, named pipes for DogStatsD/APM) will be added as Windows feature support lands.
+func volumesForWindowsAgent(_ metav1.Object) []corev1.Volume {
+	return []corev1.Volume{
+		// Shared config volume: init-config-windows copies the image's C:/ProgramData/Datadog
+		// here; core agent and trace agent both mount it at windowsDatadogConfigPath so they
+		// share the same datadog.yaml and auth_token.
+		{
+			Name:         windowsConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+	}
+}
+
+func volumeMountsForWindowsCoreAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		// Mount shared config vol so core agent reads from init-populated
+		// C:/ProgramData/Datadog and writes auth_token there for trace agent.
+		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
+	}
+}
+
+func volumeMountsForWindowsTraceAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		// Mount same shared config vol so trace agent sees auth_token from core agent.
+		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
+	}
+}
+
+func volumeMountsForWindowsProcessAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
+	}
+}
+
+// windowsAllowedContainerNames is the allowlist of agent containers supported on Windows.
+// StripLinuxOnlySettings keeps ONLY these; everything else a feature might inject
+// (system-probe, security-agent, host-profiler, flightrecorder, fips-proxy, otel-agent,
+// agent-data-plane, private-action-runner, …) is removed. An allowlist is used instead
+// of a denylist so new Linux-only container classes don't silently leak onto Windows.
+var windowsAllowedContainerNames = map[string]bool{
+	string(apicommon.CoreAgentContainerName):    true,
+	string(apicommon.TraceAgentContainerName):   true,
+	string(apicommon.ProcessAgentContainerName): true,
+}
+
+// windowsAllowedInitContainerNames is the allowlist of init containers on Windows.
+// Only the Windows config-bootstrap init container is kept; Linux init containers
+// (seccomp-setup, init-volume, init-config, …) are removed.
+var windowsAllowedInitContainerNames = map[string]bool{
+	windowsInitContainerName: true,
+}
+
+// StripLinuxOnlySettings removes Linux-incompatible mutations from a Windows PodSpec.
+// See stripLinuxOnlyFromSpec for the full description; prefer
+// StripLinuxOnlySettingsFromTemplate which also cleans container-scoped pod annotations.
+func StripLinuxOnlySettings(spec *corev1.PodSpec) {
+	stripLinuxOnlyFromSpec(spec, nil)
+}
+
+// StripLinuxOnlySettingsFromTemplate removes Linux-incompatible mutations from a full
+// PodTemplateSpec — including container-scoped pod annotations (AppArmor profiles, etc.)
+// that reference removed containers, which Kubernetes would otherwise reject.
+//
+// It is called AFTER features run their ManageNodeAgent hooks. The model is an allowlist,
+// not a denylist, because the feature surface grows over time and a denylist is always
+// one feature behind:
+//
+//   - Containers: keep ONLY windowsAllowedContainerNames (core/trace/process agent).
+//     Everything else (system-probe, security-agent, host-profiler, flightrecorder,
+//     fips-proxy, otel-agent, …) is removed.
+//   - Init containers: keep ONLY windowsAllowedInitContainerNames (the Windows bootstrap).
+//   - Volume mounts: on each surviving container, drop any mount whose MountPath is a
+//     Linux absolute path (starts with "/"). Windows mounts use C:/... paths, so this
+//     uniformly catches hostPath mounts (/proc, /), emptyDir mounts at Linux paths
+//     (/var/run/sysprobe, /var/run/datadog/flightrecorder), and config mounts.
+//   - Volumes: drop any volume not referenced by a surviving container's mounts.
+//   - SecurityContext: clear Linux fields (capabilities, seccomp, SELinux, AppArmor,
+//     readOnlyRootFilesystem).
+//
+// Preserved: all feature env vars, Windows-path mounts/volumes added by the Windows builder.
+func StripLinuxOnlySettingsFromTemplate(tmpl *corev1.PodTemplateSpec) {
+	stripLinuxOnlyFromSpec(&tmpl.Spec, &tmpl.Annotations)
+}
+
+func stripLinuxOnlyFromSpec(spec *corev1.PodSpec, annotations *map[string]string) {
+	// 0. Clear Linux pod-level namespace-sharing fields. Features can set these (e.g.
+	//    DogStatsD origin detection sets hostPID=true); they are Linux-only and produce
+	//    a Windows-invalid PodSpec.
+	spec.HostPID = false
+	spec.HostIPC = false
+
+	// 1. Keep only allowlisted main containers; drop their Linux mounts, Unix-socket
+	//    env vars, and security context.
+	var keepContainers []corev1.Container
+	for _, c := range spec.Containers {
+		if !windowsAllowedContainerNames[c.Name] {
+			continue
+		}
+		c.VolumeMounts = stripLinuxMounts(c.VolumeMounts)
+		c.Env = stripWindowsIncompatibleEnvVars(c.Env)
+		c.SecurityContext = stripLinuxSecurityContext(c.SecurityContext)
+		keepContainers = append(keepContainers, c)
+	}
+	spec.Containers = keepContainers
+
+	// 2. Keep only allowlisted init containers; drop their Linux mounts + security context.
+	var keepInits []corev1.Container
+	for _, c := range spec.InitContainers {
+		if !windowsAllowedInitContainerNames[c.Name] {
+			continue
+		}
+		c.VolumeMounts = stripLinuxMounts(c.VolumeMounts)
+		c.Env = stripWindowsIncompatibleEnvVars(c.Env)
+		c.SecurityContext = stripLinuxSecurityContext(c.SecurityContext)
+		keepInits = append(keepInits, c)
+	}
+	spec.InitContainers = keepInits
+
+	// 3. Drop any volume no longer referenced by a surviving container's mounts.
+	referenced := make(map[string]bool)
+	for _, c := range spec.Containers {
+		for _, m := range c.VolumeMounts {
+			referenced[m.Name] = true
+		}
+	}
+	for _, c := range spec.InitContainers {
+		for _, m := range c.VolumeMounts {
+			referenced[m.Name] = true
+		}
+	}
+	var keepVols []corev1.Volume
+	for _, v := range spec.Volumes {
+		if referenced[v.Name] {
+			keepVols = append(keepVols, v)
+		}
+	}
+	spec.Volumes = keepVols
+
+	// 4. Remove pod annotations that reference now-removed containers (e.g. AppArmor
+	//    profiles: container.apparmor.security.beta.kubernetes.io/<name>). Kubernetes
+	//    rejects pods with annotations referencing non-existent containers.
+	if annotations != nil && *annotations != nil {
+		present := make(map[string]bool)
+		for _, c := range spec.Containers {
+			present[c.Name] = true
+		}
+		for _, c := range spec.InitContainers {
+			present[c.Name] = true
+		}
+		for key := range *annotations {
+			if containerName, ok := strings.CutPrefix(key, "container.apparmor.security.beta.kubernetes.io/"); ok {
+				if !present[containerName] {
+					delete(*annotations, key)
+				}
+			}
+		}
+	}
+}
+
+// stripLinuxMounts removes any volume mount whose MountPath is a Linux absolute path
+// (starts with "/"). Windows mounts use C:/... drive-letter paths, so this is safe and
+// catches hostPath mounts, emptyDir mounts at Linux paths, and config mounts uniformly.
+func stripLinuxMounts(mounts []corev1.VolumeMount) []corev1.VolumeMount {
+	var keep []corev1.VolumeMount
+	for _, m := range mounts {
+		if strings.HasPrefix(m.MountPath, "/") {
+			continue
+		}
+		keep = append(keep, m)
+	}
+	return keep
+}
+
+// linuxOnlyEnvVarNames are env vars that global settings / features inject with
+// Linux-specific path or transport values (Unix socket, host CA path, vsock) that are
+// invalid on Windows. Their backing volumes/mounts are already stripped; the env vars
+// must be removed too or the Windows agent gets fed bad paths/transports. Names mirror
+// the constants in internal/.../global/envvar.go (literals used to avoid an import cycle).
+var linuxOnlyEnvVarNames = map[string]bool{
+	"DOCKER_HOST":          true, // global.dockerSocketPath -> unix:///... (DD_CRI_SOCKET_PATH is caught by the SOCKET rule)
+	"DD_KUBELET_CLIENT_CA": true, // global.kubelet.hostCAPath -> /var/run/host-kubelet-ca.crt
+	"DD_VSOCK_ADDR":        true, // global.useVSock -> Linux vsock transport
+}
+
+// stripWindowsIncompatibleEnvVars removes env vars that don't work on Windows:
+//   - any name containing "SOCKET" (Unix-domain-socket config: DD_APM_RECEIVER_SOCKET,
+//     DD_DOGSTATSD_SOCKET, DD_*_HOST_SOCKET_PATH, DD_CRI_SOCKET_PATH). APM/DogStatsD
+//     default to UDS-enabled, so removing these lets them fall back to TCP/UDP.
+//   - the Linux-only global env vars in linuxOnlyEnvVarNames (docker host, kubelet CA path,
+//     vsock) whose Linux path/transport values are invalid on Windows.
+//
+// Windows named-pipe config (DD_*_WINDOWS_PIPE_NAME) does not match and is preserved.
+func stripWindowsIncompatibleEnvVars(envs []corev1.EnvVar) []corev1.EnvVar {
+	var keep []corev1.EnvVar
+	for _, e := range envs {
+		if strings.Contains(e.Name, "SOCKET") || linuxOnlyEnvVarNames[e.Name] {
+			continue
+		}
+		keep = append(keep, e)
+	}
+	return keep
+}
+
+func stripLinuxSecurityContext(sc *corev1.SecurityContext) *corev1.SecurityContext {
+	if sc == nil {
+		return nil
+	}
+	stripped := sc.DeepCopy()
+	// Linux capabilities not supported on Windows.
+	stripped.Capabilities = nil
+	// seccomp profiles are Linux-only.
+	stripped.SeccompProfile = nil
+	// SELinux is Linux-only; Windows kubelet rejects pods with SELinuxOptions set.
+	stripped.SELinuxOptions = nil
+	// AppArmor profiles are Linux-only (added in k8s 1.30).
+	stripped.AppArmorProfile = nil
+	// readOnlyRootFilesystem is not supported by the Windows container runtime.
+	stripped.ReadOnlyRootFilesystem = nil
+	// Return nil if nothing meaningful remains.
+	if stripped.RunAsUser == nil && stripped.RunAsGroup == nil &&
+		stripped.RunAsNonRoot == nil && stripped.AllowPrivilegeEscalation == nil &&
+		stripped.Privileged == nil && stripped.ProcMount == nil &&
+		stripped.WindowsOptions == nil {
+		return nil
+	}
+	return stripped
+}

--- a/internal/controller/datadogagent/component/agent/windows_test.go
+++ b/internal/controller/datadogagent/component/agent/windows_test.go
@@ -1,0 +1,656 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+)
+
+// testDDA returns a minimal metav1.Object suitable for builder calls.
+func testDDA(name string) metav1.Object {
+	return &metav1.ObjectMeta{Name: name, Namespace: "datadog"}
+}
+
+func testRequiredComponent(containers ...apicommon.AgentContainerName) feature.RequiredComponent {
+	return feature.RequiredComponent{
+		IsRequired: ptr.To(true),
+		Containers: containers,
+	}
+}
+
+// --- GetWindowsAgentName ---
+
+func TestGetWindowsAgentName(t *testing.T) {
+	assert.Equal(t, "myagent-agent-windows", GetWindowsAgentName(testDDA("myagent")))
+}
+
+// --- NewDefaultWindowsAgentDaemonset ---
+
+func TestNewDefaultWindowsAgentDaemonset_NodeSelector(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	ns := ds.Spec.Template.Spec.NodeSelector
+	require.NotNil(t, ns)
+	assert.Equal(t, "windows", ns["kubernetes.io/os"])
+}
+
+func TestNewDefaultWindowsAgentDaemonset_Toleration(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	tols := ds.Spec.Template.Spec.Tolerations
+	require.Len(t, tols, 1)
+	assert.Equal(t, "node.kubernetes.io/os", tols[0].Key)
+	assert.Equal(t, corev1.TolerationOpEqual, tols[0].Operator)
+	assert.Equal(t, "windows", tols[0].Value)
+	assert.Equal(t, corev1.TaintEffectNoSchedule, tols[0].Effect)
+}
+
+func TestNewDefaultWindowsAgentDaemonset_NoPodSecurityContext(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	// Windows does not support RunAsUser — PodSecurityContext must be nil.
+	assert.Nil(t, ds.Spec.Template.Spec.SecurityContext)
+}
+
+func TestNewDefaultWindowsAgentDaemonset_InitContainer(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	inits := ds.Spec.Template.Spec.InitContainers
+	require.Len(t, inits, 1, "expected exactly one init container")
+
+	init := inits[0]
+	assert.Equal(t, "init-config-windows", init.Name)
+	// Must create datadog.yaml inside the shared config volume.
+	assert.Contains(t, strings.Join(init.Args, " "), "datadog.yaml")
+
+	// Init container mounts at C:/ProgramData/Datadog — same as main containers —
+	// so all three share the same emptyDir and the created datadog.yaml is visible.
+	require.Len(t, init.VolumeMounts, 1)
+	assert.Equal(t, windowsConfigVolumeName, init.VolumeMounts[0].Name)
+	assert.Equal(t, windowsDatadogConfigPath, init.VolumeMounts[0].MountPath)
+}
+
+func TestNewDefaultWindowsAgentDaemonset_Volumes(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	vols := ds.Spec.Template.Spec.Volumes
+
+	// Only the shared config volume should be declared.
+	require.Len(t, vols, 1)
+	assert.Equal(t, windowsConfigVolumeName, vols[0].Name)
+	assert.NotNil(t, vols[0].EmptyDir)
+
+	// Linux-only volumes must not be present.
+	for _, v := range vols {
+		assert.NotEqual(t, "procdir", v.Name, "/proc volume must not be present on Windows")
+		assert.NotEqual(t, "cgroups", v.Name, "/sys/fs/cgroup volume must not be present on Windows")
+		assert.NotEqual(t, "passwd", v.Name, "/etc/passwd volume must not be present on Windows")
+	}
+}
+
+func TestNewDefaultWindowsAgentDaemonset_NoLinuxHostPathVolumes(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	for _, v := range ds.Spec.Template.Spec.Volumes {
+		if v.HostPath != nil {
+			assert.Fail(t, "unexpected hostPath volume on Windows DaemonSet", "volume %q has hostPath %q", v.Name, v.HostPath.Path)
+		}
+	}
+}
+
+// --- Container selection ---
+
+func TestWindowsAgentContainers_CoreOnly(t *testing.T) {
+	dda := testDDA("dd")
+	// Only core agent requested.
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	names := containerNames(ds.Spec.Template.Spec.Containers)
+	assert.Contains(t, names, string(apicommon.CoreAgentContainerName))
+	assert.NotContains(t, names, string(apicommon.SystemProbeContainerName))
+	assert.NotContains(t, names, string(apicommon.SecurityAgentContainerName))
+}
+
+func TestWindowsAgentContainers_WithTraceAgent(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName, apicommon.TraceAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	names := containerNames(ds.Spec.Template.Spec.Containers)
+	assert.Contains(t, names, string(apicommon.CoreAgentContainerName))
+	assert.Contains(t, names, string(apicommon.TraceAgentContainerName))
+}
+
+func TestWindowsAgentContainers_SystemProbeExcluded(t *testing.T) {
+	dda := testDDA("dd")
+	// Even when system-probe is requested it must be excluded on Windows.
+	rc := testRequiredComponent(
+		apicommon.CoreAgentContainerName,
+		apicommon.SystemProbeContainerName,
+		apicommon.SecurityAgentContainerName,
+	)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	names := containerNames(ds.Spec.Template.Spec.Containers)
+	assert.NotContains(t, names, string(apicommon.SystemProbeContainerName))
+	assert.NotContains(t, names, string(apicommon.SecurityAgentContainerName))
+}
+
+// --- SecurityContext ---
+
+func TestWindowsContainers_NoSecurityContext(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName, apicommon.TraceAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		assert.Nil(t, c.SecurityContext,
+			"container %q must have no securityContext on Windows", c.Name)
+	}
+}
+
+// --- Volume mounts ---
+
+func TestWindowsContainers_MountSharedConfigVolume(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName, apicommon.TraceAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		found := false
+		for _, m := range c.VolumeMounts {
+			if m.Name == windowsConfigVolumeName && m.MountPath == windowsDatadogConfigPath {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found,
+			"container %q must mount %q at %q", c.Name, windowsConfigVolumeName, windowsDatadogConfigPath)
+	}
+}
+
+// --- Auth token env var ---
+
+func TestWindowsContainers_AuthTokenPathOverridden(t *testing.T) {
+	dda := testDDA("dd")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName, apicommon.TraceAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		val, found := findEnvVar(c.Env, common.DDAuthTokenFilePath)
+		require.True(t, found, "container %q must set %s", c.Name, common.DDAuthTokenFilePath)
+		assert.Equal(t, windowsAuthTokenFilePath, val,
+			"container %q: %s must be Windows path", c.Name, common.DDAuthTokenFilePath)
+		assert.False(t, strings.Contains(val, "/etc/"),
+			"container %q: %s must not contain Linux path /etc/", c.Name, common.DDAuthTokenFilePath)
+	}
+}
+
+// --- DaemonSet name / labels ---
+
+func TestNewDefaultWindowsAgentDaemonset_Name(t *testing.T) {
+	dda := testDDA("myagent")
+	rc := testRequiredComponent(apicommon.CoreAgentContainerName)
+	ds := NewDefaultWindowsAgentDaemonset(dda, &ExtendedDaemonsetOptions{}, rc, GetWindowsAgentName(dda))
+
+	assert.Equal(t, "myagent-agent-windows", ds.Name)
+	assert.Equal(t, "datadog", ds.Namespace)
+}
+
+// --- overrideAuthTokenPath ---
+
+func TestOverrideAuthTokenPath_ReplacesExisting(t *testing.T) {
+	envs := []corev1.EnvVar{
+		{Name: "DD_SITE", Value: "datadoghq.com"},
+		{Name: common.DDAuthTokenFilePath, Value: "/etc/datadog-agent/auth/token"},
+	}
+	original := make([]corev1.EnvVar, len(envs))
+	copy(original, envs)
+
+	out := overrideAuthTokenPath(envs)
+
+	// Input slice is not mutated.
+	assert.Equal(t, original, envs, "overrideAuthTokenPath must not mutate the input slice")
+
+	val, found := findEnvVar(out, common.DDAuthTokenFilePath)
+	assert.True(t, found)
+	assert.Equal(t, windowsAuthTokenFilePath, val)
+}
+
+func TestOverrideAuthTokenPath_AppendsWhenAbsent(t *testing.T) {
+	envs := []corev1.EnvVar{{Name: "DD_SITE", Value: "datadoghq.com"}}
+	out := overrideAuthTokenPath(envs)
+
+	val, found := findEnvVar(out, common.DDAuthTokenFilePath)
+	assert.True(t, found)
+	assert.Equal(t, windowsAuthTokenFilePath, val)
+}
+
+// --- StripLinuxOnlySettings ---
+
+// --- StripLinuxOnlySettingsFromTemplate (allowlist model) ---
+
+// Only core/trace/process agent containers survive; everything else (including
+// fips-proxy, otel-agent, system-probe, etc.) is removed regardless of denylist.
+func TestStripLinuxOnly_ContainerAllowlist(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "agent"},
+				{Name: "trace-agent"},
+				{Name: "process-agent"},
+				{Name: string(apicommon.SystemProbeContainerName)},
+				{Name: string(apicommon.SecurityAgentContainerName)},
+				{Name: string(apicommon.HostProfiler)},
+				{Name: string(apicommon.FlightRecorderContainerName)},
+				{Name: "fips-proxy"},
+				{Name: "otel-agent"},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	names := containerNames(tmpl.Spec.Containers)
+	assert.ElementsMatch(t, []string{"agent", "trace-agent", "process-agent"}, names,
+		"only core/trace/process agent should survive; fips-proxy/otel/system-probe/etc. removed")
+}
+
+// Init containers: only the Windows bootstrap survives.
+func TestStripLinuxOnly_InitContainerAllowlist(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init-config-windows"},
+				{Name: string(apicommon.SeccompSetupContainerName)},
+				{Name: string(apicommon.InitVolumeContainerName)},
+				{Name: string(apicommon.InitConfigContainerName)},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.InitContainers, 1)
+	assert.Equal(t, "init-config-windows", tmpl.Spec.InitContainers[0].Name)
+}
+
+// Any mount with a Linux absolute path is stripped from surviving containers;
+// Windows (C:/...) mounts are kept. Covers the reviewer's verified leaks:
+// hostPath / (SBOM), emptyDir /var/run/sysprobe (NPM/USM), /var/run/datadog/flightrecorder.
+func TestStripLinuxOnly_StripsLinuxMountPaths(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "hostroot", MountPath: "/host/root"},
+						{Name: "sysprobe-socket", MountPath: "/var/run/sysprobe"},
+						{Name: "runtimesocket", MountPath: "/run"},
+						{Name: "win-datadog-config", MountPath: "C:/ProgramData/Datadog"},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "hostroot", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
+				{Name: "sysprobe-socket", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "runtimesocket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run"}}},
+				{Name: "win-datadog-config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	// Only the Windows mount survives on the container.
+	require.Len(t, tmpl.Spec.Containers, 1)
+	require.Len(t, tmpl.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Containers[0].VolumeMounts[0].Name)
+
+	// Only the referenced Windows volume survives; hostPath / and Linux emptyDirs are dropped.
+	require.Len(t, tmpl.Spec.Volumes, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Volumes[0].Name)
+}
+
+// Volumes not referenced by any surviving container are dropped (even emptyDirs).
+func TestStripLinuxOnly_DropsUnreferencedVolumes(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "agent", VolumeMounts: []corev1.VolumeMount{{Name: "win-datadog-config", MountPath: "C:/ProgramData/Datadog"}}},
+				// system-probe gets removed; its emptyDir should then be unreferenced and dropped.
+				{Name: string(apicommon.SystemProbeContainerName), VolumeMounts: []corev1.VolumeMount{{Name: "sysprobe-only", MountPath: "C:/foo"}}},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "win-datadog-config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "sysprobe-only", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Volumes, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Volumes[0].Name)
+}
+
+func TestStripLinuxOnly_ClearsLinuxSecurityContext(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities:           &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}},
+						SeccompProfile:         &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeLocalhost},
+						SELinuxOptions:         &corev1.SELinuxOptions{Level: "s0"},
+						ReadOnlyRootFilesystem: ptr.To(true),
+					},
+				},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Containers, 1)
+	assert.Nil(t, tmpl.Spec.Containers[0].SecurityContext,
+		"SecurityContext should be nil after stripping all Linux fields")
+}
+
+func TestStripLinuxOnly_RemovesAppArmorAnnotationsForStrippedContainers(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"container.apparmor.security.beta.kubernetes.io/system-probe": "localhost/system-probe",
+				"container.apparmor.security.beta.kubernetes.io/agent":        "runtime/default",
+				"ad.datadoghq.com/tags":                                       "{}",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "agent"},
+				{Name: string(apicommon.SystemProbeContainerName)},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	_, hasSystemProbe := tmpl.Annotations["container.apparmor.security.beta.kubernetes.io/system-probe"]
+	assert.False(t, hasSystemProbe, "AppArmor annotation for stripped system-probe must be removed")
+	_, hasAgent := tmpl.Annotations["container.apparmor.security.beta.kubernetes.io/agent"]
+	assert.True(t, hasAgent, "AppArmor annotation for surviving agent must be kept")
+	_, hasTags := tmpl.Annotations["ad.datadoghq.com/tags"]
+	assert.True(t, hasTags, "unrelated annotation must be kept")
+}
+
+// Windows-incompatible env vars must be removed: Unix-domain-socket config (anything with
+// "SOCKET" in the name) and the Linux-only global env vars (DOCKER_HOST, DD_KUBELET_CLIENT_CA,
+// DD_VSOCK_ADDR). The agent then falls back to TCP/UDP. Non-matching env vars are preserved.
+func TestStripLinuxOnly_StripsWindowsIncompatibleEnvVars(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					Env: []corev1.EnvVar{
+						{Name: "DD_APM_RECEIVER_SOCKET", Value: "/var/run/datadog/apm.socket"},
+						{Name: "DD_DOGSTATSD_SOCKET", Value: "/var/run/datadog/dsd.socket"},
+						{Name: "DD_DOGSTATSD_HOST_SOCKET_PATH", Value: "/var/run/datadog"},
+						{Name: "DD_CRI_SOCKET_PATH", Value: "/var/run/containerd/containerd.sock"},
+						{Name: "DOCKER_HOST", Value: "unix:///host/var/run/docker.sock"},
+						{Name: "DD_KUBELET_CLIENT_CA", Value: "/var/run/host-kubelet-ca.crt"},
+						{Name: "DD_VSOCK_ADDR", Value: "vsock://..."},
+						{Name: "DD_APM_ENABLED", Value: "true"},
+						{Name: "DD_API_KEY", Value: "x"},
+					},
+				},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Containers, 1)
+	names := make(map[string]bool)
+	for _, e := range tmpl.Spec.Containers[0].Env {
+		names[e.Name] = true
+	}
+	for _, stripped := range []string{
+		"DD_APM_RECEIVER_SOCKET", "DD_DOGSTATSD_SOCKET", "DD_DOGSTATSD_HOST_SOCKET_PATH",
+		"DD_CRI_SOCKET_PATH", "DOCKER_HOST", "DD_KUBELET_CLIENT_CA", "DD_VSOCK_ADDR",
+	} {
+		assert.False(t, names[stripped], "%s must be stripped on Windows", stripped)
+	}
+	assert.True(t, names["DD_APM_ENABLED"], "non-Linux env must be preserved")
+	assert.True(t, names["DD_API_KEY"], "non-Linux env must be preserved")
+}
+
+func TestStripLinuxOnly_PreservesEnvVars(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					Env: []corev1.EnvVar{
+						{Name: "DD_APM_ENABLED", Value: "true"},
+						{Name: "DD_LOGS_ENABLED", Value: "true"},
+						{Name: "DD_TAGS", Value: "env:prod"},
+					},
+				},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Containers, 1)
+	require.Len(t, tmpl.Spec.Containers[0].Env, 3)
+}
+
+// --- helpers ---
+
+func containerNames(containers []corev1.Container) []string {
+	names := make([]string, len(containers))
+	for i, c := range containers {
+		names[i] = c.Name
+	}
+	return names
+}
+
+func findEnvVar(envs []corev1.EnvVar, name string) (string, bool) {
+	for _, e := range envs {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+// EnsureWindowsIntakeReachable must force non-local traffic on even when a feature
+// (e.g. DogStatsD) already wrote the env var to "false" — last-writer-wins. This is the
+// regression guard for the clobber the reviewer found.
+func TestEnsureWindowsIntakeReachable_WinsOverFeatureValue(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: string(apicommon.CoreAgentContainerName),
+					// Simulate the DogStatsD feature having set it to the default false.
+					Env: []corev1.EnvVar{{Name: "DD_DOGSTATSD_NON_LOCAL_TRAFFIC", Value: "false"}},
+				},
+				{Name: string(apicommon.TraceAgentContainerName)},
+			},
+		},
+	}
+	managers := feature.NewPodTemplateManagers(tmpl)
+	EnsureWindowsIntakeReachable(managers)
+
+	check := func(container, env string) {
+		for _, c := range tmpl.Spec.Containers {
+			if c.Name == container {
+				for _, e := range c.Env {
+					if e.Name == env {
+						assert.Equal(t, "true", e.Value, "%s on %s must be forced true", env, container)
+						return
+					}
+				}
+				t.Fatalf("%s not found on %s", env, container)
+			}
+		}
+	}
+	check(string(apicommon.CoreAgentContainerName), "DD_DOGSTATSD_NON_LOCAL_TRAFFIC")
+	check(string(apicommon.TraceAgentContainerName), "DD_APM_NON_LOCAL_TRAFFIC")
+}
+
+// EnsureWindowsServercoreImage must re-add the -servercore suffix that the generic image
+// override drops (e.g. a user pinning image.tag=7.81.0), while leaving images that already
+// carry servercore untouched.
+func TestEnsureWindowsServercoreImage(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"gcr.io/datadoghq/agent:7.81.0", "gcr.io/datadoghq/agent:7.81.0-servercore"},
+		{"gcr.io/datadoghq/agent:7.81.0-servercore", "gcr.io/datadoghq/agent:7.81.0-servercore"},
+		{"gcr.io/datadoghq/agent:7.81.0-servercore-ltsc2022", "gcr.io/datadoghq/agent:7.81.0-servercore-ltsc2022"},
+		{"localhost:5000/agent:7.81.0", "localhost:5000/agent:7.81.0-servercore"}, // registry port not mistaken for tag
+		// Custom (non-"agent") images are the user's responsibility — left untouched.
+		{"registry.local/custom-agent:win2022", "registry.local/custom-agent:win2022"},
+	}
+	for _, c := range cases {
+		spec := &corev1.PodSpec{
+			Containers:     []corev1.Container{{Name: "agent", Image: c.in}},
+			InitContainers: []corev1.Container{{Name: "init-config-windows", Image: c.in}},
+		}
+		EnsureWindowsServercoreImage(spec)
+		assert.Equal(t, c.want, spec.Containers[0].Image, "container image for %q", c.in)
+		assert.Equal(t, c.want, spec.InitContainers[0].Image, "init image for %q", c.in)
+	}
+}
+
+// AddWindowsLogCollectionVolumes adds the three Windows host-log hostPath volumes + mounts
+// on the core agent (mirrors the Helm chart), and survives the strip because they use C:/ paths.
+func TestAddWindowsLogCollectionVolumes(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: string(apicommon.CoreAgentContainerName)},
+			{Name: string(apicommon.TraceAgentContainerName)},
+		},
+	}
+	AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{}) // empty → Windows defaults
+
+	// 3 hostPath volumes with the expected default Windows paths.
+	paths := map[string]string{}
+	for _, v := range spec.Volumes {
+		require.NotNil(t, v.HostPath, "volume %q must be hostPath", v.Name)
+		paths[v.Name] = v.HostPath.Path
+	}
+	assert.Equal(t, "C:/var/log", paths[windowsPointerVolumeName])
+	assert.Equal(t, "C:/var/log/pods", paths[windowsPodLogsVolumeName])
+	assert.Equal(t, "C:/ProgramData", paths[windowsContainerLogVolumeName])
+
+	// Mounts land on the core agent only, at the same Windows paths.
+	var core, trace corev1.Container
+	for _, c := range spec.Containers {
+		if c.Name == string(apicommon.CoreAgentContainerName) {
+			core = c
+		}
+		if c.Name == string(apicommon.TraceAgentContainerName) {
+			trace = c
+		}
+	}
+	assert.Len(t, core.VolumeMounts, 3, "core agent gets the 3 log mounts")
+	assert.Empty(t, trace.VolumeMounts, "trace agent gets no log mounts")
+	for _, m := range core.VolumeMounts {
+		assert.True(t, strings.HasPrefix(m.MountPath, "C:/"), "mount %q must be a Windows path", m.MountPath)
+	}
+
+	// And they survive the strip (Windows paths, not Linux).
+	tmpl := &corev1.PodTemplateSpec{Spec: *spec}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+	surviving := 0
+	for _, v := range tmpl.Spec.Volumes {
+		if v.Name == windowsPointerVolumeName || v.Name == windowsPodLogsVolumeName || v.Name == windowsContainerLogVolumeName {
+			surviving++
+		}
+	}
+	assert.Equal(t, 3, surviving, "Windows log volumes must survive the strip")
+}
+
+// Configured logCollection paths must override the Windows defaults.
+func TestAddWindowsLogCollectionVolumes_CustomPaths(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: string(apicommon.CoreAgentContainerName)}},
+	}
+	AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{
+		TempStoragePath:   "D:/dd/run",
+		PodLogsPath:       "D:/logs/pods",
+		ContainerLogsPath: "D:/containerd",
+	})
+
+	paths := map[string]string{}
+	for _, v := range spec.Volumes {
+		paths[v.Name] = v.HostPath.Path
+	}
+	// Custom paths set the HOST path...
+	assert.Equal(t, "D:/dd/run", paths[windowsPointerVolumeName])
+	assert.Equal(t, "D:/logs/pods", paths[windowsPodLogsVolumeName])
+	assert.Equal(t, "D:/containerd", paths[windowsContainerLogVolumeName])
+
+	// ...but the in-container mount path is always the Agent's standard Windows path, so the
+	// Agent reads logs where it expects regardless of the host path (Linux model).
+	mountPaths := map[string]string{}
+	for _, m := range spec.Containers[0].VolumeMounts {
+		mountPaths[m.Name] = m.MountPath
+	}
+	assert.Equal(t, windowsVarLogPath, mountPaths[windowsPointerVolumeName])
+	assert.Equal(t, windowsPodLogsPath, mountPaths[windowsPodLogsVolumeName])
+	assert.Equal(t, windowsProgramDataPath, mountPaths[windowsContainerLogVolumeName])
+}
+
+// Linux-absolute paths (the logCollection feature's defaults, e.g. /var/log/pods) must be
+// treated as unset so the Windows defaults apply — otherwise Linux hostPaths land on Windows.
+func TestAddWindowsLogCollectionVolumes_LinuxDefaultsTreatedAsUnset(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: string(apicommon.CoreAgentContainerName)}},
+	}
+	AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{
+		TempStoragePath:   "/var/lib/datadog-agent/logs",
+		PodLogsPath:       "/var/log/pods",
+		ContainerLogsPath: "/var/lib/docker/containers",
+	})
+
+	for _, v := range spec.Volumes {
+		require.NotNil(t, v.HostPath)
+		assert.False(t, strings.HasPrefix(v.HostPath.Path, "/"),
+			"Linux default %q must be replaced by a Windows path", v.HostPath.Path)
+	}
+	paths := map[string]string{}
+	for _, v := range spec.Volumes {
+		paths[v.Name] = v.HostPath.Path
+	}
+	assert.Equal(t, "C:/var/log", paths[windowsPointerVolumeName])
+	assert.Equal(t, "C:/var/log/pods", paths[windowsPodLogsVolumeName])
+	assert.Equal(t, "C:/ProgramData", paths[windowsContainerLogVolumeName])
+}

--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -196,6 +196,7 @@ func (r *Reconciler) addDDAIStatusToDDAStatus(status *v2alpha1.DatadogAgentStatu
 	}
 
 	status.Agent = condition.CombineDaemonSetStatus(status.Agent, currentDDAI.Status.Agent)
+	status.AgentWindows = condition.CombineDaemonSetStatus(status.AgentWindows, currentDDAI.Status.AgentWindows)
 	status.ClusterAgent = condition.CombineDeploymentStatus(status.ClusterAgent, currentDDAI.Status.ClusterAgent)
 	status.ClusterChecksRunner = condition.CombineDeploymentStatus(status.ClusterChecksRunner, currentDDAI.Status.ClusterChecksRunner)
 
@@ -274,6 +275,7 @@ func IsEqualStatus(current *v2alpha1.DatadogAgentStatus, newStatus *v2alpha1.Dat
 	}
 
 	if !condition.IsEqualDaemonSetStatus(current.Agent, newStatus.Agent) ||
+		!condition.IsEqualDaemonSetStatus(current.AgentWindows, newStatus.AgentWindows) ||
 		!apiequality.Semantic.DeepEqual(current.RemoteConfigConfiguration, newStatus.RemoteConfigConfiguration) {
 		return false
 	}

--- a/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
@@ -108,3 +108,16 @@ func Test_addDDAIStatusToDDAStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEqualStatus_DetectsAgentWindowsChange(t *testing.T) {
+	base := &v2alpha1.DatadogAgentStatus{
+		Agent: &v2alpha1.DaemonSetStatus{DaemonsetName: "dd-agent", Desired: 1, Ready: 1},
+	}
+	// Same Agent, but AgentWindows differs → must be detected as not-equal so the
+	// status update is persisted (regression guard for the IsEqualStatus omission).
+	withWin := base.DeepCopy()
+	withWin.AgentWindows = &v2alpha1.DaemonSetStatus{DaemonsetName: "dd-agent-windows", Desired: 1, Ready: 1}
+
+	assert.False(t, IsEqualStatus(base, withWin), "AgentWindows change must be detected")
+	assert.True(t, IsEqualStatus(base, base.DeepCopy()), "identical status must be equal")
+}

--- a/internal/controller/datadogagent/override/podtemplatespec.go
+++ b/internal/controller/datadogagent/override/podtemplatespec.go
@@ -123,11 +123,20 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 	// Override agent configurations such as datadog.yaml, system-probe.yaml, etc.
 	overrideCustomConfigVolumes(logger, manager, override.CustomConfigurations, componentName, ddaName)
 
+	// ExtraConfd / ExtraChecksd rely on init containers and /etc/datadog-agent mount paths
+	// that don't exist in the Windows DaemonSet, so they are not supported there. Skip with
+	// an explicit log rather than adding volumes that would be stripped as a silent no-op.
+	// All other overrides (image, env, resources, tolerations, nodeSelector, …) still apply.
+	skipExtraConfigForWindows := componentName == v2alpha1.WindowsNodeAgentComponentName
+	if skipExtraConfigForWindows && (override.ExtraConfd != nil || override.ExtraChecksd != nil) {
+		logger.V(1).Info("extraConfd/extraChecksd are ignored for windowsNodeAgent: unsupported on Windows")
+	}
+
 	// For ExtraConfd and ExtraChecksd, the ConfigMap contents to an init container. This allows use of
 	// the workaround to merge existing config and check files with custom ones. The VolumeMount is already
 	// defined in the init container; just overwrite the Volume to mount the ConfigMap instead of an EmptyDir.
 	// If both ConfigMap and ConfigData exist, ConfigMap has higher priority.
-	if override.ExtraConfd != nil {
+	if !skipExtraConfigForWindows && override.ExtraConfd != nil {
 		cmName := fmt.Sprintf(extraConfdConfigMapName, strings.ToLower((string(componentName))))
 		vol := volume.GetVolumeFromMultiCustomConfig(override.ExtraConfd, common.ConfdVolumeName, cmName)
 		manager.Volume().AddVolume(&vol)
@@ -144,7 +153,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 	}
 
 	// If both ConfigMap and ConfigData exist, ConfigMap has higher priority.
-	if override.ExtraChecksd != nil {
+	if !skipExtraConfigForWindows && override.ExtraChecksd != nil {
 		cmName := fmt.Sprintf(extraChecksdConfigMapName, strings.ToLower((string(componentName))))
 		vol := volume.GetVolumeFromMultiCustomConfig(override.ExtraChecksd, common.ChecksdVolumeName, cmName)
 		manager.Volume().AddVolume(&vol)
@@ -234,6 +243,12 @@ func overrideCustomConfigVolumes(logger logr.Logger, manager feature.PodTemplate
 		customConfig := customConfs[fileName]
 		defaultConfigMapName := fmt.Sprintf("%s-%s", getDefaultConfigMapName(ddaName, string(fileName)), strings.ToLower(string(componentName)))
 		switch componentName {
+		case v2alpha1.WindowsNodeAgentComponentName:
+			// CustomConfigurations for windowsNodeAgent are not applied: the volume mount
+			// path would be /etc/datadog-agent/ (a Linux path), which is incompatible with
+			// Windows containers. Windows-native custom config support is deferred.
+			logger.V(1).Info("customConfigurations ignored for windowsNodeAgent: Linux mount paths unsupported on Windows", "fileName", fileName)
+			continue
 		case v2alpha1.NodeAgentComponentName, v2alpha1.ClusterChecksRunnerComponentName:
 			// For the NodeAgent, there are a few possible config files and each need their own volume.
 			// Use a volumeName that matches the defaultConfigMapName.

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/providercaps"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
+	pkgutils "github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -56,6 +57,25 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 	// This is to make deployments simpler. With multiple EDS there would be
 	// multiple canaries, etc.
 	if r.options.ExtendedDaemonsetOptions.Enabled && !isDDAILabeledWithProfile(ddai) {
+		// Windows DaemonSets are not supported when ExtendedDaemonSet is enabled.
+		// Always remove any previously-created Windows DaemonSet (the EDS path returns
+		// before reconcileV2WindowsAgent's absent-key cleanup would run, so a stale DS
+		// must be cleaned here regardless of the current override key). Only emit the
+		// unsupported condition when the user actually requested windowsNodeAgent.
+		if _, hasWindows := ddai.Spec.Override[datadoghqv2alpha1.WindowsNodeAgentComponentName]; hasWindows {
+			condition.UpdateDatadogAgentInternalStatusConditions(
+				newStatus,
+				metav1.NewTime(time.Now()),
+				"WindowsAgentReconcile",
+				metav1.ConditionFalse,
+				"EDSWindowsUnsupported",
+				"windowsNodeAgent is not supported when ExtendedDaemonSet is enabled",
+				true,
+			)
+		}
+		if err := r.ensureWindowsDaemonSetAbsent(ctx, ddai, newStatus); err != nil {
+			return result, err
+		}
 		// Start by creating the Default Agent extendeddaemonset
 		eds = componentagent.NewDefaultAgentExtendedDaemonset(ddai, &r.options.ExtendedDaemonsetOptions, requiredComponents.Agent)
 		objLogger := daemonsetLogger.WithValues("object.kind", "ExtendedDaemonSet", "object.namespace", eds.Namespace, "object.name", eds.Name)
@@ -187,10 +207,16 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 			return reconcile.Result{}, err
 		}
 		deleteStatusWithAgent(newStatus)
-		return reconcile.Result{}, nil
+		// Still reconcile Windows even when Linux nodeAgent is disabled-by-override,
+		// so Linux-disabled / Windows-only clusters work correctly.
+		return r.reconcileV2WindowsAgent(ctx, requiredComponents, features, ddai, resourcesManager, newStatus)
 	}
 
-	return r.createOrUpdateDaemonset(ctx, ddai, daemonset, newStatus, updateDSStatusV2WithAgent)
+	if res, err := r.createOrUpdateDaemonset(ctx, ddai, daemonset, newStatus, updateDSStatusV2WithAgent); pkgutils.ShouldReturn(res, err) {
+		return res, err
+	}
+
+	return r.reconcileV2WindowsAgent(ctx, requiredComponents, features, ddai, resourcesManager, newStatus)
 }
 
 func updateDSStatusV2WithAgent(dsName string, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string) {

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
@@ -256,8 +256,10 @@ func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1
 		if !needUpdate {
 			// Even if the DaemonSet is still the same, its status might have
 			// changed (for example, the number of pods ready). This call is
-			// needed to keep the agent status updated.
-			newStatus.Agent = condition.UpdateDaemonSetStatusDDAI(currentDaemonset.Name, currentDaemonset, newStatus.Agent, &now)
+			// needed to keep the agent status updated. Use updateStatusFunc (not a
+			// hardcoded newStatus.Agent) so the correct status field is written —
+			// e.g. AgentWindows for the Windows DaemonSet rather than the Linux Agent.
+			updateStatusFunc(currentDaemonset.Name, currentDaemonset, newStatus, now, metav1.ConditionTrue, updateSucceeded, "Daemonset up to date")
 
 			// Stop reconcile loop since DaemonSet hasn't changed
 			return reconcile.Result{}, nil

--- a/internal/controller/datadogagentinternal/controller_reconcile_windows_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_windows_agent.go
@@ -1,0 +1,277 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Windows agent reconciler — prototype for CONTP-1448.
+// Creates a Windows-targeted DaemonSet alongside the Linux one when
+// spec.override.windowsNodeAgent is present in the DatadogAgentInternal.
+//
+// Known limitations:
+//   - Only reached in the non-EDS path of reconcileV2Agent. EDS + Windows is
+//     not supported; document as out-of-scope for the prototype.
+//   - Also not reached when nodeAgent is disabled-by-override (reconcileV2Agent
+//     returns early before the Windows call). Linux-disabled / Windows-only
+//     configurations cannot work until the Windows reconcile is hoisted out.
+//   - FIPS + Windows is not supported: ApplyGlobalSettingsNodeAgent calls
+//     updateContainerImages which may produce "agent:X.Y.Z-servercore-fips",
+//     a tag that does not exist. FIPS users should set windowsNodeAgent.Disabled.
+
+package datadogagentinternal
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	componentagent "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
+	"github.com/DataDog/datadog-operator/pkg/condition"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+// windowsSupportedFeatures is the allowlist of feature IDs whose ManageNodeAgent hook
+// runs against the Windows DaemonSet. Features absent here are gated out so they don't
+// inject env vars / config that would misconfigure the Windows agent (eBPF/system-probe
+// features in particular). This is an allowlist (not a denylist) so new Linux-only
+// features don't silently leak onto Windows. The `default` feature is required — it
+// configures the base agent. Expand as Windows support for more features is verified.
+var windowsSupportedFeatures = map[feature.IDType]bool{
+	feature.DefaultIDType:              true, // base agent config (required)
+	feature.APMIDType:                  true, // trace-agent runs on Windows (TCP; see non-local-traffic)
+	feature.LogCollectionIDType:        true, // log collection — Windows host-log mounts added post-strip
+	feature.LiveContainerIDType:        true, // container collection
+	feature.LiveProcessIDType:          true, // process collection (no eBPF on Windows)
+	feature.ProcessDiscoveryIDType:     true,
+	feature.DogstatsdIDType:            true, // dogstatsd (UDP non-local; named pipe future)
+	feature.OrchestratorExplorerIDType: true, // node-side config is env-only
+	feature.RemoteConfigurationIDType:  true,
+	feature.PrometheusScrapeIDType:     true,
+	feature.EventCollectionIDType:      true,
+}
+
+// windowsContainersFromFeatures derives the Windows agent container set used to undo the
+// single-container-strategy rewrite (which collapses the list to unprivileged-single-agent).
+//
+// It re-derives each feature's *node-agent* required containers by calling Configure (the same
+// source the feature factory uses), then keeps only the Windows-supported containers. This is
+// deliberately driven by node-agent requirements, not feature-ID presence: e.g. APM can be
+// enabled cluster-side only (SSI) with node APM disabled, in which case the apm feature does
+// NOT require the trace-agent and we must not add an unconfigured one. The core agent is always
+// included. Configure is called against a deep copy of the spec to avoid mutating the original.
+func windowsContainersFromFeatures(features []feature.Feature, ddai *datadoghqv1alpha1.DatadogAgentInternal) []apicommon.AgentContainerName {
+	specCopy := ddai.Spec.DeepCopy()
+	merged := &feature.RequiredComponents{}
+	for _, feat := range features {
+		rc := feat.Configure(ddai, specCopy, ddai.Status.RemoteConfigConfiguration)
+		merged.Merge(&rc)
+	}
+
+	containers := []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
+	seen := map[apicommon.AgentContainerName]bool{}
+	for _, c := range merged.Agent.Containers {
+		// Only the Windows-supported sidecars; the core agent is already included and
+		// Linux-only containers (system-probe, …) never appear under single-container strategy.
+		if (c == apicommon.TraceAgentContainerName || c == apicommon.ProcessAgentContainerName) && !seen[c] {
+			seen[c] = true
+			containers = append(containers, c)
+		}
+	}
+	return containers
+}
+
+// windowsLogPaths extracts the configured logCollection host paths from the DDAI spec so the
+// Windows log mounts honor user overrides. Empty fields fall back to the Windows defaults.
+func windowsLogPaths(ddai *datadoghqv1alpha1.DatadogAgentInternal) componentagent.WindowsLogPaths {
+	var p componentagent.WindowsLogPaths
+	if ddai.Spec.Features == nil || ddai.Spec.Features.LogCollection == nil {
+		return p
+	}
+	lc := ddai.Spec.Features.LogCollection
+	if lc.TempStoragePath != nil {
+		p.TempStoragePath = *lc.TempStoragePath
+	}
+	if lc.PodLogsPath != nil {
+		p.PodLogsPath = *lc.PodLogsPath
+	}
+	if lc.ContainerLogsPath != nil {
+		p.ContainerLogsPath = *lc.ContainerLogsPath
+	}
+	return p
+}
+
+// reconcileV2WindowsAgent creates or updates the Windows agent DaemonSet when
+// spec.override.windowsNodeAgent is present. It is called at the end of reconcileV2Agent
+// (non-EDS path only) after the Linux DaemonSet has been reconciled.
+func (r *Reconciler) reconcileV2WindowsAgent(
+	ctx context.Context,
+	requiredComponents feature.RequiredComponents,
+	features []feature.Feature,
+	ddai *datadoghqv1alpha1.DatadogAgentInternal,
+	resourcesManager feature.ResourceManagers,
+	newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus,
+) (reconcile.Result, error) {
+	// No windowsNodeAgent override: ensure no stale Windows DaemonSet lingers from a
+	// previous opt-in (the key may have been removed), then no-op.
+	windowsOverride, ok := ddai.Spec.Override[datadoghqv2alpha1.WindowsNodeAgentComponentName]
+	if !ok {
+		return reconcile.Result{}, r.ensureWindowsDaemonSetAbsent(ctx, ddai, newStatus)
+	}
+
+	// FIPS + Windows is not supported: updateContainerImages would produce
+	// agent:X.Y.Z-servercore-fips which does not exist, causing ImagePullBackOff.
+	// Surface a clear condition AND remove any previously-created Windows DaemonSet
+	// rather than leaving it running misconfigured.
+	if ddai.Spec.Global != nil && apiutils.BoolValue(ddai.Spec.Global.UseFIPSAgent) {
+		condition.UpdateDatadogAgentInternalStatusConditions(
+			newStatus,
+			metav1.NewTime(time.Now()),
+			"WindowsAgentReconcile",
+			metav1.ConditionFalse,
+			"FIPSWindowsUnsupported",
+			"windowsNodeAgent cannot be used with global.useFIPSAgent: the Windows servercore image has no FIPS variant",
+			true,
+		)
+		return reconcile.Result{}, r.ensureWindowsDaemonSetAbsent(ctx, ddai, newStatus)
+	}
+
+	// Honour the Disabled flag the same way the Linux agent reconciler does.
+	if apiutils.BoolValue(windowsOverride.Disabled) {
+		return reconcile.Result{}, r.ensureWindowsDaemonSetAbsent(ctx, ddai, newStatus)
+	}
+
+	logger := ctrl.LoggerFrom(ctx).WithValues("component", "windowsNodeAgent")
+	ctx = ctrl.LoggerInto(ctx, logger)
+
+	// Build the Windows DaemonSet from the Windows-specific template.
+	// The single-container strategy is a Linux optimization (the factory rewrites the
+	// container list to just unprivileged-single-agent); Windows always uses separate
+	// containers, so rebuild the container set from the enabled features instead — otherwise
+	// the Windows DS would silently run only the core agent and drop trace/process.
+	agentComponent := requiredComponents.Agent
+	if agentComponent.SingleContainerStrategyEnabled() {
+		agentComponent = feature.RequiredComponent{
+			IsRequired: agentComponent.IsRequired,
+			Containers: windowsContainersFromFeatures(features, ddai),
+		}
+	}
+
+	instanceName := componentagent.GetWindowsAgentName(ddai)
+	daemonset := componentagent.NewDefaultWindowsAgentDaemonset(ddai, &r.options.ExtendedDaemonsetOptions, agentComponent, instanceName)
+	podManagers := feature.NewPodTemplateManagers(&daemonset.Spec.Template)
+
+	// Apply global settings: site, credentials (DD_API_KEY), cluster-agent token, etc.
+	// Note: ApplyGlobalSettingsNodeAgent may also inject Linux hostPath volumes/mounts
+	// when global.criSocketPath, hostCAPath, dockerSocketPath, or useVSock are set.
+	// StripLinuxOnlySettings (called below) removes those before the DS is applied.
+	global.ApplyGlobalSettingsNodeAgent(logger, podManagers, ddai.GetObjectMeta(), &ddai.Spec, resourcesManager, false, requiredComponents)
+
+	// Run ManageNodeAgent only for features supported on Windows. Linux/eBPF-only
+	// features (NPM, USM, CWS, CSPM, OOMKill, eBPF check, TCP queue length, GPU,
+	// host-profiler, …) are gated out so they don't inject env vars telling the Windows
+	// agent to do Linux-only things (e.g. dial a non-existent system-probe socket).
+	// StripLinuxOnlySettings is still applied below as a pod-spec safety net.
+	logCollectionEnabled := false
+	for _, feat := range features {
+		if !windowsSupportedFeatures[feat.ID()] {
+			logger.V(1).Info("skipping feature on Windows node agent (no Windows support)", "feature", feat.ID())
+			continue
+		}
+		if feat.ID() == feature.LogCollectionIDType {
+			logCollectionEnabled = true
+		}
+		if err := feat.ManageNodeAgent(podManagers); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	// Apply spec.override.windowsNodeAgent on top of features + global settings.
+	override.PodTemplateSpec(logger, podManagers, windowsOverride, datadoghqv2alpha1.WindowsNodeAgentComponentName, ddai.Name)
+	override.DaemonSet(daemonset, windowsOverride)
+
+	// Re-assert the -servercore image suffix: the image override above replaces the whole
+	// tag, so a user pinning image.tag=7.81.0 would otherwise get the Linux agent image.
+	componentagent.EnsureWindowsServercoreImage(&daemonset.Spec.Template.Spec)
+
+	// Strip Linux-incompatible mutations AFTER overrides so that user-supplied
+	// Linux hostPath volumes in the override are also caught.
+	// Strips: Linux hostPath volumes, corresponding mounts, Linux-only containers
+	// (system-probe, security-agent, …), Linux-only init containers (seccomp-setup, …),
+	// and Linux security context fields (capabilities, seccomp, SELinux, readOnlyRootFilesystem).
+	// Preserves: feature env vars, emptyDir/configMap volumes, Windows-specific mounts.
+	componentagent.StripLinuxOnlySettingsFromTemplate(&daemonset.Spec.Template)
+
+	// Force APM/DogStatsD non-local traffic AFTER features + strip so it wins over the
+	// DogStatsD feature (which writes DD_DOGSTATSD_NON_LOCAL_TRAFFIC=<user value, default
+	// false> with last-writer-wins merge). Windows has no Unix socket, so the agents must
+	// listen on non-local TCP/UDP to be reachable.
+	// NOTE: the component=agent local services created by the APM/DogStatsD features do NOT
+	// select Windows pods (labeled component=agent-windows), so workload->agent traffic on
+	// Windows currently requires hostPort (features.apm/dogstatsd hostPort) or a future
+	// Windows-specific local service. See windowsNodeAgent docs.
+	componentagent.EnsureWindowsIntakeReachable(podManagers)
+
+	// Add the Windows host-log hostPath volumes/mounts when log collection is enabled. The
+	// logcollection feature only injects the Linux paths (stripped above); these Windows-path
+	// mounts survive the strip. Honor any configured logCollection paths (Windows defaults
+	// otherwise) so custom Windows log/runtime paths take effect.
+	if logCollectionEnabled {
+		componentagent.AddWindowsLogCollectionVolumes(&daemonset.Spec.Template.Spec, windowsLogPaths(ddai))
+	}
+
+	return r.createOrUpdateDaemonset(ctx, ddai, daemonset, newStatus, updateDSStatusV2WithWindowsAgent)
+}
+
+func updateDSStatusV2WithWindowsAgent(dsName string, ds *appsv1.DaemonSet, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus, updateTime metav1.Time, status metav1.ConditionStatus, reason, message string) {
+	// Track the Windows DaemonSet rollout in its own status field, separate from the
+	// Linux Agent field, so the two don't clobber each other.
+	newStatus.AgentWindows = condition.UpdateDaemonSetStatusDDAI(dsName, ds, newStatus.AgentWindows, &updateTime)
+	condition.UpdateDatadogAgentInternalStatusConditions(newStatus, updateTime, "WindowsAgentReconcile", status, reason, message, true)
+}
+
+// ensureWindowsDaemonSetAbsent removes the Windows DaemonSet(s) and clears the AgentWindows
+// status field. It is idempotent and used by every path that must NOT run a Windows
+// DaemonSet: the override key being absent (opt-out / removed), Disabled, FIPS, and EDS.
+//
+// It lists by the Windows component label (agent.datadoghq.com/component=agent-windows)
+// rather than the default name so a user-renamed DaemonSet (via override.name) is also
+// cleaned up. It only ever touches AgentWindows, never the Linux Agent status.
+func (r *Reconciler) ensureWindowsDaemonSetAbsent(ctx context.Context, ddai *datadoghqv1alpha1.DatadogAgentInternal, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus) error {
+	dsList := &appsv1.DaemonSetList{}
+	if err := r.client.List(ctx, dsList,
+		client.InNamespace(ddai.GetNamespace()),
+		client.MatchingLabels{
+			apicommon.AgentDeploymentComponentLabelKey: componentagent.WindowsAgentResourceSuffix,
+			// Owner-scope by part-of so we never delete another DatadogAgent(Internal)'s
+			// Windows DaemonSet that happens to share the namespace.
+			kubernetes.AppKubernetesPartOfLabelKey: object.NewPartOfLabelValue(ddai).String(),
+		},
+	); err != nil {
+		return err
+	}
+	for i := range dsList.Items {
+		ds := &dsList.Items[i]
+		if err := r.client.Delete(ctx, ds); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		ctrl.LoggerFrom(ctx).WithValues("object.kind", "DaemonSet", "object.namespace", ds.Namespace, "object.name", ds.Name).Info("Deleted Windows DaemonSet")
+		event := buildEventInfo(ds.Name, ds.Namespace, kubernetes.DaemonSetKind, datadog.DeletionEvent)
+		r.recordEvent(ddai, event)
+	}
+	newStatus.AgentWindows = nil
+	return nil
+}

--- a/internal/controller/datadogagentinternal/controller_reconcile_windows_agent_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_windows_agent_test.go
@@ -1,0 +1,307 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagentinternal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	componentagent "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+)
+
+func newWindowsTestReconciler(objs ...runtime.Object) *Reconciler {
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	_ = datadoghqv1alpha1.AddToScheme(sch)
+	clientObjs := make([]client.Object, 0, len(objs))
+	for _, o := range objs {
+		if co, ok := o.(client.Object); ok {
+			clientObjs = append(clientObjs, co)
+		}
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(clientObjs...).Build()
+	recorder := record.NewBroadcaster().NewRecorder(sch, corev1.EventSource{Component: "windows-test"})
+	return &Reconciler{
+		client:   fakeClient,
+		scheme:   sch,
+		recorder: recorder,
+	}
+}
+
+func windowsTestDDAI(override map[datadoghqv2alpha1.ComponentName]*datadoghqv2alpha1.DatadogAgentComponentOverride, global *datadoghqv2alpha1.GlobalConfig) *datadoghqv1alpha1.DatadogAgentInternal {
+	return &datadoghqv1alpha1.DatadogAgentInternal{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd", Namespace: "datadog"},
+		Spec: datadoghqv2alpha1.DatadogAgentSpec{
+			Global:   global,
+			Override: override,
+		},
+	}
+}
+
+// No windowsNodeAgent key → no-op, no DaemonSet created.
+func TestReconcileV2WindowsAgent_NoOpWhenKeyAbsent(t *testing.T) {
+	r := newWindowsTestReconciler()
+	ddai := windowsTestDDAI(map[datadoghqv2alpha1.ComponentName]*datadoghqv2alpha1.DatadogAgentComponentOverride{}, nil)
+	newStatus := &datadoghqv1alpha1.DatadogAgentInternalStatus{}
+
+	_, err := r.reconcileV2WindowsAgent(context.Background(), feature.RequiredComponents{}, nil, ddai, nil, newStatus)
+	require.NoError(t, err)
+
+	// No Windows DaemonSet created.
+	dsList := &appsv1.DaemonSetList{}
+	require.NoError(t, r.client.List(context.Background(), dsList))
+	assert.Empty(t, dsList.Items)
+	assert.Nil(t, newStatus.AgentWindows)
+}
+
+// FIPS + Windows → no DaemonSet, condition surfaced, Linux Agent status untouched.
+func TestReconcileV2WindowsAgent_FIPSGuard(t *testing.T) {
+	r := newWindowsTestReconciler()
+	ddai := windowsTestDDAI(
+		map[datadoghqv2alpha1.ComponentName]*datadoghqv2alpha1.DatadogAgentComponentOverride{
+			datadoghqv2alpha1.WindowsNodeAgentComponentName: {},
+		},
+		&datadoghqv2alpha1.GlobalConfig{UseFIPSAgent: ptr.To(true)},
+	)
+	newStatus := &datadoghqv1alpha1.DatadogAgentInternalStatus{}
+
+	_, err := r.reconcileV2WindowsAgent(context.Background(), feature.RequiredComponents{}, nil, ddai, nil, newStatus)
+	require.NoError(t, err)
+
+	// No Windows DaemonSet created under FIPS.
+	dsList := &appsv1.DaemonSetList{}
+	require.NoError(t, r.client.List(context.Background(), dsList))
+	assert.Empty(t, dsList.Items)
+
+	// A WindowsAgentReconcile condition with the FIPS reason is set to False.
+	found := false
+	for _, c := range newStatus.Conditions {
+		if c.Type == "WindowsAgentReconcile" {
+			found = true
+			assert.Equal(t, metav1.ConditionFalse, c.Status)
+			assert.Equal(t, "FIPSWindowsUnsupported", c.Reason)
+		}
+	}
+	assert.True(t, found, "expected WindowsAgentReconcile condition")
+}
+
+// Disabled flag → delete the Windows DS and clear ONLY AgentWindows, never the Linux Agent status.
+func TestReconcileV2WindowsAgent_DisabledClearsOnlyWindowsStatus(t *testing.T) {
+	existingWinDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-agent-windows", Namespace: "datadog", Labels: map[string]string{"agent.datadoghq.com/component": "agent-windows", "app.kubernetes.io/part-of": "datadog-dd"}},
+	}
+	r := newWindowsTestReconciler(existingWinDS)
+
+	ddai := windowsTestDDAI(
+		map[datadoghqv2alpha1.ComponentName]*datadoghqv2alpha1.DatadogAgentComponentOverride{
+			datadoghqv2alpha1.WindowsNodeAgentComponentName: {Disabled: ptr.To(true)},
+		},
+		nil,
+	)
+	// Pre-populate both Linux and Windows status to verify only Windows is cleared.
+	linuxStatus := &datadoghqv2alpha1.DaemonSetStatus{DaemonsetName: "dd-agent", Desired: 3, Ready: 3}
+	newStatus := &datadoghqv1alpha1.DatadogAgentInternalStatus{
+		Agent:        linuxStatus,
+		AgentWindows: &datadoghqv2alpha1.DaemonSetStatus{DaemonsetName: "dd-agent-windows", Desired: 1, Ready: 1},
+	}
+
+	_, err := r.reconcileV2WindowsAgent(context.Background(), feature.RequiredComponents{}, nil, ddai, nil, newStatus)
+	require.NoError(t, err)
+
+	// Windows DS deleted.
+	ds := &appsv1.DaemonSet{}
+	err = r.client.Get(context.Background(), types.NamespacedName{Name: "dd-agent-windows", Namespace: "datadog"}, ds)
+	assert.True(t, err != nil, "Windows DaemonSet should have been deleted")
+
+	// AgentWindows cleared, Linux Agent status untouched.
+	assert.Nil(t, newStatus.AgentWindows, "AgentWindows must be cleared")
+	require.NotNil(t, newStatus.Agent, "Linux Agent status must NOT be cleared")
+	assert.Equal(t, "dd-agent", newStatus.Agent.DaemonsetName)
+	assert.Equal(t, int32(3), newStatus.Agent.Desired)
+}
+
+// GetWindowsAgentName naming sanity (cross-check with reconciler delete target).
+func TestReconcileV2WindowsAgent_DeleteTargetsCorrectName(t *testing.T) {
+	ddai := windowsTestDDAI(nil, nil)
+	assert.Equal(t, "dd-agent-windows", componentagent.GetWindowsAgentName(ddai))
+}
+
+// Removing the windowsNodeAgent override (key absent) must delete a previously-created
+// Windows DaemonSet and clear AgentWindows, without touching the Linux Agent status.
+func TestReconcileV2WindowsAgent_KeyAbsentCleansUpStaleDS(t *testing.T) {
+	existingWinDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-agent-windows", Namespace: "datadog", Labels: map[string]string{"agent.datadoghq.com/component": "agent-windows", "app.kubernetes.io/part-of": "datadog-dd"}},
+	}
+	r := newWindowsTestReconciler(existingWinDS)
+	ddai := windowsTestDDAI(map[datadoghqv2alpha1.ComponentName]*datadoghqv2alpha1.DatadogAgentComponentOverride{}, nil)
+	newStatus := &datadoghqv1alpha1.DatadogAgentInternalStatus{
+		Agent:        &datadoghqv2alpha1.DaemonSetStatus{DaemonsetName: "dd-agent", Desired: 2, Ready: 2},
+		AgentWindows: &datadoghqv2alpha1.DaemonSetStatus{DaemonsetName: "dd-agent-windows"},
+	}
+
+	_, err := r.reconcileV2WindowsAgent(context.Background(), feature.RequiredComponents{}, nil, ddai, nil, newStatus)
+	require.NoError(t, err)
+
+	ds := &appsv1.DaemonSet{}
+	err = r.client.Get(context.Background(), types.NamespacedName{Name: "dd-agent-windows", Namespace: "datadog"}, ds)
+	assert.True(t, err != nil, "stale Windows DaemonSet should be deleted when key is removed")
+	assert.Nil(t, newStatus.AgentWindows, "AgentWindows must be cleared")
+	require.NotNil(t, newStatus.Agent, "Linux Agent status must survive")
+	assert.Equal(t, "dd-agent", newStatus.Agent.DaemonsetName)
+}
+
+// Enabling FIPS while windowsNodeAgent is set must delete the Windows DS (not leave it
+// running misconfigured) and surface the FIPS condition.
+func TestReconcileV2WindowsAgent_FIPSCleansUpStaleDS(t *testing.T) {
+	existingWinDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "dd-agent-windows", Namespace: "datadog", Labels: map[string]string{"agent.datadoghq.com/component": "agent-windows", "app.kubernetes.io/part-of": "datadog-dd"}},
+	}
+	r := newWindowsTestReconciler(existingWinDS)
+	ddai := windowsTestDDAI(
+		map[datadoghqv2alpha1.ComponentName]*datadoghqv2alpha1.DatadogAgentComponentOverride{
+			datadoghqv2alpha1.WindowsNodeAgentComponentName: {},
+		},
+		&datadoghqv2alpha1.GlobalConfig{UseFIPSAgent: ptr.To(true)},
+	)
+	newStatus := &datadoghqv1alpha1.DatadogAgentInternalStatus{}
+
+	_, err := r.reconcileV2WindowsAgent(context.Background(), feature.RequiredComponents{}, nil, ddai, nil, newStatus)
+	require.NoError(t, err)
+
+	ds := &appsv1.DaemonSet{}
+	err = r.client.Get(context.Background(), types.NamespacedName{Name: "dd-agent-windows", Namespace: "datadog"}, ds)
+	assert.True(t, err != nil, "Windows DaemonSet should be deleted under FIPS")
+	found := false
+	for _, c := range newStatus.Conditions {
+		if c.Type == "WindowsAgentReconcile" && c.Reason == "FIPSWindowsUnsupported" {
+			found = true
+		}
+	}
+	assert.True(t, found, "FIPS condition should be surfaced")
+}
+
+// Cleanup must be owner-scoped: removing windowsNodeAgent on one DDAI must NOT delete
+// another DDAI's Windows DaemonSet in the same namespace (regression guard).
+func TestReconcileV2WindowsAgent_CleanupOwnerScoped(t *testing.T) {
+	// Our DDAI's Windows DS.
+	ownDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dd-agent-windows", Namespace: "datadog",
+			Labels: map[string]string{"agent.datadoghq.com/component": "agent-windows", "app.kubernetes.io/part-of": "datadog-dd"},
+		},
+	}
+	// A different DDAI's Windows DS in the same namespace (different part-of).
+	otherDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other-agent-windows", Namespace: "datadog",
+			Labels: map[string]string{"agent.datadoghq.com/component": "agent-windows", "app.kubernetes.io/part-of": "datadog-other"},
+		},
+	}
+	r := newWindowsTestReconciler(ownDS, otherDS)
+	ddai := windowsTestDDAI(map[datadoghqv2alpha1.ComponentName]*datadoghqv2alpha1.DatadogAgentComponentOverride{}, nil)
+	newStatus := &datadoghqv1alpha1.DatadogAgentInternalStatus{}
+
+	_, err := r.reconcileV2WindowsAgent(context.Background(), feature.RequiredComponents{}, nil, ddai, nil, newStatus)
+	require.NoError(t, err)
+
+	// Our DS deleted.
+	err = r.client.Get(context.Background(), types.NamespacedName{Name: "dd-agent-windows", Namespace: "datadog"}, &appsv1.DaemonSet{})
+	assert.True(t, err != nil, "own Windows DaemonSet should be deleted")
+	// Other DDAI's DS must survive.
+	err = r.client.Get(context.Background(), types.NamespacedName{Name: "other-agent-windows", Namespace: "datadog"}, &appsv1.DaemonSet{})
+	assert.NoError(t, err, "another DDAI's Windows DaemonSet must NOT be deleted")
+}
+
+// stubFeature is a minimal feature.Feature whose Configure returns a fixed set of
+// node-agent required containers (enough to test windowsContainersFromFeatures).
+type stubFeature struct {
+	id             feature.IDType
+	nodeContainers []apicommon.AgentContainerName
+}
+
+func (f stubFeature) ID() feature.IDType { return f.id }
+func (f stubFeature) Configure(metav1.Object, *datadoghqv2alpha1.DatadogAgentSpec, *datadoghqv2alpha1.RemoteConfigConfiguration) feature.RequiredComponents {
+	return feature.RequiredComponents{
+		Agent: feature.RequiredComponent{Containers: f.nodeContainers},
+	}
+}
+func (f stubFeature) ManageDependencies(feature.ResourceManagers) error                { return nil }
+func (f stubFeature) ManageClusterAgent(feature.PodTemplateManagers) error             { return nil }
+func (f stubFeature) ManageNodeAgent(feature.PodTemplateManagers) error                { return nil }
+func (f stubFeature) ManageSingleContainerNodeAgent(feature.PodTemplateManagers) error { return nil }
+func (f stubFeature) ManageClusterChecksRunner(feature.PodTemplateManagers) error      { return nil }
+func (f stubFeature) ManageOtelAgentGateway(feature.PodTemplateManagers) error         { return nil }
+
+// windowsContainersFromFeatures rebuilds the Windows container set from each feature's
+// node-agent RequiredComponents (Configure), filtered to the Windows-supported sidecars.
+func TestWindowsContainersFromFeatures(t *testing.T) {
+	core := apicommon.CoreAgentContainerName
+	trace := apicommon.TraceAgentContainerName
+	process := apicommon.ProcessAgentContainerName
+	ddai := windowsTestDDAI(nil, nil)
+
+	cases := []struct {
+		name  string
+		feats []feature.Feature
+		want  []apicommon.AgentContainerName
+	}{
+		{
+			name:  "core only (feature needs no node sidecar)",
+			feats: []feature.Feature{stubFeature{id: feature.LogCollectionIDType}},
+			want:  []apicommon.AgentContainerName{core},
+		},
+		{
+			name:  "node APM requires trace-agent",
+			feats: []feature.Feature{stubFeature{id: feature.APMIDType, nodeContainers: []apicommon.AgentContainerName{core, trace}}},
+			want:  []apicommon.AgentContainerName{core, trace},
+		},
+		{
+			// APM enabled cluster-side only (SSI): node APM off → Configure returns no trace.
+			// Must NOT add an unconfigured trace-agent.
+			name:  "cluster-only APM does not add trace-agent",
+			feats: []feature.Feature{stubFeature{id: feature.APMIDType, nodeContainers: nil}},
+			want:  []apicommon.AgentContainerName{core},
+		},
+		{
+			name: "process feature adds process (deduped across features)",
+			feats: []feature.Feature{
+				stubFeature{id: feature.LiveProcessIDType, nodeContainers: []apicommon.AgentContainerName{core, process}},
+				stubFeature{id: feature.ProcessDiscoveryIDType, nodeContainers: []apicommon.AgentContainerName{core, process}},
+			},
+			want: []apicommon.AgentContainerName{core, process},
+		},
+		{
+			name: "apm + process",
+			feats: []feature.Feature{
+				stubFeature{id: feature.APMIDType, nodeContainers: []apicommon.AgentContainerName{core, trace}},
+				stubFeature{id: feature.LiveContainerIDType, nodeContainers: []apicommon.AgentContainerName{core, process}},
+			},
+			want: []apicommon.AgentContainerName{core, trace, process},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.ElementsMatch(t, c.want, windowsContainersFromFeatures(c.feats, ddai))
+		})
+	}
+}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -54,6 +54,8 @@ const (
 	FIPSTagSuffix = "-fips"
 	// FullTagSuffix tag suffix for full agent images
 	FullTagSuffix = "-full"
+	// WindowsServerCoreTagSuffix tag suffix for Windows Server Core agent images
+	WindowsServerCoreTagSuffix = "-servercore"
 	// Default Image names
 	DefaultAgentImageName         string = "agent"
 	DefaultClusterAgentImageName  string = "cluster-agent"
@@ -153,6 +155,16 @@ func (i *Image) FIPSVersionError() error {
 // GetLatestAgentImage returns the latest stable agent release version
 func GetLatestAgentImage() string {
 	image := newImage(DefaultImageRegistry, DefaultAgentImageName, AgentLatestVersion, false, false, false)
+	return image.ToString()
+}
+
+// GetLatestWindowsAgentImage returns the Windows Server Core variant of the latest agent image.
+// Windows agent images use the "-servercore" tag suffix (e.g. 7.80.2-servercore).
+// Note: the registry is overwritten by updateContainerImages when GlobalConfig.Registry is set;
+// the tag suffix "-servercore" is also incompatible with FIPS (which would produce a non-existent
+// tag like "7.80.2-servercore-fips") — FIPS + Windows is not supported.
+func GetLatestWindowsAgentImage() string {
+	image := newImage(DefaultImageRegistry, DefaultAgentImageName, AgentLatestVersion+WindowsServerCoreTagSuffix, false, false, false)
 	return image.ToString()
 }
 

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -8,6 +8,7 @@ package images
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,26 @@ func TestGetLatestAgentImage(t *testing.T) {
 				t.Errorf("GetLatestAgentImage() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetLatestWindowsAgentImage(t *testing.T) {
+	got := GetLatestWindowsAgentImage()
+	// Must use the default registry (consistent with other sibling functions).
+	if !strings.HasPrefix(got, DefaultImageRegistry+"/") {
+		t.Errorf("GetLatestWindowsAgentImage() registry = %q, want prefix %q", got, DefaultImageRegistry+"/")
+	}
+	// Must carry the -servercore suffix.
+	if !strings.HasSuffix(got, WindowsServerCoreTagSuffix) {
+		t.Errorf("GetLatestWindowsAgentImage() = %q, want suffix %q", got, WindowsServerCoreTagSuffix)
+	}
+	// Must embed the current agent version.
+	if !strings.Contains(got, AgentLatestVersion) {
+		t.Errorf("GetLatestWindowsAgentImage() = %q, want version %q", got, AgentLatestVersion)
+	}
+	want := fmt.Sprintf("%s/agent:%s%s", DefaultImageRegistry, AgentLatestVersion, WindowsServerCoreTagSuffix)
+	if got != want {
+		t.Errorf("GetLatestWindowsAgentImage() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds opt-in Windows node Agent support via `spec.override.windowsNodeAgent`. When configured, the Operator creates a Windows-targeted Agent DaemonSet alongside the existing Linux Agent DaemonSet.


### Motivation
Enable Datadog Agent deployment on mixed Linux/Windows Kubernetes clusters managed by the Datadog Operator.
Key Changes: 
1. internal/controller/datadogagent/component/agent/windows.go
New Windows Agent DaemonSet builder and Windows-specific pod sanitization. Handles Windows node targeting, init config, safe container allowlisting, Linux-only field stripping, -servercore image handling, non-local APM/DogStatsD traffic, and Windows log collection mounts.

2. internal/controller/datadogagentinternal/controller_reconcile_windows_agent.go
New Windows Agent reconciler. Handles opt-in behavior, unsupported FIPS/EDS cleanup, disabled cleanup, Windows container selection, feature filtering, pod sanitization, image normalization, intake reachability, log mounts, and DaemonSet create/update.

3. internal/controller/datadogagentinternal/controller_reconcile_agent.go
Chains Windows reconciliation into the existing node Agent flow so Linux and Windows DaemonSets stay in sync across normal, disabled, and EDS paths.  `reconcileV2WindowsAgent` is called on every DDAI reconcile, for linux only DDA that means `ensureWindowsDaemonSetAbsent` will be always called on each reconcile. 

4. API/status generated files
Adds status.agentWindows and the agent-windows printer column for both DatadogAgent and DatadogAgentInternal. Also fixes status handling so AgentWindows is preserved and compared correctly.

5. examples/datadogagent/datadog-agent-with-windows-nodes.yaml
Adds an example Windows configuration and documents current limitations, especially that local APM/DogStatsD services do not yet route to Windows pods.
<img width="2669" height="1555" alt="image" src="https://github.com/user-attachments/assets/5009e2ae-8d25-4ae5-af2f-f9fca2d3bfe0" />

#### Gaps addressed

| # | Gap | Root cause | Addressed by |
|---|-----|------------|--------------|
| 1 | **Windows taint not tolerated** | The DaemonSet ships `tolerations: []`. Every Kubernetes distribution (GKE, EKS, AKS, kubeadm) automatically applies `node.kubernetes.io/os=windows:NoSchedule` to Windows nodes via kubelet, so no Windows pod is ever scheduled. | `NewDefaultWindowsAgentPodTemplateSpec` adds the `node.kubernetes.io/os=windows:NoSchedule` toleration + `nodeSelector os=windows` (`windows.go`). |
| 2 | **No Windows DaemonSet** | The operator generates a single DaemonSet with no OS awareness. Even if the taint were tolerated, the Linux pod spec would fail on all remaining gaps. | New `reconcileV2WindowsAgent` builds a dedicated `datadog-agent-windows` DaemonSet, chained after the Linux DS on every reconcile path (`controller_reconcile_windows_agent.go`, `controller_reconcile_agent.go`). |
| 3 | **Linux-only container image** | The operator always uses `agent:X.Y.Z` — a Linux binary. Windows requires a separate image (`agent:X.Y.Z-servercore`) compiled for Windows APIs. No Windows image reference exists anywhere in the codebase. | `GetLatestWindowsAgentImage` + `EnsureWindowsServercoreImage` coerce the default agent image to the `-servercore` tag (`pkg/images/images.go`, `windows.go`). |
| 4 | **Linux-specific `securityContext`** | Linux capabilities (`SYS_ADMIN`, `NET_RAW`, etc.), seccomp profiles, and `readOnlyRootFilesystem` are all rejected by the Windows container runtime. | `StripLinuxOnlySettings` (allowlist) clears capabilities, seccomp, SELinux, AppArmor, `readOnlyRootFilesystem`, hostPID/hostIPC, and uses a nil pod `SecurityContext` (`windows.go`). |
| 5 | **Linux-only hostPath volumes** | `/proc`, `/sys/fs/cgroup`, `/etc/passwd`, and Unix sockets at `/var/run` do not exist on Windows. The pod would fail to start. | `StripLinuxOnlySettings` allowlist drops every mount/volume with a `/`-prefixed path and every `*SOCKET*`/`DOCKER_HOST`/`DD_VSOCK_ADDR` env var; `AddWindowsLogCollectionVolumes` adds the Windows `C:/` log hostPaths (`windows.go`). |
| 6 | **`system-probe` / `security-agent` always injected** | Both use eBPF (Linux kernel only). They are unconditionally added when features like `liveProcessCollection` or CSPM are enabled. | `windowsContainersFromFeatures` + `windowsSupportedFeatures` allowlist keep only core/trace/process-agent; the strip allowlist removes any other container (`controller_reconcile_windows_agent.go`, `windows.go`). |
| 7 | **Linux init containers** | The three init containers use `bash` and Linux paths. Windows has no `bash`. The trace-agent also requires a config file at `C:\ProgramData\Datadog\datadog.yaml`, which the Windows image does not include. | Single PowerShell `init-config-windows` init container creates `C:\ProgramData\Datadog\datadog.yaml` + auth dir; all Linux init containers are stripped (`windowsInitContainers` in `windows.go`). |
| 8 | **No Windows API surface** | No field in the `DatadogAgent` CRD to opt in to Windows or configure a Windows-specific image, resources, or tolerations. | New `spec.override.windowsNodeAgent` component (`WindowsNodeAgentComponentName`) optrride fields (image, resources, etc.)(`api/datadoghq/v2alpha1/datadogagent_types.go`). |                                                      | 9 | **Log collection wired for Linu` feature injects Linux hostPaths(`/var/log/pods`, `/var/lib/docker/cors`) and defaults its paths to Linuxvalues — none of which exist on Windows. On Windows, pod logs live at `C:\var\log\pods` (symlinks into   `C:\ProgramData`), and only file-bases container-runtime socket). The Linuxpaths get stripped, leaving log collegCollectionVolumes` adds the Windows`C:/` log hostPaths — configurable **host** path, fixed standard **in-container** mount (Linux model) — treating Linux-default paths as unsetCONTAINER_USE_FILE=true`. Gated on`logCollection` enabled (`windows.go`ws_agent.go`). |

### Additional Notes

Windows support is currently limited to the core Agent, trace Agent, and process Agent. Linux-only containers, mounts, security settings, and socket/env configuration are stripped from the Windows DaemonSet.

Current limitations:
- Not supported with ExtendedDaemonSet.
- Not supported with `global.useFIPSAgent`.
- APM/DogStatsD require hostPort for Windows workload traffic because the existing local service selects Linux Agent pods only.

### Describe your test plan

1. Added unit tests for Windows DaemonSet construction, image selection, pod sanitization, status propagation, and cleanup behavior.
2. E2E test on a cluster with a Linux node pool (operator, cluster-agent) and a Windows node pool, Deploy a DatadogAgent(DDA) that **opts into Windows**
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata: {name: datadog, namespace: datadog}
spec:
  global:
    credentials: {apiSecret: {secretName: datadog-secret, keyName: api-key}}
    site: datadoghq.com
  features:
    apm: {enabled: true}
  override:
    windowsNodeAgent: {}   # opt in
```
3. Verify the two DaemonSets and the Windows pod
```
kubectl get ds -n datadog
#   datadog-agent           <linux node count>   NODE SELECTOR: <none>
#   datadog-agent-windows   <win node count>     NODE SELECTOR: kubernetes.io/os=windows

kubectl get pods -n datadog -o wide
#   datadog-agent-windows-xxxx   2/2 Running   <on the Windows node>
Expect: the Windows pod is 2/2 Running (agent + trace-agent) on the Windows node; the Linux DaemonSet is unchanged.
```
4. Verify the status field & printer column
```
kubectl get datadogagent datadog -n datadog -o wide
# AGENT  AGENT-WINDOWS  CLUSTER-AGENT ...
# Running (n/n/n)  Running (m/m/m)  Running (1/1/1)
Expect: distinct AGENT and AGENT-WINDOWS columns; the Linux AGENT status is not overwritten.
```

5. Verify the allowlist strip with eBPF/Linux features enabled (key test)
Enable Linux-only features, then inspect the Windows DaemonSet — the allowlist guarantees it stays clean:
```
kubectl patch datadogagent datadog -n datadog --type merge -p \
  '{"spec":{"features":{"npm":{"enabled":true},"cspm":{"enabled":true},"sbom":{"enabled":true,"host":{"enabled":true}}}}}'
kubectl get ds datadog-agent-windows -n datadog -o json | jq '{
  containers: [.spec.template.spec.containers[].name],
  hostPathVolumes: [.spec.template.spec.volumes[].hostPath.path] | map(select(.)),
  hostPID: .spec.template.spec.hostPID,
  hostIPC: .spec.template.spec.hostIPC,
  linuxEnvLeaks: [.spec.template.spec.containers[].env[]? | select(.name|test("SOCKET|DOCKER_HOST|KUBELET_CLIENT_CA|VSOCK")) | .name]
}'

Result:
{
  "containers": ["agent", "trace-agent", "process-agent"],
  "hostPathVolumes": [],
  "hostPID": null,
  "hostIPC": null,
  "linuxEnvLeaks": []
}
```

6. Verify cleanup on opt-out

```
kubectl patch datadogagent datadog -n datadog --type=json \
  -p='[{"op":"remove","path":"/spec/override/windowsNodeAgent"}]'
kubectl get ds datadog-agent-windows -n datadog        # → NotFound (deleted)
kubectl get datadogagent datadog -n datadog -o jsonpath='{.status.agentWindows}'   # → empty
kubectl get pods -n datadog | grep '^nt still Running
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits