### PR TITLE
[CASCL-1386] (12/12) Evict Karpenter user NodePools

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
@@ -2,6 +2,9 @@ package evict
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 
 	"k8s.io/client-go/kubernetes"
 )
@@ -20,5 +23,17 @@ import (
 // That case is surfaced by a pre-flight warning in the orchestrator; this
 // function makes no attempt to re-balance the weights.
 func evictKarpenterUserNodePool(ctx context.Context, clientset kubernetes.Interface, nodePoolName string, nodes []string, drainOpts nodeDrainOptions) error {
-	panic("TODO: evictKarpenterUserNodePool — implemented in PR #12")
+	// Cordon every node up front so a pod evicted from one node is never
+	// rescheduled onto another node of the same NodePool that is itself about
+	// to be drained.
+	cordoned, errs := cordonNodes(ctx, clientset, nodes, drainOpts.DryRun)
+	for _, node := range cordoned {
+		if err := drainNode(ctx, clientset, node.Name, drainOpts); err != nil {
+			errs = append(errs, fmt.Errorf("drain node %s: %w", node.Name, err))
+		}
+	}
+	if !drainOpts.DryRun && len(errs) == 0 {
+		log.Printf("Drained %d node(s) from user NodePool %s; Karpenter will terminate their NodeClaims once empty.", len(cordoned), nodePoolName)
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
@@ -1,0 +1,33 @@
+package evict
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEvictKarpenterUserNodePool(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		dryRun            bool
+		wantUnschedulable bool
+	}{
+		{name: "cordons and drains", dryRun: false, wantUnschedulable: true},
+		{name: "dry-run touches nothing", dryRun: true, wantUnschedulable: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+			client := fake.NewClientset(node)
+
+			require.NoError(t, evictKarpenterUserNodePool(t.Context(), client, "user-np", []string{"n1"}, newDrainOpts(tc.dryRun)))
+
+			got, err := client.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUnschedulable, got.Spec.Unschedulable)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Implements Karpenter user NodePool eviction: cordon and drain (Karpenter reclaims the emptied instances).

### Motivation

PR #3026 is too large to review as a single change. This is **part 12 of 12** of a stack that splits it into small, individually-reviewable pieces that each build and pass tests on their own. See #3026 for the full feature context and end-to-end QA.

### Additional Notes

**Stacked PR — the base branch is `lenaic/CASCL-1386-evict-11-standalone`, _not_ `main`**, so the diff shows only this step's change. Implements logic that earlier stack parts left stubbed with `panic("TODO …")`. The code is taken verbatim from #3026 (rebased onto `main`); there are no logic changes versus #3026.

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only.

### Describe your test plan

`go test ./cmd/kubectl-datadog/autoscaling/cluster/...` passes at this commit. Full end-to-end QA is tracked on #3026.

### Checklist

- [x] PR has at least one valid label
- [x] `qa/skip-qa` label applied (not independently shippable; QA tracked on #3026)
- [x] All commits are signed