### PR TITLE
[CONTP-1782] Add appProtocol to OTLP gRPC services

### DIFF
--- a/internal/controller/datadogagent/common/service.go
+++ b/internal/controller/datadogagent/common/service.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package common
+
+const (
+	// KubernetesAppProtocolH2C identifies HTTP/2 prior knowledge over cleartext.
+	KubernetesAppProtocolH2C = "kubernetes.io/h2c"
+)

--- a/internal/controller/datadogagent/feature/otelagentgateway/feature.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature.go
@@ -146,10 +146,11 @@ func (f *otelAgentGatewayFeature) ManageDependencies(managers feature.ResourceMa
 	}
 
 	otlpGrpcPort := &corev1.ServicePort{
-		Name:       "otlpgrpcport",
-		Port:       int32(grpcPort),
-		Protocol:   corev1.ProtocolTCP,
-		TargetPort: intstr.FromInt(grpcPort),
+		Name:        "otlpgrpcport",
+		Port:        int32(grpcPort),
+		Protocol:    corev1.ProtocolTCP,
+		TargetPort:  intstr.FromInt(grpcPort),
+		AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
 	}
 	otlpHttpPort := &corev1.ServicePort{
 		Name:       "otlphttpport",

--- a/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 type expectedPorts struct {
@@ -331,10 +332,11 @@ func testExpectedDepsCreatedCM(t testing.TB, store store.StoreClient) {
 		service := serviceObject.(*corev1.Service)
 		assert.Equal(t, []corev1.ServicePort{
 			{
-				Name:       "otlpgrpcport",
-				Port:       4317,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(4317),
+				Name:        "otlpgrpcport",
+				Port:        4317,
+				Protocol:    corev1.ProtocolTCP,
+				TargetPort:  intstr.FromInt(4317),
+				AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
 			},
 			{
 				Name:       "otlphttpport",
@@ -348,10 +350,11 @@ func testExpectedDepsCreatedCM(t testing.TB, store store.StoreClient) {
 		service := serviceObject.(*corev1.Service)
 		assert.Equal(t, []corev1.ServicePort{
 			{
-				Name:       "otlpgrpcport",
-				Port:       4444,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(4444),
+				Name:        "otlpgrpcport",
+				Port:        4444,
+				Protocol:    corev1.ProtocolTCP,
+				TargetPort:  intstr.FromInt(4444),
+				AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
 			},
 			{
 				Name:       "otlphttpport",

--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -247,10 +247,11 @@ func (o *otelCollectorFeature) ManageDependencies(managers feature.ResourceManag
 	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
 	if common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), o.forceEnableLocalService) {
 		otlpGrpcPort := &corev1.ServicePort{
-			Name:       "otlpgrpcport",
-			Port:       int32(grpcPort),
-			Protocol:   corev1.ProtocolTCP,
-			TargetPort: intstr.FromInt(grpcPort),
+			Name:        "otlpgrpcport",
+			Port:        int32(grpcPort),
+			Protocol:    corev1.ProtocolTCP,
+			TargetPort:  intstr.FromInt(grpcPort),
+			AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
 		}
 		otlpHttpPort := &corev1.ServicePort{
 			Name:       "otlphttpport",

--- a/internal/controller/datadogagent/feature/otelcollector/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature_test.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/utils/ptr"
 )
 
 type expectedPorts struct {
@@ -708,10 +709,11 @@ func testExpectedDepsCreatedCM(t testing.TB, store store.StoreClient) {
 		service := serviceObject.(*corev1.Service)
 		assert.Equal(t, []corev1.ServicePort{
 			{
-				Name:       "otlpgrpcport",
-				Port:       4317,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(4317),
+				Name:        "otlpgrpcport",
+				Port:        4317,
+				Protocol:    corev1.ProtocolTCP,
+				TargetPort:  intstr.FromInt(4317),
+				AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
 			},
 			{
 				Name:       "otlphttpport",
@@ -725,10 +727,11 @@ func testExpectedDepsCreatedCM(t testing.TB, store store.StoreClient) {
 		service := serviceObject.(*corev1.Service)
 		assert.Equal(t, []corev1.ServicePort{
 			{
-				Name:       "otlpgrpcport",
-				Port:       4444,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(4444),
+				Name:        "otlpgrpcport",
+				Port:        4444,
+				Protocol:    corev1.ProtocolTCP,
+				TargetPort:  intstr.FromInt(4444),
+				AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
 			},
 			{
 				Name:       "otlphttpport",

--- a/internal/controller/datadogagent/feature/otlp/feature.go
+++ b/internal/controller/datadogagent/feature/otlp/feature.go
@@ -159,10 +159,11 @@ func (f *otlpFeature) ManageDependencies(managers feature.ResourceManagers) erro
 		if common.ShouldCreateAgentLocalService(versionInfo, f.forceEnableLocalService) {
 			servicePort := []corev1.ServicePort{
 				{
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(int(port)),
-					Port:       port,
-					Name:       otlpGRPCPortName,
+					Protocol:    corev1.ProtocolTCP,
+					TargetPort:  intstr.FromInt(int(port)),
+					Port:        port,
+					Name:        otlpGRPCPortName,
+					AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
 				},
 			}
 			serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal

--- a/internal/controller/datadogagent/feature/otlp/feature_test.go
+++ b/internal/controller/datadogagent/feature/otlp/feature_test.go
@@ -11,21 +11,27 @@ import (
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/utils/ptr"
 )
 
 func TestOTLPFeature(t *testing.T) {
 	tests := test.FeatureTestSuite{
 		{
 			Name: "gRPC and HTTP enabled, APM",
-			DDA: newAgent(Settings{
+			DDA: withForcedLocalService(newAgent(Settings{
 				EnabledGRPC:         true,
 				EnabledGRPCHostPort: true,
 				CustomGRPCHostPort:  4317,
@@ -35,8 +41,34 @@ func TestOTLPFeature(t *testing.T) {
 				CustomHTTPHostPort:  4318,
 				EndpointHTTP:        "0.0.0.0:4318",
 				APM:                 true,
-			}),
+			})),
 			WantConfigure: true,
+			StoreOption: &store.StoreOptions{
+				PlatformInfo: kubernetes.NewPlatformInfo(
+					&version.Info{
+						Major:      "1",
+						Minor:      "32",
+						GitVersion: "1.32.0",
+					},
+					nil,
+					nil,
+				),
+			},
+			WantDependenciesFunc: testExpectedGRPCServicePorts([]corev1.ServicePort{
+				{
+					Protocol:    corev1.ProtocolTCP,
+					TargetPort:  intstr.FromInt(4317),
+					Port:        4317,
+					Name:        otlpGRPCPortName,
+					AppProtocol: ptr.To(common.KubernetesAppProtocolH2C),
+				},
+				{
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(4318),
+					Port:       4318,
+					Name:       otlpHTTPPortName,
+				},
+			}),
 			Agent: testExpected(Expected{
 				EnvVars: []*corev1.EnvVar{
 					{
@@ -408,6 +440,13 @@ func newAgentSingleContainer(set Settings) *v2alpha1.DatadogAgent {
 		Build()
 }
 
+func withForcedLocalService(dda *v2alpha1.DatadogAgent) *v2alpha1.DatadogAgent {
+	dda.Spec.Global.LocalService = &v2alpha1.LocalService{
+		ForceEnableLocalService: ptr.To(true),
+	}
+	return dda
+}
+
 type Expected struct {
 	EnvVars         []*corev1.EnvVar
 	CheckTraceAgent bool
@@ -443,6 +482,15 @@ func testExpected(exp Expected) *test.ComponentTest {
 			)
 		},
 	)
+}
+
+func testExpectedGRPCServicePorts(expectedPorts []corev1.ServicePort) func(testing.TB, store.StoreClient) {
+	return func(t testing.TB, store store.StoreClient) {
+		serviceObject, found := store.Get(kubernetes.ServicesKind, "", "-agent")
+		assert.True(t, found)
+		service := serviceObject.(*corev1.Service)
+		assert.Equal(t, expectedPorts, service.Spec.Ports)
+	}
 }
 
 func testExpectedSingleContainer(exp Expected) *test.ComponentTest {


### PR DESCRIPTION
### What does this PR do?

Adds `appProtocol: kubernetes.io/h2c` to Service ports that expose OTLP/gRPC traffic:

- Datadog Agent OTLP/gRPC local service port
- OTel Agent standalone gRPC service port
- OTel Agent Gateway gRPC service port

This intentionally leaves non-gRPC and OTLP/HTTP service ports unchanged.

### Motivation

Fixes #2145.

Some gateways and service mesh integrations use `ServicePort.appProtocol` as a hint to configure upstream protocol handling. Without an HTTP/2 hint, OTLP/gRPC traffic can be proxied as HTTP/1.1 and fail with protocol errors.

This PR uses `kubernetes.io/h2c` instead of kgateway's `http2` alias because it is the Kubernetes-defined `appProtocol` value for cleartext HTTP/2. OTLP/gRPC uses gRPC over HTTP/2, and these service ports are cleartext in-cluster endpoints, so `kubernetes.io/h2c` is both more explicit and more portable across Kubernetes-aware consumers.

References:

- Kubernetes `appProtocol` docs: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
- kgateway HTTP/2 backend protocol docs: https://kgateway.dev/docs/envoy/latest/traffic-management/http2/

### Additional Notes

`appProtocol` is only a protocol hint. It does not enforce traffic at the Kubernetes Service layer and does not change kube-proxy forwarding behavior.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Deploy DDA with gateway and otelAgent enabled:

```yaml
spec:
  features:
    otelAgentGateway:
      enabled: true
    otelCollector:
      enabled: true
```

Assert the Agent and gateway k8s services (note the service names might be different as they depend on your DatadogAgent name and override) expose the appProtocol `kubernetes.io/h2c` for the gRPC port 4317:
```console
╰─❯ k describe svc datadog-agent-otel-agent-gateway
Name:                     datadog-agent-otel-agent-gateway
Namespace:                system
Labels:                   app.kubernetes.io/instance=datadog-agent
                          app.kubernetes.io/managed-by=datadog-operator
                          app.kubernetes.io/name=datadog-agent-deployment
                          app.kubernetes.io/part-of=system-datadog--agent
                          app.kubernetes.io/version=
                          operator.datadoghq.com/managed-by-store=true
Annotations:              <none>
Selector:                 agent.datadoghq.com/component=otel-agent-gateway,app.kubernetes.io/part-of=system-datadog--agent
Type:                     ClusterIP
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.96.123.191
IPs:                      10.96.123.191
Port:                     otlpgrpcport  4317/TCP
TargetPort:               4317/TCP
AppProtocol:              kubernetes.io/h2c
Endpoints:                10.244.1.12:4317
Port:                     otlphttpport  4318/TCP
TargetPort:               4318/TCP
Endpoints:                10.244.1.12:4318
Session Affinity:         None
Internal Traffic Policy:  Cluster
Events:                   <none>

╰─❯ k describe svc datadog-agent-agent
Name:                     datadog-agent-agent
Namespace:                system
Labels:                   app.kubernetes.io/instance=datadog-agent
                          app.kubernetes.io/managed-by=datadog-operator
                          app.kubernetes.io/name=datadog-agent-deployment
                          app.kubernetes.io/part-of=system-datadog--agent
                          app.kubernetes.io/version=
                          operator.datadoghq.com/managed-by-store=true
Annotations:              <none>
Selector:                 agent.datadoghq.com/component=agent,app.kubernetes.io/part-of=system-datadog--agent
Type:                     ClusterIP
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.96.193.19
IPs:                      10.96.193.19
Port:                     traceport  8126/TCP
TargetPort:               8126/TCP
Endpoints:                10.244.0.8:8126,10.244.1.11:8126
Port:                     dogstatsdport  8125/UDP
TargetPort:               8125/UDP
Endpoints:                10.244.0.8:8125,10.244.1.11:8125
Port:                     otlpgrpcport  4317/TCP
TargetPort:               4317/TCP
AppProtocol:              kubernetes.io/h2c
Endpoints:                10.244.0.8:4317,10.244.1.11:4317
Session Affinity:         None
Internal Traffic Policy:  Local
Events:                   <none>
```

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits