### PR TITLE
[CASCL-1386] (7/12) Create temporary PodDisruptionBudgets during eviction

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/pdb.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/pdb.go
@@ -2,9 +2,41 @@ package evict
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
+	"reflect"
+	"slices"
+	"strings"
 
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/pager"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonk8s "github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/k8s"
+)
+
+// Label keys used to mark PodDisruptionBudgets created by this command. Both
+// must be present for cleanup to consider the PDB ours — this makes the
+// cleanup safe against accidentally removing a user PDB with a colliding name.
+const (
+	pdbManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	pdbManagedByLabelValue = "kubectl-datadog"
+	pdbTempLabelKey        = "autoscaling.datadoghq.com/temporary-pdb"
+	pdbTempLabelValue      = "true"
+	// pdbNameSuffix is appended to the controller name to form the temp PDB
+	// name. Kept short so that long controller names stay under the 63-char
+	// DNS label limit after truncation.
+	pdbNameSuffix = "-evict-legacy"
 )
 
 // ensureTempPDBs scans the pods running on the nodes of every target and
@@ -17,7 +49,48 @@ import (
 // created them. ensureTempPDBs itself is idempotent: a PDB created by a
 // previous (possibly crashed) run is detected by its labels and left alone.
 func ensureTempPDBs(ctx context.Context, clientset kubernetes.Interface, ctrlClient client.Client, targets []Target, dryRun bool) error {
-	panic("TODO: ensureTempPDBs — implemented in PR #6")
+	// Targets across all manager types are merged: the orchestrator blocks
+	// on waitEKSNodegroupEmpty before cleaning up the temporary PDBs, so EKS
+	// MNG nodes observe the PDBs during their drain too — without that, EKS
+	// could disrupt every replica of an otherwise unprotected workload at
+	// once when all replicas happen to live on the same node group.
+	allNodes := lo.FlatMap(targets, func(t Target, _ int) []string { return t.Nodes })
+	nodeSet := lo.SliceToMap(allNodes, func(n string) (string, struct{}) { return n, struct{}{} })
+	if len(nodeSet) == 0 {
+		return nil
+	}
+
+	controllers, err := discoverControllers(ctx, clientset, nodeSet)
+	if err != nil {
+		return fmt.Errorf("failed to discover controllers: %w", err)
+	}
+	if len(controllers) == 0 {
+		return nil
+	}
+
+	// Group controllers by namespace to amortize the per-namespace PDB list.
+	byNamespace := make(map[string][]controllerInfo)
+	for _, c := range controllers {
+		byNamespace[c.Namespace] = append(byNamespace[c.Namespace], c)
+	}
+
+	var errs []error
+	for ns, ctrls := range byNamespace {
+		existing, err := listNamespacePDBs(ctx, clientset, ns)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("namespace %s: failed to list PDBs: %w", ns, err))
+			continue
+		}
+		for _, c := range ctrls {
+			if hasUserPDB(existing, c.Selector) {
+				continue
+			}
+			if err := createTempPDB(ctx, ctrlClient, c, dryRun); err != nil {
+				errs = append(errs, fmt.Errorf("controller %s/%s/%s: %w", c.Namespace, c.Kind, c.Name, err))
+			}
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // cleanupTempPDBs deletes every PodDisruptionBudget cluster-wide that carries
@@ -25,5 +98,258 @@ func ensureTempPDBs(ctx context.Context, clientset kubernetes.Interface, ctrlCli
 // ensureTempPDBs) is what makes the command crash-safe: a re-run after a kill
 // still finds and removes the orphans left by the previous attempt.
 func cleanupTempPDBs(ctx context.Context, ctrlClient client.Client, dryRun bool) error {
-	panic("TODO: cleanupTempPDBs — implemented in PR #6")
+	list := &policyv1.PodDisruptionBudgetList{}
+	if err := ctrlClient.List(ctx, list, client.MatchingLabels{
+		pdbManagedByLabelKey: pdbManagedByLabelValue,
+		pdbTempLabelKey:      pdbTempLabelValue,
+	}); err != nil {
+		return fmt.Errorf("failed to list temporary PDBs: %w", err)
+	}
+	if len(list.Items) == 0 {
+		return nil
+	}
+	var errs []error
+	for i := range list.Items {
+		pdb := &list.Items[i]
+		if dryRun {
+			log.Printf("[dry-run] would delete PDB %s/%s", pdb.Namespace, pdb.Name)
+			continue
+		}
+		if err := commonk8s.Delete(ctx, ctrlClient, pdb); err != nil {
+			errs = append(errs, fmt.Errorf("PDB %s/%s: %w", pdb.Namespace, pdb.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// controllerKey identifies a top-level controller that owns evictable pods on
+// our target nodes. It is the dedup key in the seen map and the identity half
+// of controllerInfo.
+type controllerKey struct {
+	Namespace string
+	Kind      string // "Deployment", "StatefulSet", "ReplicaSet"
+	Name      string
+}
+
+// controllerInfo is a controllerKey plus the controller's pod selector — what a
+// PDB would match on.
+type controllerInfo struct {
+	controllerKey
+	Selector *metav1.LabelSelector
+}
+
+// discoverControllers lists every Pod cluster-wide once (paginated) and, for
+// each Pod scheduled on one of the target nodes, resolves the top-level
+// controller. Listing once and filtering client-side avoids the N-API-calls
+// problem of doing one List per node, which on a large legacy fleet would
+// dominate the command's wall-clock time. The resulting slice contains each
+// controller at most once.
+func discoverControllers(ctx context.Context, clientset kubernetes.Interface, nodeSet map[string]struct{}) ([]controllerInfo, error) {
+	seen := make(map[controllerKey]*metav1.LabelSelector)
+	depCache := make(map[client.ObjectKey]*appsv1.Deployment)
+	rsCache := make(map[client.ObjectKey]*appsv1.ReplicaSet)
+	stsCache := make(map[client.ObjectKey]*appsv1.StatefulSet)
+
+	p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return clientset.CoreV1().Pods(metav1.NamespaceAll).List(ctx, opts)
+	})
+	if err := p.EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		pod := obj.(*corev1.Pod)
+		if _, onTarget := nodeSet[pod.Spec.NodeName]; !onTarget {
+			return nil
+		}
+		if shouldSkipEviction(pod) {
+			return nil
+		}
+		info, err := resolveTopLevelController(ctx, clientset, pod, depCache, rsCache, stsCache)
+		if err != nil {
+			log.Printf("Warning: cannot resolve controller for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			return nil
+		}
+		if info == nil {
+			return nil
+		}
+		seen[info.controllerKey] = info.Selector
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+
+	return lo.MapToSlice(seen, func(key controllerKey, selector *metav1.LabelSelector) controllerInfo {
+		return controllerInfo{controllerKey: key, Selector: selector}
+	}), nil
+}
+
+// resolveTopLevelController walks a Pod's owner chain up to the workload
+// controller (Deployment > ReplicaSet > Pod, StatefulSet > Pod). Returns nil
+// for Pods whose top-level owner is not a stable workload — Jobs (TTL-managed),
+// DaemonSets (already skipped at eviction), or bare Pods.
+func resolveTopLevelController(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	pod *corev1.Pod,
+	depCache map[client.ObjectKey]*appsv1.Deployment,
+	rsCache map[client.ObjectKey]*appsv1.ReplicaSet,
+	stsCache map[client.ObjectKey]*appsv1.StatefulSet,
+) (*controllerInfo, error) {
+	owner := metav1.GetControllerOf(pod)
+	if owner == nil {
+		return nil, nil
+	}
+	switch owner.Kind {
+	case "ReplicaSet":
+		rs, err := getCached(ctx, rsCache, pod.Namespace, owner.Name, clientset.AppsV1().ReplicaSets(pod.Namespace).Get)
+		if err != nil {
+			return nil, err
+		}
+		rsOwner := metav1.GetControllerOf(rs)
+		if rsOwner != nil && rsOwner.Kind == "Deployment" {
+			dep, err := getCached(ctx, depCache, pod.Namespace, rsOwner.Name, clientset.AppsV1().Deployments(pod.Namespace).Get)
+			if err != nil {
+				return nil, err
+			}
+			return &controllerInfo{
+				controllerKey: controllerKey{Namespace: pod.Namespace, Kind: "Deployment", Name: dep.Name},
+				Selector:      dep.Spec.Selector,
+			}, nil
+		}
+		return &controllerInfo{
+			controllerKey: controllerKey{Namespace: pod.Namespace, Kind: "ReplicaSet", Name: rs.Name},
+			Selector:      rs.Spec.Selector,
+		}, nil
+	case "StatefulSet":
+		sts, err := getCached(ctx, stsCache, pod.Namespace, owner.Name, clientset.AppsV1().StatefulSets(pod.Namespace).Get)
+		if err != nil {
+			return nil, err
+		}
+		return &controllerInfo{
+			controllerKey: controllerKey{Namespace: pod.Namespace, Kind: "StatefulSet", Name: sts.Name},
+			Selector:      sts.Spec.Selector,
+		}, nil
+	default:
+		// DaemonSet (skipped before reaching here), Job (TTL), CronJob,
+		// custom controllers — none get a temporary PDB.
+		return nil, nil
+	}
+}
+
+// getCached returns the object identified by (ns, name) from cache, fetching it
+// via get — the namespace-bound typed clientset accessor, e.g.
+// clientset.AppsV1().ReplicaSets(ns).Get — and populating the cache on a miss.
+// T is inferred from the cache's value type, collapsing the per-kind getters
+// into a single generic lookup.
+func getCached[T any](
+	ctx context.Context,
+	cache map[client.ObjectKey]*T,
+	ns, name string,
+	get func(ctx context.Context, name string, opts metav1.GetOptions) (*T, error),
+) (*T, error) {
+	key := client.ObjectKey{Namespace: ns, Name: name}
+	if obj, ok := cache[key]; ok {
+		return obj, nil
+	}
+	obj, err := get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	cache[key] = obj
+	return obj, nil
+}
+
+// listNamespacePDBs returns every PDB in the namespace. Used to detect
+// pre-existing user PDBs covering a controller we'd otherwise PDB-protect.
+func listNamespacePDBs(ctx context.Context, clientset kubernetes.Interface, namespace string) ([]policyv1.PodDisruptionBudget, error) {
+	list, err := clientset.PolicyV1().PodDisruptionBudgets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// hasUserPDB returns true when an existing non-temporary PDB has the same
+// selector as the controller's pod selector. This is a conservative
+// equality check: a broader user PDB will NOT be detected, and we'll create
+// our own. Eviction will then respect the most restrictive of the two,
+// preserving the user's intent.
+func hasUserPDB(existing []policyv1.PodDisruptionBudget, controllerSelector *metav1.LabelSelector) bool {
+	if controllerSelector == nil {
+		return false
+	}
+	return slices.ContainsFunc(existing, func(pdb policyv1.PodDisruptionBudget) bool {
+		return !isTemporaryPDB(&pdb) && reflect.DeepEqual(pdb.Spec.Selector, controllerSelector)
+	})
+}
+
+func isTemporaryPDB(pdb *policyv1.PodDisruptionBudget) bool {
+	return pdb.Labels[pdbManagedByLabelKey] == pdbManagedByLabelValue &&
+		pdb.Labels[pdbTempLabelKey] == pdbTempLabelValue
+}
+
+// createTempPDB writes (or no-ops if our PDB already exists) a temporary
+// PodDisruptionBudget with maxUnavailable: 1. Existing PDBs that aren't ours
+// at the same name are left alone with a logged warning — that's a name
+// collision the user must resolve.
+func createTempPDB(ctx context.Context, ctrlClient client.Client, c controllerInfo, dryRun bool) error {
+	name := tempPDBName(c.Kind, c.Name)
+	if dryRun {
+		log.Printf("[dry-run] would create PDB %s/%s (maxUnavailable: 1, selector: %s)", c.Namespace, name, formatSelector(c.Selector))
+		return nil
+	}
+
+	existing := &policyv1.PodDisruptionBudget{}
+	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: c.Namespace, Name: name}, existing)
+	switch {
+	case err == nil:
+		if !isTemporaryPDB(existing) {
+			log.Printf("Warning: PDB %s/%s exists but is not labelled as temporary; leaving it untouched", c.Namespace, name)
+			return nil
+		}
+		// Our PDB from a previous (possibly crashed) run. Leave as-is; the
+		// cleanup step will remove it at the end of the current run.
+		return nil
+	case !apierrors.IsNotFound(err):
+		return fmt.Errorf("failed to get PDB %s/%s: %w", c.Namespace, name, err)
+	}
+
+	maxUnavailable := intstr.FromInt(1)
+	pdb := &policyv1.PodDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{APIVersion: "policy/v1", Kind: "PodDisruptionBudget"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.Namespace,
+			Labels: map[string]string{
+				pdbManagedByLabelKey: pdbManagedByLabelValue,
+				pdbTempLabelKey:      pdbTempLabelValue,
+			},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector:       c.Selector.DeepCopy(),
+			MaxUnavailable: &maxUnavailable,
+		},
+	}
+	if err := ctrlClient.Create(ctx, pdb); err != nil {
+		return fmt.Errorf("failed to create PDB %s/%s: %w", c.Namespace, name, err)
+	}
+	log.Printf("Created temporary PDB %s/%s for %s/%s (maxUnavailable: 1).", c.Namespace, name, c.Kind, c.Name)
+	return nil
+}
+
+// tempPDBName builds a DNS-label-safe PDB name. Long controller names are
+// truncated so the final name (including the suffix) fits the 63-char limit.
+func tempPDBName(kind, controllerName string) string {
+	prefix := strings.ToLower(kind) + "-" + controllerName
+	if len(prefix)+len(pdbNameSuffix) > validation.DNS1123LabelMaxLength {
+		prefix = prefix[:validation.DNS1123LabelMaxLength-len(pdbNameSuffix)]
+	}
+	return prefix + pdbNameSuffix
+}
+
+func formatSelector(s *metav1.LabelSelector) string {
+	if s == nil {
+		return "<nil>"
+	}
+	parts := lo.MapToSlice(s.MatchLabels, func(k, v string) string {
+		return k + "=" + v
+	})
+	return strings.Join(parts, ",")
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/pdb_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/pdb_test.go
@@ -1,0 +1,367 @@
+package evict
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newCtrlScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	sch := runtime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(sch))
+	return sch
+}
+
+func TestTempPDBName(t *testing.T) {
+	for _, tc := range []struct {
+		kind   string
+		name   string
+		expect string
+	}{
+		{"Deployment", "my-app", "deployment-my-app-evict-legacy"},
+		{"StatefulSet", "db", "statefulset-db-evict-legacy"},
+		// Long name that must be truncated to fit 63 chars
+		{"Deployment", strings.Repeat("a", 80), "deployment-" + strings.Repeat("a", 63-len("deployment-")-len(pdbNameSuffix)) + pdbNameSuffix},
+	} {
+		got := tempPDBName(tc.kind, tc.name)
+		assert.LessOrEqual(t, len(got), 63, "tempPDBName output exceeds 63 chars: %s", got)
+		assert.Equal(t, tc.expect, got)
+	}
+}
+
+func TestIsTemporaryPDB(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name: "both labels present",
+			labels: map[string]string{
+				pdbManagedByLabelKey: pdbManagedByLabelValue,
+				pdbTempLabelKey:      pdbTempLabelValue,
+			},
+			want: true,
+		},
+		{name: "no labels", labels: map[string]string{"app": "x"}, want: false},
+		{
+			name:   "only managed-by label, must require BOTH",
+			labels: map[string]string{pdbManagedByLabelKey: pdbManagedByLabelValue},
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pdb := &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Labels: tc.labels}}
+			assert.Equal(t, tc.want, isTemporaryPDB(pdb))
+		})
+	}
+}
+
+func TestHasUserPDB(t *testing.T) {
+	matchingSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}}
+	otherSelector := &metav1.LabelSelector{MatchLabels: map[string]string{"app": "y"}}
+	userPDB := policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "user", Namespace: "default"},
+		Spec:       policyv1.PodDisruptionBudgetSpec{Selector: matchingSelector},
+	}
+	tempPDB := policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "temp", Namespace: "default", Labels: map[string]string{
+			pdbManagedByLabelKey: pdbManagedByLabelValue,
+			pdbTempLabelKey:      pdbTempLabelValue,
+		}},
+		Spec: policyv1.PodDisruptionBudgetSpec{Selector: matchingSelector},
+	}
+
+	for _, tc := range []struct {
+		name               string
+		existing           []policyv1.PodDisruptionBudget
+		controllerSelector *metav1.LabelSelector
+		want               bool
+	}{
+		{name: "matching user PDB", existing: []policyv1.PodDisruptionBudget{userPDB}, controllerSelector: matchingSelector, want: true},
+		{name: "temp PDB ignored", existing: []policyv1.PodDisruptionBudget{tempPDB}, controllerSelector: matchingSelector, want: false},
+		{name: "nil controller selector", existing: []policyv1.PodDisruptionBudget{userPDB}, controllerSelector: nil, want: false},
+		{name: "different selector", existing: []policyv1.PodDisruptionBudget{userPDB}, controllerSelector: otherSelector, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasUserPDB(tc.existing, tc.controllerSelector))
+		})
+	}
+}
+
+func TestCleanupTempPDBs(t *testing.T) {
+	tempPDB := func() *policyv1.PodDisruptionBudget {
+		return &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp", Namespace: "default",
+				Labels: map[string]string{
+					pdbManagedByLabelKey: pdbManagedByLabelValue,
+					pdbTempLabelKey:      pdbTempLabelValue,
+				},
+			},
+		}
+	}
+	userPDB := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "user", Namespace: "default"},
+	}
+	otherManaged := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other", Namespace: "kube-system",
+			Labels: map[string]string{pdbManagedByLabelKey: "some-other-tool"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name string
+		// existing seeds the controller-runtime fake client.
+		existing []ctrlclient.Object
+		dryRun   bool
+		// wantRemaining is the expected `<namespace>/<name>` set after cleanup.
+		wantRemaining []string
+	}{
+		{
+			// Only PDBs carrying BOTH temp labels are removed; user PDBs
+			// and PDBs from other tools stay put.
+			name:          "deletes only fully-labelled temp PDBs",
+			existing:      []ctrlclient.Object{tempPDB(), userPDB, otherManaged},
+			wantRemaining: []string{"default/user", "kube-system/other"},
+		},
+		{
+			name:          "no temp PDBs is a no-op",
+			existing:      []ctrlclient.Object{userPDB},
+			wantRemaining: []string{"default/user"},
+		},
+		{
+			name:          "dry-run does not delete",
+			existing:      []ctrlclient.Object{tempPDB()},
+			dryRun:        true,
+			wantRemaining: []string{"default/temp"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cli := ctrlfake.NewClientBuilder().WithScheme(newCtrlScheme(t)).WithObjects(tc.existing...).Build()
+
+			require.NoError(t, cleanupTempPDBs(t.Context(), cli, tc.dryRun))
+
+			list := &policyv1.PodDisruptionBudgetList{}
+			require.NoError(t, cli.List(t.Context(), list))
+			names := make([]string, 0, len(list.Items))
+			for _, p := range list.Items {
+				names = append(names, p.Namespace+"/"+p.Name)
+			}
+			assert.ElementsMatch(t, tc.wantRemaining, names)
+		})
+	}
+}
+
+func TestCreateTempPDB(t *testing.T) {
+	appController := controllerInfo{
+		controllerKey: controllerKey{Namespace: "default", Kind: "Deployment", Name: "app"},
+		Selector:      &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+	}
+	existingTempPDB := func() *policyv1.PodDisruptionBudget {
+		return &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: tempPDBName("Deployment", "app"), Namespace: "default",
+				Labels: map[string]string{
+					pdbManagedByLabelKey: pdbManagedByLabelValue,
+					pdbTempLabelKey:      pdbTempLabelValue,
+				},
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MaxUnavailable: ptr.To(intstr.FromInt(1)),
+				Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			},
+		}
+	}
+	userPDBAtSameName := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: tempPDBName("Deployment", "app"), Namespace: "default",
+			// no temp-pdb labels: looks like a user PDB that happens to share
+			// our naming.
+		},
+	}
+
+	// ownership describes the expected ownership of the surviving PDB.
+	type ownership int
+	const (
+		expectNoPDB   ownership = iota // 0 PDBs in cluster
+		expectOurs                     // 1 PDB, with our temp labels + MaxUnavailable=1
+		expectUserPDB                  // 1 PDB, NOT carrying our labels
+		expectAny                      // 1 PDB, ownership irrelevant (idempotent case)
+	)
+
+	for _, tc := range []struct {
+		name string
+		// existing seeds the controller-runtime fake client.
+		existing []ctrlclient.Object
+		dryRun   bool
+		// expect describes the expected post-create cluster state.
+		expect ownership
+		// runCleanupAfter, when true, runs cleanupTempPDBs after createTempPDB
+		// and asserts the cluster ends up empty — exercises the crash-recovery
+		// loop where a previous run left a temp PDB behind.
+		runCleanupAfter bool
+	}{
+		{
+			name:   "creates PDB when missing",
+			expect: expectOurs,
+		},
+		{
+			// Crash-recovery scenario: a previous run created a temp PDB
+			// and was killed. A fresh ensure must NOT duplicate it, and
+			// cleanup must still remove it.
+			name:            "idempotent on pre-existing temp PDB",
+			existing:        []ctrlclient.Object{existingTempPDB()},
+			expect:          expectAny,
+			runCleanupAfter: true,
+		},
+		{
+			// User-owned PDB at the same name (no temp labels) must be
+			// left untouched.
+			name:     "name collision with user PDB leaves it untouched",
+			existing: []ctrlclient.Object{userPDBAtSameName},
+			expect:   expectUserPDB,
+		},
+		{
+			name:   "dry-run does not create",
+			dryRun: true,
+			expect: expectNoPDB,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cli := ctrlfake.NewClientBuilder().WithScheme(newCtrlScheme(t)).WithObjects(tc.existing...).Build()
+
+			require.NoError(t, createTempPDB(t.Context(), cli, appController, tc.dryRun))
+
+			list := &policyv1.PodDisruptionBudgetList{}
+			require.NoError(t, cli.List(t.Context(), list))
+			switch tc.expect {
+			case expectNoPDB:
+				assert.Empty(t, list.Items)
+			case expectOurs:
+				require.Len(t, list.Items, 1)
+				pdb := list.Items[0]
+				assert.Equal(t, pdbManagedByLabelValue, pdb.Labels[pdbManagedByLabelKey])
+				assert.Equal(t, pdbTempLabelValue, pdb.Labels[pdbTempLabelKey])
+				require.NotNil(t, pdb.Spec.MaxUnavailable)
+				assert.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
+			case expectUserPDB:
+				require.Len(t, list.Items, 1)
+				assert.NotEqual(t, pdbManagedByLabelValue, list.Items[0].Labels[pdbManagedByLabelKey])
+			case expectAny:
+				require.Len(t, list.Items, 1)
+			}
+
+			if tc.runCleanupAfter {
+				require.NoError(t, cleanupTempPDBs(t.Context(), cli, false))
+				require.NoError(t, cli.List(t.Context(), list))
+				assert.Empty(t, list.Items, "cleanup must remove pre-existing temp PDB even with no state from ensure")
+			}
+		})
+	}
+}
+
+// TestDiscoverControllers_FiltersByNodeSet locks in the cluster-wide-list +
+// client-side filter shape of discoverControllers: pods on target nodes
+// resolve to their top-level controllers, pods elsewhere are ignored, and
+// duplicate controllers (multiple pods of one Deployment) collapse to a
+// single entry.
+func TestDiscoverControllers_FiltersByNodeSet(t *testing.T) {
+	mkDeployment := func(name, ns, appLabel string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			},
+		}
+	}
+	mkReplicaSet := func(name, ns, owningDeployment string) *appsv1.ReplicaSet {
+		return &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: ns,
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: owningDeployment, Controller: ptr.To(true)}},
+			},
+		}
+	}
+	// mkBareReplicaSet is a ReplicaSet with no owning Deployment — its pods
+	// resolve to the ReplicaSet itself as the top-level controller.
+	mkBareReplicaSet := func(name, ns, appLabel string) *appsv1.ReplicaSet {
+		return &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.ReplicaSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			},
+		}
+	}
+	mkStatefulSet := func(name, ns, appLabel string) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			},
+		}
+	}
+	mkPod := func(name, ns, nodeName, ownerKind, ownerName string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: ns,
+				OwnerReferences: []metav1.OwnerReference{{Kind: ownerKind, Name: ownerName, Controller: ptr.To(true)}},
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+	}
+
+	client := fake.NewClientset(
+		mkDeployment("target-app", "default", "target"),
+		mkReplicaSet("target-app-abc", "default", "target-app"),
+		// two pods of the same Deployment, both on the target node — must dedup.
+		mkPod("target-pod-1", "default", "target-node", "ReplicaSet", "target-app-abc"),
+		mkPod("target-pod-2", "default", "target-node", "ReplicaSet", "target-app-abc"),
+		// StatefulSet pod on the target node — resolves to the StatefulSet.
+		mkStatefulSet("target-sts", "default", "target-sts"),
+		mkPod("target-sts-0", "default", "target-node", "StatefulSet", "target-sts"),
+		// bare ReplicaSet (no owning Deployment) on the target node — resolves
+		// to the ReplicaSet itself.
+		mkBareReplicaSet("target-bare-rs", "default", "target-bare"),
+		mkPod("target-bare-rs-xyz", "default", "target-node", "ReplicaSet", "target-bare-rs"),
+		// DaemonSet-owned pod on the target node — the default switch arm
+		// returns no controller (DaemonSets get no temporary PDB).
+		mkPod("target-ds-pod", "default", "target-node", "DaemonSet", "target-ds"),
+		// orphan pod (no controller owner) on the target node — ignored.
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "target-orphan", Namespace: "default"},
+			Spec:       corev1.PodSpec{NodeName: "target-node"},
+		},
+		// pod on a non-target node, must be ignored.
+		mkDeployment("off-target-app", "default", "off"),
+		mkReplicaSet("off-target-app-def", "default", "off-target-app"),
+		mkPod("off-target-pod", "default", "other-node", "ReplicaSet", "off-target-app-def"),
+	)
+
+	controllers, err := discoverControllers(t.Context(), client, map[string]struct{}{"target-node": {}})
+	require.NoError(t, err)
+	got := make(map[string]string, len(controllers)) // name -> kind
+	for _, c := range controllers {
+		got[c.Name] = c.Kind
+	}
+	assert.Equal(t, map[string]string{
+		"target-app":     "Deployment",
+		"target-sts":     "StatefulSet",
+		"target-bare-rs": "ReplicaSet",
+	}, got)
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/run_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/run_test.go
@@ -8,9 +8,75 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo"
 )
