### PR TITLE
[CASCL-1386] (10/11) Evict Karpenter user NodePools

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/asg.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/asg.go
@@ -2,9 +2,15 @@ package evict
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"k8s.io/client-go/kubernetes"
+
+	commonaws "github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/aws"
 )
 
 type AutoscalingAPI interface {
@@ -14,5 +20,100 @@ type AutoscalingAPI interface {
 }
 
 func evictASG(ctx context.Context, clientset kubernetes.Interface, asg AutoscalingAPI, asgName string, nodes []string, drainOpts nodeDrainOptions) error {
-	panic("TODO: evictASG — implemented in PR https://github.com/DataDog/datadog-operator/pull/3175")
+	if drainOpts.DryRun {
+		log.Printf("[dry-run] would suspend AZRebalance and set MinSize=0 on ASG %s", asgName)
+	} else if err := prepareASGForTermination(ctx, asg, asgName); err != nil {
+		return fmt.Errorf("prepare ASG %s for termination: %w", asgName, err)
+	}
+
+	cordoned, errs := cordonNodes(ctx, clientset, nodes, drainOpts.DryRun)
+	for _, node := range cordoned {
+		nodeName := node.Name
+		id, hasInstanceID := commonaws.ExtractEC2InstanceID(node)
+		if !hasInstanceID {
+			log.Printf("Warning: node %s has unexpected providerID %q; its instance will be terminated by the final scale-to-zero instead", nodeName, node.Spec.ProviderID)
+		}
+		if err := drainNode(ctx, clientset, nodeName, drainOpts); err != nil {
+			errs = append(errs, fmt.Errorf("drain node %s: %w", nodeName, err))
+			continue // do NOT terminate this instance: workloads are still on it
+		}
+		if !hasInstanceID {
+			continue
+		}
+		if drainOpts.DryRun {
+			log.Printf("[dry-run] would terminate instance %s in ASG %s (decrementing desired capacity)", id, asgName)
+			continue
+		}
+		if err := terminateASGInstance(ctx, asg, id); err != nil {
+			errs = append(errs, fmt.Errorf("terminate instance %s in ASG %s: %w", id, asgName, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		log.Printf("ASG %s: at least one node failed to cordon, drain, or terminate; leaving the ASG at MinSize=0 without locking MaxSize. Re-run after addressing the errors above.", asgName)
+		return errors.Join(errs...)
+	}
+
+	if drainOpts.DryRun {
+		log.Printf("[dry-run] would scale ASG %s to min=max=desired=0", asgName)
+		return nil
+	}
+
+	log.Printf("ASG %s: all nodes drained; locking the ASG at min=max=desired=0.", asgName)
+	if err := scaleASGToZero(ctx, asg, asgName); err != nil {
+		errs = append(errs, fmt.Errorf("scale ASG %s to 0: %w", asgName, err))
+	}
+	return errors.Join(errs...)
+}
+
+// prepareASGForTermination makes the ASG safe for the per-instance termination
+// performed during the drain loop:
+//
+//   - AZRebalance is suspended so that decrementing desired capacity one
+//     instance at a time cannot trigger AZ rebalancing — which would terminate
+//     a not-yet-drained instance in another availability zone.
+//   - MinSize is set to 0 so that TerminateInstanceInAutoScalingGroup may
+//     decrement DesiredCapacity (AWS rejects the decrement while
+//     MinSize == DesiredCapacity).
+func prepareASGForTermination(ctx context.Context, asg AutoscalingAPI, asgName string) error {
+	if _, err := asg.SuspendProcesses(ctx, &autoscaling.SuspendProcessesInput{
+		AutoScalingGroupName: awssdk.String(asgName),
+		ScalingProcesses:     []string{"AZRebalance"},
+	}); err != nil {
+		return fmt.Errorf("suspend AZRebalance: %w", err)
+	}
+	if _, err := asg.UpdateAutoScalingGroup(ctx, &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: awssdk.String(asgName),
+		MinSize:              awssdk.Int32(0),
+	}); err != nil {
+		return fmt.Errorf("set MinSize=0: %w", err)
+	}
+	log.Printf("Prepared ASG %s for termination (AZRebalance suspended, MinSize=0).", asgName)
+	return nil
+}
+
+// terminateASGInstance terminates a single (already drained) instance and
+// decrements the ASG's desired capacity so it is not relaunched.
+func terminateASGInstance(ctx context.Context, asg AutoscalingAPI, instanceID string) error {
+	if _, err := asg.TerminateInstanceInAutoScalingGroup(ctx, &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     awssdk.String(instanceID),
+		ShouldDecrementDesiredCapacity: awssdk.Bool(true),
+	}); err != nil {
+		return err
+	}
+	log.Printf("Terminated instance %s and decremented ASG desired capacity.", instanceID)
+	return nil
+}
+
+func scaleASGToZero(ctx context.Context, asg AutoscalingAPI, asgName string) error {
+	if _, err := asg.UpdateAutoScalingGroup(ctx, &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: awssdk.String(asgName),
+		MinSize:              awssdk.Int32(0),
+		MaxSize:              awssdk.Int32(0),
+		DesiredCapacity:      awssdk.Int32(0),
+	}); err != nil {
+		return err
+	}
+	log.Printf("Scaled ASG %s to min=max=desired=0.", asgName)
+	return nil
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/asg_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/asg_test.go
@@ -1,0 +1,367 @@
+package evict
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// stubAutoscaling implements AutoscalingAPI by recording each call. Returning
+// a non-nil output keeps the production code happy without exercising any AWS
+// SDK middleware.
+type stubAutoscaling struct {
+	updates              []autoscaling.UpdateAutoScalingGroupInput // captured UpdateAutoScalingGroup inputs, in order
+	suspendedAZRebalance []string                                  // asg names for which AZRebalance was suspended
+	terminated           []string                                  // instance IDs terminated in-ASG
+	suspendErr           error                                     // returned by SuspendProcesses
+	prepUpdateErr        error                                     // returned by the MinSize-only prep update
+	lockErr              error                                     // returned by the final min=max=desired=0 lock update
+	terminateErr         error                                     // returned by TerminateInstanceInAutoScalingGroup
+}
+
+func (s *stubAutoscaling) UpdateAutoScalingGroup(_ context.Context, in *autoscaling.UpdateAutoScalingGroupInput, _ ...func(*autoscaling.Options)) (*autoscaling.UpdateAutoScalingGroupOutput, error) {
+	s.updates = append(s.updates, *in)
+	// The prep update sets MinSize only (MaxSize left nil); the final lock
+	// update sets all three fields. Fail the one the test asked for.
+	if in.MaxSize == nil {
+		return &autoscaling.UpdateAutoScalingGroupOutput{}, s.prepUpdateErr
+	}
+	return &autoscaling.UpdateAutoScalingGroupOutput{}, s.lockErr
+}
+
+func (s *stubAutoscaling) SuspendProcesses(_ context.Context, in *autoscaling.SuspendProcessesInput, _ ...func(*autoscaling.Options)) (*autoscaling.SuspendProcessesOutput, error) {
+	if slices.Contains(in.ScalingProcesses, "AZRebalance") {
+		s.suspendedAZRebalance = append(s.suspendedAZRebalance, awssdk.ToString(in.AutoScalingGroupName))
+	}
+	return &autoscaling.SuspendProcessesOutput{}, s.suspendErr
+}
+
+func (s *stubAutoscaling) TerminateInstanceInAutoScalingGroup(_ context.Context, in *autoscaling.TerminateInstanceInAutoScalingGroupInput, _ ...func(*autoscaling.Options)) (*autoscaling.TerminateInstanceInAutoScalingGroupOutput, error) {
+	s.terminated = append(s.terminated, awssdk.ToString(in.InstanceId))
+	return &autoscaling.TerminateInstanceInAutoScalingGroupOutput{}, s.terminateErr
+}
+
+// minSizeZeroPrepped reports whether a "prep" update (MinSize=0 only, MaxSize
+// left untouched) was issued for asgName.
+func (s *stubAutoscaling) minSizeZeroPrepped(asgName string) bool {
+	return slices.ContainsFunc(s.updates, func(u autoscaling.UpdateAutoScalingGroupInput) bool {
+		return awssdk.ToString(u.AutoScalingGroupName) == asgName &&
+			u.MinSize != nil && *u.MinSize == 0 && u.MaxSize == nil
+	})
+}
+
+// locked reports whether the final min=max=desired=0 update was issued for
+// asgName.
+func (s *stubAutoscaling) locked(asgName string) bool {
+	return slices.ContainsFunc(s.updates, func(u autoscaling.UpdateAutoScalingGroupInput) bool {
+		return awssdk.ToString(u.AutoScalingGroupName) == asgName &&
+			u.MinSize != nil && *u.MinSize == 0 &&
+			u.MaxSize != nil && *u.MaxSize == 0 &&
+			u.DesiredCapacity != nil && *u.DesiredCapacity == 0
+	})
+}
+
+func newDrainOpts(dryRun bool) nodeDrainOptions {
+	return nodeDrainOptions{
+		DryRun:          dryRun,
+		EvictionTimeout: time.Second,
+		NodeTimeout:     time.Second,
+		PollInterval:    10 * time.Millisecond,
+	}
+}
+
+// installPodEvictionReactor makes the fake clientset accept Eviction
+// subresource creates and echo the eviction object back WITHOUT removing the
+// pod from the tracker — so a drain-failure case can keep a pod "stuck" on its
+// node past the eviction and drive drainNode to its NodeTimeout.
+func installPodEvictionReactor(client *fake.Clientset) {
+	client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok || ca.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		return true, ca.GetObject(), nil
+	})
+}
+
+func TestEvictASG(t *testing.T) {
+	ec2Node := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-0123456789abcdef0"},
+		}
+	}
+	fargateNode := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/fargate-ip-10-0-1-2"},
+		}
+	}
+	stuckNode := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "ip-stuck"},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-aaaaaaaaaaaaaaaaa"},
+		}
+	}
+	stuckPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "blocker", Namespace: "default"},
+			Spec:       corev1.PodSpec{NodeName: "ip-stuck"},
+		}
+	}
+	fastDrain := nodeDrainOptions{
+		EvictionTimeout: 50 * time.Millisecond,
+		NodeTimeout:     100 * time.Millisecond,
+		PollInterval:    10 * time.Millisecond,
+	}
+
+	for _, tc := range []struct {
+		name string
+		// objects pre-populate the fake clientset.
+		objects []runtime.Object
+		// installEvictionReactor wires a 200-OK Eviction subresource reactor
+		// that keeps the pod alive in the store (so drainNode hits its node
+		// timeout). Used only by the drain-failure case.
+		installEvictionReactor bool
+		// nodes is the slice passed to evictASG.
+		nodes []string
+		opts  nodeDrainOptions
+		// terminateErr / lockErr inject AWS failures into the per-instance
+		// termination and the final lock update respectively.
+		terminateErr error
+		lockErr      error
+		// wantErr=true requires evictASG to return a non-nil error.
+		wantErr bool
+		// wantPrepped: the ASG was prepped for termination (AZRebalance
+		// suspended + MinSize=0).
+		wantPrepped bool
+		// wantTerminated is the expected set of instance IDs terminated via
+		// TerminateInstanceInAutoScalingGroup. nil ⇒ none.
+		wantTerminated []string
+		// wantLocked: the final min=max=desired=0 update was issued.
+		wantLocked bool
+		// wantUnschedulable: per-node expected `Spec.Unschedulable`. Nodes
+		// absent from the map (or absent from the cluster) aren't checked.
+		wantUnschedulable map[string]bool
+	}{
+		{
+			name:              "happy path",
+			objects:           []runtime.Object{ec2Node()},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(false),
+			wantPrepped:       true,
+			wantTerminated:    []string{"i-0123456789abcdef0"},
+			wantLocked:        true,
+			wantUnschedulable: map[string]bool{"ip-1": true},
+		},
+		{
+			// ASG neutralization still happens even when the requested K8s
+			// node is already gone — the operator may be re-running after a
+			// partial earlier execution and the AWS-side scale-to-zero must
+			// still land. No per-instance termination: the node (hence its
+			// instance ID) is gone.
+			name:        "node already gone",
+			nodes:       []string{"ip-1"},
+			opts:        newDrainOpts(false),
+			wantPrepped: true,
+			wantLocked:  true,
+		},
+		{
+			name:              "dry-run mutates nothing",
+			objects:           []runtime.Object{ec2Node()},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(true),
+			wantUnschedulable: map[string]bool{"ip-1": false},
+			// wantPrepped/wantLocked false, wantTerminated nil ⇒ no AWS
+			// mutation must happen.
+		},
+		{
+			// A node with a non-EC2 providerID (e.g. Fargate-ish) yields no
+			// instance ID: it still drains, but per-instance termination is
+			// skipped and the instance is cleaned up by the final
+			// scale-to-zero instead.
+			name:              "non-EC2 providerID drains, skips per-instance terminate, still locks",
+			objects:           []runtime.Object{fargateNode()},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(false),
+			wantPrepped:       true,
+			wantLocked:        true,
+			wantUnschedulable: map[string]bool{"ip-1": true},
+		},
+		{
+			// Safety regression: a node failing to drain (here a PDB-blocked
+			// pod stays in the fake store past the eviction reactor) must
+			// leave the instance running and the ASG unlocked (MaxSize not
+			// forced to 0) so a re-run can pick up where this one stopped.
+			// The up-front prep (MinSize=0, AZRebalance suspended) has
+			// happened and is idempotent on re-run.
+			name:                   "drain failure leaves ASG unlocked",
+			objects:                []runtime.Object{stuckNode(), stuckPod()},
+			installEvictionReactor: true,
+			nodes:                  []string{"ip-stuck"},
+			opts:                   fastDrain,
+			wantErr:                true,
+			wantPrepped:            true,
+			wantLocked:             false,
+		},
+		{
+			// A per-instance termination failure must propagate and, like a
+			// drain failure, leave the ASG unlocked for a re-run.
+			name:           "terminate failure leaves ASG unlocked",
+			objects:        []runtime.Object{ec2Node()},
+			nodes:          []string{"ip-1"},
+			opts:           newDrainOpts(false),
+			terminateErr:   errTerminate,
+			wantErr:        true,
+			wantPrepped:    true,
+			wantTerminated: []string{"i-0123456789abcdef0"},
+			wantLocked:     false,
+		},
+		{
+			// A failure of the final lock update must surface as an error
+			// (the lock call was still attempted).
+			name:           "final lock failure surfaces error",
+			objects:        []runtime.Object{ec2Node()},
+			nodes:          []string{"ip-1"},
+			opts:           newDrainOpts(false),
+			lockErr:        errLock,
+			wantErr:        true,
+			wantPrepped:    true,
+			wantTerminated: []string{"i-0123456789abcdef0"},
+			wantLocked:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(tc.objects...)
+			if tc.installEvictionReactor {
+				installPodEvictionReactor(client)
+			}
+			stub := &stubAutoscaling{terminateErr: tc.terminateErr, lockErr: tc.lockErr}
+
+			err := evictASG(t.Context(), client, stub, "my-asg", tc.nodes, tc.opts)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.wantPrepped {
+				assert.Equal(t, []string{"my-asg"}, stub.suspendedAZRebalance, "AZRebalance must be suspended once")
+				assert.True(t, stub.minSizeZeroPrepped("my-asg"), "MinSize=0 prep update must be issued")
+			} else {
+				assert.Empty(t, stub.suspendedAZRebalance, "AZRebalance must not be suspended")
+				assert.Empty(t, stub.updates, "no UpdateAutoScalingGroup call must happen")
+			}
+
+			if tc.wantTerminated == nil {
+				assert.Empty(t, stub.terminated, "no instance must be terminated")
+			} else {
+				assert.ElementsMatch(t, tc.wantTerminated, stub.terminated)
+			}
+
+			assert.Equal(t, tc.wantLocked, stub.locked("my-asg"), "final scale-to-zero")
+
+			for nodeName, want := range tc.wantUnschedulable {
+				got, getErr := client.CoreV1().Nodes().Get(t.Context(), nodeName, metav1.GetOptions{})
+				require.NoError(t, getErr)
+				assert.Equal(t, want, got.Spec.Unschedulable, "Spec.Unschedulable for %s", nodeName)
+			}
+		})
+	}
+}
+
+var (
+	errSuspend   = errors.New("suspend boom")
+	errPrepMin   = errors.New("min-size boom")
+	errTerminate = errors.New("terminate boom")
+	errLock      = errors.New("lock boom")
+)
+
+// TestEvictASGCordonFailure verifies that when a node cannot be cordoned, it is
+// left undrained and the ASG is NOT locked at MaxSize=0 — a re-run must be able
+// to finish the job. The up-front prep (AZRebalance suspend + MinSize=0) still
+// ran and is idempotent on the re-run.
+func TestEvictASGCordonFailure(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-0123456789abcdef0"},
+	}
+	client := fake.NewClientset(node)
+	// Every node Update fails with a non-conflict error so the cordon gives up.
+	client.PrependReactor("update", "nodes", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errors.New("cordon boom"))
+	})
+	stub := &stubAutoscaling{}
+
+	err := evictASG(t.Context(), client, stub, "my-asg", []string{"ip-1"}, newDrainOpts(false))
+	require.Error(t, err)
+
+	// Prep precedes the cordon, so it ran...
+	assert.Equal(t, []string{"my-asg"}, stub.suspendedAZRebalance, "AZRebalance suspended up front")
+	assert.True(t, stub.minSizeZeroPrepped("my-asg"), "MinSize=0 prep update issued up front")
+	// ...but the un-cordoned node was never drained or terminated, and the ASG
+	// stays unlocked so a re-run can finish.
+	assert.Empty(t, stub.terminated, "no instance terminated when the node failed to cordon")
+	assert.False(t, stub.locked("my-asg"), "ASG must not be locked when a node failed to cordon")
+}
+
+// TestEvictASGPrepFailure covers the up-front prepareASGForTermination failure
+// branches: when either the AZRebalance suspend or the MinSize=0 update fails,
+// evictASG must abort before touching any node (no cordon, no drain, no
+// termination, no lock) so a re-run can start cleanly.
+func TestEvictASGPrepFailure(t *testing.T) {
+	ec2Node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "aws:///eu-west-3a/i-0123456789abcdef0"},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		suspendErr    error
+		prepUpdateErr error
+		// wantMinSizeUpdate: the MinSize=0 prep update was attempted (only
+		// reached when the suspend succeeded).
+		wantMinSizeUpdate bool
+	}{
+		{
+			name:       "suspend failure aborts before draining",
+			suspendErr: errSuspend,
+		},
+		{
+			name:              "min-size update failure aborts before draining",
+			prepUpdateErr:     errPrepMin,
+			wantMinSizeUpdate: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(ec2Node)
+			stub := &stubAutoscaling{suspendErr: tc.suspendErr, prepUpdateErr: tc.prepUpdateErr}
+
+			err := evictASG(t.Context(), client, stub, "my-asg", []string{"ip-1"}, newDrainOpts(false))
+			require.Error(t, err)
+
+			// The drain loop must never have run: the node stays schedulable
+			// and no instance is terminated or locked.
+			assert.Empty(t, stub.terminated, "no instance must be terminated")
+			assert.False(t, stub.locked("my-asg"), "ASG must not be locked")
+			assert.Equal(t, tc.wantMinSizeUpdate, stub.minSizeZeroPrepped("my-asg"), "MinSize=0 prep update attempted")
+
+			got, getErr := client.CoreV1().Nodes().Get(t.Context(), "ip-1", metav1.GetOptions{})
+			require.NoError(t, getErr)
+			assert.False(t, got.Spec.Unschedulable, "node must not be cordoned when prep fails")
+		})
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon.go
@@ -1,0 +1,69 @@
+package evict
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+// cordonNodes marks every node in the group Unschedulable up front, before any
+// of them is drained. A pod evicted from one node is then never rescheduled
+// onto another node of the same group that is itself about to be drained.
+//
+// It returns the Node objects that are now cordoned and safe to drain, so the
+// caller can read their immutable fields (e.g. providerID) without a second
+// Get. A node that is already gone is skipped silently (absent from both
+// return values); a node that fails to cordon is recorded in errs and left out
+// of cordoned so the caller never drains a node that can still receive pods.
+func cordonNodes(ctx context.Context, clientset kubernetes.Interface, nodes []string, dryRun bool) (cordoned []*corev1.Node, errs []error) {
+	for _, nodeName := range nodes {
+		if node, err := cordonNode(ctx, clientset, nodeName, dryRun); err != nil {
+			errs = append(errs, fmt.Errorf("cordon node %s: %w", nodeName, err))
+		} else if node != nil {
+			cordoned = append(cordoned, node)
+		}
+	}
+	return cordoned, errs
+}
+
+// cordonNode marks the node Unschedulable and returns the resulting Node so the
+// caller can read immutable fields (e.g. providerID) without a second Get. It
+// returns (nil, nil) when the node is already gone: there is nothing to
+// schedule onto a deleted node, and a re-run rediscovers any surviving nodes.
+// The Get + mutate + Update is wrapped in RetryOnConflict to survive races
+// against kubelet, the scheduler, and any other controller that mutates Node
+// objects.
+func cordonNode(ctx context.Context, clientset kubernetes.Interface, name string, dryRun bool) (*corev1.Node, error) {
+	var cordoned *corev1.Node
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil // node already gone: nothing to schedule on it
+			}
+			return fmt.Errorf("failed to get node %s: %w", name, err)
+		}
+		if dryRun {
+			log.Printf("[dry-run] would cordon node %s", name)
+		} else if !node.Spec.Unschedulable {
+			node.Spec.Unschedulable = true
+			node, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil // deleted concurrently: nothing to schedule on it
+				}
+				return fmt.Errorf("failed to update node %s: %w", name, err)
+			}
+			log.Printf("Cordoned node %s.", name)
+		}
+		cordoned = node
+		return nil
+	})
+	return cordoned, err
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon_test.go
@@ -1,0 +1,134 @@
+package evict
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestCordonNode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// initialUnschedulable is the node's starting `Spec.Unschedulable`.
+		initialUnschedulable bool
+		// conflictFirstUpdate forces a Conflict on the first Update so
+		// RetryOnConflict has to refetch and re-apply.
+		conflictFirstUpdate bool
+		// updateNotFound makes the Update return NotFound, simulating the node
+		// being deleted between the Get and the Update.
+		updateNotFound bool
+		dryRun         bool
+		// wantUpdateCalls is the minimum number of Update invocations
+		// expected on the Nodes endpoint.
+		wantMinUpdateCalls int
+		wantUnschedulable  bool
+		// wantNilNode expects cordonNode to return a nil Node (the node is gone).
+		wantNilNode bool
+	}{
+		{
+			name:               "schedulable node becomes cordoned",
+			wantMinUpdateCalls: 1,
+			wantUnschedulable:  true,
+		},
+		{
+			// Already cordoned ⇒ no Update issued (idempotent).
+			name:                 "already cordoned is a no-op",
+			initialUnschedulable: true,
+			wantMinUpdateCalls:   0,
+			wantUnschedulable:    true,
+		},
+		{
+			name:                "retries on Conflict",
+			conflictFirstUpdate: true,
+			wantMinUpdateCalls:  2,
+			wantUnschedulable:   true,
+		},
+		{
+			name:               "dry-run touches nothing",
+			dryRun:             true,
+			wantMinUpdateCalls: 0,
+			wantUnschedulable:  false,
+		},
+		{
+			// Node deleted between the Get and the Update ⇒ NotFound on Update
+			// is a silent success (nothing to schedule onto a deleted node).
+			name:               "deleted between get and update is a no-op",
+			updateNotFound:     true,
+			wantMinUpdateCalls: 1,
+			wantUnschedulable:  false,
+			wantNilNode:        true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				Spec:       corev1.NodeSpec{Unschedulable: tc.initialUnschedulable},
+			}
+			client := fake.NewClientset(node)
+
+			var updateCalls int
+			client.PrependReactor("update", "nodes", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+				updateCalls++
+				if tc.conflictFirstUpdate && updateCalls == 1 {
+					return true, nil, apierrors.NewConflict(
+						schema.GroupResource{Resource: "nodes"}, "n1", errors.New("forced conflict"),
+					)
+				}
+				if tc.updateNotFound {
+					return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "n1")
+				}
+				return false, nil, nil
+			})
+
+			gotNode, cordonErr := cordonNode(t.Context(), client, "n1", tc.dryRun)
+			require.NoError(t, cordonErr)
+			assert.Equal(t, tc.wantNilNode, gotNode == nil, "cordonNode nil-node contract")
+
+			assert.GreaterOrEqual(t, updateCalls, tc.wantMinUpdateCalls, "minimum Update calls")
+			got, err := client.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUnschedulable, got.Spec.Unschedulable)
+		})
+	}
+}
+
+// TestCordonNodes covers the up-front cordon pass: a live node is cordoned and
+// returned (carrying its state so the caller needs no second Get), an
+// already-gone node is a silent skip (no error, absent from the result, so a
+// re-run after a partial execution is not derailed), and a node that fails to
+// cordon is recorded as an error and excluded so the caller never drains a node
+// that can still receive pods.
+func TestCordonNodes(t *testing.T) {
+	client := fake.NewClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "ip-live"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "ip-bad"}},
+	)
+	// Updates to ip-bad fail with a non-conflict error so cordonNode gives up
+	// immediately (RetryOnConflict only retries Conflict).
+	client.PrependReactor("update", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(clienttesting.UpdateAction)
+		if !ok || ua.GetObject().(*corev1.Node).Name != "ip-bad" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewInternalError(errors.New("update boom"))
+	})
+
+	// ip-gone is absent from the cluster: cordonNode must treat NotFound as a
+	// silent skip.
+	cordoned, errs := cordonNodes(t.Context(), client, []string{"ip-live", "ip-gone", "ip-bad"}, false)
+
+	require.Len(t, cordoned, 1, "only the live, successfully-cordoned node is returned")
+	assert.Equal(t, "ip-live", cordoned[0].Name)
+	assert.True(t, cordoned[0].Spec.Unschedulable, "the returned node carries the cordoned state")
+	require.Len(t, errs, 1)
+	assert.ErrorContains(t, errs[0], "ip-bad")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng.go
@@ -3,18 +3,84 @@ package evict
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log"
+	"time"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/pager"
+
+	commonaws "github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/aws"
 )
 
