### PR TITLE
fix: handle operator CSI upgrade migration

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -2394,6 +2394,10 @@ func getDefaultDDAI(dda *v2alpha1.DatadogAgent) v1alpha1.DatadogAgentInternal {
 func setDDAIHash(t *testing.T, ddai *v1alpha1.DatadogAgentInternal) {
 	t.Helper()
 
+	if ddai.Annotations == nil {
+		ddai.Annotations = make(map[string]string)
+	}
+	ddai.Annotations[constants.DDAIRenderedByOperatorVersionAnnotationKey] = "0.0.0"
 	_, err := comparison.SetMD5GenerationAnnotation(&ddai.ObjectMeta, ddai.Spec, constants.MD5DDAIDeploymentAnnotationKey)
 	assert.NoError(t, err, "failed to compute DDAI spec hash")
 }

--- a/internal/controller/datadogagent/ddai.go
+++ b/internal/controller/datadogagent/ddai.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/DataDog/datadog-operator/pkg/version"
 )
 
 func (r *Reconciler) generateDDAIFromDDA(dda *v2alpha1.DatadogAgent, provider string) (*v1alpha1.DatadogAgentInternal, error) {
@@ -65,6 +66,10 @@ func generateObjMetaFromDDA(dda *v2alpha1.DatadogAgent, ddai *v1alpha1.DatadogAg
 		}
 		ddaiAnnotations[kubernetes.ProviderAnnotationKey] = provider
 	}
+	if ddaiAnnotations == nil {
+		ddaiAnnotations = make(map[string]string)
+	}
+	ddaiAnnotations[constants.DDAIRenderedByOperatorVersionAnnotationKey] = version.GetVersion()
 
 	ddai.ObjectMeta = metav1.ObjectMeta{
 		Name:        dda.Name,

--- a/internal/controller/datadogagent/ddai_test.go
+++ b/internal/controller/datadogagent/ddai_test.go
@@ -41,6 +41,9 @@ func Test_generateObjMetaFromDDA(t *testing.T) {
 					Labels: map[string]string{
 						"agent.datadoghq.com/datadogagent": "foo",
 					},
+					Annotations: map[string]string{
+						constants.DDAIRenderedByOperatorVersionAnnotationKey: "0.0.0",
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         "datadoghq.com/v2alpha1",
@@ -79,6 +82,7 @@ func Test_generateObjMetaFromDDA(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"foo": "bar",
+						constants.DDAIRenderedByOperatorVersionAnnotationKey: "0.0.0",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -333,16 +333,19 @@ func (r *DatadogAgentReconciler) SetupWithManager(mgr ctrl.Manager, metricForwar
 		}))
 	}
 
-	or := reconcile.AsReconciler[*v2alpha1.DatadogAgent](r.Client, r)
-	if err := builder.For(&v2alpha1.DatadogAgent{}, builderOptions...).WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, datadogAnnotationChangedPredicate(), experimentPhaseChangedPredicate())).Complete(or); err != nil {
-		return err
-	}
-
 	internal, err := datadogagent.NewReconciler(r.Options, r.Client, r.PlatformInfo, r.Scheme, r.Log, r.Recorder, metricForwardersMgr)
 	if err != nil {
 		return err
 	}
 	r.internal = internal
+
+	or := reconcile.AsReconciler[*v2alpha1.DatadogAgent](r.Client, r)
+	if err := builder.For(&v2alpha1.DatadogAgent{}, builderOptions...).WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, datadogAnnotationChangedPredicate(), experimentPhaseChangedPredicate())).Complete(or); err != nil {
+		return err
+	}
+	if err := addDatadogAgentStartupReconcile(mgr, r); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/controller/datadogagentinternal_controller.go
+++ b/internal/controller/datadogagentinternal_controller.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -102,14 +103,28 @@ func (r *DatadogAgentInternalReconciler) SetupWithManager(mgr ctrl.Manager, metr
 		}))
 	}
 
+	r.internal = datadogagentinternal.NewReconciler(r.Options, r.Client, r.PlatformInfo, r.Scheme, r.Recorder, metricForwardersMgr)
+
 	or := reconcile.AsReconciler[*v1alpha1.DatadogAgentInternal](r.Client, r)
