### PR TITLE
ci(issue-triage): add reusable workflow from DataDog/issue-triage-action

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
       actions: write
       id-token: write
-    uses: DataDog/issue-triage-action/.github/workflows/issue-triage.yml@06ce7d8dcdf35cb6b6ae89344e7e9ee2d60429e6 # v1.0.0
+    uses: DataDog/issue-triage-action/.github/workflows/issue-triage.yml@ee200860ba35ba6ed3ad565e918afb16811fe975 # v1.0.0
     with:
       slack_map_path: .github/workflows/config/github_slack_map.yaml
       environment_name: main

--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -1,0 +1,27 @@
+---
+name: "Assign issue to a team"
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to triage'
+        required: true
+        type: number
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      issues: write
+      actions: write
+      id-token: write
+    uses: DataDog/issue-triage-action/.github/workflows/issue-triage.yml@06ce7d8dcdf35cb6b6ae89344e7e9ee2d60429e6 # v1.0.0
+    with:
+      slack_map_path: .github/workflows/config/github_slack_map.yaml
+      environment_name: main
+      fallback_team: container-platform
+      issue_number: ${{ github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.issue_number) || 0 }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Add `assign-issue.yml` workflow that delegates to the shared reusable action at `DataDog/issue-triage-action` v1.0.0
- On each new issue: runs Claude-based triage to identify the owning team, applies a `team/` label, and sends a Slack notification
- Slack map: `.github/workflows/config/github_slack_map.yaml`; fallback team: `container-platform`

https://datadoghq.atlassian.net/browse/ACIX-1356

## Prerequisites

The `main` GitHub environment must have two secrets defined:
- `ANTHROPIC_API_KEY`
- `SLACK_BOT_TOKEN`

## Test plan

- [ ] Manually trigger via `workflow_dispatch` with an existing issue number and verify end-to-end (label applied + Slack notification sent)
- [ ] Open a test issue and confirm the `pending` / `oss/0` labels are applied and a team label is assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)