-var errEKSDrainIncomplete = errors.New("EKS managed node group drain did not complete within the timeout")
-
 type EKSManagedNodeGroupAPI interface {
-	DescribeNodegroup(ctx context.Context, in *eks.DescribeNodegroupInput, opts ...func(*eks.Options)) (*eks.DescribeNodegroupOutput, error)
 	UpdateNodegroupConfig(ctx context.Context, in *eks.UpdateNodegroupConfigInput, opts ...func(*eks.Options)) (*eks.UpdateNodegroupConfigOutput, error)
 }
 
-func evictEKSManagedNodeGroup(ctx context.Context, eksAPI EKSManagedNodeGroupAPI, clientset kubernetes.Interface, clusterName, nodegroupName string, drainOpts nodeDrainOptions) error {
-	panic("TODO: evictEKSManagedNodeGroup — implemented in PR https://github.com/DataDog/datadog-operator/pull/3174")
+func evictEKSManagedNodeGroup(ctx context.Context, eksAPI EKSManagedNodeGroupAPI, clientset kubernetes.Interface, clusterName, nodegroupName string, nodes []string, drainOpts nodeDrainOptions) error {
+	cordoned, errs := cordonNodes(ctx, clientset, nodes, drainOpts.DryRun)
+	for _, node := range cordoned {
+		if err := drainNode(ctx, clientset, node.Name, drainOpts); err != nil {
+			errs = append(errs, fmt.Errorf("drain node %s: %w", node.Name, err))
+		}
+	}
+	if len(errs) > 0 {
+		// A node still holds workloads: do NOT scale to zero, which would
+		// terminate instances with pods still on them and bypass their PDBs.
+		// The group is left untouched for a re-run.
+		return fmt.Errorf("EKS node group %s/%s drain incomplete: %w", clusterName, nodegroupName, errors.Join(errs...))
+	}
+
+	if drainOpts.DryRun {
+		log.Printf("[dry-run] would scale EKS node group %s/%s to min=desired=0 (max preserved)", clusterName, nodegroupName)
+		return nil
+	}
+
+	if _, err := eksAPI.UpdateNodegroupConfig(ctx, &eks.UpdateNodegroupConfigInput{
+		ClusterName:   awssdk.String(clusterName),
+		NodegroupName: awssdk.String(nodegroupName),
+		ScalingConfig: &ekstypes.NodegroupScalingConfig{
+			MinSize:     awssdk.Int32(0),
+			DesiredSize: awssdk.Int32(0),
+		},
+	}); err != nil {
+		return fmt.Errorf("UpdateNodegroupConfig: %w", err)
+	}
+	log.Printf("EKS node group %s/%s drained; scaling config set to min=desired=0 (max preserved).", clusterName, nodegroupName)
+
+	return waitEKSNodegroupEmpty(ctx, clientset, clusterName, nodegroupName, drainOpts.NodeTimeout, drainOpts.PollInterval)
+}
+
+// waitEKSNodegroupEmpty polls the Kubernetes API for nodes carrying the
+// `eks.amazonaws.com/nodegroup=<name>` label until none remain or the deadline
+// expires (the nodes are already drained; this waits for EKS to terminate the
+// instances). The wait is bounded by drainOpts.NodeTimeout — for large node
+// groups, callers should raise this above the default.
+func waitEKSNodegroupEmpty(ctx context.Context, clientset kubernetes.Interface, clusterName, nodegroupName string, timeout, pollInterval time.Duration) error {
+	selector := commonaws.LabelEKSNodegroup + "=" + nodegroupName
+	p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return clientset.CoreV1().Nodes().List(ctx, opts)
+	})
+	var remaining int
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		remaining = 0
+		if err := p.EachListItem(ctx, metav1.ListOptions{LabelSelector: selector}, func(runtime.Object) error {
+			remaining++
+			return nil
+		}); err != nil {
+			return false, fmt.Errorf("list EKS managed node group %s/%s nodes: %w", clusterName, nodegroupName, err)
+		}
+		return remaining == 0, nil
+	})
+	if err != nil {
+		return fmt.Errorf("EKS node group %s/%s drain incomplete, %d node(s) still present: %w", clusterName, nodegroupName, remaining, err)
+	}
+	log.Printf("EKS node group %s/%s fully drained.", clusterName, nodegroupName)
+	return nil
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng_test.go
@@ -1,0 +1,197 @@
+package evict
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	commonaws "github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/aws"
+)
+
+type stubEKS struct {
+	gotInputs []*eks.UpdateNodegroupConfigInput
+	err       error
+}
+
+func (s *stubEKS) UpdateNodegroupConfig(_ context.Context, in *eks.UpdateNodegroupConfigInput, _ ...func(*eks.Options)) (*eks.UpdateNodegroupConfigOutput, error) {
+	s.gotInputs = append(s.gotInputs, in)
+	return &eks.UpdateNodegroupConfigOutput{}, s.err
+}
+
+func mngDrainOpts() nodeDrainOptions {
+	return nodeDrainOptions{
+		EvictionTimeout: time.Second,
+		NodeTimeout:     5 * time.Second,
+		PollInterval:    10 * time.Millisecond,
+	}
+}
+
+func TestEvictEKSManagedNodeGroup(t *testing.T) {
+	const cluster, mng, nodeName = "my-cluster", "my-mng", "ip-1"
+	newMngNode := func() *corev1.Node {
+		return &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:   nodeName,
+			Labels: map[string]string{commonaws.LabelEKSNodegroup: mng},
+		}}
+	}
+	podOnNode := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: nodeName},
+	}
+
+	// installEvictionReactor makes the fake accept Eviction creates (echoing
+	// the object) or fail them with evictErr.
+	installEvictionReactor := func(client *fake.Clientset, evictErr error) {
+		client.PrependReactor("create", "pods", func(a clienttesting.Action) (bool, runtime.Object, error) {
+			ca, ok := a.(clienttesting.CreateAction)
+			if !ok || ca.GetSubresource() != "eviction" {
+				return false, nil, nil
+			}
+			if evictErr != nil {
+				return true, nil, evictErr
+			}
+			return true, ca.GetObject(), nil
+		})
+	}
+	// installPodListReactor returns the pod list for each 1-based List call, so a
+	// case can drain a node across successive polls.
+	installPodListReactor := func(client *fake.Clientset, lists func(call int) []corev1.Pod) {
+		var n int
+		client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			n++
+			return true, &corev1.PodList{Items: lists(n)}, nil
+		})
+	}
+	// installNodeListReactor drives waitEKSNodegroupEmpty's Nodes().List (by
+	// nodegroup label). It does not affect cordonNodes, which uses Get + Update.
+	installNodeListReactor := func(client *fake.Clientset, items []corev1.Node) {
+		client.PrependReactor("list", "nodes", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, &corev1.NodeList{Items: items}, nil
+		})
+	}
+	assertScaledToZero := func(t *testing.T, in *eks.UpdateNodegroupConfigInput) {
+		t.Helper()
+		assert.Equal(t, cluster, awssdk.ToString(in.ClusterName))
+		assert.Equal(t, mng, awssdk.ToString(in.NodegroupName))
+		require.NotNil(t, in.ScalingConfig)
+		assert.Equal(t, int32(0), awssdk.ToInt32(in.ScalingConfig.MinSize))
+		assert.Equal(t, int32(0), awssdk.ToInt32(in.ScalingConfig.DesiredSize))
+		// MaxSize is deliberately omitted so EKS preserves the existing ceiling
+		// (partial ScalingConfig update).
+		assert.Nil(t, in.ScalingConfig.MaxSize)
+	}
+
+	t.Run("dry-run cordons nothing and skips Update", func(t *testing.T) {
+		stub := &stubEKS{}
+		client := fake.NewClientset(newMngNode())
+		opts := mngDrainOpts()
+		opts.DryRun = true
+
+		err := evictEKSManagedNodeGroup(t.Context(), stub, client, cluster, mng, []string{nodeName}, opts)
+		require.NoError(t, err)
+		assert.Empty(t, stub.gotInputs)
+		got, getErr := client.CoreV1().Nodes().Get(t.Context(), nodeName, metav1.GetOptions{})
+		require.NoError(t, getErr)
+		assert.False(t, got.Spec.Unschedulable, "dry-run must not cordon")
+	})
+
+	t.Run("cordons, drains gracefully, then scales to zero", func(t *testing.T) {
+		stub := &stubEKS{}
+		client := fake.NewClientset(newMngNode())
+		installEvictionReactor(client, nil)
+		// The node still hosts the pod when drainNode enumerates it (call 1);
+		// the eviction takes effect by the time waitForNodeEmpty polls (call 2+).
+		installPodListReactor(client, func(call int) []corev1.Pod {
+			if call == 1 {
+				return []corev1.Pod{podOnNode}
+			}
+			return nil
+		})
+		// EKS has terminated the instance by the time we poll for nodes.
+		installNodeListReactor(client, nil)
+
+		err := evictEKSManagedNodeGroup(t.Context(), stub, client, cluster, mng, []string{nodeName}, mngDrainOpts())
+		require.NoError(t, err)
+		require.Len(t, stub.gotInputs, 1)
+		assertScaledToZero(t, stub.gotInputs[0])
+		got, getErr := client.CoreV1().Nodes().Get(t.Context(), nodeName, metav1.GetOptions{})
+		require.NoError(t, getErr)
+		assert.True(t, got.Spec.Unschedulable, "the node must be cordoned before draining")
+	})
+
+	t.Run("drain failure skips scale-down", func(t *testing.T) {
+		stub := &stubEKS{}
+		// The seeded pod is never removed, so the node never empties.
+		client := fake.NewClientset(newMngNode(), &podOnNode)
+		installEvictionReactor(client, apierrors.NewTooManyRequests("PDB blocked", 1))
+		opts := mngDrainOpts()
+		opts.EvictionTimeout = 30 * time.Millisecond
+		opts.NodeTimeout = 60 * time.Millisecond
+
+		err := evictEKSManagedNodeGroup(t.Context(), stub, client, cluster, mng, []string{nodeName}, opts)
+		require.Error(t, err)
+		assert.Empty(t, stub.gotInputs, "must not scale down while a node still holds workloads")
+	})
+
+	t.Run("cordon failure skips scale-down", func(t *testing.T) {
+		stub := &stubEKS{}
+		client := fake.NewClientset(newMngNode())
+		client.PrependReactor("update", "nodes", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewInternalError(errors.New("cordon boom"))
+		})
+
+		err := evictEKSManagedNodeGroup(t.Context(), stub, client, cluster, mng, []string{nodeName}, mngDrainOpts())
+		require.Error(t, err)
+		assert.Empty(t, stub.gotInputs)
+	})
+
+	t.Run("UpdateNodegroupConfig failure after drain surfaces the error", func(t *testing.T) {
+		stub := &stubEKS{err: errors.New("api error")}
+		client := fake.NewClientset(newMngNode()) // no pods ⇒ the node drains immediately
+
+		err := evictEKSManagedNodeGroup(t.Context(), stub, client, cluster, mng, []string{nodeName}, mngDrainOpts())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "UpdateNodegroupConfig")
+		require.Len(t, stub.gotInputs, 1)
+	})
+
+	t.Run("post-scale wait timeout surfaces an error", func(t *testing.T) {
+		stub := &stubEKS{}
+		client := fake.NewClientset(newMngNode()) // no pods ⇒ the node drains immediately
+		// The instance never terminates, so waitEKSNodegroupEmpty times out.
+		installNodeListReactor(client, []corev1.Node{*newMngNode()})
+		opts := mngDrainOpts()
+		opts.NodeTimeout = 60 * time.Millisecond
+
+		err := evictEKSManagedNodeGroup(t.Context(), stub, client, cluster, mng, []string{nodeName}, opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), mng)
+		require.Len(t, stub.gotInputs, 1)
+	})
+
+	t.Run("post-scale node-list error surfaces an error", func(t *testing.T) {
+		stub := &stubEKS{}
+		client := fake.NewClientset(newMngNode()) // no pods ⇒ the node drains immediately
+		// The scale-down succeeded, but the Nodes().List used to confirm the
+		// group emptied errors out, so the drain cannot be confirmed complete.
+		client.PrependReactor("list", "nodes", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewInternalError(errors.New("apiserver unreachable"))
+		})
+
+		err := evictEKSManagedNodeGroup(t.Context(), stub, client, cluster, mng, []string{nodeName}, mngDrainOpts())
+		require.Error(t, err)
+		require.Len(t, stub.gotInputs, 1)
+	})
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
@@ -1,6 +1,24 @@
 package evict
 
