### PR TITLE
Add env var overrides for controller enable flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	goruntime "runtime"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -209,8 +210,84 @@ func (opts *options) Parse() {
 	flag.IntVar(&opts.edsCanaryAutoFailMaxRestarts, "edsCanaryAutoFailMaxRestarts", defaultCanaryAutoFailMaxRestarts, "ExtendedDaemonset canary auto fail max restart count")
 	flag.DurationVar(&opts.edsCanaryAutoPauseMaxSlowStartDuration, "edsCanaryAutoPauseMaxSlowStartDuration", defaultCanaryAutoPauseMaxSlowStartDuration*time.Minute, "ExtendedDaemonset canary max slow start duration")
 
+	// Environment variable overrides applied before flag.Parse() so that
+	// explicit CLI flags take precedence (default < env < CLI).
+	applyEnvOptions([]envOption{
+		stringEnv(&opts.metricsAddr, "DD_METRICS_ADDR"),
+		boolEnv(&opts.secureMetrics, "DD_METRICS_SECURE"),
+		boolEnv(&opts.profilingEnabled, "DD_PROFILING_ENABLED"),
+		boolEnv(&opts.pprofActive, "DD_PPROF_ENABLED"),
+		boolEnv(&opts.enableLeaderElection, "DD_LEADER_ELECTION_ENABLED"),
+		durationEnv(&opts.leaderElectionLeaseDuration, "DD_LEADER_ELECTION_LEASE_DURATION"),
+		boolEnv(&opts.supportCilium, "DD_SUPPORT_CILIUM"),
+		boolEnv(&opts.datadogAgentEnabled, "DD_AGENT_CONTROLLER_ENABLED"),
+		boolEnv(&opts.datadogMonitorEnabled, "DD_MONITOR_CONTROLLER_ENABLED"),
+		boolEnv(&opts.datadogSLOEnabled, "DD_SLO_CONTROLLER_ENABLED"),
+		boolEnv(&opts.operatorMetricsEnabled, "DD_OPERATOR_METRICS_ENABLED"),
+		intEnv(&opts.maximumGoroutines, "DD_MAXIMUM_GOROUTINES"),
+		boolEnv(&opts.introspectionEnabled, "DD_INTROSPECTION_ENABLED"),
+		boolEnv(&opts.datadogAgentProfileEnabled, "DD_AGENT_PROFILE_CONTROLLER_ENABLED"),
+		boolEnv(&opts.remoteConfigEnabled, "DD_REMOTE_CONFIG_ENABLED"),
+		boolEnv(&opts.remoteUpdatesEnabled, "DD_REMOTE_UPDATES_ENABLED"),
+		boolEnv(&opts.datadogDashboardEnabled, "DD_DASHBOARD_CONTROLLER_ENABLED"),
+		boolEnv(&opts.datadogGenericResourceEnabled, "DD_GENERIC_RESOURCE_CONTROLLER_ENABLED"),
+		boolEnv(&opts.datadogCSIDriverEnabled, "DD_CSI_DRIVER_CONTROLLER_ENABLED"),
+		boolEnv(&opts.untaintControllerEnabled, "DD_UNTAINT_CONTROLLER_ENABLED"),
+		boolEnv(&opts.untaintControllerWaitForCSIDriver, "DD_UNTAINT_CONTROLLER_WAIT_FOR_CSI_DRIVER"),
+		boolEnv(&opts.createControllerRevisions, "DD_CREATE_CONTROLLER_REVISIONS"),
+	})
+
 	// Parsing flags
 	flag.Parse()
+}
+
+type envOption struct {
+	name  string
+	apply func(string) error
+}
+
+func applyEnvOptions(options []envOption) {
+	for _, opt := range options {
+		val, found := os.LookupEnv(opt.name)
+		if !found {
+			continue
+		}
+		if err := opt.apply(val); err != nil {
+			fmt.Fprintf(os.Stderr, "ignoring invalid env var %s=%q: %v\n", opt.name, val, err)
+		}
+	}
+}
+
+func envOptionFor[T any](dst *T, envVar string, parse func(string) (T, error)) envOption {
+	return envOption{
+		name: envVar,
+		apply: func(val string) error {
+			parsed, err := parse(val)
+			if err != nil {
+				return err
+			}
+			*dst = parsed
+			return nil
+		},
+	}
+}
+
+func boolEnv(dst *bool, envVar string) envOption {
+	return envOptionFor(dst, envVar, strconv.ParseBool)
+}
+
+func stringEnv(dst *string, envVar string) envOption {
+	return envOptionFor(dst, envVar, func(val string) (string, error) {
+		return val, nil
+	})
+}
+
+func intEnv(dst *int, envVar string) envOption {
+	return envOptionFor(dst, envVar, strconv.Atoi)
+}
+
+func durationEnv(dst *time.Duration, envVar string) envOption {
+	return envOptionFor(dst, envVar, time.ParseDuration)
 }
 
 func main() {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,9 +6,13 @@
 package main
 
 import (
+	"flag"
+	"io"
 	"net/http"
+	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/require"
@@ -16,6 +20,92 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestOptionsParse_EnvOverridesDefaults(t *testing.T) {
+	resetCommandLine(t)
+	t.Setenv("DD_METRICS_ADDR", ":9090")
+	t.Setenv("DD_METRICS_SECURE", "true")
+	t.Setenv("DD_PROFILING_ENABLED", "true")
+	t.Setenv("DD_PPROF_ENABLED", "true")
+	t.Setenv("DD_LEADER_ELECTION_ENABLED", "false")
+	t.Setenv("DD_LEADER_ELECTION_LEASE_DURATION", "90s")
+	t.Setenv("DD_SUPPORT_CILIUM", "true")
+	t.Setenv("DD_MONITOR_CONTROLLER_ENABLED", "true")
+	t.Setenv("DD_MAXIMUM_GOROUTINES", "123")
+	t.Setenv("DD_UNTAINT_CONTROLLER_WAIT_FOR_CSI_DRIVER", "true")
+	t.Setenv("DD_CREATE_CONTROLLER_REVISIONS", "true")
+
+	var opts options
+	opts.Parse()
+
+	require.Equal(t, ":9090", opts.metricsAddr)
+	require.True(t, opts.secureMetrics)
+	require.True(t, opts.profilingEnabled)
+	require.True(t, opts.pprofActive)
+	require.False(t, opts.enableLeaderElection)
+	require.Equal(t, 90*time.Second, opts.leaderElectionLeaseDuration)
+	require.True(t, opts.supportCilium)
+	require.True(t, opts.datadogMonitorEnabled)
+	require.Equal(t, 123, opts.maximumGoroutines)
+	require.True(t, opts.untaintControllerWaitForCSIDriver)
+	require.True(t, opts.createControllerRevisions)
+}
+
+func TestOptionsParse_CLIOverridesEnv(t *testing.T) {
+	resetCommandLine(t,
+		"-metrics-addr=:7070",
+		"-metrics-secure=false",
+		"-datadogMonitorEnabled=false",
+		"-maximumGoroutines=456",
+		"-leader-election-lease-duration=2m",
+		"-untaintControllerWaitForCSIDriver=false",
+	)
+	t.Setenv("DD_METRICS_ADDR", ":9090")
+	t.Setenv("DD_METRICS_SECURE", "true")
+	t.Setenv("DD_MONITOR_CONTROLLER_ENABLED", "true")
+	t.Setenv("DD_MAXIMUM_GOROUTINES", "123")
+	t.Setenv("DD_LEADER_ELECTION_LEASE_DURATION", "90s")
+	t.Setenv("DD_UNTAINT_CONTROLLER_WAIT_FOR_CSI_DRIVER", "true")
+
+	var opts options
+	opts.Parse()
+
+	require.Equal(t, ":7070", opts.metricsAddr)
+	require.False(t, opts.secureMetrics)
+	require.False(t, opts.datadogMonitorEnabled)
+	require.Equal(t, 456, opts.maximumGoroutines)
+	require.Equal(t, 2*time.Minute, opts.leaderElectionLeaseDuration)
+	require.False(t, opts.untaintControllerWaitForCSIDriver)
+}
+
+func TestOptionsParse_InvalidEnvLeavesDefault(t *testing.T) {
+	resetCommandLine(t)
+	t.Setenv("DD_MAXIMUM_GOROUTINES", "not-an-int")
+	t.Setenv("DD_LEADER_ELECTION_LEASE_DURATION", "not-a-duration")
+	t.Setenv("DD_MONITOR_CONTROLLER_ENABLED", "not-a-boolean-meaning-string")
+
+	var opts options
+	opts.Parse()
+
+	require.Equal(t, defaultMaximumGoroutines, opts.maximumGoroutines)
+	require.Equal(t, 60*time.Second, opts.leaderElectionLeaseDuration)
+	require.False(t, opts.datadogMonitorEnabled)
+}
+
+func resetCommandLine(t *testing.T, args ...string) {
+	t.Helper()
+
+	previousCommandLine := flag.CommandLine
+	previousArgs := os.Args
+	flag.CommandLine = flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	os.Args = append([]string{t.Name()}, args...)
+
+	t.Cleanup(func() {
+		flag.CommandLine = previousCommandLine
+		os.Args = previousArgs
+	})
+}
 
 func TestGoroutinesNumberHealthzCheck_LogsOnceOnFailureAndRecovery(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)

--- a/docs/control_plane_monitoring.md
+++ b/docs/control_plane_monitoring.md
@@ -40,7 +40,22 @@ Using the command line:
 helm install datadog-operator datadog/datadog-operator --set introspection.enabled=true
 ```
 
-Or, for **OpenShift users** who installed the operator via OperatorHub/Marketplace (the [recommended method](install-openshift.md)), by patching the operator cluster service version:
+Or, for **OpenShift users** who installed the operator using OperatorHub/Marketplace (the [recommended method](install-openshift.md), because it survives operator upgrades), set the environment variable in the `Subscription`:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: datadog-operator
+spec:
+  # ... channel, source, etc.
+  config:
+    env:
+      - name: DD_INTROSPECTION_ENABLED
+        value: "true"
+```
+
+Alternatively, you can patch the CSV directly, which does not persist after operator upgrades:
 
 ```bash
 oc patch csv <datadog-operator.VERSION> -n <datadog-operator-namespace> \

--- a/docs/datadog_agent_profiles.md
+++ b/docs/datadog_agent_profiles.md
@@ -64,6 +64,15 @@ DAP is disabled by default. To enable DAP using the [datadog-operator helm chart
 * `datadogAgentProfile.enabled=true`: this instructs the Operator deployment to start the `DatadogAgentProfile` controller.
 * `datadogCRDs.crds.datadogAgentProfiles=true`: this installs the `DatadogAgentProfile` CRD.
 
+For **OLM deployments** where container args cannot be set, enable the controller
+via environment variable in the `Subscription`:
+```yaml
+config:
+  env:
+    - name: DD_AGENT_PROFILE_CONTROLLER_ENABLED
+      value: "true"
+```
+
 > [!CAUTION]
 > Enabling DAP will increase the resource usage of the Operator. Please ensure the operator pod has enough resources allocated to it prior to enabling DAP.
 

--- a/docs/datadog_dashboard.md
+++ b/docs/datadog_dashboard.md
@@ -22,6 +22,14 @@ To deploy a `DatadogDashboard` with the Datadog Operator, use the [`datadog-oper
     helm repo add datadog https://helm.datadoghq.com
     ```
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_DASHBOARD_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 1. Choose one of the following options:
 
     * Run the install command, substituting your [Datadog API and application keys][6]:

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -16,6 +16,14 @@ This page describes the simplest and fastest way to deploy a [Datadog monitor](h
 
 To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operator` Helm chart][3].
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_MONITOR_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 1. Install the [Datadog Operator][4]:
 
    First, add the Datadog Helm chart with

--- a/docs/datadog_slo.md
+++ b/docs/datadog_slo.md
@@ -23,6 +23,14 @@ To deploy a `DatadogSLO` with the Datadog Operator, use the [`datadog-operator` 
     helm repo add datadog https://helm.datadoghq.com
     ```
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_SLO_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 1. Choose one of the following options:
 
     * Run the install command, substituting your [Datadog API and application keys][6]:

--- a/docs/datadoggenericresource/datadog_generic_resource.md
+++ b/docs/datadoggenericresource/datadog_generic_resource.md
@@ -70,6 +70,14 @@ To deploy a `DatadogGenericResource` with the Datadog Operator, follow the steps
     helm repo add datadog https://helm.datadoghq.com
     ```
 
+    For **OLM deployments**, enable the controller via environment variable in the `Subscription`:
+    ```yaml
+    config:
+      env:
+        - name: DD_GENERIC_RESOURCE_CONTROLLER_ENABLED
+          value: "true"
+    ```
+
 2. The DDGR controller and its CRD are both disabled by default. The controller also requires an API and an application key. Choose one of the following options:
     * Override the default values by providing your [API and application keys][2], installing the CRD, and enabling the controller:
       ```shell

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -183,17 +183,16 @@ Other operator startup options can also be configured via environment variable:
 | Metrics address            | `--metrics-addr`                     | `DD_METRICS_ADDR`                     | `:8080` |
 | Secure metrics             | `--metrics-secure`                   | `DD_METRICS_SECURE`                   | `false` |
 | Profiling                  | `--profiling-enabled`                | `DD_PROFILING_ENABLED`                | `false` |
-| Pprof                      | `--pprof`                            | `DD_PPROF_ENABLED`                    | `false` |
-| Leader election            | `--enable-leader-election`           | `DD_LEADER_ELECTION_ENABLED`          | `true`  |
 | Leader election lease      | `--leader-election-lease-duration`   | `DD_LEADER_ELECTION_LEASE_DURATION`   | `60s`   |
 | Cilium network policies    | `--supportCilium`                    | `DD_SUPPORT_CILIUM`                   | `false` |
 | Maximum goroutines         | `--maximumGoroutines`                | `DD_MAXIMUM_GOROUTINES`               | `400`   |
 | Controller revisions       | `--createControllerRevisions`        | `DD_CREATE_CONTROLLER_REVISIONS`      | `false` |
 
 ExtendedDaemonset options (`--supportExtendedDaemonset` and `--eds*`),
+the leader election toggle (`--enable-leader-election`), pprof (`--pprof`),
 log options (`--loglevel`, `--logEncoder`), secret backend options
 (`--secretBackend*`, `--secretRefreshInterval`), and `--version` are only
-configurable using CLI flags.
+configurable using CLI flags in the shipped manifests.
 
 Boolean values follow Go's [`strconv.ParseBool`](https://pkg.go.dev/strconv#ParseBool):
 `true`, `True`, `TRUE`, `1` or `false`, `False`, `FALSE`, `0`. The strings

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,6 +154,74 @@ spec:
    ```
 
 
+### Enable optional controllers with OLM
+
+Each optional controller can be toggled via a CLI flag (highest precedence) or
+an environment variable (middle precedence). If neither is set, the compiled
+default applies.
+
+| Controller              | CLI flag                          | Env var                                  | Default |
+|-------------------------|-----------------------------------|------------------------------------------|---------|
+| DatadogAgent            | `--datadogAgentEnabled`           | `DD_AGENT_CONTROLLER_ENABLED`            | `true`  |
+| DatadogMonitor          | `--datadogMonitorEnabled`         | `DD_MONITOR_CONTROLLER_ENABLED`          | `false` |
+| DatadogSLO              | `--datadogSLOEnabled`             | `DD_SLO_CONTROLLER_ENABLED`              | `false` |
+| DatadogDashboard        | `--datadogDashboardEnabled`       | `DD_DASHBOARD_CONTROLLER_ENABLED`        | `false` |
+| DatadogGenericResource  | `--datadogGenericResourceEnabled` | `DD_GENERIC_RESOURCE_CONTROLLER_ENABLED` | `false` |
+| DatadogCSIDriver        | `--datadogCSIDriverEnabled`       | `DD_CSI_DRIVER_CONTROLLER_ENABLED`       | `false` |
+| DatadogAgentProfile     | `--datadogAgentProfileEnabled`    | `DD_AGENT_PROFILE_CONTROLLER_ENABLED`    | `false` |
+| Introspection           | `--introspectionEnabled`          | `DD_INTROSPECTION_ENABLED`               | `false` |
+| RemoteConfig            | `--remoteConfigEnabled`           | `DD_REMOTE_CONFIG_ENABLED`               | `false` |
+| RemoteUpdates           | `--remoteUpdatesEnabled`          | `DD_REMOTE_UPDATES_ENABLED`              | `false` |
+| OperatorMetrics         | `--operatorMetricsEnabled`        | `DD_OPERATOR_METRICS_ENABLED`            | `true`  |
+| UntaintController       | `--untaintControllerEnabled`      | `DD_UNTAINT_CONTROLLER_ENABLED`          | `false` |
+| UntaintWaitForCSIDriver | `--untaintControllerWaitForCSIDriver` | `DD_UNTAINT_CONTROLLER_WAIT_FOR_CSI_DRIVER` | `false` |
+
+Other operator startup options can also be configured via environment variable:
+
+| Option                     | CLI flag                             | Env var                               | Default |
+|----------------------------|--------------------------------------|---------------------------------------|---------|
+| Metrics address            | `--metrics-addr`                     | `DD_METRICS_ADDR`                     | `:8080` |
+| Secure metrics             | `--metrics-secure`                   | `DD_METRICS_SECURE`                   | `false` |
+| Profiling                  | `--profiling-enabled`                | `DD_PROFILING_ENABLED`                | `false` |
+| Pprof                      | `--pprof`                            | `DD_PPROF_ENABLED`                    | `false` |
+| Leader election            | `--enable-leader-election`           | `DD_LEADER_ELECTION_ENABLED`          | `true`  |
+| Leader election lease      | `--leader-election-lease-duration`   | `DD_LEADER_ELECTION_LEASE_DURATION`   | `60s`   |
+| Cilium network policies    | `--supportCilium`                    | `DD_SUPPORT_CILIUM`                   | `false` |
+| Maximum goroutines         | `--maximumGoroutines`                | `DD_MAXIMUM_GOROUTINES`               | `400`   |
+| Controller revisions       | `--createControllerRevisions`        | `DD_CREATE_CONTROLLER_REVISIONS`      | `false` |
+
+ExtendedDaemonset options (`--supportExtendedDaemonset` and `--eds*`),
+log options (`--loglevel`, `--logEncoder`), secret backend options
+(`--secretBackend*`, `--secretRefreshInterval`), and `--version` are only
+configurable using CLI flags.
+
+Boolean values follow Go's [`strconv.ParseBool`](https://pkg.go.dev/strconv#ParseBool):
+`true`, `True`, `TRUE`, `1` or `false`, `False`, `FALSE`, `0`. The strings
+`yes` and `no` are **not** accepted and are logged as errors, leaving the
+default in effect.
+
+Duration values follow Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration);
+for example, `30s`, `5m`, or `1h`. Integer values use base 10.
+
+For example, to enable the DatadogMonitor controller in an OLM deployment:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-datadog-operator
+  namespace: operators
+spec:
+  channel: stable
+  name: datadog-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  config:
+    env:
+      - name: DD_MONITOR_CONTROLLER_ENABLED
+        value: "true"
+```
+
 ## Deploy the DatadogAgent custom resource managed by the Operator
 
 After deploying the Datadog Operator, create the `DatadogAgent` resource that triggers the deployment of the Datadog Agent, Cluster Agent, and Cluster Checks Runners (if used) in your Kubernetes cluster. The Datadog Agent is deployed as a DaemonSet, running a pod on every node of your cluster.

--- a/docs/introspection.md
+++ b/docs/introspection.md
@@ -28,6 +28,15 @@ datadog-agent-gke-cos   2         2         2       2            2           <no
 
 Introspection is disabled by default. To enable introspection using the [datadog-operator helm chart](https://github.com/DataDog/helm-charts/tree/main/charts/datadog-operator), set `introspection.enabled=true` in your `values.yaml` file or as a flag in the command line arguments `--set introspection.enabled=true`.
 
+For **OLM deployments** where container args cannot be set, enable introspection
+via environment variable in the `Subscription`:
+```yaml
+config:
+  env:
+    - name: DD_INTROSPECTION_ENABLED
+      value: "true"
+```
+
 ## Migration from Operator Version < 1.4.0
 
 ### Operator v1.4.0 <= x < v1.6.0

--- a/docs/untaint_controller.md
+++ b/docs/untaint_controller.md
@@ -69,14 +69,26 @@ timeouts are global and cannot be tuned per Node (Group), DDA, or DAP.
 
 ## Enable the Untaint controller
 
-The Untaint controller is disabled by default. Enable it on the operator
-manager:
+The Untaint controller is disabled by default. Enable it via CLI flag or
+environment variable:
 
+**CLI flag:**
 ```yaml
 args:
   - --untaintControllerEnabled=true
   # Optional: require CSI node-server Ready before untainting (see Overview).
   - --untaintControllerWaitForCSIDriver=true
+```
+
+**Environment variable** (useful for OLM / GitOps deployments where container
+args cannot be set):
+```yaml
+env:
+  - name: DD_UNTAINT_CONTROLLER_ENABLED
+    value: "true"
+  # Optional: require CSI node-server Ready before untainting (see Overview).
+  - name: DD_UNTAINT_CONTROLLER_WAIT_FOR_CSI_DRIVER
+    value: "true"
 ```
 
 | `--untaintControllerEnabled` | `--untaintControllerWaitForCSIDriver` | Behavior |
@@ -125,4 +137,3 @@ Kubernetes Events (gated by `DD_UNTAINT_CONTROLLER_EVENTS_ENABLED=true`):
   `--untaintControllerWaitForCSIDriver` is enabled) after both the Agent and
   CSI node-server pods became Ready.
 - `UntaintTimeout` — a timeout fired. Normal under `remove`, Warning under `keep`. Message carries the reason, elapsed time, and policy.
-


### PR DESCRIPTION
>[!NOTE]
> This PR is created by pushing locally the commits from https://github.com/DataDog/datadog-operator/pull/3097 for the purpose of CI. Original commits are preserved with authorship.

>[!IMPORTANT]
> This PR now goes beyond the original controller-only boolean env-var fallback. It centralizes environment override parsing through a small typed helper so options can share the same precedence model: compiled default < environment variable < CLI flag.
>
> The updated implementation supports boolean, string, integer, and duration env vars, while still applying them before `flag.Parse()` so explicit CLI arguments win. In addition to the controller enable flags, it now covers selected non-EDS startup options such as metrics binding, secure metrics, profiling, pprof, leader election, Cilium support, maximum goroutines, controller revisions, and the untaint controller's CSI readiness gate.
>
> EDS flags, log flags, secret backend flags, and `--version` remain CLI-only. Tests were added for env-over-default behavior, CLI-over-env precedence, and invalid env values preserving defaults.
   
## Changes

   ### `cmd/main.go`
   - Added `boolFromEnv` helper using `os.LookupEnv` + `strconv.ParseBool`
   - 12 env var overrides applied before `flag.Parse()` so CLI flags take precedence
   - Invalid values logged to stderr (logger is not initialized at parse time)

   ### Documentation
   | Doc | Env var documented |
   |-----|--------------------|
   | `docs/installation.md` | Full reference table with all 12 flags |
   | `docs/untaint_controller.md` | `DD_UNTAINT_CONTROLLER_ENABLED` |
   | `docs/datadog_agent_profiles.md` | `DD_AGENT_PROFILE_CONTROLLER_ENABLED` |
   | `docs/introspection.md` | `DD_INTROSPECTION_ENABLED` |
   | `docs/control_plane_monitoring.md` | `DD_INTROSPECTION_ENABLED` (OLM alternative to CSV patch) |
   | `docs/datadog_dashboard.md` | `DD_DASHBOARD_CONTROLLER_ENABLED` |
   | `docs/datadog_monitor.md` | `DD_MONITOR_CONTROLLER_ENABLED` |
   | `docs/datadog_slo.md` | `DD_SLO_CONTROLLER_ENABLED` |
   | `docs/datadog_generic_resource.md` | `DD_GENERIC_RESOURCE_CONTROLLER_ENABLED` |

   ## Test plan
   - [x] `go build ./cmd/main.go` passes
   - [x] `go test ./cmd/...` passes
   - [x] `go vet ./cmd/...` clean
   - [ ] Set `DD_DASHBOARD_CONTROLLER_ENABLED=true` on operator pod, verify controller starts
   - [ ] Set invalid value (e.g. `yes`), verify stderr error message
   - [ ] Set env var + CLI flag, verify CLI flag wins
