### PR TITLE
Do not set process-agent AppArmor for NPM fallback

### DIFF
--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -112,9 +112,6 @@ func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
-	if !f.directSend {
-		managers.Annotation().AddAnnotation(common.AppArmorAnnotationKey+"/"+string(apicommon.ProcessAgentContainerName), "unconfined")
-	}
 
 	// security context capabilities
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommon.SystemProbeContainerName)

--- a/internal/controller/datadogagent/feature/npm/feature_test.go
+++ b/internal/controller/datadogagent/feature/npm/feature_test.go
@@ -217,6 +217,13 @@ func Test_npmFeature_Configure(t *testing.T) {
 	cnmDirectSendDisabledWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
 
+		// check annotations
+		wantAnnotations := map[string]string{
+			common.SystemProbeAppArmorAnnotationKey: common.SystemProbeAppArmorAnnotationValue,
+		}
+		annotations := mgr.AnnotationMgr.Annotations
+		assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+
 		// check volume mounts
 		wantVolumeMounts := []corev1.VolumeMount{
 			{

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -126,9 +126,6 @@ func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
-	if !f.directSend {
-		managers.Annotation().AddAnnotation(common.AppArmorAnnotationKey+"/"+string(apicommon.ProcessAgentContainerName), "unconfined")
-	}
 
 	// security context capabilities
 	managers.SecurityContext().AddCapabilitiesToContainer(agent.DefaultCapabilitiesForSystemProbe(), apicommon.SystemProbeContainerName)

--- a/internal/controller/datadogagent/feature/usm/feature_test.go
+++ b/internal/controller/datadogagent/feature/usm/feature_test.go
@@ -175,6 +175,13 @@ func Test_usmFeature_Configure(t *testing.T) {
 	usmDirectSendDisabledNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
 
+		// check annotations
+		wantAnnotations := map[string]string{
+			common.SystemProbeAppArmorAnnotationKey: common.SystemProbeAppArmorAnnotationValue,
+		}
+		annotations := mgr.AnnotationMgr.Annotations
+		assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+
 		processWantVolumeMounts := []corev1.VolumeMount{
 			{
 				Name:      common.ProcdirVolumeName,


### PR DESCRIPTION
### What does this PR do?

Removes the `container.apparmor.security.beta.kubernetes.io/process-agent: unconfined` annotation added by the NPM/USM non-direct-send fallback path.

`process-agent` is still created and configured when CNM/USM direct-send is disabled or unavailable, but only `system-probe` keeps its existing AppArmor annotation.

### Motivation

The process-agent AppArmor annotation was introduced while enabling CNM direct-send by default: https://github.com/DataDog/datadog-operator/pull/3045. That changed the legacy fallback rendering even though this annotation was not previously emitted and the Helm chart does not add an AppArmor profile for `process-agent`.

On GKE Autopilot, the extra annotation causes the Datadog daemonset to be rejected by the WorkloadAllowlist because the allowlist does not permit a container-level AppArmor profile for `process-agent`.

### Additional Notes

This is intentionally not an Autopilot-specific workaround. It restores the previous operator behavior for process-agent while keeping the existing system-probe AppArmor behavior unchanged.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

```console
go test ./internal/controller/datadogagent/feature/npm ./internal/controller/datadogagent/feature/usm ./internal/controller/datadogagent/feature/...
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commits/signing-commits