-import "time"
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/pager"
+	"k8s.io/client-go/util/retry"
+)
 
 // nodeDrainOptions captures the per-call tunables for evicting a node's pods.
 type nodeDrainOptions struct {
@@ -8,4 +26,150 @@ type nodeDrainOptions struct {
 	EvictionTimeout time.Duration // per pod, bound for retries on 429
 	NodeTimeout     time.Duration // total wait for the node to become empty
 	PollInterval    time.Duration // interval between empty-checks; default 2s
+}
+
+// TODO(CASCL-1386): remove this block once the EKS managed node group eviction
+// (next PR in the stack) calls these primitives. They are introduced here as
+// shared building blocks; golangci-lint's `unused` runs with `tests = false`,
+// so the test coverage in this package does not count as use. Referencing the
+// two entry points keeps `unused` quiet until the first production caller lands
+// (drainNode/cordonNodes transitively reach every other helper below).
+var (
+	_ = drainNode
+	_ = cordonNodes
+)
+
+// drainNode evicts every evictable pod from the node and waits for the node to
+// become empty. Pods owned by a DaemonSet, mirror pods, terminating pods and
+// completed Job pods are skipped — the kubelet handles their cleanup when the
+// underlying instance disappears.
+//
+// Pods that cannot be evicted (PDB-blocked beyond EvictionTimeout, etc.) are
+// logged as warnings; drainNode then continues with the remaining pods rather
+// than aborting the whole run.
+func drainNode(ctx context.Context, clientset kubernetes.Interface, nodeName string, opts nodeDrainOptions) error {
+	if opts.DryRun {
+		log.Printf("[dry-run] would drain node %s", nodeName)
+		return nil
+	}
+	pods, err := listPodsOnNode(ctx, clientset, nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+	}
+	for _, p := range pods {
+		if shouldSkipEviction(&p) {
+			continue
+		}
+		if err := evictPodWithRetry(ctx, clientset, &p, opts.EvictionTimeout, opts.PollInterval); err != nil {
+			log.Printf("Warning: pod %s/%s: %v", p.Namespace, p.Name, err)
+		}
+	}
+	return waitForNodeEmpty(ctx, clientset, nodeName, opts.NodeTimeout, opts.PollInterval)
+}
+
+// listPodsOnNode enumerates pods scheduled on the given node, server-side
+// filtered via the spec.nodeName field selector.
+func listPodsOnNode(ctx context.Context, clientset kubernetes.Interface, nodeName string) (pods []corev1.Pod, err error) {
+	p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return clientset.CoreV1().Pods(metav1.NamespaceAll).List(ctx, opts)
+	})
+	if err = p.EachListItem(ctx, metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+	}, func(obj runtime.Object) error {
+		pods = append(pods, *obj.(*corev1.Pod))
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return pods, nil
+}
+
+// evictPodWithRetry sends a single Eviction request and retries while the
+// apiserver returns 429 TooManyRequests (the canonical PDB-blocked signal).
+// Retries at retryInterval for up to timeout's worth of attempts; the caller
+// then logs and moves to the next pod.
+//
+// 404 (pod already gone) is treated as success — the eviction goal is met.
+// Non-429 errors are returned immediately.
+func evictPodWithRetry(ctx context.Context, clientset kubernetes.Interface, p *corev1.Pod, timeout, retryInterval time.Duration) error {
+	eviction := &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace},
+	}
+	steps := 1
+	if retryInterval > 0 {
+		steps = max(1, int(timeout/retryInterval))
+	}
+	backoff := wait.Backoff{Duration: retryInterval, Factor: 1, Steps: steps}
+	err := retry.OnError(backoff, apierrors.IsTooManyRequests, func() error {
+		return clientset.CoreV1().Pods(p.Namespace).EvictV1(ctx, eviction)
+	})
+	switch {
+	case err == nil:
+		log.Printf("Evicted pod %s/%s.", p.Namespace, p.Name)
+		return nil
+	case apierrors.IsNotFound(err):
+		return nil // already gone — eviction goal met
+	case apierrors.IsTooManyRequests(err):
+		// OnError exhausted its retries while still 429-blocked.
+		return fmt.Errorf("eviction timed out (likely PDB-blocked): %w", err)
+	default:
+		return fmt.Errorf("eviction failed: %w", err)
+	}
+}
+
+// waitForNodeEmpty polls the node until no pod still occupies it. A pod is
+// considered to still occupy the node until it is actually gone from the API
+// server — including pods that are merely terminating (DeletionTimestamp
+// set). This matters for callers that terminate the underlying EC2 instance
+// next: returning early while a pod is mid-grace-period would kill the
+// container before its preStop hook / graceful shutdown finishes.
+//
+// DaemonSet pods, mirror pods and completed pods are not counted: DS and
+// mirror pods are tied to the node's lifecycle and disappear with it,
+// completed pods are inert and GC'd promptly.
+func waitForNodeEmpty(ctx context.Context, clientset kubernetes.Interface, nodeName string, timeout, pollInterval time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := listPodsOnNode(ctx, clientset, nodeName)
+		if err != nil {
+			return false, fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+		}
+		return lo.NoneBy(pods, func(p corev1.Pod) bool {
+			return podOccupiesNode(&p)
+		}), nil
+	})
+}
+
+// shouldSkipEviction reports whether drainNode should leave a pod alone
+// rather than call the Eviction API on it. A pod already terminating is
+// skipped because issuing another eviction would 404 once the kubelet
+// finishes the deletion; every pod that does not occupy the node for drain
+// purposes (mirror, DaemonSet and completed pods) needs no eviction either.
+func shouldSkipEviction(p *corev1.Pod) bool {
+	return p.DeletionTimestamp != nil || !podOccupiesNode(p)
+}
+
+// podOccupiesNode reports whether a pod still consumes the node from a drain
+// perspective. Terminating pods DO occupy the node until they are gone;
+// returning false for them prematurely would let the caller terminate the
+// instance before the container finished its grace period.
+func podOccupiesNode(p *corev1.Pod) bool {
+	return !isMirrorPod(p) && !isDaemonSetPod(p) && !isCompleted(p)
+}
+
+func isMirrorPod(p *corev1.Pod) bool {
+	_, ok := p.Annotations[corev1.MirrorPodAnnotationKey]
+	return ok
+}
+
+func isDaemonSetPod(p *corev1.Pod) bool {
+	ctrl := metav1.GetControllerOf(p)
+	if ctrl == nil || ctrl.Kind != "DaemonSet" {
+		return false
+	}
+	gv, _ := schema.ParseGroupVersion(ctrl.APIVersion)
+	return gv.Group == "apps"
+}
+
+func isCompleted(p *corev1.Pod) bool {
+	return p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
@@ -28,17 +28,6 @@ type nodeDrainOptions struct {
 	PollInterval    time.Duration // interval between empty-checks; default 2s
 }
 
-// TODO(CASCL-1386): remove this block once the EKS managed node group eviction
-// (next PR in the stack) calls these primitives. They are introduced here as
-// shared building blocks; golangci-lint's `unused` runs with `tests = false`,
-// so the test coverage in this package does not count as use. Referencing the
-// two entry points keeps `unused` quiet until the first production caller lands
-// (drainNode/cordonNodes transitively reach every other helper below).
-var (
-	_ = drainNode
-	_ = cordonNodes
-)
-
 // drainNode evicts every evictable pod from the node and waits for the node to
 // become empty. Pods owned by a DaemonSet, mirror pods, terminating pods and
 // completed Job pods are skipped — the kubelet handles their cleanup when the

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods_test.go
@@ -1,0 +1,415 @@
+package evict
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+)
+
+func TestShouldSkipEviction(t *testing.T) {
+	now := metav1.Now()
+	for _, tc := range []struct {
+		name string
+		pod  *corev1.Pod
+		skip bool
+	}{
+		{name: "regular pod", pod: &corev1.Pod{}, skip: false},
+		{name: "terminating", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}}, skip: true},
+		{name: "mirror", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{corev1.MirrorPodAnnotationKey: "x"},
+		}}, skip: true},
+		{name: "daemonset", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true)}},
+		}}, skip: true},
+		{name: "non-controller DaemonSet owner is not skipped", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds"}},
+		}}, skip: false},
+		{name: "succeeded job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}, skip: true},
+		{name: "failed job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}}, skip: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.skip, shouldSkipEviction(tc.pod))
+		})
+	}
+}
+
+// TestPodOccupiesNode locks in the asymmetry between "skip eviction" and
+// "keeps the node busy": terminating pods are skipped from eviction (the
+// kubelet is already deleting them) BUT still occupy the node for drain
+// purposes (otherwise we'd terminate the instance mid-grace-period and kill
+// the container before its preStop hook finishes).
+func TestPodOccupiesNode(t *testing.T) {
+	now := metav1.Now()
+	for _, tc := range []struct {
+		name     string
+		pod      *corev1.Pod
+		occupies bool
+	}{
+		{name: "regular pod", pod: &corev1.Pod{}, occupies: true},
+		{name: "terminating pod still occupies", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}}, occupies: true},
+		{name: "mirror pod", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{corev1.MirrorPodAnnotationKey: "x"},
+		}}, occupies: false},
+		{name: "daemonset pod", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true)}},
+		}}, occupies: false},
+		{name: "non-controller DaemonSet owner still occupies", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds"}},
+		}}, occupies: true},
+		{name: "succeeded job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}, occupies: false},
+		{name: "failed job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}}, occupies: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.occupies, podOccupiesNode(tc.pod))
+		})
+	}
+}
+
+func TestEvictPodWithRetry(t *testing.T) {
+	// evictionResponder shapes the test-side of the Eviction subresource
+	// reactor. `call` is the 1-based call counter.
+	type evictionResponder func(call int, eviction *policyv1.Eviction) (resp runtime.Object, err error)
+
+	echoSuccess := evictionResponder(func(_ int, e *policyv1.Eviction) (runtime.Object, error) {
+		return e, nil
+	})
+	tooManyOnceThenSuccess := evictionResponder(func(call int, e *policyv1.Eviction) (runtime.Object, error) {
+		if call == 1 {
+			return nil, apierrors.NewTooManyRequests("PDB blocked", 1)
+		}
+		return e, nil
+	})
+	notFound := evictionResponder(func(_ int, e *policyv1.Eviction) (runtime.Object, error) {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, e.Name)
+	})
+	nonRetryable := evictionResponder(func(_ int, _ *policyv1.Eviction) (runtime.Object, error) {
+		return nil, errors.New("non-retryable")
+	})
+	alwaysTooMany := evictionResponder(func(_ int, _ *policyv1.Eviction) (runtime.Object, error) {
+		return nil, apierrors.NewTooManyRequests("PDB blocked", 1)
+	})
+
+	for _, tc := range []struct {
+		name string
+		// pod is the object passed to evictPodWithRetry (and pre-loaded
+		// into the fake when seedPod is true).
+		pod     *corev1.Pod
+		seedPod bool
+		// responder controls what the Eviction reactor returns each call.
+		responder evictionResponder
+		timeout   time.Duration
+
+		wantErr          bool
+		wantErrContains  string
+		wantMinCalls     int
+		wantCapturedName string
+		wantCapturedNs   string
+	}{
+		{
+			name:         "success on first call",
+			pod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:      true,
+			responder:    echoSuccess,
+			timeout:      5 * time.Second,
+			wantMinCalls: 1,
+		},
+		{
+			name:         "retries on 429 then succeeds",
+			pod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:      true,
+			responder:    tooManyOnceThenSuccess,
+			timeout:      10 * time.Second,
+			wantMinCalls: 2,
+		},
+		{
+			// Pod already gone: 404 from the apiserver is treated as
+			// success — the eviction goal is met regardless.
+			name:         "404 from apiserver is success",
+			pod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:      false,
+			responder:    notFound,
+			timeout:      time.Second,
+			wantMinCalls: 1,
+		},
+		{
+			name:            "non-retryable error returned",
+			pod:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:         true,
+			responder:       nonRetryable,
+			timeout:         5 * time.Second,
+			wantErr:         true,
+			wantErrContains: "eviction failed",
+			wantMinCalls:    1,
+		},
+		{
+			// Always 429: OnError exhausts its retries while still
+			// PDB-blocked, and the last 429 is surfaced as a timeout.
+			name:            "exhausts retries while 429-blocked",
+			pod:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:         true,
+			responder:       alwaysTooMany,
+			timeout:         50 * time.Millisecond,
+			wantErr:         true,
+			wantErrContains: "eviction timed out",
+			wantMinCalls:    2,
+		},
+		{
+			// Smoke check that the Eviction object carries the pod's
+			// Name/Namespace through to the apiserver.
+			name:             "eviction object name/namespace",
+			pod:              &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"}},
+			seedPod:          true,
+			responder:        echoSuccess,
+			timeout:          time.Second,
+			wantMinCalls:     1,
+			wantCapturedName: "p1",
+			wantCapturedNs:   "ns1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seed []runtime.Object
+			if tc.seedPod {
+				seed = append(seed, tc.pod)
+			}
+			client := fake.NewClientset(seed...)
+
+			var (
+				calls    int
+				captured *policyv1.Eviction
+			)
+			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				ca, ok := action.(clienttesting.CreateAction)
+				if !ok || ca.GetSubresource() != "eviction" {
+					return false, nil, nil
+				}
+				calls++
+				eviction := ca.GetObject().(*policyv1.Eviction)
+				captured = eviction
+				resp, err := tc.responder(calls, eviction)
+				return true, resp, err
+			})
+
+			err := evictPodWithRetry(t.Context(), client, tc.pod, tc.timeout, 10*time.Millisecond)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			assert.GreaterOrEqual(t, calls, tc.wantMinCalls)
+			if tc.wantCapturedName != "" {
+				require.NotNil(t, captured)
+				assert.Equal(t, tc.wantCapturedName, captured.Name)
+				assert.Equal(t, tc.wantCapturedNs, captured.Namespace)
+			}
+		})
+	}
+}
+
+// TestEvictPodWithRetryZeroInterval pins the guard against a non-positive
+// retryInterval: it must not panic (division by zero) and degrades to a single
+// eviction attempt.
+func TestEvictPodWithRetryZeroInterval(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}}
+	client := fake.NewClientset(pod)
+	var calls int
+	client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok || ca.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		calls++
+		return true, ca.GetObject(), nil
+	})
+
+	err := evictPodWithRetry(t.Context(), client, pod, time.Second, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+// TestListPodsOnNode locks in the server-side node scoping: the fake client
+// does not enforce field selectors, so we assert explicitly that the request
+// carries spec.nodeName=<node>. A regression here would silently drain pods
+// from every node, not just the target.
+func TestListPodsOnNode(t *testing.T) {
+	client := fake.NewClientset()
+	var gotFieldSelector string
+	client.PrependReactor("list", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		gotFieldSelector = action.(clienttesting.ListAction).GetListRestrictions().Fields.String()
+		return true, &corev1.PodList{Items: []corev1.Pod{occupyingPod("a"), occupyingPod("b")}}, nil
+	})
+
+	pods, err := listPodsOnNode(t.Context(), client, "ip-7")
+	require.NoError(t, err)
+	assert.Len(t, pods, 2)
+	assert.Equal(t, "spec.nodeName=ip-7", gotFieldSelector)
+}
+
+// occupyingPod and dsPod are the two fixtures the drain/wait tests reuse: a
+// plain pod that keeps the node busy, and a DaemonSet pod that never does.
+func occupyingPod(name string) corev1.Pod {
+	return corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
+}
+
+func dsPod(name string) corev1.Pod {
+	return corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:            name,
+		Namespace:       "default",
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true)}},
+	}}
+}
+
+func TestWaitForNodeEmpty(t *testing.T) {
+	occupying := occupyingPod("app")
+	ds := dsPod("agent")
+
+	for _, tc := range []struct {
+		name string
+		// listResponder returns the pod list for each 1-based List call,
+		// letting a case spread a transition across successive polls.
+		listResponder   func(call int) (runtime.Object, error)
+		timeout         time.Duration
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:          "empty on first poll",
+			listResponder: func(int) (runtime.Object, error) { return &corev1.PodList{}, nil },
+			timeout:       time.Second,
+		},
+		{
+			// Only DaemonSet/mirror/completed pods linger: the node does not
+			// "occupy" for drain purposes, so the wait returns immediately.
+			name: "only non-occupying pods counts as empty",
+			listResponder: func(int) (runtime.Object, error) {
+				return &corev1.PodList{Items: []corev1.Pod{ds}}, nil
+			},
+			timeout: time.Second,
+		},
+		{
+			name: "becomes empty after the first poll",
+			listResponder: func(call int) (runtime.Object, error) {
+				if call == 1 {
+					return &corev1.PodList{Items: []corev1.Pod{occupying}}, nil
+				}
+				return &corev1.PodList{}, nil
+			},
+			timeout: time.Second,
+		},
+		{
+			name: "times out while an occupying pod remains",
+			listResponder: func(int) (runtime.Object, error) {
+				return &corev1.PodList{Items: []corev1.Pod{occupying}}, nil
+			},
+			timeout: 60 * time.Millisecond,
+			wantErr: true,
+		},
+		{
+			name: "list error is wrapped",
+			listResponder: func(int) (runtime.Object, error) {
+				return nil, errors.New("apiserver unreachable")
+			},
+			timeout:         time.Second,
+			wantErr:         true,
+			wantErrContains: "failed to list pods on node",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset()
+			var calls int
+			client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+				calls++
+				obj, err := tc.listResponder(calls)
+				return true, obj, err
+			})
+			err := waitForNodeEmpty(t.Context(), client, "ip-1", tc.timeout, 10*time.Millisecond)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDrainNode(t *testing.T) {
+	occupying := occupyingPod("app")
+	ds := dsPod("agent")
+
+	// countingEvictionReactor installs an Eviction reactor that echoes success
+	// and increments *n on every eviction create.
+	countingEvictionReactor := func(client *fake.Clientset, n *int) {
+		client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			ca, ok := action.(clienttesting.CreateAction)
+			if !ok || ca.GetSubresource() != "eviction" {
+				return false, nil, nil
+			}
+			*n++
+			return true, ca.GetObject(), nil
+		})
+	}
+
+	t.Run("dry-run evicts nothing", func(t *testing.T) {
+		client := fake.NewClientset(&occupying)
+		var evictions int
+		countingEvictionReactor(client, &evictions)
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{DryRun: true})
+		require.NoError(t, err)
+		assert.Zero(t, evictions)
+	})
+
+	t.Run("evicts the occupying pod then waits for the node to empty", func(t *testing.T) {
+		client := fake.NewClientset(&occupying)
+		var evictions, lists int
+		countingEvictionReactor(client, &evictions)
+		// First List (drainNode's own enumeration) still sees the pod; the
+		// subsequent List from waitForNodeEmpty sees the node drained.
+		client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			lists++
+			if lists == 1 {
+				return true, &corev1.PodList{Items: []corev1.Pod{occupying}}, nil
+			}
+			return true, &corev1.PodList{}, nil
+		})
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{
+			EvictionTimeout: time.Second,
+			NodeTimeout:     time.Second,
+			PollInterval:    10 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, evictions)
+	})
+
+	t.Run("skips non-evictable pods and treats the node as empty", func(t *testing.T) {
+		client := fake.NewClientset(&ds)
+		var evictions int
+		countingEvictionReactor(client, &evictions)
+		client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, &corev1.PodList{Items: []corev1.Pod{ds}}, nil
+		})
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{
+			EvictionTimeout: time.Second,
+			NodeTimeout:     time.Second,
+			PollInterval:    10 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		assert.Zero(t, evictions)
+	})
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
@@ -2,10 +2,22 @@ package evict
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 
 	"k8s.io/client-go/kubernetes"
 )
 
 func evictKarpenterUserNodePool(ctx context.Context, clientset kubernetes.Interface, nodePoolName string, nodes []string, drainOpts nodeDrainOptions) error {
-	panic("TODO: evictKarpenterUserNodePool — implemented in PR https://github.com/DataDog/datadog-operator/pull/3177")
+	cordoned, errs := cordonNodes(ctx, clientset, nodes, drainOpts.DryRun)
+	for _, node := range cordoned {
+		if err := drainNode(ctx, clientset, node.Name, drainOpts); err != nil {
+			errs = append(errs, fmt.Errorf("drain node %s: %w", node.Name, err))
+		}
+	}
+	if !drainOpts.DryRun && len(errs) == 0 {
+		log.Printf("Drained %d node(s) from user NodePool %s; Karpenter will terminate their NodeClaims once empty.", len(cordoned), nodePoolName)
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
@@ -1,0 +1,33 @@
+package evict
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEvictKarpenterUserNodePool(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		dryRun            bool
+		wantUnschedulable bool
+	}{
+		{name: "cordons and drains", dryRun: false, wantUnschedulable: true},
+		{name: "dry-run touches nothing", dryRun: true, wantUnschedulable: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
+			client := fake.NewClientset(node)
+
+			require.NoError(t, evictKarpenterUserNodePool(t.Context(), client, "user-np", []string{"n1"}, newDrainOpts(tc.dryRun)))
+
+			got, err := client.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUnschedulable, got.Spec.Unschedulable)
+		})
+	}
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/prompt.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/prompt.go
@@ -38,13 +38,6 @@ func printPlan(streams genericclioptions.IOStreams, info *clusterinfo.ClusterInf
 	}
 	if ensurePDBs {
 		fmt.Fprintln(streams.Out, "  • Remove the temporary PodDisruptionBudgets created above")
-		// Cleanup is deferred when an EKS managed node group drain times out
-		// (see run.go): EKS may still be evicting pods, so the temp PDBs are
-		// left in place and reclaimed on a later rerun. Only mention this when
-		// the plan actually targets an EKS managed node group.
-		if _, hasEKS := grouped[clusterinfo.NodeManagerEKSManagedNodeGroup]; hasEKS {
-			fmt.Fprintln(streams.Out, "      ◦ (deferred to a later rerun if an EKS managed node group drain times out)")
-		}
 	}
 	fmt.Fprintln(streams.Out, color.YellowString("\n⚠ This will drain workloads and terminate the underlying instances of non-Datadog node groups."))
 	fmt.Fprintln(streams.Out, color.YellowString("  Verify the Datadog Karpenter NodePool has enough capacity headroom for the migrated pods."))

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/prompt_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/prompt_test.go
@@ -52,21 +52,6 @@ func TestPrintPlan(t *testing.T) {
 				// Standalone entry with empty name renders as "(all)".
 				"(all) (1 node(s))",
 			},
