### PR TITLE
[CASCL-1386] (8/12) Extract shared EC2 instance-ID helper to common/aws

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/common/aws/node.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/aws/node.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// awsProviderIDRegexp matches the AWS provider ID for EC2-backed nodes.
+// Format: aws:///<az>/i-<hex> (e.g. aws:///us-east-1a/i-0abc123def456789).
+// Fargate nodes use a different shape (aws:///<az>/fargate-ip-...) and must
+// therefore be classified by label before reaching this regex.
+var awsProviderIDRegexp = regexp.MustCompile(`^aws:///[^/]+/(i-[0-9a-f]+)$`)
+
+// LabelEKSNodegroup is the label EKS stamps on every node that belongs to a
+// managed node group. The label value is the node group name. Exposed as a
+// constant so every consumer (classifier, evict-legacy-nodes, future code)
+// references the same string.
+const LabelEKSNodegroup = "eks.amazonaws.com/nodegroup"
+
+// ExtractEC2InstanceID returns the EC2 instance ID (i-...) from a Node's
+// providerID, or false when the providerID is not an EC2 instance (Fargate
+// uses `aws:///<az>/fargate-ip-...`, GCP/Azure use entirely different shapes,
+// etc.). Lives here in `common/aws` so both `common/clusterinfo` (which
+// imports `common/karpenter`) and `common/karpenter` (which classifies its
+// own nodes) can use it without creating an import cycle.
+func ExtractEC2InstanceID(node *corev1.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	m := awsProviderIDRegexp.FindStringSubmatch(node.Spec.ProviderID)
+	if len(m) != 2 {
+		return "", false
+	}
+	return m[1], true
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/aws/node_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/aws/node_test.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestExtractEC2InstanceID(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider string
+		wantID   string
+		wantOK   bool
+	}{
+		{name: "ec2", provider: "aws:///eu-west-3a/i-0123456789abcdef0", wantID: "i-0123456789abcdef0", wantOK: true},
+		{name: "ec2 short id", provider: "aws:///us-east-1b/i-abc123", wantID: "i-abc123", wantOK: true},
+		{name: "fargate", provider: "aws:///eu-west-3a/fargate-ip-10-0-1-2", wantOK: false},
+		{name: "gcp", provider: "gce://project/zone/instance", wantOK: false},
+		{name: "empty", provider: "", wantOK: false},
+		{name: "missing prefix", provider: "i-0123456789abcdef0", wantOK: false},
+		{name: "missing AZ", provider: "aws:////i-0123456789abcdef0", wantOK: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{Spec: corev1.NodeSpec{ProviderID: tc.provider}}
+			id, ok := ExtractEC2InstanceID(node)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.wantID, id)
+			}
+		})
+	}
+	t.Run("nil node", func(t *testing.T) {
+		_, ok := ExtractEC2InstanceID(nil)
+		assert.False(t, ok)
+	})
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clusterinfo/classify.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"maps"
-	"regexp"
 	"strings"
 	"time"
 
@@ -35,11 +34,6 @@ import (
 // autoscaling:DescribeAutoScalingInstances. Sending more triggers a
 // ValidationError at the API.
 const describeASGInstancesMaxIDs = 50
-
-// awsProviderIDRegexp matches the AWS provider ID for EC2-backed nodes.
-// Format: aws:///<az>/i-<hex>. Fargate nodes use a different shape and
-// must therefore be classified by label before reaching this regex.
-var awsProviderIDRegexp = regexp.MustCompile(`^aws:///[^/]+/(i-[0-9a-f]+)$`)
 
 // nodePoolDatadogCreatedLabel is the label set by every Datadog autoscaling
 // product (kubectl-datadog AND the cluster agent) on the NodePools they
@@ -173,10 +167,9 @@ func classifyByLabels(ctx context.Context, k8sClient kubernetes.Interface, farga
 			return nil
 		}
 
-		matches := awsProviderIDRegexp.FindStringSubmatch(node.Spec.ProviderID)
-		if len(matches) == 2 {
+		if id, ok := commonaws.ExtractEC2InstanceID(node); ok {
 			candidates = append(candidates, asgCandidate{
-				instanceID: matches[1],
+				instanceID: id,
 				nodeName:   node.Name,
 			})
 		} else {

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/fromnodes.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/fromnodes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"maps"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -17,11 +16,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/pager"
-)
 
-// awsProviderIDRegexp matches the AWS provider ID format for EC2 instances.
-// Format: aws:///ZONE/INSTANCE_ID (e.g., aws:///us-east-1a/i-0abc123def456789)
-var awsProviderIDRegexp = regexp.MustCompile(`^aws:///[^/]+/(i-[0-9a-f]+)$`)
+	commonaws "github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/aws"
+)
 
 // ec2DescribeBatchSize bounds the number of instance IDs we hand to a single
 // ec2:DescribeInstances / ec2:DescribeImages call. The K8s pager streams
@@ -62,12 +59,12 @@ func GetNodesProperties(ctx context.Context, clientset *kubernetes.Clientset, ec
 		if _, isKarpenter := node.Labels["karpenter.k8s.aws/ec2nodeclass"]; isKarpenter {
 			return nil
 		}
-		matches := awsProviderIDRegexp.FindStringSubmatch(node.Spec.ProviderID)
-		if len(matches) != 2 {
+		id, ok := commonaws.ExtractEC2InstanceID(node)
+		if !ok {
 			log.Printf("Skipping node %s with unexpected provider ID: %s", node.Name, node.Spec.ProviderID)
 			return nil
 		}
-		pending[matches[1]] = pendingNode{labels: node.Labels, taints: node.Spec.Taints}
+		pending[id] = pendingNode{labels: node.Labels, taints: node.Spec.Taints}
 		if len(pending) >= ec2DescribeBatchSize {
 			return flush()
 		}


### PR DESCRIPTION
### What does this PR do?

Extracts EC2 provider-ID parsing into a shared `commonaws.ExtractEC2InstanceID` helper and reuses it from `classify` and `fromnodes`, removing the duplicated regex.

### Motivation

PR #3026 is too large to review as a single change. This is **part 8 of 12** of a stack that splits it into small, individually-reviewable pieces that each build and pass tests on their own. See #3026 for the full feature context and end-to-end QA.

### Additional Notes

**Stacked PR — the base branch is `lenaic/CASCL-1386-evict-07-pdb`, _not_ `main`**, so the diff shows only this step's change. Implements logic that earlier stack parts left stubbed with `panic("TODO …")`. The code is taken verbatim from #3026 (rebased onto `main`); there are no logic changes versus #3026.

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only.

### Describe your test plan

`go test ./cmd/kubectl-datadog/autoscaling/cluster/...` passes at this commit. Full end-to-end QA is tracked on #3026.

### Checklist

- [x] PR has at least one valid label
- [x] `qa/skip-qa` label applied (not independently shippable; QA tracked on #3026)
- [x] All commits are signed