### PR TITLE
fix podstartup

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1486,7 +1486,14 @@ func Test_Control_Plane_Monitoring(t *testing.T) {
 			name:            "Control Plane Monitoring for Openshift",
 			clusterProvider: "openshift-rhcos",
 			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
-				return createDatadogAgentWithClusterChecks(c, resourcesNamespace, resourcesName)
+				dda := createDatadogAgentWithClusterChecks(c, resourcesNamespace, resourcesName)
+				_ = c.Create(context.TODO(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "etcd-metric-client",
+						Namespace: resourcesNamespace,
+					},
+				})
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -50,7 +49,6 @@ type controlPlaneMonitoringFeature struct {
 	eksConfigMapName       string
 	client                 client.Reader
 
-	etcdSecretChecked bool
 	etcdSecretPresent bool
 }
 
@@ -157,10 +155,16 @@ func (f *controlPlaneMonitoringFeature) copyOpenShiftEtcdSecret(managers feature
 	}
 
 	f.logger.V(1).Info("Copied OpenShift etcd metric client secret", "sourceNamespace", sourceKey.Namespace, "targetNamespace", target.Namespace, "name", target.Name)
+	f.etcdSecretPresent = true
 	return true
 }
 
 func (f *controlPlaneMonitoringFeature) keepExistingOpenShiftEtcdSecret(managers feature.ResourceManagers) bool {
+	if f.client == nil {
+		f.logger.V(1).Info("Skipping existing OpenShift etcd metric client secret lookup: Kubernetes reader is not configured")
+		return false
+	}
+
 	target := &corev1.Secret{}
 	targetKey := types.NamespacedName{
 		Namespace: f.owner.GetNamespace(),
@@ -180,6 +184,7 @@ func (f *controlPlaneMonitoringFeature) keepExistingOpenShiftEtcdSecret(managers
 	}
 
 	f.logger.V(1).Info("Keeping existing OpenShift etcd metric client secret after source read failure", "namespace", target.Namespace, "name", target.Name)
+	f.etcdSecretPresent = true
 	return true
 }
 
@@ -310,33 +315,12 @@ func (f *controlPlaneMonitoringFeature) ManageSingleContainerNodeAgent(managers 
 	return nil
 }
 
-// etcdCertsSecretAvailable reports whether the OpenShift etcd metric client secret
-// exists in the owner namespace. The etcd-certs volume reference is non-optional,
-// so mounting it when secret doesn't exist leads to pod getting stuck in ContainerCreating.
-// ManageNodeAgent/ManageClusterChecksRunner gate mounting the volume until
-// the secret is available allows the pod to start.
+// etcdCertsSecretAvailable reports whether ManageDependencies successfully added
+// the OpenShift etcd metric client secret to the dependency store for the owner
+// namespace. The etcd-certs volume reference is non-optional, so mounting it
+// when the secret will not be managed would wedge the pod in ContainerCreating.
 func (f *controlPlaneMonitoringFeature) etcdCertsSecretAvailable() bool {
-	if f.etcdSecretChecked {
-		return f.etcdSecretPresent
-	}
-	f.etcdSecretChecked = true
-
-	if f.client == nil {
-		return false
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	key := types.NamespacedName{Namespace: f.owner.GetNamespace(), Name: etcdCertsSecretName}
-	if err := f.client.Get(ctx, key, &corev1.Secret{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			f.logger.V(1).Info("Unable to verify OpenShift etcd metric client secret; skipping etcd cert mount", "namespace", key.Namespace, "name", key.Name, "error", err)
-		}
-		return false
-	}
-
-	f.etcdSecretPresent = true
-	return true
+	return f.etcdSecretPresent
 }
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -48,6 +49,9 @@ type controlPlaneMonitoringFeature struct {
 	openshiftConfigMapName string
 	eksConfigMapName       string
 	client                 client.Reader
+
+	etcdSecretChecked bool
+	etcdSecretPresent bool
 }
 
 // ID returns the ID of the Feature
@@ -306,30 +310,63 @@ func (f *controlPlaneMonitoringFeature) ManageSingleContainerNodeAgent(managers 
 	return nil
 }
 
+// etcdCertsSecretAvailable reports whether the OpenShift etcd metric client secret
+// exists in the owner namespace. The etcd-certs volume reference is non-optional,
+// so mounting it when secret doesn't exist leads to pod getting stuck in ContainerCreating.
+// ManageNodeAgent/ManageClusterChecksRunner gate mounting the volume until
+// the secret is available allows the pod to start.
+func (f *controlPlaneMonitoringFeature) etcdCertsSecretAvailable() bool {
+	if f.etcdSecretChecked {
+		return f.etcdSecretPresent
+	}
+	f.etcdSecretChecked = true
+
+	if f.client == nil {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	key := types.NamespacedName{Namespace: f.owner.GetNamespace(), Name: etcdCertsSecretName}
+	if err := f.client.Get(ctx, key, &corev1.Secret{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			f.logger.V(1).Info("Unable to verify OpenShift etcd metric client secret; skipping etcd cert mount", "namespace", key.Namespace, "name", key.Name, "error", err)
+		}
+		return false
+	}
+
+	f.etcdSecretPresent = true
+	return true
+}
+
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *controlPlaneMonitoringFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
 	providerLabel, _ := kubernetes.GetProviderLabelKeyValue(f.provider)
 	if providerLabel == kubernetes.OpenShiftProviderLabel {
-		// Add etcd-certs volume (secret)
-		etcdCertsVolume := &corev1.Volume{
-			Name: etcdCertsVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName:  etcdCertsSecretName,
-					DefaultMode: ptr.To[int32](420),
+		// Only mount the etcd-certs secret when it is present; the volume is
+		// non-optional and would otherwise wedge the pod in ContainerCreating.
+		if f.etcdCertsSecretAvailable() {
+			// Add etcd-certs volume (secret)
+			etcdCertsVolume := &corev1.Volume{
+				Name: etcdCertsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  etcdCertsSecretName,
+						DefaultMode: ptr.To[int32](420),
+					},
 				},
-			},
-		}
-		managers.Volume().AddVolume(etcdCertsVolume)
+			}
+			managers.Volume().AddVolume(etcdCertsVolume)
 
-		// Add etcd-certs volume mount
-		etcdCertsVolumeMount := corev1.VolumeMount{
-			Name:      etcdCertsVolumeName,
-			MountPath: etcdCertsVolumeMountPath,
-			ReadOnly:  true,
+			// Add etcd-certs volume mount
+			etcdCertsVolumeMount := corev1.VolumeMount{
+				Name:      etcdCertsVolumeName,
+				MountPath: etcdCertsVolumeMountPath,
+				ReadOnly:  true,
+			}
+			managers.VolumeMount().AddVolumeMountToContainer(&etcdCertsVolumeMount, apicommon.CoreAgentContainerName)
 		}
-		managers.VolumeMount().AddVolumeMountToContainer(&etcdCertsVolumeMount, apicommon.CoreAgentContainerName)
 
 		// Add disable-etcd-autoconf volume (emptyDir)
 		disableEtcdAutoconfVolume := &corev1.Volume{
@@ -355,24 +392,28 @@ func (f *controlPlaneMonitoringFeature) ManageNodeAgent(managers feature.PodTemp
 func (f *controlPlaneMonitoringFeature) ManageClusterChecksRunner(managers feature.PodTemplateManagers) error {
 	providerLabel, _ := kubernetes.GetProviderLabelKeyValue(f.provider)
 	if providerLabel == kubernetes.OpenShiftProviderLabel {
-		// Add etcd-certs volume (secret)
-		etcdCertsVolume := &corev1.Volume{
-			Name: etcdCertsVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: etcdCertsSecretName,
+		// Only mount the etcd-certs secret when it is present; the volume is
+		// non-optional and would otherwise wedge the pod in ContainerCreating.
+		if f.etcdCertsSecretAvailable() {
+			// Add etcd-certs volume (secret)
+			etcdCertsVolume := &corev1.Volume{
+				Name: etcdCertsVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: etcdCertsSecretName,
+					},
 				},
-			},
-		}
-		managers.Volume().AddVolume(etcdCertsVolume)
+			}
+			managers.Volume().AddVolume(etcdCertsVolume)
 
-		// Add etcd-certs volume mount
-		etcdCertsVolumeMount := corev1.VolumeMount{
-			Name:      etcdCertsVolumeName,
-			MountPath: etcdCertsVolumeMountPath,
-			ReadOnly:  true,
+			// Add etcd-certs volume mount
+			etcdCertsVolumeMount := corev1.VolumeMount{
+				Name:      etcdCertsVolumeName,
+				MountPath: etcdCertsVolumeMountPath,
+				ReadOnly:  true,
+			}
+			managers.VolumeMount().AddVolumeMountToContainer(&etcdCertsVolumeMount, apicommon.ClusterChecksRunnersContainerName)
 		}
-		managers.VolumeMount().AddVolumeMountToContainer(&etcdCertsVolumeMount, apicommon.ClusterChecksRunnersContainerName)
 
 		// Add disable-etcd-autoconf volume (emptyDir)
 		disableEtcdAutoconfVolume := &corev1.Volume{

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
@@ -90,10 +90,65 @@ func Test_controlPlaneMonitoringFeature_Configure(t *testing.T) {
 			},
 			WantConfigure:        true,
 			WantDependenciesFunc: openShiftControlPlaneWantExistingSecretDepsFunc(),
+			// Secret is present in the owner namespace, so the etcd-certs volume is mounted.
+			Agent:               etcdCertsMountWantFunc(apicommon.CoreAgentContainerName, true),
+			ClusterChecksRunner: etcdCertsMountWantFunc(apicommon.ClusterChecksRunnersContainerName, true),
+		},
+		{
+			Name: "Control Plane Monitoring enabled with OpenShift provider skips etcd-certs mount when secret is absent",
+			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+				WithAnnotations(map[string]string{kubernetes.ProviderAnnotationKey: "openshift-rhcos"}).
+				WithControlPlaneMonitoring(true).
+				Build(),
+			FeatureOptions: &feature.Options{
+				Client: fakeClientWithSecrets(t),
+			},
+			WantConfigure: true,
+			// Neither source nor target secret exists, so the non-optional etcd-certs
+			// volume must be skipped to avoid wedging the pod in ContainerCreating.
+			Agent:               etcdCertsMountWantFunc(apicommon.CoreAgentContainerName, false),
+			ClusterChecksRunner: etcdCertsMountWantFunc(apicommon.ClusterChecksRunnersContainerName, false),
 		},
 	}
 
 	tests.Run(t, buildControlPlaneMonitoringFeature)
+}
+
+// etcdCertsMountWantFunc asserts whether the OpenShift etcd-certs secret volume and
+// its mount on containerName are present, while verifying the disable-etcd-autoconf
+// emptyDir volume is always added for OpenShift regardless of the secret.
+func etcdCertsMountWantFunc(containerName apicommon.AgentContainerName, mounted bool) *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+			vols := mgr.VolumeMgr.Volumes
+			mounts := mgr.VolumeMountMgr.VolumeMountsByC[containerName]
+
+			assert.Equal(t, mounted, hasVolumeNamed(vols, etcdCertsVolumeName),
+				"etcd-certs volume presence mismatch (want mounted=%v)", mounted)
+			assert.Equal(t, mounted, hasVolumeMountNamed(mounts, etcdCertsVolumeName),
+				"etcd-certs volume mount presence mismatch (want mounted=%v)", mounted)
+			assert.True(t, hasVolumeNamed(vols, disableEtcdAutoconfVolumeName),
+				"disable-etcd-autoconf volume should always be present for OpenShift")
+		})
+}
+
+func hasVolumeNamed(vols []*corev1.Volume, name string) bool {
+	for _, v := range vols {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVolumeMountNamed(mounts []*corev1.VolumeMount, name string) bool {
+	for _, m := range mounts {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func fakeClientWithSecrets(t testing.TB, secrets ...*corev1.Secret) client.Client {

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
@@ -68,6 +68,8 @@ func Test_controlPlaneMonitoringFeature_Configure(t *testing.T) {
 			},
 			WantConfigure:        true,
 			WantDependenciesFunc: openShiftControlPlaneWantDepsFunc(),
+			Agent:                etcdCertsMountWantFunc(apicommon.CoreAgentContainerName, true),
+			ClusterChecksRunner:  etcdCertsMountWantFunc(apicommon.ClusterChecksRunnersContainerName, true),
 		},
 		{
 			Name: "Control Plane Monitoring enabled with OpenShift provider keeps existing target secret when source read fails",


### PR DESCRIPTION
### What does this PR do?

If Operator can't read the etcd secret agent pod gets stuck in `ContainerCreating`. To avoid we check if secret exists before mounting. Unmounted secret leads to check failure but everything else work fine.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

To reproduce the failure
```
k scale deploy etcd-operator -n openshift-etcd-operator --replicas 0
k delete secret etcd-metric-client -n openshift-etcd-operator
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits