### PR TITLE
Support volume/volumeMounts in DatadogAgentProfile

### DIFF
--- a/api/datadoghq/v1alpha1/datadogagentprofile_validation.go
+++ b/api/datadoghq/v1alpha1/datadogagentprofile_validation.go
@@ -26,11 +26,13 @@ var datadogAgentProfileComponentOverrideAllowlist = map[string]struct{}{
 	"runtimeClassName":  {},
 	"updateStrategy":    {},
 	"labels":            {},
+	"volumes":           {},
 }
 
 var datadogAgentProfileContainerOverrideAllowlist = map[string]struct{}{
-	"resources": {},
-	"env":       {},
+	"resources":    {},
+	"env":          {},
+	"volumeMounts": {},
 }
 
 // ValidateDatadogAgentProfileSpec is used to check if a DatadogAgentProfileSpec is valid

--- a/api/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
+++ b/api/datadoghq/v1alpha1/datadogagentprofile_validation_test.go
@@ -303,6 +303,7 @@ func TestValidateDatadogAgentProfileComponentOverrideAllowlist(t *testing.T) {
 		"RuntimeClassName":  {},
 		"UpdateStrategy":    {},
 		"Labels":            {},
+		"Volumes":           {},
 	}
 
 	overrideType := reflect.TypeOf(v2alpha1.DatadogAgentComponentOverride{})