-	if err := builder.For(&datadoghqv1alpha1.DatadogAgentInternal{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).Complete(or); err != nil {
+	if err := builder.For(&datadoghqv1alpha1.DatadogAgentInternal{}, builderOptions...).WithEventFilter(datadogAgentInternalEventFilter()).Complete(or); err != nil {
+		return err
+	}
+	if err := addDatadogAgentInternalStartupReconcile(mgr, r); err != nil {
 		return err
 	}
 
-	r.internal = datadogagentinternal.NewReconciler(r.Options, r.Client, r.PlatformInfo, r.Scheme, r.Recorder, metricForwardersMgr)
-
 	return nil
+}
+
+func datadogAgentInternalEventFilter() predicate.Predicate {
+	return predicate.Or(
+		predicate.GenerationChangedPredicate{},
+		predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return !apiequality.Semantic.DeepEqual(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations())
+			},
+		},
+	)
 }
 
 func enqueueIfOwnedByDatadogAgentInternal(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/internal/controller/datadogagentinternal_controller_test.go
+++ b/internal/controller/datadogagentinternal_controller_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+)
+
+func TestDatadogAgentInternalEventFilterAllowsAnnotationUpdates(t *testing.T) {
+	oldDDAI := &v1alpha1.DatadogAgentInternal{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog",
+			Namespace: "datadog",
+			Annotations: map[string]string{
+				constants.DDAIRenderedByOperatorVersionAnnotationKey: "1.27.1",
+			},
+		},
+	}
+	newDDAI := oldDDAI.DeepCopy()
+	newDDAI.Annotations[constants.DDAIRenderedByOperatorVersionAnnotationKey] = "1.28.0-rc.3"
+
+	assert.True(t, datadogAgentInternalEventFilter().Update(event.UpdateEvent{
+		ObjectOld: oldDDAI,
+		ObjectNew: newDDAI,
+	}))
+}

--- a/internal/controller/datadogcsidriver/controller.go
+++ b/internal/controller/datadogcsidriver/controller.go
@@ -185,17 +185,17 @@ func (r *Reconciler) reconcileCSIDriver(ctx context.Context, instance *v1alpha1.
 		return nil
 	}
 
