### PR TITLE
[CASCL-1386] (10/12) Evict ASG nodes

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/asg.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/asg.go
@@ -2,9 +2,15 @@ package evict
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"k8s.io/client-go/kubernetes"
+
+	commonaws "github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/aws"
 )
 
 // AutoscalingAPI is the subset of *autoscaling.Client used by evictASG.
@@ -50,5 +56,114 @@ type AutoscalingAPI interface {
 // We never delete the ASG: it may be managed by Terraform/CloudFormation/Helm,
 // and only the original owner should remove it.
 func evictASG(ctx context.Context, clientset kubernetes.Interface, asg AutoscalingAPI, asgName string, nodes []string, drainOpts nodeDrainOptions) error {
-	panic("TODO: evictASG — implemented in PR #10")
+	if drainOpts.DryRun {
+		log.Printf("[dry-run] would suspend AZRebalance and set MinSize=0 on ASG %s", asgName)
+	} else if err := prepareASGForTermination(ctx, asg, asgName); err != nil {
+		return fmt.Errorf("prepare ASG %s for termination: %w", asgName, err)
+	}
+
+	// Cordon every node up front so a pod evicted from one node is never
+	// rescheduled onto another node of the same ASG that is itself about to be
+	// drained. A node that fails to cordon is left undrained; treat that as a
+	// drain failure so the ASG keeps its original MaxSize for a re-run instead
+	// of being locked away with workloads still on it.
+	cordoned, errs := cordonNodes(ctx, clientset, nodes, drainOpts.DryRun)
+
+	for _, node := range cordoned {
+		nodeName := node.Name
+		id, hasInstanceID := commonaws.ExtractEC2InstanceID(node)
+		if !hasInstanceID {
+			log.Printf("Warning: node %s has unexpected providerID %q; its instance will be terminated by the final scale-to-zero instead", nodeName, node.Spec.ProviderID)
+		}
+		if err := drainNode(ctx, clientset, nodeName, drainOpts); err != nil {
+			errs = append(errs, fmt.Errorf("drain node %s: %w", nodeName, err))
+			continue // do NOT terminate this instance: workloads are still on it
+		}
+		// The node drained cleanly: terminate its instance now, decrementing
+		// the ASG's desired capacity so it is not relaunched. Nodes with an
+		// unexpected providerID are left for the final scale-to-zero.
+		if !hasInstanceID {
+			continue
+		}
+		if drainOpts.DryRun {
+			log.Printf("[dry-run] would terminate instance %s in ASG %s (decrementing desired capacity)", id, asgName)
+			continue
+		}
+		if err := terminateASGInstance(ctx, asg, id); err != nil {
+			errs = append(errs, fmt.Errorf("terminate instance %s in ASG %s: %w", id, asgName, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		log.Printf("ASG %s: at least one node failed to cordon, drain, or terminate; leaving the ASG at MinSize=0 without locking MaxSize. Re-run after addressing the errors above.", asgName)
+		return errors.Join(errs...)
+	}
+
+	// Every node drained and its instance was terminated. Lock the ASG at
+	// min=max=desired=0 so nothing is ever relaunched, and to clean up any
+	// instance that couldn't be terminated per-node (unexpected providerID).
+	if drainOpts.DryRun {
+		log.Printf("[dry-run] would scale ASG %s to min=max=desired=0", asgName)
+		return nil
+	}
+	// All instances are now terminated; only the MaxSize=0 lock remains. A
+	// crash here would leave the ASG at desired=0 but unlocked and no longer
+	// rediscoverable by a re-run (see the crash-window note on evictASG).
+	log.Printf("ASG %s: all nodes drained; locking the ASG at min=max=desired=0.", asgName)
+	if err := scaleASGToZero(ctx, asg, asgName); err != nil {
+		errs = append(errs, fmt.Errorf("scale ASG %s to 0: %w", asgName, err))
+	}
+	return errors.Join(errs...)
+}
+
+// prepareASGForTermination makes the ASG safe for the per-instance termination
+// performed during the drain loop:
+//
+//   - AZRebalance is suspended so that decrementing desired capacity one
+//     instance at a time cannot trigger AZ rebalancing — which would terminate
+//     a not-yet-drained instance in another availability zone.
+//   - MinSize is set to 0 so that TerminateInstanceInAutoScalingGroup may
+//     decrement DesiredCapacity (AWS rejects the decrement while
+//     MinSize == DesiredCapacity).
+func prepareASGForTermination(ctx context.Context, asg AutoscalingAPI, asgName string) error {
+	if _, err := asg.SuspendProcesses(ctx, &autoscaling.SuspendProcessesInput{
+		AutoScalingGroupName: awssdk.String(asgName),
+		ScalingProcesses:     []string{"AZRebalance"},
+	}); err != nil {
+		return fmt.Errorf("suspend AZRebalance: %w", err)
+	}
+	if _, err := asg.UpdateAutoScalingGroup(ctx, &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: awssdk.String(asgName),
+		MinSize:              awssdk.Int32(0),
+	}); err != nil {
+		return fmt.Errorf("set MinSize=0: %w", err)
+	}
+	log.Printf("Prepared ASG %s for termination (AZRebalance suspended, MinSize=0).", asgName)
+	return nil
+}
+
+// terminateASGInstance terminates a single (already drained) instance and
+// decrements the ASG's desired capacity so it is not relaunched.
+func terminateASGInstance(ctx context.Context, asg AutoscalingAPI, instanceID string) error {
+	if _, err := asg.TerminateInstanceInAutoScalingGroup(ctx, &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     awssdk.String(instanceID),
+		ShouldDecrementDesiredCapacity: awssdk.Bool(true),
+	}); err != nil {
+		return err
+	}
+	log.Printf("Terminated instance %s and decremented ASG desired capacity.", instanceID)
+	return nil
+}
+
+func scaleASGToZero(ctx context.Context, asg AutoscalingAPI, asgName string) error {
+	if _, err := asg.UpdateAutoScalingGroup(ctx, &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: awssdk.String(asgName),
+		MinSize:              awssdk.Int32(0),
+		MaxSize:              awssdk.Int32(0),
+		DesiredCapacity:      awssdk.Int32(0),
+	}); err != nil {
+		return err
+	}
+	log.Printf("Scaled ASG %s to min=max=desired=0.", asgName)
+	return nil
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/asg_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/asg_test.go
@@ -1,0 +1,353 @@
+package evict
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// stubAutoscaling implements AutoscalingAPI by recording each call. Returning
+// a non-nil output keeps the production code happy without exercising any AWS
+// SDK middleware.
+type stubAutoscaling struct {
+	updates              []autoscaling.UpdateAutoScalingGroupInput // captured UpdateAutoScalingGroup inputs, in order
+	suspendedAZRebalance []string                                  // asg names for which AZRebalance was suspended
+	terminated           []string                                  // instance IDs terminated in-ASG
+	suspendErr           error                                     // returned by SuspendProcesses
+	prepUpdateErr        error                                     // returned by the MinSize-only prep update
+	lockErr              error                                     // returned by the final min=max=desired=0 lock update
+	terminateErr         error                                     // returned by TerminateInstanceInAutoScalingGroup
+}
+
+func (s *stubAutoscaling) UpdateAutoScalingGroup(_ context.Context, in *autoscaling.UpdateAutoScalingGroupInput, _ ...func(*autoscaling.Options)) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
+	s.updates = append(s.updates, *in)
+	// The prep update sets MinSize only (MaxSize left nil); the final lock
+	// update sets all three fields. Fail the one the test asked for.
+	if in.MaxSize == nil {
+		return &autoscaling.UpdateAutoScalingGroupOutput{}, s.prepUpdateErr
+	}
+	return &autoscaling.UpdateAutoScalingGroupOutput{}, s.lockErr
+}
+
+func (s *stubAutoscaling) SuspendProcesses(_ context.Context, in *autoscaling.SuspendProcessesInput, _ ...func(*autoscaling.Options)) (*autoscaling.SuspendProcessesOutput, error) {
+	if slices.Contains(in.ScalingProcesses, "AZRebalance") {
+		s.suspendedAZRebalance = append(s.suspendedAZRebalance, awssdk.ToString(in.AutoScalingGroupName))
+	}
+	return &autoscaling.SuspendProcessesOutput{}, s.suspendErr
+}
+
+func (s *stubAutoscaling) TerminateInstanceInAutoScalingGroup(_ context.Context, in *autoscaling.TerminateInstanceInAutoScalingGroupInput, _ ...func(*autoscaling.Options)) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error) {
+	s.terminated = append(s.terminated, awssdk.ToString(in.InstanceId))
+	return &autoscaling.TerminateInstanceInAutoScalingGroupOutput{}, s.terminateErr
+}
+
+// minSizeZeroPrepped reports whether a "prep" update (MinSize=0 only, MaxSize
+// left untouched) was issued for asgName.
+func (s *stubAutoscaling) minSizeZeroPrepped(asgName string) bool {
+	return slices.ContainsFunc(s.updates, func(u autoscaling.UpdateAutoScalingGroupInput) bool {
+		return awssdk.ToString(u.AutoScalingGroupName) == asgName &&
+			u.MinSize != nil && *u.MinSize == 0 && u.MaxSize == nil
+	})
+}
+
+// locked reports whether the final min=max=desired=0 update was issued for
+// asgName.
+func (s *stubAutoscaling) locked(asgName string) bool {
+	return slices.ContainsFunc(s.updates, func(u autoscaling.UpdateAutoScalingGroupInput) bool {
+		return awssdk.ToString(u.AutoScalingGroupName) == asgName &&
+			u.MinSize != nil && *u.MinSize == 0 &&
+			u.MaxSize != nil && *u.MaxSize == 0 &&
+			u.DesiredCapacity != nil && *u.DesiredCapacity == 0
+	})
+}
+
+func newDrainOpts(dryRun bool) nodeDrainOptions {
+	return nodeDrainOptions{
+		DryRun:          dryRun,
+		EvictionTimeout: time.Second,
+		NodeTimeout:     time.Second,
+		PollInterval:    10 * time.Millisecond,
+	}
+}
+
+func TestEvictASG(t *testing.T) {
+	ec2Node := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-0123456789abcdef0"},
+		}
+	}
+	fargateNode := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/fargate-ip-10-0-1-2"},
+		}
+	}
+	stuckNode := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "ip-stuck"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-aaaaaaaaaaaaaaaaa"},
+		}
+	}
+	stuckPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "blocker", Namespace: "default"},
+			Spec:       corev1.PodSpec{NodeName: "ip-stuck"},
+		}
+	}
+	fastDrain := nodeDrainOptions{
+		EvictionTimeout: 50 * time.Millisecond,
+		NodeTimeout:     100 * time.Millisecond,
+		PollInterval:    10 * time.Millisecond,
+	}
+
+	for _, tc := range []struct {
+		name string
+		// objects pre-populate the fake clientset.
+		objects []runtime.Object
+		// installEvictionReactor wires a 200-OK Eviction subresource reactor
+		// that keeps the pod alive in the store (so drainNode hits its node
+		// timeout). Used only by the drain-failure case.
+		installEvictionReactor bool
+		// nodes is the slice passed to evictASG.
+		nodes []string
+		opts  nodeDrainOptions
+		// terminateErr / lockErr inject AWS failures into the per-instance
+		// termination and the final lock update respectively.
+		terminateErr error
+		lockErr      error
+		// wantErr=true requires evictASG to return a non-nil error.
+		wantErr bool
+		// wantPrepped: the ASG was prepped for termination (AZRebalance
+		// suspended + MinSize=0).
+		wantPrepped bool
+		// wantTerminated is the expected set of instance IDs terminated via
+		// TerminateInstanceInAutoScalingGroup. nil ⇒ none.
+		wantTerminated []string
+		// wantLocked: the final min=max=desired=0 update was issued.
+		wantLocked bool
+		// wantUnschedulable: per-node expected `Spec.Unschedulable`. Nodes
+		// absent from the map (or absent from the cluster) aren't checked.
+		wantUnschedulable map[string]bool
+	}{
+		{
+			name:              "happy path",
+			objects:           []runtime.Object{ec2Node()},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(false),
+			wantPrepped:       true,
+			wantTerminated:    []string{"i-0123456789abcdef0"},
+			wantLocked:        true,
+			wantUnschedulable: map[string]bool{"ip-1": true},
+		},
+		{
+			// ASG neutralization still happens even when the requested K8s
+			// node is already gone — the operator may be re-running after a
+			// partial earlier execution and the AWS-side scale-to-zero must
+			// still land. No per-instance termination: the node (hence its
+			// instance ID) is gone.
+			name:        "node already gone",
+			nodes:       []string{"ip-1"},
+			opts:        newDrainOpts(false),
+			wantPrepped: true,
+			wantLocked:  true,
+		},
+		{
+			name:              "dry-run mutates nothing",
+			objects:           []runtime.Object{ec2Node()},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(true),
+			wantUnschedulable: map[string]bool{"ip-1": false},
+			// wantPrepped/wantLocked false, wantTerminated nil ⇒ no AWS
+			// mutation must happen.
+		},
+		{
+			// A node with a non-EC2 providerID (e.g. Fargate-ish) yields no
+			// instance ID: it still drains, but per-instance termination is
+			// skipped and the instance is cleaned up by the final
+			// scale-to-zero instead.
+			name:              "non-EC2 providerID drains, skips per-instance terminate, still locks",
+			objects:           []runtime.Object{fargateNode()},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(false),
+			wantPrepped:       true,
+			wantLocked:        true,
+			wantUnschedulable: map[string]bool{"ip-1": true},
+		},
+		{
+			// Safety regression: a node failing to drain (here a PDB-blocked
+			// pod stays in the fake store past the eviction reactor) must
+			// leave the instance running and the ASG unlocked (MaxSize not
+			// forced to 0) so a re-run can pick up where this one stopped.
+			// The up-front prep (MinSize=0, AZRebalance suspended) has
+			// happened and is idempotent on re-run.
+			name:                   "drain failure leaves ASG unlocked",
+			objects:                []runtime.Object{stuckNode(), stuckPod()},
+			installEvictionReactor: true,
+			nodes:                  []string{"ip-stuck"},
+			opts:                   fastDrain,
+			wantErr:                true,
+			wantPrepped:            true,
+			wantLocked:             false,
+		},
+		{
+			// A per-instance termination failure must propagate and, like a
+			// drain failure, leave the ASG unlocked for a re-run.
+			name:           "terminate failure leaves ASG unlocked",
+			objects:        []runtime.Object{ec2Node()},
+			nodes:          []string{"ip-1"},
+			opts:           newDrainOpts(false),
+			terminateErr:   errTerminate,
+			wantErr:        true,
+			wantPrepped:    true,
+			wantTerminated: []string{"i-0123456789abcdef0"},
+			wantLocked:     false,
+		},
+		{
+			// A failure of the final lock update must surface as an error
+			// (the lock call was still attempted).
+			name:           "final lock failure surfaces error",
+			objects:        []runtime.Object{ec2Node()},
+			nodes:          []string{"ip-1"},
+			opts:           newDrainOpts(false),
+			lockErr:        errLock,
+			wantErr:        true,
+			wantPrepped:    true,
+			wantTerminated: []string{"i-0123456789abcdef0"},
+			wantLocked:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(tc.objects...)
+			if tc.installEvictionReactor {
+				installPodEvictionReactor(client)
+			}
+			stub := &stubAutoscaling{terminateErr: tc.terminateErr, lockErr: tc.lockErr}
+
+			err := evictASG(t.Context(), client, stub, "my-asg", tc.nodes, tc.opts)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.wantPrepped {
+				assert.Equal(t, []string{"my-asg"}, stub.suspendedAZRebalance, "AZRebalance must be suspended once")
+				assert.True(t, stub.minSizeZeroPrepped("my-asg"), "MinSize=0 prep update must be issued")
+			} else {
+				assert.Empty(t, stub.suspendedAZRebalance, "AZRebalance must not be suspended")
+				assert.Empty(t, stub.updates, "no UpdateAutoScalingGroup call must happen")
+			}
+
+			if tc.wantTerminated == nil {
+				assert.Empty(t, stub.terminated, "no instance must be terminated")
+			} else {
+				assert.ElementsMatch(t, tc.wantTerminated, stub.terminated)
+			}
+
+			assert.Equal(t, tc.wantLocked, stub.locked("my-asg"), "final scale-to-zero")
+
+			for nodeName, want := range tc.wantUnschedulable {
+				got, getErr := client.CoreV1().Nodes().Get(t.Context(), nodeName, metav1.GetOptions{})
+				require.NoError(t, getErr)
+				assert.Equal(t, want, got.Spec.Unschedulable, "Spec.Unschedulable for %s", nodeName)
+			}
+		})
+	}
+}
+
+var (
+	errSuspend   = errors.New("suspend boom")
+	errPrepMin   = errors.New("min-size boom")
+	errTerminate = errors.New("terminate boom")
+	errLock      = errors.New("lock boom")
+)
+
+// TestEvictASGCordonFailure verifies that when a node cannot be cordoned, it is
+// left undrained and the ASG is NOT locked at MaxSize=0 — a re-run must be able
+// to finish the job. The up-front prep (AZRebalance suspend + MinSize=0) still
+// ran and is idempotent on the re-run.
+func TestEvictASGCordonFailure(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-0123456789abcdef0"},
+	}
+	client := fake.NewClientset(node)
+	// Every node Update fails with a non-conflict error so the cordon gives up.
+	client.PrependReactor("update", "nodes", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errors.New("cordon boom"))
+	})
+	stub := &stubAutoscaling{}
+
+	err := evictASG(t.Context(), client, stub, "my-asg", []string{"ip-1"}, newDrainOpts(false))
+	require.Error(t, err)
+
+	// Prep precedes the cordon, so it ran...
+	assert.Equal(t, []string{"my-asg"}, stub.suspendedAZRebalance, "AZRebalance suspended up front")
+	assert.True(t, stub.minSizeZeroPrepped("my-asg"), "MinSize=0 prep update issued up front")
+	// ...but the un-cordoned node was never drained or terminated, and the ASG
+	// stays unlocked so a re-run can finish.
+	assert.Empty(t, stub.terminated, "no instance terminated when the node failed to cordon")
+	assert.False(t, stub.locked("my-asg"), "ASG must not be locked when a node failed to cordon")
+}
+
+// TestEvictASGPrepFailure covers the up-front prepareASGForTermination failure
+// branches: when either the AZRebalance suspend or the MinSize=0 update fails,
+// evictASG must abort before touching any node (no cordon, no drain, no
+// termination, no lock) so a re-run can start cleanly.
+func TestEvictASGPrepFailure(t *testing.T) {
+	ec2Node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-0123456789abcdef0"},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		suspendErr    error
+		prepUpdateErr error
+		// wantMinSizeUpdate: the MinSize=0 prep update was attempted (only
+		// reached when the suspend succeeded).
+		wantMinSizeUpdate bool
+	}{
+		{
+			name:       "suspend failure aborts before draining",
+			suspendErr: errSuspend,
+		},
+		{
+			name:              "min-size update failure aborts before draining",
+			prepUpdateErr:     errPrepMin,
+			wantMinSizeUpdate: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(ec2Node)
+			stub := &stubAutoscaling{suspendErr: tc.suspendErr, prepUpdateErr: tc.prepUpdateErr}
+
+			err := evictASG(t.Context(), client, stub, "my-asg", []string{"ip-1"}, newDrainOpts(false))
+			require.Error(t, err)
+
+			// The drain loop must never have run: the node stays schedulable
+			// and no instance is terminated or locked.
+			assert.Empty(t, stub.terminated, "no instance must be terminated")
+			assert.False(t, stub.locked("my-asg"), "ASG must not be locked")
+			assert.Equal(t, tc.wantMinSizeUpdate, stub.minSizeZeroPrepped("my-asg"), "MinSize=0 prep update attempted")
+
+			got, getErr := client.CoreV1().Nodes().Get(t.Context(), "ip-1", metav1.GetOptions{})
+			require.NoError(t, getErr)
+			assert.False(t, got.Spec.Unschedulable, "node must not be cordoned when prep fails")
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Implements ASG node eviction: cordon, drain, terminate the instances and lock the ASG to 0.

### Motivation

PR #3026 is too large to review as a single change. This is **part 10 of 12** of a stack that splits it into small, individually-reviewable pieces that each build and pass tests on their own. See #3026 for the full feature context and end-to-end QA.

### Additional Notes

**Stacked PR — the base branch is `lenaic/CASCL-1386-evict-09-eks-mng`, _not_ `main`**, so the diff shows only this step's change. Implements logic that earlier stack parts left stubbed with `panic("TODO …")`. The code is taken verbatim from #3026 (rebased onto `main`); there are no logic changes versus #3026.

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only.

### Describe your test plan

`go test ./cmd/kubectl-datadog/autoscaling/cluster/...` passes at this commit. Full end-to-end QA is tracked on #3026.

### Checklist

- [x] PR has at least one valid label
- [x] `qa/skip-qa` label applied (not independently shippable; QA tracked on #3026)
- [x] All commits are signed