@@ -335,8 +336,9 @@ func TestValidateDatadogAgentProfileComponentOverrideAllowlist(t *testing.T) {
 
 func TestValidateDatadogAgentProfileContainerOverrideAllowlist(t *testing.T) {
 	allowedContainerOverrideFields := map[string]struct{}{
-		"Resources": {},
-		"Env":       {},
+		"Resources":    {},
+		"Env":          {},
+		"VolumeMounts": {},
 	}
 
 	containerType := reflect.TypeOf(v2alpha1.DatadogAgentGenericContainer{})

--- a/docs/datadog_agent_profiles.md
+++ b/docs/datadog_agent_profiles.md
@@ -77,5 +77,5 @@ DAP is disabled by default. To enable DAP using the [datadog-operator helm chart
 | override.[nodeAgent].labels | v1.8.0 |
 | override.[nodeAgent].updateStrategy | v1.9.0 |
 | override.[nodeAgent].runtimeClassName | v1.12.0 |
-| override.[nodeAgent].volumes | v1.28.0 |
-| override.[nodeAgent].containers.[\*].volumeMounts | v1.28.0 |
+| override.[nodeAgent].volumes | v1.29.0 |
+| override.[nodeAgent].containers.[\*].volumeMounts | v1.29.0 |

--- a/docs/datadog_agent_profiles.md
+++ b/docs/datadog_agent_profiles.md
@@ -77,3 +77,5 @@ DAP is disabled by default. To enable DAP using the [datadog-operator helm chart
 | override.[nodeAgent].labels | v1.8.0 |
 | override.[nodeAgent].updateStrategy | v1.9.0 |
 | override.[nodeAgent].runtimeClassName | v1.12.0 |
+| override.[nodeAgent].volumes | v1.28.0 |
+| override.[nodeAgent].containers.[\*].volumeMounts | v1.28.0 |

--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -275,6 +275,7 @@ func OverrideFromProfile(profile *v1alpha1.DatadogAgentProfile, useV3Metadata bo
 			profileComponentOverride.PriorityClassName = nodeAgentOverride.PriorityClassName
 			profileComponentOverride.RuntimeClassName = nodeAgentOverride.RuntimeClassName
 			profileComponentOverride.UpdateStrategy = nodeAgentOverride.UpdateStrategy
+			profileComponentOverride.Volumes = nodeAgentOverride.Volumes
 		}
 	}
 
@@ -413,8 +414,9 @@ func containersOverride(nodeAgentOverride *v2alpha1.DatadogAgentComponentOverrid
 	for _, containerName := range containersInNodeAgent {
 		if overrideForContainer, overrideIsDefined := nodeAgentOverride.Containers[containerName]; overrideIsDefined {
 			res[containerName] = &v2alpha1.DatadogAgentGenericContainer{
-				Resources: overrideForContainer.Resources,
-				Env:       overrideForContainer.Env,
+				Resources:    overrideForContainer.Resources,
+				Env:          overrideForContainer.Env,
+				VolumeMounts: overrideForContainer.VolumeMounts,
 			}
 		}
 	}

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -336,6 +336,14 @@ func TestOverrideFromProfile(t *testing.T) {
 						},
 					},
 				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "foo",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
 				Containers: map[apicommon.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{
 					apicommon.CoreAgentContainerName: {
 						Resources: cpuRequestResource("100m"),
@@ -343,6 +351,13 @@ func TestOverrideFromProfile(t *testing.T) {
 							{
 								Name:  "foo",
 								Value: "bar",
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "foo",
+								MountPath: "/etc/foo",
+								ReadOnly:  true,
 							},
 						},
 					},
@@ -811,12 +826,27 @@ func configWithAllOverrides(cpuRequest string) *v2alpha1.DatadogAgentSpec {
 				Labels: map[string]string{
 					"foo": "bar",
 				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "foo",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
 				Containers: map[apicommon.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{
 					apicommon.CoreAgentContainerName: {
 						Env: []corev1.EnvVar{
 							{
 								Name:  "foo",
 								Value: "bar",
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "foo",
+								MountPath: "/etc/foo",
+								ReadOnly:  true,
 							},
 						},
 						Resources: cpuRequestResource(cpuRequest),


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Deploy with DAP enabled on a 2-nodes+ cluster
2. Create a DDA with extraConfd, e.g.:
    ```yaml
      extraConfd:
        configDataMap:
          openmetrics.yaml: |-
            ad_identifiers:
              - coredns
            init_config:
              debug_metrics:
                metric_contexts: true
            instances:
              - openmetrics_endpoint: http://%%host%%:9153/metrics
                namespace: k8s.debug
                metrics:
                  - .*
    ``` 
3. Create a configmap with a different config:
    ```yaml
    apiVersion: v1
    data:
      openmetrics.yaml: |-
        ad_identifiers:
          - coredns
        instances:
          - openmetrics_endpoint: http://%%host%%:9153/metrics
            min_collection_interval: 60
            namespace: k8s.debug.custom
            metrics:
              - .*
    kind: ConfigMap
    metadata:
      name: custom-openmetrics-config
    ```
4. Create a profile targetting at least one node with this configmap:
    ```yaml
    apiVersion: datadoghq.com/v1alpha1
    kind: DatadogAgentProfile
    metadata:
      name: foo-bar
    spec:
      profileAffinity:
        profileNodeAffinity:
          - key: foo
            operator: In
            values:
              - bar
      config:
        override:
          nodeAgent:
            containers:
              agent:
                volumeMounts:
                  - name: custom-check
                    mountPath: /etc/datadog-agent/conf.d/openmetrics.yaml
                    subPath: openmetrics.yaml
            volumes:
              - name: custom-check
                configMap:
                  name: custom-openmetrics-config
                  items:
                    - key: openmetrics.yaml
                      path: openmetrics.yaml
   ```
5. Verify the non DAP Agent pod has the config from extraConfd while the DAP pod has the one from the configmap:

```console
╰─❯ k exec -it foo-bar-agent-pwnhc -c agent -- bash -c 'cat /etc/datadog-agent/conf.d/openmetrics.yaml'
ad_identifiers:
  - coredns
instances:
  - openmetrics_endpoint: http://%%host%%:9153/metrics
    min_collection_interval: 60
    namespace: k8s.debug.custom
    metrics:
      - .*                                                                                                                                                                                                                         ╭─ ~/misc/k8s_stuff/minikube/operator local !10 ?8                                                                                                                                                 󱃾 kind-local-k8s/system 11:53:23
╰─❯ k exec -it foo-bar-agent-pwnhc -c agent -- bash -c 'cat /etc/datadog-agent/conf.d/openmetrics.yaml'
╭─ ~/misc/k8s_stuff/minikube/operator local !10 ?8                                                                                                                                           ✘ INT 󱃾 kind-local-k8s/system 11:53:26
╰─❯ k exec -it datadog-agent-5hntp -c agent -- bash -c 'cat /etc/datadog-agent/conf.d/openmetrics.yaml'
ad_identifiers:
  - coredns
init_config:
  debug_metrics:
    metric_contexts: true
instances:
  - openmetrics_endpoint: http://%%host%%:9153/metrics
    namespace: k8s.debug
    metrics:
      - .*
```


### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits