### PR TITLE
Do not use direct apireader client and instead make f.etcdSecretPresent as part of existing calls

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1486,7 +1486,14 @@ func Test_Control_Plane_Monitoring(t *testing.T) {
 			name:            "Control Plane Monitoring for Openshift",
 			clusterProvider: "openshift-rhcos",
 			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
-				return createDatadogAgentWithClusterChecks(c, resourcesNamespace, resourcesName)
+				dda := createDatadogAgentWithClusterChecks(c, resourcesNamespace, resourcesName)
+				_ = c.Create(context.TODO(), &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "etcd-metric-client",
+						Namespace: resourcesNamespace,
+					},
+				})
+				return dda
 			},
 			want:    reconcile.Result{RequeueAfter: defaultRequeueDuration},
 			wantErr: false,

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -50,7 +49,6 @@ type controlPlaneMonitoringFeature struct {
 	eksConfigMapName       string
 	client                 client.Reader
 
-	etcdSecretChecked bool
 	etcdSecretPresent bool
 }
 
@@ -157,10 +155,16 @@ func (f *controlPlaneMonitoringFeature) copyOpenShiftEtcdSecret(managers feature
 	}
 
 	f.logger.V(1).Info("Copied OpenShift etcd metric client secret", "sourceNamespace", sourceKey.Namespace, "targetNamespace", target.Namespace, "name", target.Name)
+	f.etcdSecretPresent = true
 	return true
 }
 
 func (f *controlPlaneMonitoringFeature) keepExistingOpenShiftEtcdSecret(managers feature.ResourceManagers) bool {
+	if f.client == nil {
+		f.logger.V(1).Info("Skipping existing OpenShift etcd metric client secret lookup: Kubernetes reader is not configured")
+		return false
+	}
+
 	target := &corev1.Secret{}
 	targetKey := types.NamespacedName{
 		Namespace: f.owner.GetNamespace(),
@@ -180,6 +184,7 @@ func (f *controlPlaneMonitoringFeature) keepExistingOpenShiftEtcdSecret(managers
 	}
 
 	f.logger.V(1).Info("Keeping existing OpenShift etcd metric client secret after source read failure", "namespace", target.Namespace, "name", target.Name)
+	f.etcdSecretPresent = true
 	return true
 }
 
@@ -310,33 +315,12 @@ func (f *controlPlaneMonitoringFeature) ManageSingleContainerNodeAgent(managers 
 	return nil
 }
 
-// etcdCertsSecretAvailable reports whether the OpenShift etcd metric client secret
-// exists in the owner namespace. The etcd-certs volume reference is non-optional,
-// so mounting it when secret doesn't exist leads to pod getting stuck in ContainerCreating.
-// ManageNodeAgent/ManageClusterChecksRunner gate mounting the volume until
-// the secret is available allows the pod to start.
+// etcdCertsSecretAvailable reports whether ManageDependencies successfully added
+// the OpenShift etcd metric client secret to the dependency store for the owner
+// namespace. The etcd-certs volume reference is non-optional, so mounting it
+// when the secret will not be managed would wedge the pod in ContainerCreating.
 func (f *controlPlaneMonitoringFeature) etcdCertsSecretAvailable() bool {
-	if f.etcdSecretChecked {
-		return f.etcdSecretPresent
-	}
-	f.etcdSecretChecked = true
-
-	if f.client == nil {
-		return false
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	key := types.NamespacedName{Namespace: f.owner.GetNamespace(), Name: etcdCertsSecretName}
-	if err := f.client.Get(ctx, key, &corev1.Secret{}); err != nil {
-		if !apierrors.IsNotFound(err) {
-			f.logger.V(1).Info("Unable to verify OpenShift etcd metric client secret; skipping etcd cert mount", "namespace", key.Namespace, "name", key.Name, "error", err)
-		}
-		return false
-	}
-
-	f.etcdSecretPresent = true
-	return true
+	return f.etcdSecretPresent
 }
 
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature_test.go
@@ -68,6 +68,8 @@ func Test_controlPlaneMonitoringFeature_Configure(t *testing.T) {
 			},
 			WantConfigure:        true,
 			WantDependenciesFunc: openShiftControlPlaneWantDepsFunc(),
+			Agent:                etcdCertsMountWantFunc(apicommon.CoreAgentContainerName, true),
+			ClusterChecksRunner:  etcdCertsMountWantFunc(apicommon.ClusterChecksRunnersContainerName, true),
 		},
 		{
 			Name: "Control Plane Monitoring enabled with OpenShift provider keeps existing target secret when source read fails",


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

Review of #3179 

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits