### PR TITLE
[CONTP-1608] enrich untaint controller metrics with tags

### DIFF
--- a/docs/untaint_controller.md
+++ b/docs/untaint_controller.md
@@ -115,8 +115,8 @@ start normally.
 
 Metrics, under the `untaint` Prometheus subsystem:
 
-- `untaint_taint_removals_total` — counter, every taint removal regardless of cause.
-- `untaint_taint_removal_latency_seconds` — histogram, time between pod Ready and taint removal.
+- `untaint_taint_removals_total{node, reason}` — counter, every taint removal. `reason` in {`agent_ready`, `timeout`}, labeled by `node`.
+- `untaint_taint_removal_latency_seconds{node}` — histogram, time between pod Ready and taint removal, labeled by `node`.
 - `untaint_taint_timeouts_total{reason, policy}` — counter, timeout decisions. `reason` in {`readiness`, `scheduling`}; `policy` in {`remove`, `keep`}. Alert on `policy="keep"` to investigate stuck nodes.
 
 Kubernetes Events (gated by `DD_UNTAINT_CONTROLLER_EVENTS_ENABLED=true`):

--- a/go.mod
+++ b/go.mod
@@ -186,6 +186,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect

--- a/internal/controller/metrics/untaint.go
+++ b/internal/controller/metrics/untaint.go
@@ -30,6 +30,10 @@ const (
 	// UntaintRemovalReasonTimeout signals the taint was removed because a
 	// readiness or scheduling timeout fired under policy=remove.
 	UntaintRemovalReasonTimeout = "timeout"
+
+	// untaintNodeLabel is the label key carrying the node name on the
+	// node-scoped untaint metrics.
+	untaintNodeLabel = "node"
 )
 
 var (
@@ -41,7 +45,7 @@ var (
 			Name:      "taint_removals_total",
 			Help:      "Total number of taints removed from nodes, by node and reason",
 		},
-		[]string{"node", "reason"},
+		[]string{untaintNodeLabel, "reason"},
 	)
 
 	// TaintRemovalLatency is the time between agent pod becoming Ready and taint
@@ -53,7 +57,7 @@ var (
 			Help:      "Time between agent pod becoming Ready and taint removal from the node, by node",
 			Buckets:   prometheus.DefBuckets,
 		},
-		[]string{"node"},
+		[]string{untaintNodeLabel},
 	)
 
 	// TaintTimeoutsTotal counts timeout decisions broken down by reason and policy.
@@ -79,6 +83,18 @@ var (
 		},
 	)
 )
+
+// DeleteNodeSeries removes every child series labeled with the given node from
+// the node-scoped untaint metrics: TaintRemovalsTotal (across all reason values)
+// and TaintRemovalLatency (across all histogram buckets). It is a no-op when the
+// node has no series. Call it when a node is deleted to prevent unbounded growth
+// of per-node series for the operator's lifetime as clusters autoscale or
+// replace nodes.
+func DeleteNodeSeries(node string) {
+	match := prometheus.Labels{untaintNodeLabel: node}
+	TaintRemovalsTotal.DeletePartialMatch(match)
+	TaintRemovalLatency.DeletePartialMatch(match)
+}
 
 func init() {
 	metrics.Registry.MustRegister(TaintRemovalsTotal)

--- a/internal/controller/metrics/untaint.go
+++ b/internal/controller/metrics/untaint.go
@@ -23,26 +23,37 @@ const (
 	UntaintTimeoutPolicyRemove = "remove"
 	// UntaintTimeoutPolicyKeep leaves the taint in place but emits observability signals.
 	UntaintTimeoutPolicyKeep = "keep"
+
+	// UntaintRemovalReasonAgentReady signals the taint was removed because the
+	// readiness criteria were met (agent — and optionally CSI — pods Ready).
+	UntaintRemovalReasonAgentReady = "agent_ready"
+	// UntaintRemovalReasonTimeout signals the taint was removed because a
+	// readiness or scheduling timeout fired under policy=remove.
+	UntaintRemovalReasonTimeout = "timeout"
 )
 
 var (
-	// TaintRemovalsTotal is the total number of taints removed from nodes.
-	TaintRemovalsTotal = prometheus.NewCounter(
+	// TaintRemovalsTotal is the total number of taints removed from nodes,
+	// broken down by node and removal reason (agent_ready or timeout).
+	TaintRemovalsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: untaintSubsystem,
 			Name:      "taint_removals_total",
-			Help:      "Total number of taints removed from nodes",
+			Help:      "Total number of taints removed from nodes, by node and reason",
 		},
+		[]string{"node", "reason"},
 	)
 
-	// TaintRemovalLatency is the time between agent pod becoming Ready and taint removal.
-	TaintRemovalLatency = prometheus.NewHistogram(
+	// TaintRemovalLatency is the time between agent pod becoming Ready and taint
+	// removal, broken down by node.
+	TaintRemovalLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: untaintSubsystem,
 			Name:      "taint_removal_latency_seconds",
-			Help:      "Time between agent pod becoming Ready and taint removal from the node",
+			Help:      "Time between agent pod becoming Ready and taint removal from the node, by node",
 			Buckets:   prometheus.DefBuckets,
 		},
+		[]string{"node"},
 	)
 
 	// TaintTimeoutsTotal counts timeout decisions broken down by reason and policy.

