### PR TITLE
Add dd-octo-sts trust policy for release-dashboard-api on us1.ddbuild.io

### DIFF
--- a/.github/chainguard/release-dashboard-api-ddbuild.sts.yaml
+++ b/.github/chainguard/release-dashboard-api-ddbuild.sts.yaml
@@ -1,0 +1,9 @@
+# Issued to: rapid-agent-delivery/release-dashboard-api on us1.ddbuild.io
+issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
+
+# ddtool auth whois --datacenter us1.ddbuild.io rapid-agent-delivery-release-dashboard-api --format json | jq -r .id
+subject: f860d242-3262-386f-c2d2-defb62604163
+
+permissions:
+  contents: read
+  pull_requests: read


### PR DESCRIPTION
## Summary

- Adds `.github/chainguard/release-dashboard-api-ddbuild.sts.yaml` trust policy authorizing the `release-dashboard-api` service on `us1.ddbuild.io` to read repository contents and pull requests via dd-octo-sts
- Uses `vault.us1.ddbuild.io` issuer and the ddbuild Vault UUID, following the same permissions (`contents: read`, `pull_requests: read`) as the existing prod and staging policies

## Related PRs

- dd-source allowlist: https://github.com/ddoghq/dd-source/pull/1663
- dd-source policy selector: https://github.com/ddoghq/dd-source/pull/1649
- datadog-agent trust policy: https://github.com/DataDog/datadog-agent/pull/52827

## Merge order

1. Merge this PR and the agent trust policy PR first — the policy must be on the default branch before the service can exchange tokens
2. Then merge the allowlist and policy selector PRs

## Test plan

- [ ] Verify "Trust Policy Validation" CI check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)