### PR TITLE
[CASCL-1386] (1/11) Add evict-legacy-nodes command skeleton

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/cluster.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/cluster.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/evict"
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/install"
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/uninstall"
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/update"
@@ -35,6 +36,7 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.AddCommand(install.New(streams))
 	cmd.AddCommand(uninstall.New(streams))
 	cmd.AddCommand(update.New(streams))
+	cmd.AddCommand(evict.New(streams))
 
 	o := newOptions(streams)
 	o.configFlags.AddFlags(cmd.Flags())

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/asg.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/asg.go
@@ -1,0 +1,18 @@
+package evict
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"k8s.io/client-go/kubernetes"
+)
+
+type AutoscalingAPI interface {
+	UpdateAutoScalingGroup(ctx context.Context, in *autoscaling.UpdateAutoScalingGroupInput, opts ...func(*autoscaling.Options)) (*autoscaling.UpdateAutoScalingGroupOutput, error)
+	SuspendProcesses(ctx context.Context, in *autoscaling.SuspendProcessesInput, opts ...func(*autoscaling.Options)) (*autoscaling.SuspendProcessesOutput, error)
+	TerminateInstanceInAutoScalingGroup(ctx context.Context, in *autoscaling.TerminateInstanceInAutoScalingGroupInput, opts ...func(*autoscaling.Options)) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error)
+}
+
+func evictASG(ctx context.Context, clientset kubernetes.Interface, asg AutoscalingAPI, asgName string, nodes []string, drainOpts nodeDrainOptions) error {
+	panic("TODO: evictASG — implemented in PR https://github.com/DataDog/datadog-operator/pull/3175")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/clusterautoscaler.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/clusterautoscaler.go
@@ -1,0 +1,13 @@
+package evict
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo"
+)
+
+func scaleDownClusterAutoscaler(ctx context.Context, clientset kubernetes.Interface, ca clusterinfo.ClusterAutoscaler, dryRun bool) error {
+	panic("TODO: scaleDownClusterAutoscaler — implemented in PR https://github.com/DataDog/datadog-operator/pull/3164")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng.go
@@ -1,0 +1,20 @@
+package evict
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"k8s.io/client-go/kubernetes"
+)
+
+var errEKSDrainIncomplete = errors.New("EKS managed node group drain did not complete within the timeout")
+
+type EKSManagedNodeGroupAPI interface {
+	DescribeNodegroup(ctx context.Context, in *eks.DescribeNodegroupInput, opts ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error)
+	UpdateNodegroupConfig(ctx context.Context, in *eks.UpdateNodegroupConfigInput, opts ...func(*eks.Options)) (*eks.UpdateNodegroupConfigOutput, error)
+}
+
+func evictEKSManagedNodeGroup(ctx context.Context, eksAPI EKSManagedNodeGroupAPI, clientset kubernetes.Interface, clusterName, nodegroupName string, drainOpts nodeDrainOptions) error {
+	panic("TODO: evictEKSManagedNodeGroup — implemented in PR https://github.com/DataDog/datadog-operator/pull/3174")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict.go
@@ -1,0 +1,157 @@
+package evict
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clients"
+	"github.com/DataDog/datadog-operator/pkg/plugin/common"
+)
+
+var evictExample = `
+  # evict every node group that is not Datadog-managed (cluster-autoscaler ASGs,
+  # EKS managed node groups, user Karpenter NodePools, standalone EC2)
+  %[1]s evict-legacy-nodes --all
+
+  # evict a single ASG by name
+  %[1]s evict-legacy-nodes --target=asg/my-legacy-asg
+
+  # preview the actions without performing them
+  %[1]s evict-legacy-nodes --all --dry-run
+`
+
+type options struct {
+	genericclioptions.IOStreams
+	common.Options
+	args []string
+
+	clusterName        string
+	karpenterNamespace string
+	all                bool
+	targetSpecs        []string
+	targets            []Target // populated by validate()
+	skipCA             bool
+	ensurePDBs         bool
+	evictionTimeout    time.Duration
+	nodeTimeout        time.Duration
+	dryRun             bool
+	yes                bool
+	debug              bool
+}
+
+func newOptions(streams genericclioptions.IOStreams) *options {
+	o := &options{
+		IOStreams:       streams,
+		ensurePDBs:      true,
+		evictionTimeout: 5 * time.Minute,
+		nodeTimeout:     15 * time.Minute,
+	}
+	o.SetConfigFlags()
+	return o
+}
+
+// New returns the cobra command for `kubectl datadog autoscaling cluster evict-legacy-nodes`.
+func New(streams genericclioptions.IOStreams) *cobra.Command {
+	o := newOptions(streams)
+	cmd := &cobra.Command{
+		Use:          "evict-legacy-nodes",
+		Short:        "Drain workloads from non-Datadog node groups onto Datadog-managed Karpenter NodePools",
+		Example:      fmt.Sprintf(evictExample, "kubectl datadog autoscaling cluster"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.complete(c, args); err != nil {
+				return err
+			}
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return o.run()
+		},
+	}
+
+	cmd.Flags().StringVar(&o.clusterName, "cluster-name", "", "Name of the EKS cluster")
+	cmd.Flags().StringVar(&o.karpenterNamespace, "karpenter-namespace", "", "Namespace where Karpenter is deployed (auto-detected when empty)")
+	cmd.Flags().BoolVar(&o.all, "all", false, "Evict every node group that is not managed by Datadog")
+	cmd.Flags().StringSliceVar(&o.targetSpecs, "target", nil, "Target a specific node group: <manager>/<name>, with <manager> one of asg, eksManagedNodeGroup, karpenter. Use `standalone` (no name) for standalone EC2 instances. Repeatable. Mutually exclusive with --all.")
+	cmd.Flags().BoolVar(&o.skipCA, "skip-cluster-autoscaler", false, "Do not scale the cluster-autoscaler Deployment to 0 replicas as step 1")
+	cmd.Flags().BoolVar(&o.ensurePDBs, "ensure-pdbs", true, "Create temporary PodDisruptionBudgets (maxUnavailable: 1) for workloads without one, and remove them at the end")
+	cmd.Flags().DurationVar(&o.evictionTimeout, "eviction-timeout", 5*time.Minute, "Time budget per pod for the Eviction API to succeed before giving up (PDB-blocked pods)")
+	cmd.Flags().DurationVar(&o.nodeTimeout, "node-timeout", 15*time.Minute, "Time budget per node for it to become empty after pods have been evicted")
+	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "Log the actions that would be taken without performing them")
+	cmd.Flags().BoolVar(&o.yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&o.debug, "debug", false, "Enable debug logs")
+
+	o.ConfigFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *options) complete(cmd *cobra.Command, args []string) error {
+	o.args = args
+	return o.Init(cmd)
+}
+
+func (o *options) validate() error {
+	if len(o.args) > 0 {
+		return errors.New("no positional arguments are allowed")
+	}
+	if o.all && len(o.targetSpecs) > 0 {
+		return errors.New("--all and --target are mutually exclusive")
+	}
+	if !o.all && len(o.targetSpecs) == 0 {
+		return errors.New("at least one of --all or --target must be provided")
+	}
+	if o.evictionTimeout <= 0 {
+		return errors.New("--eviction-timeout must be positive")
+	}
+	if o.nodeTimeout <= 0 {
+		return errors.New("--node-timeout must be positive")
+	}
+	var (
+		parsed []Target
+		errs   []error
+	)
+	for _, spec := range o.targetSpecs {
+		if t, err := ParseTargetSpec(spec); err != nil {
+			errs = append(errs, err)
+		} else {
+			parsed = append(parsed, t)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	o.targets = parsed
+	return nil
+}
+
+func (o *options) run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	clusterName, err := clients.ResolveClusterName(o.ConfigFlags, o.clusterName)
+	if err != nil {
+		return err
+	}
+
+	return Run(ctx, o.IOStreams, o.ConfigFlags, o.Clientset, RunOptions{
+		ClusterName:        clusterName,
+		KarpenterNamespace: o.karpenterNamespace,
+		All:                o.all,
+		Targets:            o.targets,
+		SkipCA:             o.skipCA,
+		EnsurePDBs:         o.ensurePDBs,
+		DryRun:             o.dryRun,
+		Yes:                o.yes,
+		EvictionTimeout:    o.evictionTimeout,
+		NodeTimeout:        o.nodeTimeout,
+		Debug:              o.debug,
+	})
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
@@ -1,0 +1,11 @@
+package evict
+
+import "time"
+
+// nodeDrainOptions captures the per-call tunables for evicting a node's pods.
+type nodeDrainOptions struct {
+	DryRun          bool
+	EvictionTimeout time.Duration // per pod, bound for retries on 429
+	NodeTimeout     time.Duration // total wait for the node to become empty
+	PollInterval    time.Duration // interval between empty-checks; default 2s
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
@@ -1,0 +1,11 @@
+package evict
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+func evictKarpenterUserNodePool(ctx context.Context, clientset kubernetes.Interface, nodePoolName string, nodes []string, drainOpts nodeDrainOptions) error {
+	panic("TODO: evictKarpenterUserNodePool — implemented in PR https://github.com/DataDog/datadog-operator/pull/3177")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/pdb.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/pdb.go
@@ -1,0 +1,16 @@
+package evict
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ensureTempPDBs(ctx context.Context, clientset kubernetes.Interface, ctrlClient client.Client, targets []Target, dryRun bool) error {
+	panic("TODO: ensureTempPDBs — implemented in PR https://github.com/DataDog/datadog-operator/pull/3178")
+}
+
+func cleanupTempPDBs(ctx context.Context, ctrlClient client.Client, dryRun bool) error {
+	panic("TODO: cleanupTempPDBs — implemented in PR https://github.com/DataDog/datadog-operator/pull/3178")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/plan.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/plan.go
@@ -1,0 +1,62 @@
+package evict
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo"
+)
+
+// Target identifies a single node-management entity to evict. The Entity field
+// is the bucket name within `ClusterInfo.NodeManagement[Manager]` — an ASG
+// name, an EKS managed node group name, a Karpenter NodePool name, or the
+// empty string for the standalone bucket.
+type Target struct {
+	Manager clusterinfo.NodeManager
+	Entity  string
+	Nodes   []string
+}
+
+// ParseTargetSpec parses a CLI `--target` value into a Target with an empty
+// Nodes slice (Nodes are filled in by BuildPlan from the cluster snapshot).
+//
+// Format: `<manager>/<entity>`, with the entity omitted for the standalone
+// manager. Fargate and unknown are rejected here — their migration is out of
+// scope of this command.
+func ParseTargetSpec(raw string) (Target, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Target{}, errors.New("--target value cannot be empty")
+	}
+	mgrStr, entity, hasSlash := strings.Cut(raw, "/")
+	mgr := clusterinfo.NodeManager(mgrStr)
+	switch mgr {
+	case clusterinfo.NodeManagerASG,
+		clusterinfo.NodeManagerEKSManagedNodeGroup,
+		clusterinfo.NodeManagerKarpenter:
+		if !hasSlash || entity == "" {
+			return Target{}, fmt.Errorf("--target=%s requires a name: %s/<name>", mgrStr, mgrStr)
+		}
+		return Target{Manager: mgr, Entity: entity}, nil
+	case clusterinfo.NodeManagerStandalone:
+		if hasSlash && entity != "" {
+			return Target{}, fmt.Errorf("--target=standalone does not take a name (got %q)", entity)
+		}
+		return Target{Manager: mgr, Entity: ""}, nil
+	case clusterinfo.NodeManagerFargate:
+		return Target{}, errors.New("--target=fargate is not supported: manage Fargate profiles directly via AWS")
+	case clusterinfo.NodeManagerUnknown:
+		return Target{}, errors.New("--target=unknown is not supported: nodes with unknown providers cannot be migrated automatically")
+	default:
+		return Target{}, fmt.Errorf("--target=%s: unknown manager type (supported: asg, eksManagedNodeGroup, karpenter, standalone)", mgrStr)
+	}
+}
+
+func BuildPlan(info *clusterinfo.ClusterInfo, all bool, specs []Target) ([]Target, error) {
+	panic("TODO: BuildPlan — implemented in PR https://github.com/DataDog/datadog-operator/pull/3161")
+}
+
+func hasDatadogManagedNodePool(info *clusterinfo.ClusterInfo) bool {
+	panic("TODO: hasDatadogManagedNodePool — implemented in PR https://github.com/DataDog/datadog-operator/pull/3161")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/preflight.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/preflight.go
@@ -1,0 +1,12 @@
+package evict
+
+import (
+	"context"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func runPreflightWarnings(ctx context.Context, streams genericclioptions.IOStreams, ctrlClient client.Client, targets []Target) {
+	panic("TODO: runPreflightWarnings — implemented in PR https://github.com/DataDog/datadog-operator/pull/3163")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/prompt.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/prompt.go
@@ -1,0 +1,15 @@
+package evict
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo"
+)
+
+func printPlan(streams genericclioptions.IOStreams, info *clusterinfo.ClusterInfo, targets []Target, scaleCA, ensurePDBs bool) {
+	panic("TODO: printPlan — implemented in PR https://github.com/DataDog/datadog-operator/pull/3162")
+}
+
+func promptConfirmation(streams genericclioptions.IOStreams) bool {
+	panic("TODO: promptConfirmation — implemented in PR https://github.com/DataDog/datadog-operator/pull/3162")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/run.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/run.go
@@ -1,0 +1,262 @@
+package evict
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clients"
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo"
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/display"
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter"
+)
+
+type RunOptions struct {
+	ClusterName        string
+	KarpenterNamespace string // override; auto-detected when empty
+	All                bool
+	Targets            []Target // parsed --target=<type>/<name>
+	SkipCA             bool
+	EnsurePDBs         bool
+	DryRun             bool
+	Yes                bool
+	EvictionTimeout    time.Duration
+	NodeTimeout        time.Duration
+	Debug              bool
+}
+
+// Run is the orchestrator entry point. Idempotent: a second invocation on a
+// cluster already migrated returns success without changes. Crash-safe: a
+// killed run leaves no permanently corrupting state — re-running cleans up.
+func Run(ctx context.Context, streams genericclioptions.IOStreams, configFlags *genericclioptions.ConfigFlags, clientset *kubernetes.Clientset, opts RunOptions) error {
+	log.SetOutput(streams.ErrOut)
+	ctrl.SetLogger(zap.New(zap.UseDevMode(false), zap.WriteTo(streams.ErrOut)))
+
+	cli, err := clients.Build(ctx, configFlags, clientset)
+	if err != nil {
+		return fmt.Errorf("failed to build clients: %w", err)
+	}
+	if err = clients.ValidateAWSAccountConsistency(ctx, cli, opts.ClusterName, configFlags); err != nil {
+		return err
+	}
+	k, err := karpenter.FindInstallation(ctx, clientset)
+	if err != nil {
+		return fmt.Errorf("failed to check for an existing Karpenter installation: %w", err)
+	}
+	if k == nil {
+		return errors.New("Karpenter is not installed on this cluster; run `kubectl datadog autoscaling cluster install` first")
+	}
+	namespace := opts.KarpenterNamespace
+	if namespace == "" {
+		namespace = k.Namespace
+	}
+
+	display.PrintBox(streams.Out, "Evicting legacy nodes from cluster "+opts.ClusterName+".")
+
+	info, err := classify(ctx, clientset, cli, opts.ClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to classify cluster nodes: %w", err)
+	}
+	if info.Autoscaling.EKSAutoMode.Enabled {
+		return errors.New("EKS auto-mode is enabled on this cluster; eviction is not applicable (auto-mode manages its own node lifecycle)")
+	}
+	// Skip the ConfigMap write on dry-run: a preview must not mutate the
+	// cluster (and must not require write RBAC on the Karpenter namespace).
+	if opts.DryRun {
+		log.Printf("[dry-run] would persist cluster-info to ConfigMap %s/%s", namespace, clusterinfo.ConfigMapName)
+	} else if err = clusterinfo.Persist(ctx, cli.K8sClient, namespace, info); err != nil {
+		log.Printf("Warning: failed to persist updated cluster-info ConfigMap: %v", err)
+	}
+
+	// Before any destructive work, verify there is at least one Datadog-managed
+	// NodePool to receive the evicted pods. Without this guard, scaling legacy
+	// capacity to 0 would leave the cluster with no working capacity (e.g. when
+	// `install` was run with --create-karpenter-resources=none, or the user
+	// deleted the Datadog NodePools out of band).
+	if !hasDatadogManagedNodePool(info) {
+		return errors.New("no Datadog-managed Karpenter NodePool found in the cluster snapshot; legacy nodes would have no destination to migrate to. Run `kubectl datadog autoscaling cluster install` (or `update`) to create the Datadog NodePool first")
+	}
+
+	targets, err := BuildPlan(info, opts.All, opts.Targets)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		// A previous run may have been interrupted (e.g. an EKS managed node
+		// group timed out, leaving its temporary PDBs in place for a later
+		// rerun). By the time that rerun finds nothing left to evict, those
+		// leaked PDBs would otherwise persist indefinitely with
+		// maxUnavailable: 1 and throttle future rollouts/disruptions, so
+		// reclaim anything left behind before the no-op exit.
+		if opts.EnsurePDBs {
+			if err := cleanupTempPDBs(ctx, cli.K8sClient, opts.DryRun); err != nil {
+				log.Printf("Warning: failed to cleanup leftover temporary PDBs: %v", err)
+			}
+		}
+		display.PrintBox(streams.Out, "Nothing to evict — the cluster is already on Datadog-managed Karpenter NodePools.")
+		return nil
+	}
+
+	runPreflightWarnings(ctx, streams, cli.K8sClient, targets)
+	printPlan(streams, info, targets, !opts.SkipCA, opts.EnsurePDBs)
+
+	if !opts.Yes && !opts.DryRun {
+		if !promptConfirmation(streams) {
+			return nil
+		}
+	}
+
+	// Step 1: cluster-autoscaler scale-down — first, so it does not undo our
+	// work by provisioning new legacy nodes while we drain.
+	if !opts.SkipCA {
+		if err := scaleDownClusterAutoscaler(ctx, clientset, info.Autoscaling.ClusterAutoscaler, opts.DryRun); err != nil {
+			return fmt.Errorf("failed to scale down cluster-autoscaler: %w", err)
+		}
+	}
+
+	// Step 2: ensure temporary PDBs. On error, attempt cleanup of whatever
+	// landed before the failure — the temp PDBs carry our labels so the
+	// label-based cleanup picks them up. On a SIGINT mid-flight the temp
+	// PDBs may leak; a subsequent run cleans them up via the same label.
+	if opts.EnsurePDBs {
+		if err := ensureTempPDBs(ctx, clientset, cli.K8sClient, targets, opts.DryRun); err != nil {
+			if cleanupErr := cleanupTempPDBs(ctx, cli.K8sClient, opts.DryRun); cleanupErr != nil {
+				log.Printf("Warning: failed to cleanup partial temporary PDBs: %v", cleanupErr)
+			}
+			return fmt.Errorf("failed to ensure temporary PDBs: %w", err)
+		}
+	}
+
+	drainOpts := nodeDrainOptions{
+		DryRun:          opts.DryRun,
+		EvictionTimeout: opts.EvictionTimeout,
+		NodeTimeout:     opts.NodeTimeout,
+		PollInterval:    2 * time.Second,
+	}
+	evictor := func(c context.Context, t Target, d nodeDrainOptions) error {
+		return evictTarget(c, clientset, cli, opts.ClusterName, t, d)
+	}
+	result := evictAllTargets(ctx, targets, drainOpts, evictor)
+	errs := result.Errors
+
+	// Step 4: cleanup temporary PDBs explicitly here — keeping it inline
+	// (rather than deferred) means the "Deleted temporary PDB …" log lines
+	// appear BEFORE the final success/failure summary, so the user does not
+	// experience an apparent hang after seeing the "✅" box.
+	//
+	// When at least one EKS managed node group did not finish draining
+	// within the timeout, we skip the cleanup: EKS may still be evicting
+	// pods on those nodes, and dropping the temp PDBs now would leave
+	// cross-type workloads unprotected mid-drain. The label-based cleanup
+	// on a subsequent run picks the PDBs up once EKS converges.
+	switch {
+	case !opts.EnsurePDBs:
+	case result.EKSDrainIncomplete:
+		log.Printf("Note: at least one EKS managed node group did not finish draining within --node-timeout; temporary PDBs left in place so EKS can finish safely. Re-run the command once `aws eks describe-nodegroup` reports the group at 0 nodes — the next run will clean them up.")
+	default:
+		if err := cleanupTempPDBs(ctx, cli.K8sClient, opts.DryRun); err != nil {
+			log.Printf("Warning: failed to cleanup temporary PDBs: %v", err)
+		}
+	}
+
+	// Re-classify and persist to reflect the final state. Skipped on dry-run
+	// for the same reason as the pre-eviction Persist above.
+	if opts.DryRun {
+		log.Printf("[dry-run] would re-classify and persist post-eviction cluster-info to ConfigMap %s/%s", namespace, clusterinfo.ConfigMapName)
+	} else if final, classifyErr := classify(ctx, clientset, cli, opts.ClusterName); classifyErr == nil {
+		if err := clusterinfo.Persist(ctx, cli.K8sClient, namespace, final); err != nil {
+			log.Printf("Warning: failed to persist post-eviction cluster-info: %v", err)
+		}
+	} else {
+		log.Printf("Warning: failed to re-classify post-eviction: %v", classifyErr)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("eviction completed with %d error(s):\n%w", len(errs), errors.Join(errs...))
+	}
+	display.PrintBox(streams.Out, "✅ Legacy nodes drained from cluster "+opts.ClusterName+".")
+	return nil
+}
+
+// classify wraps clusterinfo.Classify with the call-site boilerplate shared by
+// the pre- and post-eviction snapshots.
+func classify(ctx context.Context, clientset *kubernetes.Clientset, cli *clients.Clients, clusterName string) (*clusterinfo.ClusterInfo, error) {
+	return clusterinfo.Classify(ctx, clusterinfo.ClassifyInput{
+		K8sClient:   clientset,
+		CtrlClient:  cli.K8sClient,
+		Autoscaling: cli.Autoscaling,
+		EKS:         cli.EKS,
+		Discovery:   clientset.Discovery(),
+		ClusterName: clusterName,
+	})
+}
+
+// evictResult is the structured outcome of evictAllTargets. Errors is the
+// aggregated per-target error list (empty when everything succeeded).
+// EKSDrainIncomplete is true when at least one EKS managed node group target
+// returned an error WRAPPING errEKSDrainIncomplete — the EKS drain may still
+// be in progress, in which case the caller must NOT cleanup the temporary
+// PDBs (EKS would then over-disrupt the still-running workloads).
+type evictResult struct {
+	Errors             []error
+	EKSDrainIncomplete bool
+}
+
+// targetEvictor is the closure injected into evictAllTargets by Run. Pulling
+// the dispatch out as an interface-like function makes the orchestrator
+// unit-testable without faking the entire clients.Clients struct.
+type targetEvictor func(ctx context.Context, t Target, drainOpts nodeDrainOptions) error
+
+// evictAllTargets processes targets sequentially, in the order BuildPlan
+// produced. Errors are accumulated; a failing target does not abort the
+// others — every issue surfaces at the end so a partial migration is fully
+// visible. Sequential execution keeps logs linear, bounds the eviction
+// pressure on the apiserver, and matches the synchronous per-target shape
+// (every evictor — including EKS MNG — already blocks until its drain
+// completes).
+func evictAllTargets(ctx context.Context, targets []Target, drainOpts nodeDrainOptions, evictor targetEvictor) evictResult {
+	var (
+		errs               []error
+		eksDrainIncomplete bool
+	)
+	for _, t := range targets {
+		err := evictor(ctx, t, drainOpts)
+		if err == nil {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("%s/%s: %w", t.Manager, t.Entity, err))
+		// Only treat the drain as "still in progress" when EKS accepted the
+		// scaling change but observation of the drain failed or timed out.
+		// A failed UpdateNodegroupConfig means EKS never started draining,
+		// so cleanup is safe.
+		if errors.Is(err, errEKSDrainIncomplete) {
+			eksDrainIncomplete = true
+		}
+	}
+	return evictResult{Errors: errs, EKSDrainIncomplete: eksDrainIncomplete}
+}
+
+// evictTarget dispatches a single Target to the manager-specific evictor.
+// Wrapped into a closure inside Run so evictAllTargets can be exercised with
+// a fake evictor in tests.
+func evictTarget(ctx context.Context, clientset kubernetes.Interface, cli *clients.Clients, clusterName string, t Target, drainOpts nodeDrainOptions) error {
+	switch t.Manager {
+	case clusterinfo.NodeManagerASG:
+		return evictASG(ctx, clientset, cli.Autoscaling, t.Entity, t.Nodes, drainOpts)
+	case clusterinfo.NodeManagerEKSManagedNodeGroup:
+		return evictEKSManagedNodeGroup(ctx, cli.EKS, clientset, clusterName, t.Entity, drainOpts)
+	case clusterinfo.NodeManagerKarpenter:
+		return evictKarpenterUserNodePool(ctx, clientset, t.Entity, t.Nodes, drainOpts)
+	case clusterinfo.NodeManagerStandalone:
+		return evictStandalone(ctx, clientset, cli.EC2, t.Nodes, drainOpts)
+	default:
+		return fmt.Errorf("unsupported manager %q", t.Manager)
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/run_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/run_test.go
@@ -1,0 +1,113 @@
+package evict
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo"
+)
+
+func TestEvictAllTargets(t *testing.T) {
+	asgTarget := Target{Manager: clusterinfo.NodeManagerASG, Entity: "asg-1"}
+	karpenterTarget := Target{Manager: clusterinfo.NodeManagerKarpenter, Entity: "np-1"}
+	eksTarget := Target{Manager: clusterinfo.NodeManagerEKSManagedNodeGroup, Entity: "mng-1"}
+	standaloneTarget := Target{Manager: clusterinfo.NodeManagerStandalone, Entity: ""}
+
+	for _, tc := range []struct {
+		name              string
+		targets           []Target
+		evictor           targetEvictor
+		wantErrors        int
+		wantEKSIncomplete bool
+		wantErrIsSentinel bool
+		// expectInvoked, when non-nil, lists managers that MUST have had
+		// their evictor called (verifies that one failing target does not
+		// abort the others).
+		expectInvoked []clusterinfo.NodeManager
+	}{
+		{
+			name:    "happy path",
+			targets: []Target{asgTarget, karpenterTarget},
+			evictor: func(_ context.Context, _ Target, _ nodeDrainOptions) error { return nil },
+		},
+		{
+			// Safety-critical signal: an EKS MNG target returning
+			// errEKSDrainIncomplete (wrapped) must flag the result so Run
+			// skips the temp-PDB cleanup.
+			name:    "EKS sentinel propagates",
+			targets: []Target{eksTarget, asgTarget},
+			evictor: func(_ context.Context, t Target, _ nodeDrainOptions) error {
+				if t.Manager == clusterinfo.NodeManagerEKSManagedNodeGroup {
+					return fmt.Errorf("simulated timeout: %w", errEKSDrainIncomplete)
+				}
+				return nil
+			},
+			wantErrors:        1,
+			wantEKSIncomplete: true,
+			wantErrIsSentinel: true,
+		},
+		{
+			// An EKS failure that is NOT a wait timeout (e.g. an
+			// UpdateNodegroupConfig API rejection) means EKS never started
+			// draining, so temp-PDB cleanup is safe ⇒ flag stays false.
+			name:    "non-sentinel EKS error does not flag",
+			targets: []Target{eksTarget},
+			evictor: func(_ context.Context, _ Target, _ nodeDrainOptions) error {
+				return errors.New("invalid scaling config")
+			},
+			wantErrors: 1,
+		},
+		{
+			// An ASG drain failure has nothing to do with EKS — must NOT
+			// flag.
+			name:    "non-EKS error does not flag",
+			targets: []Target{asgTarget},
+			evictor: func(_ context.Context, _ Target, _ nodeDrainOptions) error {
+				return errors.New("ASG drain failed")
+			},
+			wantErrors: 1,
+		},
+		{
+			// One failing target must not abort the rest — the loop keeps
+			// going and every other manager is still invoked.
+			name:       "failing target does not abort the others",
+			targets:    []Target{asgTarget, karpenterTarget, standaloneTarget},
+			evictor:    nil, // installed inline below to capture invocations.
+			wantErrors: 1,
+			expectInvoked: []clusterinfo.NodeManager{
+				clusterinfo.NodeManagerASG,
+				clusterinfo.NodeManagerKarpenter,
+				clusterinfo.NodeManagerStandalone,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			invoked := map[clusterinfo.NodeManager]int{}
+			evictor := tc.evictor
+			if evictor == nil {
+				evictor = func(_ context.Context, target Target, _ nodeDrainOptions) error {
+					invoked[target.Manager]++
+					if target.Manager == clusterinfo.NodeManagerASG {
+						return errors.New("boom")
+					}
+					return nil
+				}
+			}
+
+			result := evictAllTargets(t.Context(), tc.targets, nodeDrainOptions{}, evictor)
+			require.Len(t, result.Errors, tc.wantErrors)
+			assert.Equal(t, tc.wantEKSIncomplete, result.EKSDrainIncomplete)
+			if tc.wantErrIsSentinel {
+				assert.ErrorIs(t, result.Errors[0], errEKSDrainIncomplete)
+			}
+			for _, mgr := range tc.expectInvoked {
+				assert.NotZero(t, invoked[mgr], "expected %s evictor to be invoked", mgr)
+			}
+		})
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone.go
@@ -1,0 +1,16 @@
+package evict
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"k8s.io/client-go/kubernetes"
+)
+
+type EC2API interface {
+	TerminateInstances(ctx context.Context, in *ec2.TerminateInstancesInput, opts ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
+}
+
+func evictStandalone(ctx context.Context, clientset kubernetes.Interface, ec2API EC2API, nodes []string, drainOpts nodeDrainOptions) error {
+	panic("TODO: evictStandalone — implemented in PR https://github.com/DataDog/datadog-operator/pull/3176")
+}


### PR DESCRIPTION
### What does this PR do?

Introduces the `kubectl datadog autoscaling cluster evict-legacy-nodes` cobra subcommand: flag parsing, validation and the full `run.go` orchestration. The feature logic it drives is stubbed and implemented by the rest of the stack.

### Motivation

PR #3026 is too large to review as a single change. This is **part 1 of 11** of a stack that splits it into small, individually-reviewable pieces that each build and pass tests on their own. See #3026 for the full feature context and end-to-end QA.

### Additional Notes

Functions implemented later in the stack are stubbed with `panic("TODO …")`, so the command compiles and its orchestration is unit-tested but is not yet end-to-end functional. The code is taken verbatim from #3026 (rebased onto `main`); there are no logic changes versus #3026.

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only.

### Describe your test plan

`go test ./cmd/kubectl-datadog/autoscaling/cluster/...` passes at this commit. Full end-to-end QA is tracked on #3026.

### Checklist

- [x] PR has at least one valid label
- [x] `qa/skip-qa` label applied (not independently shippable; QA tracked on #3026)
- [x] All commits are signed