--- a/internal/controller/untaint_controller.go
+++ b/internal/controller/untaint_controller.go
@@ -202,6 +202,10 @@ func (r *UntaintReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	node := &corev1.Node{}
 	if err := r.client.Get(ctx, req.NamespacedName, node); err != nil {
 		if apierrors.IsNotFound(err) {
+			// Node is gone (e.g. autoscaler scale-down). Drop its per-node
+			// metric series so node names don't accumulate in the exporter for
+			// the operator's lifetime. No-op if the node never had series.
+			metrics.DeleteNodeSeries(req.Name)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get node %s: %w", req.Name, err)
@@ -593,6 +597,12 @@ func isCSINodeServerPod(pod *corev1.Pod) bool {
 // create, or when the target taint *appears* on update. The reconciler reruns
 // itself via RequeueAfter while a timeout window is pending, so we do not need
 // to fire on every unrelated node update.
+//
+// Node deletions enqueue unconditionally so Reconcile can drop the node's
+// per-node metric series (see DeleteNodeSeries). We deliberately do NOT gate
+// deletes on hasTaint: by the time a node is removed it has usually already had
+// the taint stripped (that is precisely the node whose series must be cleaned
+// up), so a hasTaint check would skip exactly the cases we care about.
 func taintedNodePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -607,7 +617,10 @@ func taintedNodePredicate() predicate.Predicate {
 			}
 			return hasTaint(newNode) && !hasTaint(oldNode)
 		},
-		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			_, ok := e.Object.(*corev1.Node)
+			return ok
+		},
 		GenericFunc: func(event.GenericEvent) bool { return false },
 	}
 }

--- a/internal/controller/untaint_controller.go
+++ b/internal/controller/untaint_controller.go
@@ -285,9 +285,9 @@ func (r *UntaintReconciler) completeUntaintFromReadiness(ctx context.Context, no
 		return result, nil
 	}
 	log.Info(infoLog)