-			// No EKS managed node group in this plan ⇒ no deferred-cleanup note.
-			wantNotContains: []string{"deferred to a later rerun"},
-		},
-		{
-			// An EKS managed node group target surfaces the deferred-cleanup
-			// caveat next to the PDB removal bullet.
-			name:       "EKS managed node group adds deferred-cleanup note",
-			info:       &clusterinfo.ClusterInfo{Autoscaling: caAbsent},
-			targets:    []Target{{Manager: clusterinfo.NodeManagerEKSManagedNodeGroup, Entity: "mng-1", Nodes: []string{"ip-5"}}},
-			scaleCA:    false,
-			ensurePDBs: true,
-			wantContains: []string{
-				"Remove the temporary PodDisruptionBudgets",
-				"deferred to a later rerun if an EKS managed node group drain times out",
-			},
 		},
 		{
 			// scaleCA=false hides the CA bullet even when CA is Present;

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/run.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/run.go
@@ -89,10 +89,9 @@ func Run(ctx context.Context, streams genericclioptions.IOStreams, configFlags *
 		return err
 	}
 	if len(targets) == 0 {
-		// A previous run may have been interrupted (e.g. an EKS managed node
-		// group timed out, leaving its temporary PDBs in place for a later
-		// rerun). By the time that rerun finds nothing left to evict, those
-		// leaked PDBs would otherwise persist indefinitely with
+		// A previous run may have been interrupted (e.g. SIGINT mid-flight),
+		// leaking temporary PDBs. By the time a rerun finds nothing left to
+		// evict, those leaked PDBs would otherwise persist indefinitely with
 		// maxUnavailable: 1 and throttle future rollouts/disruptions, so
 		// reclaim anything left behind before the no-op exit.
 		if opts.EnsurePDBs {
@@ -143,24 +142,18 @@ func Run(ctx context.Context, streams genericclioptions.IOStreams, configFlags *
 	evictor := func(c context.Context, t Target, d nodeDrainOptions) error {
 		return evictTarget(c, clientset, cli, opts.ClusterName, t, d)
 	}
-	result := evictAllTargets(ctx, targets, drainOpts, evictor)
-	errs := result.Errors
+	errs := evictAllTargets(ctx, targets, drainOpts, evictor)
 
 	// Step 4: cleanup temporary PDBs explicitly here — keeping it inline
 	// (rather than deferred) means the "Deleted temporary PDB …" log lines
 	// appear BEFORE the final success/failure summary, so the user does not
 	// experience an apparent hang after seeing the "✅" box.
 	//
-	// When at least one EKS managed node group did not finish draining
-	// within the timeout, we skip the cleanup: EKS may still be evicting
-	// pods on those nodes, and dropping the temp PDBs now would leave
-	// cross-type workloads unprotected mid-drain. The label-based cleanup
-	// on a subsequent run picks the PDBs up once EKS converges.
-	switch {
-	case !opts.EnsurePDBs:
-	case result.EKSDrainIncomplete:
-		log.Printf("Note: at least one EKS managed node group did not finish draining within --node-timeout; temporary PDBs left in place so EKS can finish safely. Re-run the command once `aws eks describe-nodegroup` reports the group at 0 nodes — the next run will clean them up.")
-	default:
+	// Every evictor drains synchronously and PDB-aware (via the Eviction API)
+	// before terminating its instances, so once eviction returns there is no
+	// background process still disrupting PDB-protected workloads. The temporary
+	// PDBs have served their purpose and are always safe to reclaim here.
+	if opts.EnsurePDBs {
 		if err := cleanupTempPDBs(ctx, cli.K8sClient, opts.DryRun); err != nil {
 			log.Printf("Warning: failed to cleanup temporary PDBs: %v", err)
 		}
@@ -198,49 +191,25 @@ func classify(ctx context.Context, clientset *kubernetes.Clientset, cli *clients
 	})
 }
 
-// evictResult is the structured outcome of evictAllTargets. Errors is the
-// aggregated per-target error list (empty when everything succeeded).
-// EKSDrainIncomplete is true when at least one EKS managed node group target
-// returned an error WRAPPING errEKSDrainIncomplete — the EKS drain may still
-// be in progress, in which case the caller must NOT cleanup the temporary
-// PDBs (EKS would then over-disrupt the still-running workloads).
-type evictResult struct {
-	Errors             []error
-	EKSDrainIncomplete bool
-}
-
 // targetEvictor is the closure injected into evictAllTargets by Run. Pulling
 // the dispatch out as an interface-like function makes the orchestrator
 // unit-testable without faking the entire clients.Clients struct.
 type targetEvictor func(ctx context.Context, t Target, drainOpts nodeDrainOptions) error
 
 // evictAllTargets processes targets sequentially, in the order BuildPlan
-// produced. Errors are accumulated; a failing target does not abort the
-// others — every issue surfaces at the end so a partial migration is fully
-// visible. Sequential execution keeps logs linear, bounds the eviction
+// produced. Errors are accumulated and returned; a failing target does not
+// abort the others — every issue surfaces at the end so a partial migration is
+// fully visible. Sequential execution keeps logs linear, bounds the eviction
 // pressure on the apiserver, and matches the synchronous per-target shape
-// (every evictor — including EKS MNG — already blocks until its drain
-// completes).
-func evictAllTargets(ctx context.Context, targets []Target, drainOpts nodeDrainOptions, evictor targetEvictor) evictResult {
-	var (
-		errs               []error
-		eksDrainIncomplete bool
-	)
+// (every evictor blocks until its drain completes).
+func evictAllTargets(ctx context.Context, targets []Target, drainOpts nodeDrainOptions, evictor targetEvictor) []error {
+	var errs []error
 	for _, t := range targets {
-		err := evictor(ctx, t, drainOpts)
-		if err == nil {
-			continue
-		}
-		errs = append(errs, fmt.Errorf("%s/%s: %w", t.Manager, t.Entity, err))
-		// Only treat the drain as "still in progress" when EKS accepted the
-		// scaling change but observation of the drain failed or timed out.
-		// A failed UpdateNodegroupConfig means EKS never started draining,
-		// so cleanup is safe.
-		if errors.Is(err, errEKSDrainIncomplete) {
-			eksDrainIncomplete = true
+		if err := evictor(ctx, t, drainOpts); err != nil {
+			errs = append(errs, fmt.Errorf("%s/%s: %w", t.Manager, t.Entity, err))
 		}
 	}
-	return evictResult{Errors: errs, EKSDrainIncomplete: eksDrainIncomplete}
+	return errs
 }
 
 // evictTarget dispatches a single Target to the manager-specific evictor.
@@ -251,7 +220,7 @@ func evictTarget(ctx context.Context, clientset kubernetes.Interface, cli *clien
 	case clusterinfo.NodeManagerASG:
 		return evictASG(ctx, clientset, cli.Autoscaling, t.Entity, t.Nodes, drainOpts)
 	case clusterinfo.NodeManagerEKSManagedNodeGroup:
-		return evictEKSManagedNodeGroup(ctx, cli.EKS, clientset, clusterName, t.Entity, drainOpts)
+		return evictEKSManagedNodeGroup(ctx, cli.EKS, clientset, clusterName, t.Entity, t.Nodes, drainOpts)
 	case clusterinfo.NodeManagerKarpenter:
 		return evictKarpenterUserNodePool(ctx, clientset, t.Entity, t.Nodes, drainOpts)
 	case clusterinfo.NodeManagerStandalone:

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/run_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/run_test.go
@@ -3,7 +3,6 @@ package evict
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,16 +14,13 @@ import (
 func TestEvictAllTargets(t *testing.T) {
 	asgTarget := Target{Manager: clusterinfo.NodeManagerASG, Entity: "asg-1"}
 	karpenterTarget := Target{Manager: clusterinfo.NodeManagerKarpenter, Entity: "np-1"}
-	eksTarget := Target{Manager: clusterinfo.NodeManagerEKSManagedNodeGroup, Entity: "mng-1"}
 	standaloneTarget := Target{Manager: clusterinfo.NodeManagerStandalone, Entity: ""}
 
 	for _, tc := range []struct {
-		name              string
-		targets           []Target
-		evictor           targetEvictor
-		wantErrors        int
-		wantEKSIncomplete bool
-		wantErrIsSentinel bool
+		name       string
+		targets    []Target
+		evictor    targetEvictor
+		wantErrors int
 		// expectInvoked, when non-nil, lists managers that MUST have had
 		// their evictor called (verifies that one failing target does not
 		// abort the others).
@@ -34,43 +30,6 @@ func TestEvictAllTargets(t *testing.T) {
 			name:    "happy path",
 			targets: []Target{asgTarget, karpenterTarget},
 			evictor: func(_ context.Context, _ Target, _ nodeDrainOptions) error { return nil },
-		},
-		{
-			// Safety-critical signal: an EKS MNG target returning
-			// errEKSDrainIncomplete (wrapped) must flag the result so Run
-			// skips the temp-PDB cleanup.
-			name:    "EKS sentinel propagates",
-			targets: []Target{eksTarget, asgTarget},
-			evictor: func(_ context.Context, t Target, _ nodeDrainOptions) error {
-				if t.Manager == clusterinfo.NodeManagerEKSManagedNodeGroup {
-					return fmt.Errorf("simulated timeout: %w", errEKSDrainIncomplete)
-				}
-				return nil
-			},
-			wantErrors:        1,
-			wantEKSIncomplete: true,
-			wantErrIsSentinel: true,
-		},
-		{
-			// An EKS failure that is NOT a wait timeout (e.g. an
-			// UpdateNodegroupConfig API rejection) means EKS never started
-			// draining, so temp-PDB cleanup is safe ⇒ flag stays false.
-			name:    "non-sentinel EKS error does not flag",
-			targets: []Target{eksTarget},
-			evictor: func(_ context.Context, _ Target, _ nodeDrainOptions) error {
-				return errors.New("invalid scaling config")
-			},
-			wantErrors: 1,
-		},
-		{
-			// An ASG drain failure has nothing to do with EKS — must NOT
-			// flag.
-			name:    "non-EKS error does not flag",
-			targets: []Target{asgTarget},
-			evictor: func(_ context.Context, _ Target, _ nodeDrainOptions) error {
-				return errors.New("ASG drain failed")
-			},
-			wantErrors: 1,
 		},
 		{
 			// One failing target must not abort the rest — the loop keeps
@@ -99,12 +58,8 @@ func TestEvictAllTargets(t *testing.T) {
 				}
 			}
 
-			result := evictAllTargets(t.Context(), tc.targets, nodeDrainOptions{}, evictor)
-			require.Len(t, result.Errors, tc.wantErrors)
-			assert.Equal(t, tc.wantEKSIncomplete, result.EKSDrainIncomplete)
-			if tc.wantErrIsSentinel {
-				assert.ErrorIs(t, result.Errors[0], errEKSDrainIncomplete)
-			}
+			errs := evictAllTargets(t.Context(), tc.targets, nodeDrainOptions{}, evictor)
+			require.Len(t, errs, tc.wantErrors)
 			for _, mgr := range tc.expectInvoked {
 				assert.NotZero(t, invoked[mgr], "expected %s evictor to be invoked", mgr)
 			}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone.go
@@ -2,9 +2,14 @@ package evict
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"k8s.io/client-go/kubernetes"
+
+	commonaws "github.com/DataDog/datadog-operator/cmd/kubectl-datadog/autoscaling/cluster/common/aws"
 )
 
 type EC2API interface {
@@ -12,5 +17,30 @@ type EC2API interface {
 }
 
 func evictStandalone(ctx context.Context, clientset kubernetes.Interface, ec2API EC2API, nodes []string, drainOpts nodeDrainOptions) error {
-	panic("TODO: evictStandalone — implemented in PR https://github.com/DataDog/datadog-operator/pull/3176")
+	cordoned, errs := cordonNodes(ctx, clientset, nodes, drainOpts.DryRun)
+	for _, node := range cordoned {
+		nodeName := node.Name
+		if err := drainNode(ctx, clientset, nodeName, drainOpts); err != nil {
+			errs = append(errs, fmt.Errorf("drain node %s: %w", nodeName, err))
+			continue // do NOT terminate this instance: workloads are still on it
+		}
+
+		id, hasInstanceID := commonaws.ExtractEC2InstanceID(node)
+		if !hasInstanceID {
+			log.Printf("Warning: node %s has unexpected providerID %q; cannot terminate the underlying instance", nodeName, node.Spec.ProviderID)
+			continue
+		}
+		if drainOpts.DryRun {
+			log.Printf("[dry-run] would terminate standalone instance %s", id)
+			continue
+		}
+		if _, err := ec2API.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+			InstanceIds: []string{id},
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("terminate instance %s: %w", id, err))
+		} else {
+			log.Printf("Terminated standalone EC2 instance %s.", id)
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone_test.go
@@ -1,0 +1,198 @@
+package evict
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+type stubEC2 struct {
+	terminated []string
+	err        error
+}
+
+func (s *stubEC2) TerminateInstances(_ context.Context, in *ec2.TerminateInstancesInput, _ ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
+	s.terminated = append(s.terminated, in.InstanceIds...)
+	return &ec2.TerminateInstancesOutput{}, s.err
+}
+
+func TestEvictStandalone(t *testing.T) {
+	ec2Node := func(name, az, id string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///" + az + "/" + id},
+		}
+	}
+	stuckPod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "blocker", Namespace: "default"},
+			Spec:       corev1.PodSpec{NodeName: "ip-stuck"},
+		}
+	}
+	gceNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "ip-1"},
+		Spec:       corev1.NodeSpec{ProviderID: "gce:///zone/instance"},
+	}
+	fastDrain := nodeDrainOptions{
+		EvictionTimeout: 50 * time.Millisecond,
+		NodeTimeout:     100 * time.Millisecond,
+		PollInterval:    10 * time.Millisecond,
+	}
+
+	for _, tc := range []struct {
+		name                   string
+		objects                []runtime.Object
+		installEvictionReactor bool
+		nodes                  []string
+		opts                   nodeDrainOptions
+		// stubErr, when set, makes every TerminateInstances call fail.
+		stubErr error
+		wantErr bool
+		// wantTerminated is the expected set of instance IDs in
+		// stubEC2.terminated. nil ⇒ TerminateInstances must not be called.
+		wantTerminated []string
+		// wantUnschedulable: per-node expected `Spec.Unschedulable`.
+		wantUnschedulable map[string]bool
+	}{
+		{
+			name:              "happy path terminates and cordons two nodes",
+			objects:           []runtime.Object{ec2Node("ip-1", "eu-west-3a", "i-aaa"), ec2Node("ip-2", "eu-west-3b", "i-bbb")},
+			nodes:             []string{"ip-1", "ip-2"},
+			opts:              newDrainOpts(false),
+			wantTerminated:    []string{"i-aaa", "i-bbb"},
+			wantUnschedulable: map[string]bool{"ip-1": true, "ip-2": true},
+		},
+		{
+			name:              "dry-run touches nothing",
+			objects:           []runtime.Object{ec2Node("ip-1", "eu-west-3a", "i-aaa")},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(true),
+			wantUnschedulable: map[string]bool{"ip-1": false},
+		},
+		{
+			// Node already gone from K8s ⇒ no instance ID extracted ⇒
+			// no TerminateInstances call.
+			name:  "node already gone skips terminate",
+			nodes: []string{"ip-1"},
+			opts:  newDrainOpts(false),
+		},
+		{
+			// Non-EC2 providerID can't yield an instance ID, but the
+			// node is still cordoned and drained.
+			name:              "non-EC2 providerID skips terminate but still cordons",
+			objects:           []runtime.Object{gceNode},
+			nodes:             []string{"ip-1"},
+			opts:              newDrainOpts(false),
+			wantUnschedulable: map[string]bool{"ip-1": true},
+		},
+		{
+			// Safety regression: drain failure must prevent the
+			// instance from being terminated (otherwise the EC2 dies
+			// mid-grace-period).
+			name:                   "drain failure prevents terminate",
+			objects:                []runtime.Object{ec2Node("ip-stuck", "eu-west-3a", "i-aaaaaaaaaaaaaaaaa"), stuckPod()},
+			installEvictionReactor: true,
+			nodes:                  []string{"ip-stuck"},
+			opts:                   fastDrain,
+			wantErr:                true,
+		},
+		{
+			// A TerminateInstances failure on one node must propagate as an
+			// error yet not stop the loop: every drained node's instance is
+			// still attempted.
+			name:           "terminate failure propagates but loop continues",
+			objects:        []runtime.Object{ec2Node("ip-1", "eu-west-3a", "i-aaa"), ec2Node("ip-2", "eu-west-3b", "i-bbb")},
+			nodes:          []string{"ip-1", "ip-2"},
+			opts:           newDrainOpts(false),
+			stubErr:        errors.New("terminate boom"),
+			wantErr:        true,
+			wantTerminated: []string{"i-aaa", "i-bbb"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(tc.objects...)
+			if tc.installEvictionReactor {
+				installPodEvictionReactor(client)
+			}
+			stub := &stubEC2{err: tc.stubErr}
+
+			err := evictStandalone(t.Context(), client, stub, tc.nodes, tc.opts)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tc.wantTerminated == nil {
+				assert.Empty(t, stub.terminated)
+			} else {
+				assert.ElementsMatch(t, tc.wantTerminated, stub.terminated)
+			}
+			for nodeName, want := range tc.wantUnschedulable {
+				got, getErr := client.CoreV1().Nodes().Get(t.Context(), nodeName, metav1.GetOptions{})
+				require.NoError(t, getErr)
+				assert.Equal(t, want, got.Spec.Unschedulable, "Spec.Unschedulable for %s", nodeName)
+			}
+		})
+	}
+}
+
+// TestEvictStandaloneCordonsAllBeforeDraining locks in the cordon-all-up-front
+// behavior: every node of the group is cordoned before ANY node starts
+// draining, so a pod evicted off one node is never rescheduled onto a sibling
+// node that is itself about to be drained. It asserts that at the moment ip-1's
+// pod is evicted, the sibling ip-2 has already been cordoned.
+func TestEvictStandaloneCordonsAllBeforeDraining(t *testing.T) {
+	ec2Node := func(name, az, id string) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       corev1.NodeSpec{ProviderID: "aws:///" + az + "/" + id},
+		}
+	}
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "ip-1"},
+	}
+	client := fake.NewClientset(ec2Node("ip-1", "eu-west-3a", "i-aaa"), ec2Node("ip-2", "eu-west-3b", "i-bbb"), pod1)
+
+	var (
+		recorded                     bool
+		node2CordonedAtFirstEviction bool
+	)
+	// On the first pod eviction (ip-1's drain), record whether ip-2 is already
+	// cordoned, then delete the evicted pod so the node becomes empty and the
+	// drain completes. Read/mutate via the tracker, not the typed client:
+	// Fake.Invokes holds a global lock for the whole reaction, so re-entering
+	// the typed client from inside a reactor would deadlock.
+	client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok || ca.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		if !recorded {
+			recorded = true
+			if obj, err := client.Tracker().Get(corev1.SchemeGroupVersion.WithResource("nodes"), "", "ip-2"); err == nil {
+				node2CordonedAtFirstEviction = obj.(*corev1.Node).Spec.Unschedulable
+			}
+		}
+		evic := ca.GetObject().(*policyv1.Eviction)
+		_ = client.Tracker().Delete(corev1.SchemeGroupVersion.WithResource("pods"), evic.Namespace, evic.Name)
+		return true, ca.GetObject(), nil
+	})
+
+	stub := &stubEC2{}
+	err := evictStandalone(t.Context(), client, stub, []string{"ip-1", "ip-2"}, newDrainOpts(false))
+	require.NoError(t, err)
+	assert.True(t, node2CordonedAtFirstEviction, "ip-2 must be cordoned before ip-1 starts draining")
+	assert.ElementsMatch(t, []string{"i-aaa", "i-bbb"}, stub.terminated)
+}


### PR DESCRIPTION
### What does this PR do?

Implements Karpenter user NodePool eviction: cordon and drain (Karpenter reclaims the emptied instances).

### Motivation

PR #3026 is too large to review as a single change. This is **part 10 of 11** of a stack that splits it into small, individually-reviewable pieces that each build and pass tests on their own. See #3026 for the full feature context and end-to-end QA.

### Additional Notes

**Stacked PR — the base branch is `lenaic/CASCL-1386-evict-09-standalone`, _not_ `main`**, so the diff shows only this step's change. Reuses the drain primitives introduced in part 8. The code is taken verbatim from #3026 (rebased onto `main`); there are no logic changes versus #3026.

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only.

### Describe your test plan

`go test ./cmd/kubectl-datadog/autoscaling/cluster/...` passes at this commit. Full end-to-end QA is tracked on #3026.

### Checklist

- [x] PR has at least one valid label
- [x] `qa/skip-qa` label applied (not independently shippable; QA tracked on #3026)
- [x] All commits are signed