+
+// TestReclaimLeakedTempPDBs covers the no-target recovery path: a temp PDB left
+// behind by a prior interrupted run is reclaimed only when PDB management is
+// enabled and not in dry-run.
+func TestReclaimLeakedTempPDBs(t *testing.T) {
+	leakedTempPDB := func() *policyv1.PodDisruptionBudget {
+		return &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "leaked", Namespace: "default",
+				Labels: map[string]string{
+					pdbManagedByLabelKey: pdbManagedByLabelValue,
+					pdbTempLabelKey:      pdbTempLabelValue,
+				},
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name        string
+		ensurePDBs  bool
+		dryRun      bool
+		wantDeleted bool
+	}{
+		{name: "enabled deletes leaked temp PDB", ensurePDBs: true, wantDeleted: true},
+		{name: "disabled is a no-op", ensurePDBs: false, wantDeleted: false},
+		{name: "dry-run does not delete", ensurePDBs: true, dryRun: true, wantDeleted: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cli := ctrlfake.NewClientBuilder().WithScheme(newCtrlScheme(t)).WithObjects(leakedTempPDB()).Build()
+
+			reclaimLeakedTempPDBs(t.Context(), cli, tc.ensurePDBs, tc.dryRun)
+
+			list := &policyv1.PodDisruptionBudgetList{}
+			require.NoError(t, cli.List(t.Context(), list))
+			if tc.wantDeleted {
+				assert.Empty(t, list.Items)
+			} else {
+				require.Len(t, list.Items, 1)
+				assert.Equal(t, "leaked", list.Items[0].Name)
+			}
+		})
+	}
+
+	// A cleanup error must be swallowed (logged, not propagated): the no-op
+	// exit must still succeed even if reclaiming the leaked PDBs fails.
+	t.Run("cleanup error is swallowed", func(t *testing.T) {
+		cli := ctrlfake.NewClientBuilder().
+			WithScheme(newCtrlScheme(t)).
+			WithObjects(leakedTempPDB()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(context.Context, ctrlclient.WithWatch, ctrlclient.ObjectList, ...ctrlclient.ListOption) error {
+					return errors.New("boom")
+				},
+			}).
+			Build()
+
+		assert.NotPanics(t, func() {
+			reclaimLeakedTempPDBs(t.Context(), cli, true, false)
+		})
+	})
+}
 
 func TestEvictAllTargets(t *testing.T) {
 	asgTarget := Target{Manager: clusterinfo.NodeManagerASG, Entity: "asg-1"}


### PR DESCRIPTION
### What does this PR do?

Implements creation and label-based cleanup of temporary PodDisruptionBudgets (`maxUnavailable: 1`) that protect workloads during the drain.

### Motivation

PR #3026 is too large to review as a single change. This is **part 7 of 12** of a stack that splits it into small, individually-reviewable pieces that each build and pass tests on their own. See #3026 for the full feature context and end-to-end QA.

### Additional Notes

**Stacked PR — the base branch is `lenaic/CASCL-1386-evict-06-drain`, _not_ `main`**, so the diff shows only this step's change. Implements logic that earlier stack parts left stubbed with `panic("TODO …")`. The code is taken verbatim from #3026 (rebased onto `main`); there are no logic changes versus #3026.

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only.

### Describe your test plan

`go test ./cmd/kubectl-datadog/autoscaling/cluster/...` passes at this commit. Full end-to-end QA is tracked on #3026.

### Checklist

- [x] PR has at least one valid label
- [x] `qa/skip-qa` label applied (not independently shippable; QA tracked on #3026)
- [x] All commits are signed