### PR TITLE
[CASCL-1386] (6½/11) Implement shared node cordon and drain primitives

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon.go
@@ -1,0 +1,69 @@
+package evict
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
+)
+
+// cordonNodes marks every node in the group Unschedulable up front, before any
+// of them is drained. A pod evicted from one node is then never rescheduled
+// onto another node of the same group that is itself about to be drained.
+//
+// It returns the Node objects that are now cordoned and safe to drain, so the
+// caller can read their immutable fields (e.g. providerID) without a second
+// Get. A node that is already gone is skipped silently (absent from both
+// return values); a node that fails to cordon is recorded in errs and left out
+// of cordoned so the caller never drains a node that can still receive pods.
+func cordonNodes(ctx context.Context, clientset kubernetes.Interface, nodes []string, dryRun bool) (cordoned []*corev1.Node, errs []error) {
+	for _, nodeName := range nodes {
+		if node, err := cordonNode(ctx, clientset, nodeName, dryRun); err != nil {
+			errs = append(errs, fmt.Errorf("cordon node %s: %w", nodeName, err))
+		} else if node != nil {
+			cordoned = append(cordoned, node)
+		}
+	}
+	return cordoned, errs
+}
+
+// cordonNode marks the node Unschedulable and returns the resulting Node so the
+// caller can read immutable fields (e.g. providerID) without a second Get. It
+// returns (nil, nil) when the node is already gone: there is nothing to
+// schedule onto a deleted node, and a re-run rediscovers any surviving nodes.
+// The Get + mutate + Update is wrapped in RetryOnConflict to survive races
+// against kubelet, the scheduler, and any other controller that mutates Node
+// objects.
+func cordonNode(ctx context.Context, clientset kubernetes.Interface, name string, dryRun bool) (*corev1.Node, error) {
+	var cordoned *corev1.Node
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node, err := clientset.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil // node already gone: nothing to schedule on it
+			}
+			return fmt.Errorf("failed to get node %s: %w", name, err)
+		}
+		if dryRun {
+			log.Printf("[dry-run] would cordon node %s", name)
+		} else if !node.Spec.Unschedulable {
+			node.Spec.Unschedulable = true
+			node, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil // deleted concurrently: nothing to schedule on it
+				}
+				return fmt.Errorf("failed to update node %s: %w", name, err)
+			}
+			log.Printf("Cordoned node %s.", name)
+		}
+		cordoned = node
+		return nil
+	})
+	return cordoned, err
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/cordon_test.go
@@ -1,0 +1,134 @@
+package evict
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestCordonNode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// initialUnschedulable is the node's starting `Spec.Unschedulable`.
+		initialUnschedulable bool
+		// conflictFirstUpdate forces a Conflict on the first Update so
+		// RetryOnConflict has to refetch and re-apply.
+		conflictFirstUpdate bool
+		// updateNotFound makes the Update return NotFound, simulating the node
+		// being deleted between the Get and the Update.
+		updateNotFound bool
+		dryRun         bool
+		// wantUpdateCalls is the minimum number of Update invocations
+		// expected on the Nodes endpoint.
+		wantMinUpdateCalls int
+		wantUnschedulable  bool
+		// wantNilNode expects cordonNode to return a nil Node (the node is gone).
+		wantNilNode bool
+	}{
+		{
+			name:               "schedulable node becomes cordoned",
+			wantMinUpdateCalls: 1,
+			wantUnschedulable:  true,
+		},
+		{
+			// Already cordoned ⇒ no Update issued (idempotent).
+			name:                 "already cordoned is a no-op",
+			initialUnschedulable: true,
+			wantMinUpdateCalls:   0,
+			wantUnschedulable:    true,
+		},
+		{
+			name:                "retries on Conflict",
+			conflictFirstUpdate: true,
+			wantMinUpdateCalls:  2,
+			wantUnschedulable:   true,
+		},
+		{
+			name:               "dry-run touches nothing",
+			dryRun:             true,
+			wantMinUpdateCalls: 0,
+			wantUnschedulable:  false,
+		},
+		{
+			// Node deleted between the Get and the Update ⇒ NotFound on Update
+			// is a silent success (nothing to schedule onto a deleted node).
+			name:               "deleted between get and update is a no-op",
+			updateNotFound:     true,
+			wantMinUpdateCalls: 1,
+			wantUnschedulable:  false,
+			wantNilNode:        true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+				Spec:       corev1.NodeSpec{Unschedulable: tc.initialUnschedulable},
+			}
+			client := fake.NewClientset(node)
+
+			var updateCalls int
+			client.PrependReactor("update", "nodes", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+				updateCalls++
+				if tc.conflictFirstUpdate && updateCalls == 1 {
+					return true, nil, apierrors.NewConflict(
+						schema.GroupResource{Resource: "nodes"}, "n1", errors.New("forced conflict"),
+					)
+				}
+				if tc.updateNotFound {
+					return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "n1")
+				}
+				return false, nil, nil
+			})
+
+			gotNode, cordonErr := cordonNode(t.Context(), client, "n1", tc.dryRun)
+			require.NoError(t, cordonErr)
+			assert.Equal(t, tc.wantNilNode, gotNode == nil, "cordonNode nil-node contract")
+
+			assert.GreaterOrEqual(t, updateCalls, tc.wantMinUpdateCalls, "minimum Update calls")
+			got, err := client.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantUnschedulable, got.Spec.Unschedulable)
+		})
+	}
+}
+
+// TestCordonNodes covers the up-front cordon pass: a live node is cordoned and
+// returned (carrying its state so the caller needs no second Get), an
+// already-gone node is a silent skip (no error, absent from the result, so a
+// re-run after a partial execution is not derailed), and a node that fails to
+// cordon is recorded as an error and excluded so the caller never drains a node
+// that can still receive pods.
+func TestCordonNodes(t *testing.T) {
+	client := fake.NewClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "ip-live"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "ip-bad"}},
+	)
+	// Updates to ip-bad fail with a non-conflict error so cordonNode gives up
+	// immediately (RetryOnConflict only retries Conflict).
+	client.PrependReactor("update", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		ua, ok := action.(clienttesting.UpdateAction)
+		if !ok || ua.GetObject().(*corev1.Node).Name != "ip-bad" {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewInternalError(errors.New("update boom"))
+	})
+
+	// ip-gone is absent from the cluster: cordonNode must treat NotFound as a
+	// silent skip.
+	cordoned, errs := cordonNodes(t.Context(), client, []string{"ip-live", "ip-gone", "ip-bad"}, false)
+
+	require.Len(t, cordoned, 1, "only the live, successfully-cordoned node is returned")
+	assert.Equal(t, "ip-live", cordoned[0].Name)
+	assert.True(t, cordoned[0].Spec.Unschedulable, "the returned node carries the cordoned state")
+	require.Len(t, errs, 1)
+	assert.ErrorContains(t, errs[0], "ip-bad")
+}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
@@ -1,6 +1,24 @@
 package evict
 