-	metrics.TaintRemovalsTotal.Inc()
+	metrics.TaintRemovalsTotal.WithLabelValues(node.Name, metrics.UntaintRemovalReasonAgentReady).Inc()
 	if !readyAt.IsZero() {
-		metrics.TaintRemovalLatency.Observe(r.clock.Since(readyAt).Seconds())
+		metrics.TaintRemovalLatency.WithLabelValues(node.Name).Observe(r.clock.Since(readyAt).Seconds())
 	}
 	if r.eventsEnabled {
 		r.recorder.Eventf(node, corev1.EventTypeNormal, "TaintRemoved", eventFmt, untaint.AgentNotReadyTaintKey, node.Name)
@@ -401,7 +401,7 @@ func (r *UntaintReconciler) applyTimeoutPolicy(ctx context.Context, node *corev1
 		return result, nil
 	}
 	log.Info(fmt.Sprintf("Removed agent-not-ready taint from node %s by timeout policy", node.Name))
-	metrics.TaintRemovalsTotal.Inc()
+	metrics.TaintRemovalsTotal.WithLabelValues(node.Name, metrics.UntaintRemovalReasonTimeout).Inc()
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/untaint_controller_test.go
+++ b/internal/controller/untaint_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,7 @@ import (
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogcsidriver"
+	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/untaint"
 )
@@ -889,4 +891,61 @@ func TestPodWatchPredicate_withCSI(t *testing.T) {
 	assert.True(t, p.Create(event.CreateEvent{Object: csi}))
 	assert.True(t, p.Create(event.CreateEvent{Object: readyAgent}))
 	assert.False(t, p.Create(event.CreateEvent{Object: other}))
+}
+
+// -----------------------------------------------------------------------------
+// metrics: labeled removal counter + latency histogram
+// -----------------------------------------------------------------------------
+
+// resetUntaintMetrics clears the package-level metric vectors so each test
+// observes only its own samples (the vectors are process-global singletons
+// registered in the metrics package init).
+func resetUntaintMetrics() {
+	metrics.TaintRemovalsTotal.Reset()
+	metrics.TaintRemovalLatency.Reset()
+}
+
+func TestReconcile_PodReady_RecordsLabeledMetrics(t *testing.T) {
+	resetUntaintMetrics()
+	now := testNow()
+	node := taintedNode(testNodeName, 0, now)
+	pod := agentPod(testPodName, testPodNS, testNodeName, true, 1*time.Minute, now)
+
+	c := newFakeClient(t, node, pod)
+	r, _ := newReconciler(t, c, now, PolicyRemove, time.Minute, time.Minute, false)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(
+		metrics.TaintRemovalsTotal.WithLabelValues(testNodeName, metrics.UntaintRemovalReasonAgentReady)),
+		"agent_ready removal counter for this node should be incremented")
+	assert.Equal(t, 0.0, testutil.ToFloat64(
+		metrics.TaintRemovalsTotal.WithLabelValues(testNodeName, metrics.UntaintRemovalReasonTimeout)),
+		"timeout reason must not be recorded for a readiness-driven removal")
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.TaintRemovalLatency),
+		"latency histogram should have one labeled series for this node")
+}
+
+func TestReconcile_Timeout_RecordsLabeledMetrics(t *testing.T) {
+	resetUntaintMetrics()
+	now := testNow()
+	// Pod never Ready, started past the readiness timeout → policy=remove untaints.
+	node := taintedNode(testNodeName, 30*time.Minute, now)
+	pod := agentPod(testPodName, testPodNS, testNodeName, false, 11*time.Minute, now)
+
+	c := newFakeClient(t, node, pod)
+	r, _ := newReconciler(t, c, now, PolicyRemove, 10*time.Minute, 5*time.Minute, false)
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: testNodeName}})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(
+		metrics.TaintRemovalsTotal.WithLabelValues(testNodeName, metrics.UntaintRemovalReasonTimeout)),
+		"timeout removal counter for this node should be incremented")
+	assert.Equal(t, 0.0, testutil.ToFloat64(
+		metrics.TaintRemovalsTotal.WithLabelValues(testNodeName, metrics.UntaintRemovalReasonAgentReady)),
+		"agent_ready reason must not be recorded for a timeout-driven removal")
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.TaintRemovalLatency),
+		"timeout-driven removal records no readiness latency")
 }

--- a/internal/controller/untaint_controller_test.go
+++ b/internal/controller/untaint_controller_test.go
@@ -325,8 +325,11 @@ func TestTaintedNodePredicate(t *testing.T) {
 	assert.False(t, p.Update(event.UpdateEvent{ObjectOld: tainted, ObjectNew: untainted}), "disappearance")
 	assert.False(t, p.Update(event.UpdateEvent{ObjectOld: untainted, ObjectNew: untainted}), "still untainted")
 
-	// Delete / Generic
-	assert.False(t, p.Delete(event.DeleteEvent{Object: tainted}))
+	// Delete: any node deletion enqueues (regardless of taint) so Reconcile can
+	// clean up the node's per-node metric series.
+	assert.True(t, p.Delete(event.DeleteEvent{Object: tainted}))
+	assert.True(t, p.Delete(event.DeleteEvent{Object: untainted}))
+	// Generic
 	assert.False(t, p.Generic(event.GenericEvent{Object: tainted}))
 }
 
@@ -948,4 +951,37 @@ func TestReconcile_Timeout_RecordsLabeledMetrics(t *testing.T) {
 		"agent_ready reason must not be recorded for a timeout-driven removal")
 	assert.Equal(t, 0, testutil.CollectAndCount(metrics.TaintRemovalLatency),
 		"timeout-driven removal records no readiness latency")