-	// Full replacement of spec, labels, and annotations ensures any external drift is reverted,
-	// including fields added manually (e.g. via kubectl edit).
-	if !apiequality.Semantic.DeepEqual(current.Spec, desired.Spec) ||
-		!apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) ||
+	// CSIDriver spec fields are immutable once the object exists. During upgrades,
+	// Kubernetes may have defaulted fields that are absent from the desired spec;
+	// replacing the spec would fail and block metadata reconciliation.
+	if !apiequality.Semantic.DeepEqual(current.Labels, desired.Labels) ||
 		!apiequality.Semantic.DeepEqual(current.Annotations, desired.Annotations) {
-		logger.Info("Updating CSIDriver to match desired state", "csidriver", desired.Name)
-		current.Spec = desired.Spec
+		logger.Info("Updating CSIDriver metadata to match desired state", "csidriver", desired.Name)
+		patchBase := current.DeepCopy()
 		current.Labels = desired.Labels
 		current.Annotations = desired.Annotations
-		if err := r.client.Update(ctx, current); err != nil {
-			return fmt.Errorf("updating CSIDriver: %w", err)
+		if err := r.client.Patch(ctx, current, client.MergeFrom(patchBase)); err != nil {
+			return fmt.Errorf("patching CSIDriver metadata: %w", err)
 		}
 	}
 

--- a/internal/controller/datadogcsidriver/controller_test.go
+++ b/internal/controller/datadogcsidriver/controller_test.go
@@ -348,8 +348,8 @@ func TestReconcile_CSIDriverLabelsAdoption(t *testing.T) {
 	attachRequired := true
 	podInfoOnMount := false
 
-	// Pre-create a CSIDriver without ownership labels and with drifted spec
-	// to validate adoption plus reconciliation of manual edits.
+	// Pre-create a CSIDriver without ownership labels and with defaulted/older
+	// immutable spec fields to validate migration adoption.
 	existingCSIDriver := &storagev1.CSIDriver{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: csiDriverName,
@@ -382,10 +382,10 @@ func TestReconcile_CSIDriverLabelsAdoption(t *testing.T) {
 	assert.Equal(t, "datadog-operator", csiDriver.Labels[kubernetes.AppKubernetesManageByLabelKey])
 	assert.Equal(t, "true", csiDriver.Annotations[apmEnabledAnnotationKey])
 	assert.NotEmpty(t, csiDriver.Labels[kubernetes.AppKubernetesPartOfLabelKey])
-	assert.Nil(t, csiDriver.Spec.AttachRequired)
-	assert.Nil(t, csiDriver.Spec.PodInfoOnMount)
+	assert.Equal(t, attachRequired, *csiDriver.Spec.AttachRequired)
+	assert.Equal(t, podInfoOnMount, *csiDriver.Spec.PodInfoOnMount)
 	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecyclePersistent)
-	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
+	assert.NotContains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
 }
 
 func TestReconcile_Overrides(t *testing.T) {
@@ -496,7 +496,7 @@ func TestReconcile_StatusConditionOnCSIDriverError(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
 }
 
-func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
+func TestReconcile_CSIDriverMetadataDriftIsReconciledWithoutChangingSpec(t *testing.T) {
 	instance := defaultCSIDriverCR()
 	r, c := newTestReconciler(t, false, instance)
 	ctx := context.Background()
@@ -509,12 +509,11 @@ func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
 	_, err = r.Reconcile(ctx, instance)
 	require.NoError(t, err)
 
-	// Simulate manual drift on the managed CSIDriver.
+	// Simulate metadata drift and immutable/defaulted spec fields on the managed CSIDriver.
 	csiDriver := &storagev1.CSIDriver{}
 	err = c.Get(ctx, types.NamespacedName{Name: csiDriverName}, csiDriver)
 	require.NoError(t, err)
 
-	// These are opposite of the default
 	csiDriver.Spec.AttachRequired = ptr.To(true)
 	csiDriver.Spec.PodInfoOnMount = ptr.To(false)
 	csiDriver.Spec.VolumeLifecycleModes = []storagev1.VolumeLifecycleMode{storagev1.VolumeLifecyclePersistent}
@@ -522,7 +521,7 @@ func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
 	err = c.Update(ctx, csiDriver)
 	require.NoError(t, err)
 
-	// Reconcile again and verify drift is reverted.
+	// Reconcile again and verify metadata drift is reverted without touching spec.
 	err = c.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, instance)
 	require.NoError(t, err)
 	_, err = r.Reconcile(ctx, instance)
@@ -530,10 +529,10 @@ func TestReconcile_CSIDriverSpecDriftIsReconciled(t *testing.T) {
 
 	err = c.Get(ctx, types.NamespacedName{Name: csiDriverName}, csiDriver)
 	require.NoError(t, err)
-	assert.Nil(t, csiDriver.Spec.AttachRequired)
-	assert.Nil(t, csiDriver.Spec.PodInfoOnMount)
+	assert.True(t, *csiDriver.Spec.AttachRequired)
+	assert.False(t, *csiDriver.Spec.PodInfoOnMount)
 	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecyclePersistent)
-	assert.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
+	assert.NotContains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
 	assert.Equal(t, "true", csiDriver.Annotations[apmEnabledAnnotationKey])
 }
 

--- a/internal/controller/datadogcsidriver_controller.go
+++ b/internal/controller/datadogcsidriver_controller.go
@@ -64,7 +64,7 @@ func (r *DatadogCSIDriverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.internal = datadogcsidriver.NewReconciler(r.Client, r.Scheme, r.Recorder, r.UntaintInjectCSIStartupToleration)
 
 	or := reconcile.AsReconciler[*datadoghqv1alpha1.DatadogCSIDriver](r.Client, r)
-	return ctrl.NewControllerManagedBy(mgr).
+	if err := ctrl.NewControllerManagedBy(mgr).
 		// GenerationChangedPredicate on For() only — filters spec-only changes
 		// on the primary resource without suppressing status updates on owned resources.
 		For(&datadoghqv1alpha1.DatadogCSIDriver{}, ctrlbuilder.WithPredicates(predicate.GenerationChangedPredicate{})).
@@ -73,7 +73,10 @@ func (r *DatadogCSIDriverReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// CSIDriver is cluster-scoped so we can't use Owns(). Watch with label-based enqueue
 		// to detect drift (manual edits, external deletions).
 		Watches(&storagev1.CSIDriver{}, handler.EnqueueRequestsFromMapFunc(enqueueIfOwnedCSIDriver)).
-		Complete(or)
+		Complete(or); err != nil {
+		return err
+	}
+	return addDatadogCSIDriverStartupReconcile(mgr, r)
 }
 
 // enqueueIfOwnedCSIDriver maps a CSIDriver change back to the owning DatadogCSIDriver CR

--- a/internal/controller/startup_reconcile.go
+++ b/internal/controller/startup_reconcile.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package controller
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+)
+
+type startupReconcileRunnable struct {
+	name  string
+	start func(context.Context) error
+}
+
+func (r startupReconcileRunnable) Start(ctx context.Context) error {
+	return r.start(ctx)
+}
+
+func (r startupReconcileRunnable) NeedLeaderElection() bool {
+	return true
+}
+
+func addDatadogAgentStartupReconcile(mgr manager.Manager, r *DatadogAgentReconciler) error {
+	return mgr.Add(startupReconcileRunnable{
+		name: "DatadogAgent",
+		start: func(ctx context.Context) error {
+			logger := ctrl.LoggerFrom(ctx).WithName("startup").WithName("DatadogAgent")
+			list := &v2alpha1.DatadogAgentList{}
+			if err := r.Client.List(ctx, list); err != nil {
+				return err
+			}
+			for i := range list.Items {
+				dda := list.Items[i].DeepCopy()
+				logger.Info("Reconciling existing DatadogAgent on startup", "namespace", dda.Namespace, "name", dda.Name)
+				if _, err := r.Reconcile(ctx, dda); err != nil {
+					logger.Error(err, "Failed to reconcile existing DatadogAgent on startup", "namespace", dda.Namespace, "name", dda.Name)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func addDatadogAgentInternalStartupReconcile(mgr manager.Manager, r *DatadogAgentInternalReconciler) error {
+	return mgr.Add(startupReconcileRunnable{
+		name: "DatadogAgentInternal",
+		start: func(ctx context.Context) error {
+			logger := ctrl.LoggerFrom(ctx).WithName("startup").WithName("DatadogAgentInternal")
+			list := &v1alpha1.DatadogAgentInternalList{}
+			if err := r.Client.List(ctx, list); err != nil {
+				return err
+			}
+			for i := range list.Items {
+				ddai := list.Items[i].DeepCopy()
+				logger.Info("Reconciling existing DatadogAgentInternal on startup", "namespace", ddai.Namespace, "name", ddai.Name)
+				if _, err := r.Reconcile(ctx, ddai); err != nil {
+					logger.Error(err, "Failed to reconcile existing DatadogAgentInternal on startup", "namespace", ddai.Namespace, "name", ddai.Name)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func addDatadogCSIDriverStartupReconcile(mgr manager.Manager, r *DatadogCSIDriverReconciler) error {
+	return mgr.Add(startupReconcileRunnable{
+		name: "DatadogCSIDriver",
+		start: func(ctx context.Context) error {
+			logger := ctrl.LoggerFrom(ctx).WithName("startup").WithName("DatadogCSIDriver")
+			list := &v1alpha1.DatadogCSIDriverList{}
+			if err := r.Client.List(ctx, list); err != nil {
+				return err
+			}
+			for i := range list.Items {
+				ddcsi := list.Items[i].DeepCopy()
+				logger.Info("Reconciling existing DatadogCSIDriver on startup", "namespace", ddcsi.Namespace, "name", ddcsi.Name)
+				if _, err := r.Reconcile(ctx, ddcsi); err != nil {
+					logger.Error(err, "Failed to reconcile existing DatadogCSIDriver on startup", "namespace", ddcsi.Namespace, "name", ddcsi.Name)
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -73,6 +73,8 @@ const (
 	MD5AgentDeploymentAnnotationKey = "agent.datadoghq.com/agentspechash"
 	// MD5DDAIDeploymentAnnotationKey annotation key is used on a DatadogAgentInternal resource to identify if changes have been made to the spec.
 	MD5DDAIDeploymentAnnotationKey = "agent.datadoghq.com/ddaispechash"
+	// DDAIRenderedByOperatorVersionAnnotationKey annotation key is used on a DatadogAgentInternal resource to identify which operator version rendered it.
+	DDAIRenderedByOperatorVersionAnnotationKey = "agent.datadoghq.com/ddai-rendered-by-operator-version"
 	// MD5ChecksumAnnotationKey annotation key is used to identify customConfig configurations
 	MD5ChecksumAnnotationKey = "checksum/%s-custom-config"
 )


### PR DESCRIPTION
## Description

Fixes the Operator upgrade path from stable to RC for CSI-based APM injection:

- Preserve existing `CSIDriver` specs during reconciliation and patch only labels/annotations on existing objects, avoiding immutable-field failures such as `attachRequired`.
- Stamp generated `DatadogAgentInternal` resources with the Operator version that rendered them so an Operator upgrade updates existing DDAIs.
- Allow `DatadogAgentInternal` annotation updates through the controller predicate so upgraded DDAIs reconcile immediately and regenerate RBAC, including the Cluster Agent `csidrivers` permissions.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [ ] Documentation updated if needed
- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

```sh
go test ./internal/controller/datadogcsidriver ./internal/controller/datadogagent ./internal/controller
```

Manual reproduction before the fix showed stable Operator -> RC migration left the Cluster Agent RBAC stale until DDAI reconcile and left `DatadogCSIDriver` `Ready=False` because the controller attempted to update an immutable `CSIDriver` spec field. These code changes cover both paths with targeted unit tests.

## Additional Notes

Opened as draft while the migration behavior is reviewed against the RC release path.