-import "time"
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/pager"
+	"k8s.io/client-go/util/retry"
+)
 
 // nodeDrainOptions captures the per-call tunables for evicting a node's pods.
 type nodeDrainOptions struct {
@@ -8,4 +26,150 @@ type nodeDrainOptions struct {
 	EvictionTimeout time.Duration // per pod, bound for retries on 429
 	NodeTimeout     time.Duration // total wait for the node to become empty
 	PollInterval    time.Duration // interval between empty-checks; default 2s
+}
+
+// TODO(CASCL-1386): remove this block once the EKS managed node group eviction
+// (next PR in the stack) calls these primitives. They are introduced here as
+// shared building blocks; golangci-lint's `unused` runs with `tests = false`,
+// so the test coverage in this package does not count as use. Referencing the
+// two entry points keeps `unused` quiet until the first production caller lands
+// (drainNode/cordonNodes transitively reach every other helper below).
+var (
+	_ = drainNode
+	_ = cordonNodes
+)
+
+// drainNode evicts every evictable pod from the node and waits for the node to
+// become empty. Pods owned by a DaemonSet, mirror pods, terminating pods and
+// completed Job pods are skipped — the kubelet handles their cleanup when the
+// underlying instance disappears.
+//
+// Pods that cannot be evicted (PDB-blocked beyond EvictionTimeout, etc.) are
+// logged as warnings; drainNode then continues with the remaining pods rather
+// than aborting the whole run.
+func drainNode(ctx context.Context, clientset kubernetes.Interface, nodeName string, opts nodeDrainOptions) error {
+	if opts.DryRun {
+		log.Printf("[dry-run] would drain node %s", nodeName)
+		return nil
+	}
+	pods, err := listPodsOnNode(ctx, clientset, nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+	}
+	for _, p := range pods {
+		if shouldSkipEviction(&p) {
+			continue
+		}
+		if err := evictPodWithRetry(ctx, clientset, &p, opts.EvictionTimeout, opts.PollInterval); err != nil {
+			log.Printf("Warning: pod %s/%s: %v", p.Namespace, p.Name, err)
+		}
+	}
+	return waitForNodeEmpty(ctx, clientset, nodeName, opts.NodeTimeout, opts.PollInterval)
+}
+
+// listPodsOnNode enumerates pods scheduled on the given node, server-side
+// filtered via the spec.nodeName field selector.
+func listPodsOnNode(ctx context.Context, clientset kubernetes.Interface, nodeName string) (pods []corev1.Pod, err error) {
+	p := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return clientset.CoreV1().Pods(metav1.NamespaceAll).List(ctx, opts)
+	})
+	if err = p.EachListItem(ctx, metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("spec.nodeName", nodeName).String(),
+	}, func(obj runtime.Object) error {
+		pods = append(pods, *obj.(*corev1.Pod))
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return pods, nil
+}
+
+// evictPodWithRetry sends a single Eviction request and retries while the
+// apiserver returns 429 TooManyRequests (the canonical PDB-blocked signal).
+// Retries at retryInterval for up to timeout's worth of attempts; the caller
+// then logs and moves to the next pod.
+//
+// 404 (pod already gone) is treated as success — the eviction goal is met.
+// Non-429 errors are returned immediately.
+func evictPodWithRetry(ctx context.Context, clientset kubernetes.Interface, p *corev1.Pod, timeout, retryInterval time.Duration) error {
+	eviction := &policyv1.Eviction{
+		ObjectMeta: metav1.ObjectMeta{Name: p.Name, Namespace: p.Namespace},
+	}
+	steps := 1
+	if retryInterval > 0 {
+		steps = max(1, int(timeout/retryInterval))
+	}
+	backoff := wait.Backoff{Duration: retryInterval, Factor: 1, Steps: steps}
+	err := retry.OnError(backoff, apierrors.IsTooManyRequests, func() error {
+		return clientset.CoreV1().Pods(p.Namespace).EvictV1(ctx, eviction)
+	})
+	switch {
+	case err == nil:
+		log.Printf("Evicted pod %s/%s.", p.Namespace, p.Name)
+		return nil
+	case apierrors.IsNotFound(err):
+		return nil // already gone — eviction goal met
+	case apierrors.IsTooManyRequests(err):
+		// OnError exhausted its retries while still 429-blocked.
+		return fmt.Errorf("eviction timed out (likely PDB-blocked): %w", err)
+	default:
+		return fmt.Errorf("eviction failed: %w", err)
+	}
+}
+
+// waitForNodeEmpty polls the node until no pod still occupies it. A pod is
+// considered to still occupy the node until it is actually gone from the API
+// server — including pods that are merely terminating (DeletionTimestamp
+// set). This matters for callers that terminate the underlying EC2 instance
+// next: returning early while a pod is mid-grace-period would kill the
+// container before its preStop hook / graceful shutdown finishes.
+//
+// DaemonSet pods, mirror pods and completed pods are not counted: DS and
+// mirror pods are tied to the node's lifecycle and disappear with it,
+// completed pods are inert and GC'd promptly.
+func waitForNodeEmpty(ctx context.Context, clientset kubernetes.Interface, nodeName string, timeout, pollInterval time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := listPodsOnNode(ctx, clientset, nodeName)
+		if err != nil {
+			return false, fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+		}
+		return lo.NoneBy(pods, func(p corev1.Pod) bool {
+			return podOccupiesNode(&p)
+		}), nil
+	})
+}
+
+// shouldSkipEviction reports whether drainNode should leave a pod alone
+// rather than call the Eviction API on it. A pod already terminating is
+// skipped because issuing another eviction would 404 once the kubelet
+// finishes the deletion; every pod that does not occupy the node for drain
+// purposes (mirror, DaemonSet and completed pods) needs no eviction either.
+func shouldSkipEviction(p *corev1.Pod) bool {
+	return p.DeletionTimestamp != nil || !podOccupiesNode(p)
+}
+
+// podOccupiesNode reports whether a pod still consumes the node from a drain
+// perspective. Terminating pods DO occupy the node until they are gone;
+// returning false for them prematurely would let the caller terminate the
+// instance before the container finished its grace period.
+func podOccupiesNode(p *corev1.Pod) bool {
+	return !isMirrorPod(p) && !isDaemonSetPod(p) && !isCompleted(p)
+}
+
+func isMirrorPod(p *corev1.Pod) bool {
+	_, ok := p.Annotations[corev1.MirrorPodAnnotationKey]
+	return ok
+}
+
+func isDaemonSetPod(p *corev1.Pod) bool {
+	ctrl := metav1.GetControllerOf(p)
+	if ctrl == nil || ctrl.Kind != "DaemonSet" {
+		return false
+	}
+	gv, _ := schema.ParseGroupVersion(ctrl.APIVersion)
+	return gv.Group == "apps"
+}
+
+func isCompleted(p *corev1.Pod) bool {
+	return p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods_test.go
@@ -1,0 +1,415 @@
+package evict
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+)
+
+func TestShouldSkipEviction(t *testing.T) {
+	now := metav1.Now()
+	for _, tc := range []struct {
+		name string
+		pod  *corev1.Pod
+		skip bool
+	}{
+		{name: "regular pod", pod: &corev1.Pod{}, skip: false},
+		{name: "terminating", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}}, skip: true},
+		{name: "mirror", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{corev1.MirrorPodAnnotationKey: "x"},
+		}}, skip: true},
+		{name: "daemonset", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true)}},
+		}}, skip: true},
+		{name: "non-controller DaemonSet owner is not skipped", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds"}},
+		}}, skip: false},
+		{name: "succeeded job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}, skip: true},
+		{name: "failed job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}}, skip: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.skip, shouldSkipEviction(tc.pod))
+		})
+	}
+}
+
+// TestPodOccupiesNode locks in the asymmetry between "skip eviction" and
+// "keeps the node busy": terminating pods are skipped from eviction (the
+// kubelet is already deleting them) BUT still occupy the node for drain
+// purposes (otherwise we'd terminate the instance mid-grace-period and kill
+// the container before its preStop hook finishes).
+func TestPodOccupiesNode(t *testing.T) {
+	now := metav1.Now()
+	for _, tc := range []struct {
+		name     string
+		pod      *corev1.Pod
+		occupies bool
+	}{
+		{name: "regular pod", pod: &corev1.Pod{}, occupies: true},
+		{name: "terminating pod still occupies", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}}, occupies: true},
+		{name: "mirror pod", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{corev1.MirrorPodAnnotationKey: "x"},
+		}}, occupies: false},
+		{name: "daemonset pod", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true)}},
+		}}, occupies: false},
+		{name: "non-controller DaemonSet owner still occupies", pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds"}},
+		}}, occupies: true},
+		{name: "succeeded job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}}, occupies: false},
+		{name: "failed job", pod: &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}}, occupies: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.occupies, podOccupiesNode(tc.pod))
+		})
+	}
+}
+
+func TestEvictPodWithRetry(t *testing.T) {
+	// evictionResponder shapes the test-side of the Eviction subresource
+	// reactor. `call` is the 1-based call counter.
+	type evictionResponder func(call int, eviction *policyv1.Eviction) (resp runtime.Object, err error)
+
+	echoSuccess := evictionResponder(func(_ int, e *policyv1.Eviction) (runtime.Object, error) {
+		return e, nil
+	})
+	tooManyOnceThenSuccess := evictionResponder(func(call int, e *policyv1.Eviction) (runtime.Object, error) {
+		if call == 1 {
+			return nil, apierrors.NewTooManyRequests("PDB blocked", 1)
+		}
+		return e, nil
+	})
+	notFound := evictionResponder(func(_ int, e *policyv1.Eviction) (runtime.Object, error) {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, e.Name)
+	})
+	nonRetryable := evictionResponder(func(_ int, _ *policyv1.Eviction) (runtime.Object, error) {
+		return nil, errors.New("non-retryable")
+	})
+	alwaysTooMany := evictionResponder(func(_ int, _ *policyv1.Eviction) (runtime.Object, error) {
+		return nil, apierrors.NewTooManyRequests("PDB blocked", 1)
+	})
+
+	for _, tc := range []struct {
+		name string
+		// pod is the object passed to evictPodWithRetry (and pre-loaded
+		// into the fake when seedPod is true).
+		pod     *corev1.Pod
+		seedPod bool
+		// responder controls what the Eviction reactor returns each call.
+		responder evictionResponder
+		timeout   time.Duration
+
+		wantErr          bool
+		wantErrContains  string
+		wantMinCalls     int
+		wantCapturedName string
+		wantCapturedNs   string
+	}{
+		{
+			name:         "success on first call",
+			pod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:      true,
+			responder:    echoSuccess,
+			timeout:      5 * time.Second,
+			wantMinCalls: 1,
+		},
+		{
+			name:         "retries on 429 then succeeds",
+			pod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:      true,
+			responder:    tooManyOnceThenSuccess,
+			timeout:      10 * time.Second,
+			wantMinCalls: 2,
+		},
+		{
+			// Pod already gone: 404 from the apiserver is treated as
+			// success — the eviction goal is met regardless.
+			name:         "404 from apiserver is success",
+			pod:          &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:      false,
+			responder:    notFound,
+			timeout:      time.Second,
+			wantMinCalls: 1,
+		},
+		{
+			name:            "non-retryable error returned",
+			pod:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:         true,
+			responder:       nonRetryable,
+			timeout:         5 * time.Second,
+			wantErr:         true,
+			wantErrContains: "eviction failed",
+			wantMinCalls:    1,
+		},
+		{
+			// Always 429: OnError exhausts its retries while still
+			// PDB-blocked, and the last 429 is surfaced as a timeout.
+			name:            "exhausts retries while 429-blocked",
+			pod:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}},
+			seedPod:         true,
+			responder:       alwaysTooMany,
+			timeout:         50 * time.Millisecond,
+			wantErr:         true,
+			wantErrContains: "eviction timed out",
+			wantMinCalls:    2,
+		},
+		{
+			// Smoke check that the Eviction object carries the pod's
+			// Name/Namespace through to the apiserver.
+			name:             "eviction object name/namespace",
+			pod:              &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "ns1"}},
+			seedPod:          true,
+			responder:        echoSuccess,
+			timeout:          time.Second,
+			wantMinCalls:     1,
+			wantCapturedName: "p1",
+			wantCapturedNs:   "ns1",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var seed []runtime.Object
+			if tc.seedPod {
+				seed = append(seed, tc.pod)
+			}
+			client := fake.NewClientset(seed...)
+
+			var (
+				calls    int
+				captured *policyv1.Eviction
+			)
+			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				ca, ok := action.(clienttesting.CreateAction)
+				if !ok || ca.GetSubresource() != "eviction" {
+					return false, nil, nil
+				}
+				calls++
+				eviction := ca.GetObject().(*policyv1.Eviction)
+				captured = eviction
+				resp, err := tc.responder(calls, eviction)
+				return true, resp, err
+			})
+
+			err := evictPodWithRetry(t.Context(), client, tc.pod, tc.timeout, 10*time.Millisecond)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			assert.GreaterOrEqual(t, calls, tc.wantMinCalls)
+			if tc.wantCapturedName != "" {
+				require.NotNil(t, captured)
+				assert.Equal(t, tc.wantCapturedName, captured.Name)
+				assert.Equal(t, tc.wantCapturedNs, captured.Namespace)
+			}
+		})
+	}
+}
+
+// TestEvictPodWithRetryZeroInterval pins the guard against a non-positive
+// retryInterval: it must not panic (division by zero) and degrades to a single
+// eviction attempt.
+func TestEvictPodWithRetryZeroInterval(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"}}
+	client := fake.NewClientset(pod)
+	var calls int
+	client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok || ca.GetSubresource() != "eviction" {
+			return false, nil, nil
+		}
+		calls++
+		return true, ca.GetObject(), nil
+	})
+
+	err := evictPodWithRetry(t.Context(), client, pod, time.Second, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+// TestListPodsOnNode locks in the server-side node scoping: the fake client
+// does not enforce field selectors, so we assert explicitly that the request
+// carries spec.nodeName=<node>. A regression here would silently drain pods
+// from every node, not just the target.
+func TestListPodsOnNode(t *testing.T) {
+	client := fake.NewClientset()
+	var gotFieldSelector string
+	client.PrependReactor("list", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		gotFieldSelector = action.(clienttesting.ListAction).GetListRestrictions().Fields.String()
+		return true, &corev1.PodList{Items: []corev1.Pod{occupyingPod("a"), occupyingPod("b")}}, nil
+	})
+
+	pods, err := listPodsOnNode(t.Context(), client, "ip-7")
+	require.NoError(t, err)
+	assert.Len(t, pods, 2)
+	assert.Equal(t, "spec.nodeName=ip-7", gotFieldSelector)
+}
+
+// occupyingPod and dsPod are the two fixtures the drain/wait tests reuse: a
+// plain pod that keeps the node busy, and a DaemonSet pod that never does.
+func occupyingPod(name string) corev1.Pod {
+	return corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
+}
+
+func dsPod(name string) corev1.Pod {
+	return corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:            name,
+		Namespace:       "default",
+		OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true)}},
+	}}
+}
+
+func TestWaitForNodeEmpty(t *testing.T) {
+	occupying := occupyingPod("app")
+	ds := dsPod("agent")
+
+	for _, tc := range []struct {
+		name string
+		// listResponder returns the pod list for each 1-based List call,
+		// letting a case spread a transition across successive polls.
+		listResponder   func(call int) (runtime.Object, error)
+		timeout         time.Duration
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:          "empty on first poll",
+			listResponder: func(int) (runtime.Object, error) { return &corev1.PodList{}, nil },
+			timeout:       time.Second,
+		},
+		{
+			// Only DaemonSet/mirror/completed pods linger: the node does not
+			// "occupy" for drain purposes, so the wait returns immediately.
+			name: "only non-occupying pods counts as empty",
+			listResponder: func(int) (runtime.Object, error) {
+				return &corev1.PodList{Items: []corev1.Pod{ds}}, nil
+			},
+			timeout: time.Second,
+		},
+		{
+			name: "becomes empty after the first poll",
+			listResponder: func(call int) (runtime.Object, error) {
+				if call == 1 {
+					return &corev1.PodList{Items: []corev1.Pod{occupying}}, nil
+				}
+				return &corev1.PodList{}, nil
+			},
+			timeout: time.Second,
+		},
+		{
+			name: "times out while an occupying pod remains",
+			listResponder: func(int) (runtime.Object, error) {
+				return &corev1.PodList{Items: []corev1.Pod{occupying}}, nil
+			},
+			timeout: 60 * time.Millisecond,
+			wantErr: true,
+		},
+		{
+			name: "list error is wrapped",
+			listResponder: func(int) (runtime.Object, error) {
+				return nil, errors.New("apiserver unreachable")
+			},
+			timeout:         time.Second,
+			wantErr:         true,
+			wantErrContains: "failed to list pods on node",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset()
+			var calls int
+			client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+				calls++
+				obj, err := tc.listResponder(calls)
+				return true, obj, err
+			})
+			err := waitForNodeEmpty(t.Context(), client, "ip-1", tc.timeout, 10*time.Millisecond)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContains != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDrainNode(t *testing.T) {
+	occupying := occupyingPod("app")
+	ds := dsPod("agent")
+
+	// countingEvictionReactor installs an Eviction reactor that echoes success
+	// and increments *n on every eviction create.
+	countingEvictionReactor := func(client *fake.Clientset, n *int) {
+		client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			ca, ok := action.(clienttesting.CreateAction)
+			if !ok || ca.GetSubresource() != "eviction" {
+				return false, nil, nil
+			}
+			*n++
+			return true, ca.GetObject(), nil
+		})
+	}
+
+	t.Run("dry-run evicts nothing", func(t *testing.T) {
+		client := fake.NewClientset(&occupying)
+		var evictions int
+		countingEvictionReactor(client, &evictions)
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{DryRun: true})
+		require.NoError(t, err)
+		assert.Zero(t, evictions)
+	})
+
+	t.Run("evicts the occupying pod then waits for the node to empty", func(t *testing.T) {
+		client := fake.NewClientset(&occupying)
+		var evictions, lists int
+		countingEvictionReactor(client, &evictions)
+		// First List (drainNode's own enumeration) still sees the pod; the
+		// subsequent List from waitForNodeEmpty sees the node drained.
+		client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			lists++
+			if lists == 1 {
+				return true, &corev1.PodList{Items: []corev1.Pod{occupying}}, nil
+			}
+			return true, &corev1.PodList{}, nil
+		})
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{
+			EvictionTimeout: time.Second,
+			NodeTimeout:     time.Second,
+			PollInterval:    10 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, evictions)
+	})
+
+	t.Run("skips non-evictable pods and treats the node as empty", func(t *testing.T) {
+		client := fake.NewClientset(&ds)
+		var evictions int
+		countingEvictionReactor(client, &evictions)
+		client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, &corev1.PodList{Items: []corev1.Pod{ds}}, nil
+		})
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{
+			EvictionTimeout: time.Second,
+			NodeTimeout:     time.Second,
+			PollInterval:    10 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		assert.Zero(t, evictions)
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Introduces the shared node-cordon and pod-eviction/drain primitives used by the `evict-legacy-nodes` command's per-manager evictors (EKS managed node groups, ASG, Karpenter, standalone):

- `cordonNodes`/`cordonNode` — idempotent, conflict-retrying cordon that treats an already-gone node as a silent skip and returns the cordoned `Node` objects.
- `drainNode` — evicts every evictable pod (skipping mirror, DaemonSet, completed and terminating pods), then waits for the node to empty.
- `evictPodWithRetry` — PDB-aware eviction that retries on 429 and treats 404 as success.
- `listPodsOnNode`, `waitForNodeEmpty`, and the pod-classification predicates (`podOccupiesNode`/`shouldSkipEviction`/`isMirrorPod`/`isDaemonSetPod`/`isCompleted`).

### Motivation

Every per-manager evictor needs these primitives. Extracting them into a dedicated PR at the base of the stack keeps each downstream PR focused on its manager-specific logic and lets them all build on a single, reviewed implementation.

### Additional Notes

- Part of the **CASCL-1386** stacked series. This PR sits at the base; the per-manager evictors (starting with EKS managed node groups) rebase on top and become the first production callers.
- golangci-lint runs with `[run] tests = false`, so unit-test usage does not count toward the `unused` linter and there is no production caller yet in this PR. A small, documented `var ( _ = drainNode; _ = cordonNodes )` block keeps `unused` quiet; it is removed by the next PR in the stack when `evictEKSManagedNodeGroup` becomes the first caller.

### Minimum Agent Versions

N/A — `kubectl-datadog` plugin only; no Datadog Agent or Cluster Agent change.

### Describe your test plan

Unit tests (`go test ./cmd/kubectl-datadog/autoscaling/cluster/evict/`) cover: cordon (idempotent / conflict-retry / already-gone / dry-run), pod eviction (429 retry, 404 success, non-retryable error, 429 exhaustion, zero-interval guard), node-empty polling (empty / becomes-empty / timeout / list-error), pod classification, and the `spec.nodeName` field-selector scoping of `listPodsOnNode`. `make lint` is clean.

### Checklist

- [x] PR has at least one valid label: `enhancement`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