+}
+
+func TestReconcile_NodeDeleted_CleansUpPerNodeSeries(t *testing.T) {
+	resetUntaintMetrics()
+	const goneNode = "gone-node"
+	const liveNode = "live-node"
+
+	// Seed series for two nodes: one that will be deleted, one that survives.
+	metrics.TaintRemovalsTotal.WithLabelValues(goneNode, metrics.UntaintRemovalReasonAgentReady).Inc()
+	metrics.TaintRemovalsTotal.WithLabelValues(goneNode, metrics.UntaintRemovalReasonTimeout).Inc()
+	metrics.TaintRemovalLatency.WithLabelValues(goneNode).Observe(1.0)
+	metrics.TaintRemovalsTotal.WithLabelValues(liveNode, metrics.UntaintRemovalReasonAgentReady).Inc()
+	metrics.TaintRemovalLatency.WithLabelValues(liveNode).Observe(2.0)
+
+	require.Equal(t, 3, testutil.CollectAndCount(metrics.TaintRemovalsTotal))
+	require.Equal(t, 2, testutil.CollectAndCount(metrics.TaintRemovalLatency))
+
+	now := testNow()
+	// goneNode is absent from the client → Reconcile hits the NotFound branch.
+	r, _ := newReconciler(t, newFakeClient(t), now, PolicyRemove, time.Minute, time.Minute, false)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: goneNode}})
+	require.NoError(t, err)
+
+	// goneNode's series (both reasons + its histogram) are gone; only liveNode's
+	// single counter series and single histogram series remain. Assert counts
+	// first, before any WithLabelValues call lazily recreates a zero series.
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.TaintRemovalsTotal),
+		"only liveNode's counter series should remain")
+	assert.Equal(t, 1, testutil.CollectAndCount(metrics.TaintRemovalLatency),
+		"only liveNode's latency series should remain")
+	assert.Equal(t, 1.0, testutil.ToFloat64(
+		metrics.TaintRemovalsTotal.WithLabelValues(liveNode, metrics.UntaintRemovalReasonAgentReady)),
+		"liveNode's counter value must survive another node's deletion")
 }


### PR DESCRIPTION
### What does this PR do?

The current `TaintRemovalsTotal` and `TaintRemovalLatency` metrics are untagged scalars, making them impossible to attribute to specific nodes or distinguish between normal removals and timeout-forced ones. This task promotes both to labeled variants.

This PR:

Promotes `TaintRemovalsTotal` to `CounterVec` with node and reason labels (agent_ready or timeout)

Promotes `TaintRemovalLatency` to `HistogramVec` with node label

Updates all call sites in the controller
Updates unit tests for new label signatures

### Additional Information

To avoid keeping series of metrics in memory for every node even after the node is removed from the cluster (due to autoscaling for example), we added cleanup mechanism to delete metrics series locally for removed nodes. 

This ensure scrape payload doesn't grow indefinitely, and memory doesn't keep holding series for removed nodes that accumulate over time.

### Describe your test plan

Added unit tests. 

Manual testing:

Create kind cluster with several nodes:

```
kind create cluster --config ./kind.yaml
```

```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:

role: control-plane
role: worker
role: worker
```

Deploy the datadog operator with the following settings:
```
- --untaintControllerEnabled=true
```

Taint the nodes. For example:

```
kubectl taint node kind-worker2  agent.datadoghq.com/not-ready=presence:NoSchedule
```

Create datadog-agent.yml. Example:

```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: system
spec:
  features:
    autoscaling:
      workload:
        enabled: true
      cluster:
        enabled: true
  global:
    clusterName: adel-csi-operator
    kubelet:
      tlsVerify: false
    csi:
      enabled: true
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
```

After some time, check the emitted metrics and make sure they are promoted to tagged metrics:
```
kubectl -n system exec deploy/datadog-operator-manager -- \
  bash -c 'exec 3<>/dev/tcp/127.0.0.1/8080; printf "GET /metrics HTTP/1.0\r\n\r\n" >&3; cat <&3' \
  | grep untaint
# HELP untaint_taint_removal_errors_total Total number of errors encountered while attempting to remove the agent-not-ready taint from a node
# TYPE untaint_taint_removal_errors_total counter
untaint_taint_removal_errors_total 0
# HELP untaint_taint_removal_latency_seconds Time between agent pod becoming Ready and taint removal from the node, by node
# TYPE untaint_taint_removal_latency_seconds histogram
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="0.005"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="0.01"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="0.025"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="0.05"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="0.1"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="0.25"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="0.5"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="1"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="2.5"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="5"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="10"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker",le="+Inf"} 1
untaint_taint_removal_latency_seconds_sum{node="kind-worker"} 0.41908018
untaint_taint_removal_latency_seconds_count{node="kind-worker"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="0.005"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="0.01"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="0.025"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="0.05"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="0.1"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="0.25"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="0.5"} 0
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="1"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="2.5"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="5"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="10"} 1
untaint_taint_removal_latency_seconds_bucket{node="kind-worker2",le="+Inf"} 1
untaint_taint_removal_latency_seconds_sum{node="kind-worker2"} 0.897452666
untaint_taint_removal_latency_seconds_count{node="kind-worker2"} 1
# HELP untaint_taint_removals_total Total number of taints removed from nodes, by node and reason
# TYPE untaint_taint_removals_total counter
untaint_taint_removals_total{node="kind-worker",reason="agent_ready"} 1
untaint_taint_removals_total{node="kind-worker2",reason="agent_ready"} 1
```


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits