### PR TITLE
fix: include version in the operator's Kubernetes client User-Agent

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -282,7 +282,7 @@ func run(opts *options) error {
 	}
 
 	restConfig := ctrl.GetConfigOrDie()
-	restConfig.UserAgent = "datadog-operator"
+	restConfig.UserAgent = "datadog-operator/" + version.Version
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                     scheme,
 		Metrics:                    metricsServerOptions,


### PR DESCRIPTION
### What does this PR do?

Appends the operator version to the User-Agent of the operator's Kubernetes client. The `rest.Config` backing the controller-runtime manager now sets `UserAgent = "datadog-operator/" + version.Version` (set before `ctrl.NewManager`, so the manager's cache and clients inherit it), instead of a static `"datadog-operator"` with no version.

### Motivation

The operator's client sent a static `datadog-operator` User-Agent with no version, so API-server audit logs and managed control-plane telemetry (GKE Cloud Audit Logs `callerSuppliedUserAgent`, EKS audit logs) could not identify which operator version was issuing calls. Adding the version makes the caller identifiable. Related to FRCONS-815, where the Cluster Agent had the analogous problem (reported as `v0.0.0`).

### Additional Notes

N/A

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- Build the operator image and deploy it to a cluster.
- Confirm the API server observes the versioned User-Agent:
  - kube-apiserver audit log → `userAgent` field, or
  - GKE/EKS control-plane (Cloud) audit logs → `callerSuppliedUserAgent`.
  - Expect `datadog-operator/<version>` instead of bare `datadog-operator`.
- Cross-check the running version via the operator's `--version` output / startup logs, which already print `version.Version`.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1]) — verified (SSH-signed)

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
