### PR TITLE
[CONTP-1448] Add Windows node support to the Datadog Operator

### DIFF
--- a/internal/controller/datadogagent/component/agent/windows.go
+++ b/internal/controller/datadogagent/component/agent/windows.go
@@ -3,17 +3,19 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Windows DaemonSet builder — prototype for CONTP-1448.
-// Creates a minimal Windows-compatible DaemonSet alongside the Linux one:
-//   - nodeSelector: kubernetes.io/os=windows
-//   - toleration for node.kubernetes.io/os=windows:NoSchedule
+// Windows node support — CONTP-1448.
+// ApplyWindowsPodTransformation turns an already-built Linux node-agent pod template into a
+// Windows-compatible one (used on the DatadogAgentProfile + provider=windows path):
+//   - nodeSelector: kubernetes.io/os=windows + toleration for node.kubernetes.io/os=windows:NoSchedule
 //   - Windows agent image (servercore variant)
-//   - PowerShell init container creates an empty datadog.yaml + auth/ dir in a shared vol
-//   - Core agent + trace agent share config vol at C:/ProgramData/Datadog
-//     so the auth_token written by core agent is visible to trace agent
-//   - Core agent + trace agent only (no system-probe/security-agent — Linux/eBPF only)
-//   - No Linux capabilities, no seccomp, no readOnlyRootFilesystem
-//   - Only emptyDir/configMap volumes (no Linux hostPath mounts)
+//   - Core agent + trace/process agent only (no system-probe/security-agent — Linux/eBPF only)
+//   - An init container copies the image's conf.d (default check configs) + a datadog.yaml into a
+//     shared emptyDir, which the agent containers then mount at C:/ProgramData/Datadog. This gives
+//     the agents a single writable config dir that keeps the image's default checks AND lets the
+//     core agent share its IPC auth token with the trace/process agents. (The copy is essential:
+//     the agents override the image entrypoint with `agent run`/`trace-agent run`, so nothing
+//     generates datadog.yaml at start, and the image ships conf.d but no datadog.yaml.)
+//   - No Linux capabilities/seccomp/securityContext; no Linux hostPath mounts
 //   - StripLinuxOnlySettings (allowlist) removes anything Linux-only that features inject
 
 package agent
@@ -31,32 +33,40 @@ import (
 )
 
 const (
-	// windowsInitContainerName is the name of the Windows config-bootstrap init container.
-	windowsInitContainerName = "init-config-windows"
-
-	// windowsConfigVolumeName is the emptyDir volume shared between the init container
-	// and the core/trace agent containers on Windows. The init container creates an empty
-	// datadog.yaml (and the auth/ dir) in this volume; both agent containers then mount it
-	// at windowsDatadogConfigPath so they share the same datadog.yaml and the auth_token
-	// the core agent writes is visible to the trace agent.
+	// windowsConfigVolumeName is the emptyDir shared across the agent containers on Windows,
+	// mounted at the whole config dir C:/ProgramData/Datadog. An init container seeds it with a
+	// copy of the image's conf.d (default check configs) + a datadog.yaml before the agents start
+	// (see windowsConfigInitContainer), so it serves three purposes at once: it carries the
+	// default checks, provides the datadog.yaml the trace/process agents require, and holds the
+	// core agent's IPC auth token (under auth/) for the other agents to read.
+	//
+	// It must be the WHOLE config dir, not just auth/: when log collection is enabled the host
+	// C:/ProgramData is mounted read-only (to follow pod-log symlinks), which would otherwise
+	// hide the image's C:/ProgramData/Datadog. This emptyDir is mounted one level deeper, at
+	// C:/ProgramData/Datadog, so it overlays that host mount and restores a writable config dir.
 	windowsConfigVolumeName = "win-datadog-config"
 
-	// windowsDatadogConfigPath is the Windows default config directory. Both the core
-	// agent and trace agent mount the shared config volume here.
+	// windowsDatadogConfigPath is the Windows Agent config directory. The shared emptyDir is
+	// mounted here on the agent containers (seeded by the init container with conf.d + datadog.yaml).
 	windowsDatadogConfigPath = "C:/ProgramData/Datadog"
 
-	// windowsAuthTokenFilePath is the auth token path for Windows containers.
-	// This overrides the Linux default (DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth/token)
-	// that commonEnvVars injects, since both containers mount the shared vol at
-	// windowsDatadogConfigPath and the core agent writes auth_token there.
+	// windowsConfigInitPath is where the init container stages the config into the shared emptyDir.
+	// It is deliberately NOT C:/ProgramData/Datadog: mounting the emptyDir there in the init
+	// container would hide the very image conf.d the init container needs to copy. Staging at a
+	// separate path lets the init read the image's C:/ProgramData/Datadog and write the emptyDir.
+	windowsConfigInitPath = "C:/config-init"
+
+	// windowsAuthTokenFilePath is the IPC auth token path, inside the shared config dir's auth
+	// subdir. It overrides the Linux default (DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth/token)
+	// that commonEnvVars injects, so the token the core agent writes is visible to the trace agent.
 	windowsAuthTokenFilePath = windowsDatadogConfigPath + "/auth/token"
 
-	// Windows log-collection host paths (mirrors the Helm chart's daemonset-volumes-windows).
-	// On Windows, pod log files under C:/var/log/pods are symlinks into C:/ProgramData
-	// (containerd/docker), so the agent needs C:/ProgramData mounted to follow them.
+	// Windows log-collection host paths. Pod logs are regular files under C:/var/log/pods on
+	// containerd, so only C:/var/log + C:/var/log/pods are mounted; C:/ProgramData is deliberately
+	// NOT mounted (it would overlap the config dir — see AddWindowsLogCollectionVolumes).
 	windowsVarLogPath      = "C:/var/log"      // pointer dir (RW: agent stores log tail offsets)
-	windowsPodLogsPath     = "C:/var/log/pods" // Kubernetes pod log files
-	windowsProgramDataPath = "C:/ProgramData"  // symlink targets for the pod log files
+	windowsPodLogsPath     = "C:/var/log/pods" // Kubernetes pod log files (regular files here)
+	windowsProgramDataPath = "C:/ProgramData"  // config-dir parent; referenced only by tests
 
 	windowsPointerVolumeName      = "win-pointerdir"
 	windowsPodLogsVolumeName      = "win-logpodpath"
@@ -67,32 +77,31 @@ const (
 // back to the Windows defaults. These come from features.logCollection.{tempStoragePath,
 // podLogsPath,containerLogsPath} so custom Windows log paths take effect.
 type WindowsLogPaths struct {
-	TempStoragePath   string // pointer dir (RW); default C:/var/log
-	PodLogsPath       string // pod logs (RO);   default C:/var/log/pods
-	ContainerLogsPath string // symlink targets (RO); default C:/ProgramData
+	TempStoragePath string // pointer dir (RW); default C:/var/log
+	PodLogsPath     string // pod logs (RO);    default C:/var/log/pods
+	// ContainerLogsPath is the container-runtime log store; only mounted when set to a
+	// non-overlapping Windows path. See AddWindowsLogCollectionVolumes.
+	ContainerLogsPath string
 }
 
-// AddWindowsLogCollectionVolumes adds the Windows host-log hostPath volumes + mounts to the
-// core agent so log collection actually works (the logcollection feature only injects the
-// Linux paths, which the strip removes). Mirrors the Helm chart's daemonset-volumes-windows,
-// but honors the configured logCollection paths (falling back to the Windows defaults):
-//   - tempStoragePath   (pointer dir, RW — agent persists tail offsets); default C:/var/log
-//   - podLogsPath       (RO — Kubernetes pod log files);                 default C:/var/log/pods
-//   - containerLogsPath (RO — symlink targets the pod logs point into);  default C:/ProgramData
+// AddWindowsLogCollectionVolumes adds the Windows host-log hostPath volumes + mounts to the core
+// agent (the logcollection feature only injects the Linux paths, which the strip removes). It
+// mounts tempStoragePath (default C:/var/log) and podLogsPath (default C:/var/log/pods).
 //
-// It is a no-op if there is no core agent container (e.g. it was stripped). Safe to call only
-// when log collection is enabled.
+// containerLogsPath (the container-runtime log store that pod logs may symlink into) has no
+// default and is mounted only when set to a Windows path that does NOT overlap the config dir. On
+// containerd (the supported Windows runtime) pod logs are regular files under C:/var/log/pods, so
+// it is normally unset; defaulting it to C:/ProgramData would overlap C:/ProgramData/Datadog and
+// rely on non-guaranteed Windows nested-mount overlay. Symlink-based runtimes set it to the
+// store's own subdirectory (a sibling of the config dir, e.g. C:/ProgramData/docker/containers). A
+// path that overlaps the config dir is skipped and returned (empty otherwise) so the caller can
+// surface a condition instead of silently failing log collection.
 //
-// Following the Linux logcollection feature model, the configured paths set the HOST path only;
-// the in-container mount path is always the Windows Agent's standard path (C:/var/log,
-// C:/var/log/pods, C:/ProgramData). The Agent reads logs from those fixed in-container paths, so
-// a custom host path (e.g. D:/logs/pods) is surfaced where the Agent expects it without extra
-// Agent config. Mounting a custom path at itself would instead leave the Agent reading an empty
-// default path and silently collecting nothing.
-func AddWindowsLogCollectionVolumes(spec *corev1.PodSpec, paths WindowsLogPaths) {
+// It is a no-op if there is no core agent container. Configured paths set the HOST path only; the
+// in-container mount path is the Agent's standard Windows path.
+func AddWindowsLogCollectionVolumes(spec *corev1.PodSpec, paths WindowsLogPaths) (skippedOverlappingContainerLogsPath string) {
 	pointerHostPath := windowsPathOrDefault(paths.TempStoragePath, windowsVarLogPath)
 	podLogsHostPath := windowsPathOrDefault(paths.PodLogsPath, windowsPodLogsPath)
-	containerLogsHostPath := windowsPathOrDefault(paths.ContainerLogsPath, windowsProgramDataPath)
 
 	// Mount on the core agent, or the consolidated single agent under single-container strategy.
 	idx := -1
@@ -103,7 +112,7 @@ func AddWindowsLogCollectionVolumes(spec *corev1.PodSpec, paths WindowsLogPaths)
 		}
 	}
 	if idx == -1 {
-		return
+		return ""
 	}
 
 	hostPathVol := func(name, path string) corev1.Volume {
@@ -116,20 +125,51 @@ func AddWindowsLogCollectionVolumes(spec *corev1.PodSpec, paths WindowsLogPaths)
 	spec.Volumes = append(spec.Volumes,
 		hostPathVol(windowsPointerVolumeName, pointerHostPath),
 		hostPathVol(windowsPodLogsVolumeName, podLogsHostPath),
-		hostPathVol(windowsContainerLogVolumeName, containerLogsHostPath),
 	)
 	// Mount paths are fixed to the Agent's standard Windows paths regardless of the host path.
 	spec.Containers[idx].VolumeMounts = append(spec.Containers[idx].VolumeMounts,
 		corev1.VolumeMount{Name: windowsPointerVolumeName, MountPath: windowsVarLogPath},
 		corev1.VolumeMount{Name: windowsPodLogsVolumeName, MountPath: windowsPodLogsPath, ReadOnly: true},
-		corev1.VolumeMount{Name: windowsContainerLogVolumeName, MountPath: windowsProgramDataPath, ReadOnly: true},
 	)
 
-	// Force file-based container log collection on Windows. The only Windows log source we
-	// mount is the file tree (C:/var/log/pods + C:/ProgramData); runtime/socket-based
-	// collection has no Windows container-runtime socket/pipe wired up, so if the user set
-	// containerCollectUsingFiles=false the agent would collect nothing. Override to file mode.
+	// Only mount the container-log store when the user explicitly configured a Windows path that
+	// does not overlap the config dir (see the function doc). Never default it to C:/ProgramData.
+	if isExplicitWindowsPath(paths.ContainerLogsPath) {
+		if windowsPathOverlapsConfigDir(paths.ContainerLogsPath) {
+			// Would re-shadow the seeded config; skip and report.
+			skippedOverlappingContainerLogsPath = paths.ContainerLogsPath
+		} else {
+			spec.Volumes = append(spec.Volumes, hostPathVol(windowsContainerLogVolumeName, paths.ContainerLogsPath))
+			spec.Containers[idx].VolumeMounts = append(spec.Containers[idx].VolumeMounts,
+				corev1.VolumeMount{Name: windowsContainerLogVolumeName, MountPath: paths.ContainerLogsPath, ReadOnly: true},
+			)
+		}
+	}
+
+	// Force file-based container log collection on Windows. The only Windows log source we mount
+	// is the file tree under C:/var/log/pods; runtime/socket-based collection has no Windows
+	// container-runtime socket/pipe wired up, so if the user set containerCollectUsingFiles=false
+	// the agent would collect nothing. Override to file mode.
 	spec.Containers[idx].Env = setEnvVar(spec.Containers[idx].Env, "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE", "true")
+	return skippedOverlappingContainerLogsPath
+}
+
+// isExplicitWindowsPath reports whether v is a non-empty genuine Windows path (not a Linux
+// "/"-prefixed default). Used to gate optional mounts that have no safe Windows default.
+func isExplicitWindowsPath(v string) bool {
+	return v != "" && !strings.HasPrefix(v, "/")
+}
+
+// windowsPathOverlapsConfigDir reports whether a host mount at p would overlap the agent config
+// dir C:/ProgramData/Datadog — i.e. p is a parent of, equal to, or nested under it. Overlapping
+// parent/child mounts on Windows are not a guaranteed overlay, so such a container-log path is
+// skipped to avoid re-shadowing the seeded config.
+func windowsPathOverlapsConfigDir(p string) bool {
+	norm := func(s string) string {
+		return strings.ToLower(strings.TrimRight(strings.ReplaceAll(s, "\\", "/"), "/"))
+	}
+	a, b := norm(p), norm(windowsDatadogConfigPath)
+	return a == b || strings.HasPrefix(a+"/", b+"/") || strings.HasPrefix(b+"/", a+"/")
 }
 
 // windowsPathOrDefault returns the Windows default when the configured path is empty OR is a
@@ -234,38 +274,6 @@ func ensureServercoreTag(image string) string {
 	return base + tag
 }
 
-// windowsInitContainers returns a PowerShell init container that creates a minimal
-// datadog.yaml inside the shared win-datadog-config emptyDir volume, which is mounted
-// at windowsDatadogConfigPath. All meaningful configuration (API key, site, cluster-agent
-// token) is supplied via environment variables injected by global settings, so an empty
-// config file is sufficient to satisfy the agent's startup requirement.
-//
-// All three containers (init, core agent, trace agent) mount the same emptyDir at
-// C:/ProgramData/Datadog, so the auth_token written by the core agent is visible to
-// the trace agent without any additional path trickery.
-func windowsInitContainers(img string) []corev1.Container {
-	return []corev1.Container{
-		{
-			Name:    windowsInitContainerName,
-			Image:   img,
-			Command: []string{"powershell", "-command"},
-			// Create the auth/ subdirectory before datadog.yaml so the trace agent
-			// can read the token path (C:/ProgramData/Datadog/auth/token) immediately
-			// on startup without waiting for the core agent to create it.
-			Args: []string{
-				"New-Item -ItemType Directory -Force -Path C:/ProgramData/Datadog/auth; " +
-					"New-Item -ItemType File -Force -Path C:/ProgramData/Datadog/datadog.yaml",
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      windowsConfigVolumeName,
-					MountPath: windowsDatadogConfigPath,
-				},
-			},
-		},
-	}
-}
-
 // overrideAuthTokenPath returns a copy of envs with DD_AUTH_TOKEN_FILE_PATH set to the
 // Windows auth token path. It builds a new slice to avoid mutating the caller's backing array.
 func overrideAuthTokenPath(envs []corev1.EnvVar) []corev1.EnvVar {
@@ -287,13 +295,11 @@ func overrideAuthTokenPath(envs []corev1.EnvVar) []corev1.EnvVar {
 
 // volumesForWindowsAgent returns the volumes for the Windows DaemonSet.
 // Only the shared config volume is declared; Linux-only volumes (/proc, /sys/fs/cgroup,
-// /etc/passwd, seccomp, Unix sockets) are omitted. Additional volumes (log collection
-// paths, named pipes for DogStatsD/APM) will be added as Windows feature support lands.
+// /etc/passwd, seccomp, Unix sockets) are omitted. Additional volumes (named pipes for
+// DogStatsD/APM) will be added as Windows feature support lands.
 func volumesForWindowsAgent(_ metav1.Object) []corev1.Volume {
 	return []corev1.Volume{
-		// Shared config volume: init-config-windows copies the image's C:/ProgramData/Datadog
-		// here; core agent and trace agent both mount it at windowsDatadogConfigPath so they
-		// share the same datadog.yaml and auth_token.
+		// Shared config emptyDir seeded by the init container; see windowsConfigVolumeName.
 		{
 			Name:         windowsConfigVolumeName,
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
@@ -301,24 +307,48 @@ func volumesForWindowsAgent(_ metav1.Object) []corev1.Volume {
 	}
 }
 
-func volumeMountsForWindowsCoreAgent() []corev1.VolumeMount {
+// volumeMountsForWindowsAgent returns the shared config-dir mount applied to every surviving
+// agent container: the whole C:/ProgramData/Datadog (init-seeded conf.d + datadog.yaml + auth).
+func volumeMountsForWindowsAgent() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
-		// Mount shared config vol so core agent reads from init-populated
-		// C:/ProgramData/Datadog and writes auth_token there for trace agent.
 		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
 	}
 }
 
-func volumeMountsForWindowsTraceAgent() []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		// Mount same shared config vol so trace agent sees auth_token from core agent.
-		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
-	}
-}
-
-func volumeMountsForWindowsProcessAgent() []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
+// windowsConfigInitContainer returns the init container that seeds the shared config emptyDir.
+// It runs on the same (servercore) agent image so it has the image's C:/ProgramData/Datadog, and
+// copies conf.d + the *.yaml config files into the emptyDir staged at windowsConfigInitPath, then
+// ensures an auth/ dir and a datadog.yaml exist. The agent containers override the image entrypoint
+// with `agent run`/`trace-agent run`, so nothing would otherwise generate datadog.yaml; and the
+// image ships conf.d but no datadog.yaml. Config values still come from env vars (DD_*); the copied
+// conf.d supplies the default checks, and the empty datadog.yaml just satisfies the file the
+// trace/process agents load at startup.
+func windowsConfigInitContainer(image string, pullPolicy corev1.PullPolicy) corev1.Container {
+	// Mirror the image's whole config dir (C:/ProgramData/Datadog) into the shared emptyDir, then
+	// ensure the auth dir + a datadog.yaml exist. robocopy /E is used (not Copy-Item) because it is:
+	//   - idempotent: the emptyDir persists for the pod lifetime while the init container re-runs
+	//     when the pod sandbox is recreated (e.g. node reboot); robocopy mirrors without the
+	//     Copy-Item "copy dir into existing dir" nesting quirk (C:\...\conf.d\conf.d).
+	//   - tolerant: a missing/empty source conf.d (custom/minimal images) is not an error, and we
+	//     guard on the source dir existing so a truly minimal image still gets auth/ + datadog.yaml.
+	//   - complete: mirroring the WHOLE dir (not just conf.d + top-level *.yaml) carries checks.d
+	//     and any other image-provided config subdir, which the later full-dir mount would else hide.
+	// robocopy exit codes 0-7 are success; >=8 is a real failure, so map those to a nonzero exit.
+	script := "$ErrorActionPreference='Stop';" +
+		" if (Test-Path C:\\ProgramData\\Datadog) {" +
+		" robocopy C:\\ProgramData\\Datadog C:\\config-init /E /NFL /NDL /NJH /NJS /NP /R:2 /W:2 | Out-Null;" +
+		" if ($LASTEXITCODE -ge 8) { exit $LASTEXITCODE } };" +
+		" New-Item -ItemType Directory -Force -Path C:\\config-init\\auth | Out-Null;" +
+		" if (!(Test-Path C:\\config-init\\datadog.yaml)) { New-Item -ItemType File -Path C:\\config-init\\datadog.yaml | Out-Null };" +
+		" exit 0"
+	return corev1.Container{
+		Name:            "init-config-windows",
+		Image:           image,
+		ImagePullPolicy: pullPolicy,
+		Command:         []string{"powershell", "-Command", script},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: windowsConfigVolumeName, MountPath: windowsConfigInitPath},
+		},
 	}
 }
 
@@ -334,12 +364,12 @@ var windowsAllowedContainerNames = map[string]bool{
 	string(apicommon.UnprivilegedSingleAgentContainerName): true, // single-container strategy (behaves as core)
 }
 
-// windowsAllowedInitContainerNames is the allowlist of init containers on Windows.
-// Only the Windows config-bootstrap init container is kept; Linux init containers
-// (seccomp-setup, init-volume, init-config, …) are removed.
-var windowsAllowedInitContainerNames = map[string]bool{
-	windowsInitContainerName: true,
-}
+// windowsAllowedInitContainerNames is the allowlist of Linux init containers to KEEP on Windows.
+// It is empty: every Linux init container a feature injects (seccomp-setup, init-volume,
+// init-config, …) is stripped. The Windows config-seed init container is added afterwards, in
+// ApplyWindowsPodTransformation (see windowsConfigInitContainer), so it is not subject to this
+// allowlist.
+var windowsAllowedInitContainerNames = map[string]bool{}
 
 // StripLinuxOnlySettings removes Linux-incompatible mutations from a Windows PodSpec.
 // See stripLinuxOnlyFromSpec for the full description; prefer
@@ -380,6 +410,25 @@ func isWindowsMainAgentContainer(name string) bool {
 		name == string(apicommon.UnprivilegedSingleAgentContainerName)
 }
 
+// windowsAgentImageForInit returns the image + pull policy to use for the config-seed init
+// container so it carries the image's conf.d and pulls consistently with the agent. It prefers
+// the primary agent container (core or single), but falls back to any surviving agent container
+// (trace/process also run the agent image) so the shared config dir is still seeded — the
+// trace/process agents require the datadog.yaml the init creates even if the core agent was
+// dropped. Returns ok=false only when no agent container survives at all.
+func windowsAgentImageForInit(spec *corev1.PodSpec) (image string, pullPolicy corev1.PullPolicy, ok bool) {
+	for i := range spec.Containers {
+		if isWindowsMainAgentContainer(spec.Containers[i].Name) {
+			return spec.Containers[i].Image, spec.Containers[i].ImagePullPolicy, true
+		}
+	}
+	// No primary agent: fall back to the first surviving container (same agent image).
+	if len(spec.Containers) > 0 {
+		return spec.Containers[0].Image, spec.Containers[0].ImagePullPolicy, true
+	}
+	return "", "", false
+}
+
 // ApplyWindowsPodTransformation converts an already-built (Linux) node-agent pod template
 // into a Windows-compatible one, in place. It is used on the DatadogAgentProfile+provider
 // path: a profile targeting Windows nodes (annotation datadoghq.com/provider=windows) builds
@@ -390,8 +439,9 @@ func isWindowsMainAgentContainer(name string) bool {
 //     containers, "/"-path mounts/volumes, Unix-socket + Linux-only env, container and pod
 //     securityContext, hostPID/hostIPC, and all Linux init containers.
 //  2. Re-add the Windows config bootstrap: a shared emptyDir + PowerShell init container that
-//     seeds datadog.yaml and the auth dir, mounted at C:/ProgramData/Datadog on the surviving
-//     agent containers, plus the Windows container commands and the Windows auth-token path.
+//     seeds it with the image's conf.d + a datadog.yaml, mounted at C:/ProgramData/Datadog on the
+//     surviving agent containers, plus the Windows container commands and the Windows auth-token
+//     path.
 //  3. Coerce the default agent image to the -servercore variant.
 //  4. Add the Windows host-log hostPath mounts when log collection is enabled.
 //  5. Force non-local traffic so APM/DogStatsD are reachable without Unix sockets.
@@ -399,50 +449,36 @@ func isWindowsMainAgentContainer(name string) bool {
 //
 // logPaths carries the configured logCollection paths (Windows defaults are applied for the
 // Linux/empty values).
-func ApplyWindowsPodTransformation(tmpl *corev1.PodTemplateSpec, dda metav1.Object, logCollectionEnabled bool, logPaths WindowsLogPaths) {
+//
+// It returns a configured logCollection.containerLogsPath that was skipped for overlapping the
+// agent config dir (empty string otherwise), so the caller can surface a warning/condition.
+func ApplyWindowsPodTransformation(tmpl *corev1.PodTemplateSpec, dda metav1.Object, logCollectionEnabled bool, logPaths WindowsLogPaths) (skippedOverlappingContainerLogsPath string) {
 	StripLinuxOnlySettingsFromTemplate(tmpl)
 	spec := &tmpl.Spec
 
-	// Re-add the Windows config bootstrap (init container + shared volume + mounts/commands).
-	// The init container must use the SAME image + pull policy as the main agent container so
-	// that registry overrides / pinned tags applied to the agent (via global registry rewriting
-	// and the nodeAgent image override, both of which ran before this transformation) are also
-	// honored by the init container — otherwise it would pull the default gcr.io image and break
-	// private-registry / air-gapped installs. EnsureWindowsServercoreImage below coerces both to
-	// the -servercore variant consistently. Falls back to the default image if no agent container
-	// survives (should not happen).
-	initImage := images.GetLatestWindowsAgentImage()
-	var initPullPolicy corev1.PullPolicy
-	for i := range spec.Containers {
-		if isWindowsMainAgentContainer(spec.Containers[i].Name) {
-			initImage = spec.Containers[i].Image
-			initPullPolicy = spec.Containers[i].ImagePullPolicy
-			break
-		}
-	}
-	spec.InitContainers = windowsInitContainers(initImage)
-	if initPullPolicy != "" {
-		spec.InitContainers[0].ImagePullPolicy = initPullPolicy
-	}
+	// Re-add the shared config volume (mounted at C:/ProgramData/Datadog on the agent containers)
+	// so they share a single writable config dir carrying the default checks + auth token.
 	spec.Volumes = append(spec.Volumes, volumesForWindowsAgent(dda)...)
+	// Windows agent commands differ from Linux (default.go): no --config (agents use their default
+	// config dir C:/ProgramData/Datadog, seeded by the init container), and the trace/process
+	// agents use the "foreground" form so they run in the foreground rather than as a Windows
+	// service. `trace-agent run --foreground` is verified live (reaches "Trace agent running",
+	// :8126). process-agent only exists on older (<7.60) pinned agents; normally checks run in-core.
 	for i := range spec.Containers {
 		c := &spec.Containers[i]
 		switch c.Name {
 		case string(apicommon.CoreAgentContainerName):
 			c.Command = []string{"agent", "run"}
-			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsCoreAgent()...)
 			c.Env = overrideAuthTokenPath(c.Env)
 			// DogStatsD has no Unix socket on Windows: accept UDP from other pods.
 			c.Env = setEnvVar(c.Env, "DD_DOGSTATSD_NON_LOCAL_TRAFFIC", "true")
 		case string(apicommon.TraceAgentContainerName):
 			c.Command = []string{"trace-agent", "run", "--foreground"}
-			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsTraceAgent()...)
 			c.Env = overrideAuthTokenPath(c.Env)
 			// APM receiver must accept TCP from other pods (no Unix socket on Windows).
 			c.Env = setEnvVar(c.Env, "DD_APM_NON_LOCAL_TRAFFIC", "true")
 		case string(apicommon.ProcessAgentContainerName):
 			c.Command = []string{"process-agent", "--foreground"}
-			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsProcessAgent()...)
 			c.Env = overrideAuthTokenPath(c.Env)
 		case string(apicommon.UnprivilegedSingleAgentContainerName):
 			// Single-container strategy: one consolidated agent process. Treat it as the core
@@ -450,17 +486,33 @@ func ApplyWindowsPodTransformation(tmpl *corev1.PodTemplateSpec, dda metav1.Obje
 			// for the in-process APM/DogStatsD). Without this it would be stripped, leaving a
 			// container-less (invalid) pod.
 			c.Command = []string{"agent", "run"}
-			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsCoreAgent()...)
 			c.Env = overrideAuthTokenPath(c.Env)
 			c.Env = setEnvVar(c.Env, "DD_DOGSTATSD_NON_LOCAL_TRAFFIC", "true")
 			c.Env = setEnvVar(c.Env, "DD_APM_NON_LOCAL_TRAFFIC", "true")
 		}
 	}
 
+	// Seed the shared config dir before the agents start: an init container copies the image's
+	// conf.d + a datadog.yaml into the emptyDir (the agents override the entrypoint so nothing
+	// else creates datadog.yaml, and the image ships no datadog.yaml). Use the agent image so the
+	// init container has the image's conf.d + the same pull policy; EnsureWindowsServercoreImage
+	// then coerces it to the servercore variant along with the agent containers.
+	if img, pullPolicy, ok := windowsAgentImageForInit(spec); ok {
+		spec.InitContainers = append(spec.InitContainers, windowsConfigInitContainer(img, pullPolicy))
+	}
+
 	EnsureWindowsServercoreImage(spec)
 
 	if logCollectionEnabled {
-		AddWindowsLogCollectionVolumes(spec, logPaths)
+		skippedOverlappingContainerLogsPath = AddWindowsLogCollectionVolumes(spec, logPaths)
+	}
+
+	// Append the config mount after the log mounts (defensive parent-before-child ordering); no
+	// host mount overlaps the config dir by default. See AddWindowsLogCollectionVolumes.
+	for i := range spec.Containers {
+		if windowsAllowedContainerNames[spec.Containers[i].Name] {
+			spec.Containers[i].VolumeMounts = append(spec.Containers[i].VolumeMounts, volumeMountsForWindowsAgent()...)
+		}
 	}
 
 	// Node scheduling: target Windows nodes and tolerate the automatic Windows taint. The
@@ -479,6 +531,8 @@ func ApplyWindowsPodTransformation(tmpl *corev1.PodTemplateSpec, dda metav1.Obje
 	if !slices.Contains(spec.Tolerations, windowsToleration) {
 		spec.Tolerations = append(spec.Tolerations, windowsToleration)
 	}
+
+	return skippedOverlappingContainerLogsPath
 }
 
 func stripLinuxOnlyFromSpec(spec *corev1.PodSpec, annotations *map[string]string) {

--- a/internal/controller/datadogagent/component/agent/windows.go
+++ b/internal/controller/datadogagent/component/agent/windows.go
@@ -1,0 +1,663 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Windows DaemonSet builder — prototype for CONTP-1448.
+// Creates a minimal Windows-compatible DaemonSet alongside the Linux one:
+//   - nodeSelector: kubernetes.io/os=windows
+//   - toleration for node.kubernetes.io/os=windows:NoSchedule
+//   - Windows agent image (servercore variant)
+//   - PowerShell init container creates an empty datadog.yaml + auth/ dir in a shared vol
+//   - Core agent + trace agent share config vol at C:/ProgramData/Datadog
+//     so the auth_token written by core agent is visible to trace agent
+//   - Core agent + trace agent only (no system-probe/security-agent — Linux/eBPF only)
+//   - No Linux capabilities, no seccomp, no readOnlyRootFilesystem
+//   - Only emptyDir/configMap volumes (no Linux hostPath mounts)
+//   - StripLinuxOnlySettings (allowlist) removes anything Linux-only that features inject
+
+package agent
+
+import (
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/pkg/images"
+)
+
+const (
+	// windowsInitContainerName is the name of the Windows config-bootstrap init container.
+	windowsInitContainerName = "init-config-windows"
+
+	// windowsConfigVolumeName is the emptyDir volume shared between the init container
+	// and the core/trace agent containers on Windows. The init container creates an empty
+	// datadog.yaml (and the auth/ dir) in this volume; both agent containers then mount it
+	// at windowsDatadogConfigPath so they share the same datadog.yaml and the auth_token
+	// the core agent writes is visible to the trace agent.
+	windowsConfigVolumeName = "win-datadog-config"
+
+	// windowsDatadogConfigPath is the Windows default config directory. Both the core
+	// agent and trace agent mount the shared config volume here.
+	windowsDatadogConfigPath = "C:/ProgramData/Datadog"
+
+	// windowsAuthTokenFilePath is the auth token path for Windows containers.
+	// This overrides the Linux default (DD_AUTH_TOKEN_FILE_PATH=/etc/datadog-agent/auth/token)
+	// that commonEnvVars injects, since both containers mount the shared vol at
+	// windowsDatadogConfigPath and the core agent writes auth_token there.
+	windowsAuthTokenFilePath = windowsDatadogConfigPath + "/auth/token"
+
+	// Windows log-collection host paths (mirrors the Helm chart's daemonset-volumes-windows).
+	// On Windows, pod log files under C:/var/log/pods are symlinks into C:/ProgramData
+	// (containerd/docker), so the agent needs C:/ProgramData mounted to follow them.
+	windowsVarLogPath      = "C:/var/log"      // pointer dir (RW: agent stores log tail offsets)
+	windowsPodLogsPath     = "C:/var/log/pods" // Kubernetes pod log files
+	windowsProgramDataPath = "C:/ProgramData"  // symlink targets for the pod log files
+
+	windowsPointerVolumeName      = "win-pointerdir"
+	windowsPodLogsVolumeName      = "win-logpodpath"
+	windowsContainerLogVolumeName = "win-logcontainerpath"
+)
+
+// WindowsLogPaths holds the host log paths to mount on the Windows agent. Empty fields fall
+// back to the Windows defaults. These come from features.logCollection.{tempStoragePath,
+// podLogsPath,containerLogsPath} so custom Windows log paths take effect.
+type WindowsLogPaths struct {
+	TempStoragePath   string // pointer dir (RW); default C:/var/log
+	PodLogsPath       string // pod logs (RO);   default C:/var/log/pods
+	ContainerLogsPath string // symlink targets (RO); default C:/ProgramData
+}
+
+// AddWindowsLogCollectionVolumes adds the Windows host-log hostPath volumes + mounts to the
+// core agent so log collection actually works (the logcollection feature only injects the
+// Linux paths, which the strip removes). Mirrors the Helm chart's daemonset-volumes-windows,
+// but honors the configured logCollection paths (falling back to the Windows defaults):
+//   - tempStoragePath   (pointer dir, RW — agent persists tail offsets); default C:/var/log
+//   - podLogsPath       (RO — Kubernetes pod log files);                 default C:/var/log/pods
+//   - containerLogsPath (RO — symlink targets the pod logs point into);  default C:/ProgramData
+//
+// It is a no-op if there is no core agent container (e.g. it was stripped). Safe to call only
+// when log collection is enabled.
+//
+// Following the Linux logcollection feature model, the configured paths set the HOST path only;
+// the in-container mount path is always the Windows Agent's standard path (C:/var/log,
+// C:/var/log/pods, C:/ProgramData). The Agent reads logs from those fixed in-container paths, so
+// a custom host path (e.g. D:/logs/pods) is surfaced where the Agent expects it without extra
+// Agent config. Mounting a custom path at itself would instead leave the Agent reading an empty
+// default path and silently collecting nothing.
+func AddWindowsLogCollectionVolumes(spec *corev1.PodSpec, paths WindowsLogPaths) {
+	pointerHostPath := windowsPathOrDefault(paths.TempStoragePath, windowsVarLogPath)
+	podLogsHostPath := windowsPathOrDefault(paths.PodLogsPath, windowsPodLogsPath)
+	containerLogsHostPath := windowsPathOrDefault(paths.ContainerLogsPath, windowsProgramDataPath)
+
+	// Mount on the core agent, or the consolidated single agent under single-container strategy.
+	idx := -1
+	for i := range spec.Containers {
+		if isWindowsMainAgentContainer(spec.Containers[i].Name) {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return
+	}
+
+	hostPathVol := func(name, path string) corev1.Volume {
+		hpType := corev1.HostPathDirectoryOrCreate
+		return corev1.Volume{
+			Name:         name,
+			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: path, Type: &hpType}},
+		}
+	}
+	spec.Volumes = append(spec.Volumes,
+		hostPathVol(windowsPointerVolumeName, pointerHostPath),
+		hostPathVol(windowsPodLogsVolumeName, podLogsHostPath),
+		hostPathVol(windowsContainerLogVolumeName, containerLogsHostPath),
+	)
+	// Mount paths are fixed to the Agent's standard Windows paths regardless of the host path.
+	spec.Containers[idx].VolumeMounts = append(spec.Containers[idx].VolumeMounts,
+		corev1.VolumeMount{Name: windowsPointerVolumeName, MountPath: windowsVarLogPath},
+		corev1.VolumeMount{Name: windowsPodLogsVolumeName, MountPath: windowsPodLogsPath, ReadOnly: true},
+		corev1.VolumeMount{Name: windowsContainerLogVolumeName, MountPath: windowsProgramDataPath, ReadOnly: true},
+	)
+
+	// Force file-based container log collection on Windows. The only Windows log source we
+	// mount is the file tree (C:/var/log/pods + C:/ProgramData); runtime/socket-based
+	// collection has no Windows container-runtime socket/pipe wired up, so if the user set
+	// containerCollectUsingFiles=false the agent would collect nothing. Override to file mode.
+	spec.Containers[idx].Env = setEnvVar(spec.Containers[idx].Env, "DD_LOGS_CONFIG_K8S_CONTAINER_USE_FILE", "true")
+}
+
+// windowsPathOrDefault returns the Windows default when the configured path is empty OR is a
+// Linux absolute path (starts with "/"). The latter is essential: the logCollection feature
+// defaults these fields to Linux paths (/var/log/pods, /var/lib/docker/containers, …), so a
+// plain empty-check would let those defaults through and produce an invalid Windows DaemonSet.
+// Only genuinely Windows paths (e.g. C:/...) are honored as overrides.
+func windowsPathOrDefault(v, def string) string {
+	if v == "" || strings.HasPrefix(v, "/") {
+		return def
+	}
+	return v
+}
+
+// setEnvVar replaces the named env var (or appends it) and returns the slice.
+func setEnvVar(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			envs[i] = corev1.EnvVar{Name: name, Value: value}
+			return envs
+		}
+	}
+	return append(envs, corev1.EnvVar{Name: name, Value: value})
+}
+
+// EnsureWindowsServercoreImage makes sure the default Datadog Agent image on the Windows
+// pod spec carries the "-servercore" tag suffix. It MUST run after override.PodTemplateSpec
+// applies the nodeAgent image override: the generic OverrideAgentImage path replaces the
+// whole tag (servercore is not modeled as a preserved suffix), so a user pinning
+// image.tag=7.81.0 on the default image would otherwise get the Linux agent image.
+//
+// Coercion is intentionally limited to the default Datadog Agent image name ("agent"): a
+// fully custom image (e.g. registry.local/custom-agent:win2022) is the user's responsibility
+// and must already be Windows-compatible — we must not mangle its tag. Images whose tag
+// already contains "servercore" are left unchanged.
+func EnsureWindowsServercoreImage(spec *corev1.PodSpec) {
+	for i := range spec.Containers {
+		spec.Containers[i].Image = ensureServercoreTag(spec.Containers[i].Image)
+	}
+	for i := range spec.InitContainers {
+		spec.InitContainers[i].Image = ensureServercoreTag(spec.InitContainers[i].Image)
+	}
+}
+
+// HasFIPSAgentImage reports whether any container uses the default Datadog Agent image with a
+// FIPS-flavored tag (e.g. gcr.io/datadoghq/agent:7.80.2-fips). ensureServercoreTag would silently
+// rewrite such a tag to a non-FIPS -servercore image, so the reconciler uses this to reject FIPS
+// on Windows even when it was requested via an image tag override (not the global FIPS flags).
+func HasFIPSAgentImage(spec *corev1.PodSpec) bool {
+	isFIPS := func(image string) bool {
+		slash := strings.LastIndex(image, "/")
+		colon := strings.LastIndex(image, ":")
+		if colon <= slash {
+			return false
+		}
+		return image[slash+1:colon] == images.DefaultAgentImageName && strings.Contains(image[colon+1:], images.FIPSTagSuffix)
+	}
+	for _, c := range spec.Containers {
+		if isFIPS(c.Image) {
+			return true
+		}
+	}
+	for _, c := range spec.InitContainers {
+		if isFIPS(c.Image) {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureServercoreTag(image string) string {
+	// The tag is the segment after the last ":" that follows the last "/" (so a registry
+	// port like localhost:5000/agent:7.81.0 isn't mistaken for the tag).
+	slash := strings.LastIndex(image, "/")
+	colon := strings.LastIndex(image, ":")
+	if colon <= slash {
+		return image // no tag present; nothing safe to do
+	}
+	// Only coerce the default Datadog Agent image ("<registry>/agent"); leave custom images alone.
+	name := image[slash+1 : colon]
+	if name != images.DefaultAgentImageName {
+		return image
+	}
+	tag := image[colon+1:]
+	if strings.Contains(tag, "servercore") {
+		return image
+	}
+	base := image[:colon+1] // includes the trailing ":"
+	// Windows agent images are published as "<version>-servercore" and "<version>-servercore-jmx".
+	// The built tag may carry Linux flavor suffixes (-jmx/-full/-fips) that must not be appended
+	// verbatim ("<version>-jmx-servercore" does not exist). Strip them, insert -servercore, and
+	// re-append only -jmx (the sole flavor with a Windows variant). -full and -fips have no
+	// Windows image, so they are dropped in favor of the plain servercore image.
+	hasJMX := strings.Contains(tag, images.JMXTagSuffix)
+	for _, suffix := range []string{images.JMXTagSuffix, images.FullTagSuffix, images.FIPSTagSuffix} {
+		tag = strings.ReplaceAll(tag, suffix, "")
+	}
+	tag += images.WindowsServerCoreTagSuffix
+	if hasJMX {
+		tag += images.JMXTagSuffix
+	}
+	return base + tag
+}
+
+// windowsInitContainers returns a PowerShell init container that creates a minimal
+// datadog.yaml inside the shared win-datadog-config emptyDir volume, which is mounted
+// at windowsDatadogConfigPath. All meaningful configuration (API key, site, cluster-agent
+// token) is supplied via environment variables injected by global settings, so an empty
+// config file is sufficient to satisfy the agent's startup requirement.
+//
+// All three containers (init, core agent, trace agent) mount the same emptyDir at
+// C:/ProgramData/Datadog, so the auth_token written by the core agent is visible to
+// the trace agent without any additional path trickery.
+func windowsInitContainers(img string) []corev1.Container {
+	return []corev1.Container{
+		{
+			Name:    windowsInitContainerName,
+			Image:   img,
+			Command: []string{"powershell", "-command"},
+			// Create the auth/ subdirectory before datadog.yaml so the trace agent
+			// can read the token path (C:/ProgramData/Datadog/auth/token) immediately
+			// on startup without waiting for the core agent to create it.
+			Args: []string{
+				"New-Item -ItemType Directory -Force -Path C:/ProgramData/Datadog/auth; " +
+					"New-Item -ItemType File -Force -Path C:/ProgramData/Datadog/datadog.yaml",
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      windowsConfigVolumeName,
+					MountPath: windowsDatadogConfigPath,
+				},
+			},
+		},
+	}
+}
+
+// overrideAuthTokenPath returns a copy of envs with DD_AUTH_TOKEN_FILE_PATH set to the
+// Windows auth token path. It builds a new slice to avoid mutating the caller's backing array.
+func overrideAuthTokenPath(envs []corev1.EnvVar) []corev1.EnvVar {
+	out := make([]corev1.EnvVar, 0, len(envs)+1)
+	replaced := false
+	for _, e := range envs {
+		if e.Name == common.DDAuthTokenFilePath {
+			out = append(out, corev1.EnvVar{Name: common.DDAuthTokenFilePath, Value: windowsAuthTokenFilePath})
+			replaced = true
+			continue
+		}
+		out = append(out, e)
+	}
+	if !replaced {
+		out = append(out, corev1.EnvVar{Name: common.DDAuthTokenFilePath, Value: windowsAuthTokenFilePath})
+	}
+	return out
+}
+
+// volumesForWindowsAgent returns the volumes for the Windows DaemonSet.
+// Only the shared config volume is declared; Linux-only volumes (/proc, /sys/fs/cgroup,
+// /etc/passwd, seccomp, Unix sockets) are omitted. Additional volumes (log collection
+// paths, named pipes for DogStatsD/APM) will be added as Windows feature support lands.
+func volumesForWindowsAgent(_ metav1.Object) []corev1.Volume {
+	return []corev1.Volume{
+		// Shared config volume: init-config-windows copies the image's C:/ProgramData/Datadog
+		// here; core agent and trace agent both mount it at windowsDatadogConfigPath so they
+		// share the same datadog.yaml and auth_token.
+		{
+			Name:         windowsConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+	}
+}
+
+func volumeMountsForWindowsCoreAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		// Mount shared config vol so core agent reads from init-populated
+		// C:/ProgramData/Datadog and writes auth_token there for trace agent.
+		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
+	}
+}
+
+func volumeMountsForWindowsTraceAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		// Mount same shared config vol so trace agent sees auth_token from core agent.
+		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
+	}
+}
+
+func volumeMountsForWindowsProcessAgent() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{Name: windowsConfigVolumeName, MountPath: windowsDatadogConfigPath},
+	}
+}
+
+// windowsAllowedContainerNames is the allowlist of agent containers supported on Windows.
+// StripLinuxOnlySettings keeps ONLY these; everything else a feature might inject
+// (system-probe, security-agent, host-profiler, flightrecorder, fips-proxy, otel-agent,
+// agent-data-plane, private-action-runner, …) is removed. An allowlist is used instead
+// of a denylist so new Linux-only container classes don't silently leak onto Windows.
+var windowsAllowedContainerNames = map[string]bool{
+	string(apicommon.CoreAgentContainerName):               true,
+	string(apicommon.TraceAgentContainerName):              true,
+	string(apicommon.ProcessAgentContainerName):            true,
+	string(apicommon.UnprivilegedSingleAgentContainerName): true, // single-container strategy (behaves as core)
+}
+
+// windowsAllowedInitContainerNames is the allowlist of init containers on Windows.
+// Only the Windows config-bootstrap init container is kept; Linux init containers
+// (seccomp-setup, init-volume, init-config, …) are removed.
+var windowsAllowedInitContainerNames = map[string]bool{
+	windowsInitContainerName: true,
+}
+
+// StripLinuxOnlySettings removes Linux-incompatible mutations from a Windows PodSpec.
+// See stripLinuxOnlyFromSpec for the full description; prefer
+// StripLinuxOnlySettingsFromTemplate which also cleans container-scoped pod annotations.
+func StripLinuxOnlySettings(spec *corev1.PodSpec) {
+	stripLinuxOnlyFromSpec(spec, nil)
+}
+
+// StripLinuxOnlySettingsFromTemplate removes Linux-incompatible mutations from a full
+// PodTemplateSpec — including container-scoped pod annotations (AppArmor profiles, etc.)
+// that reference removed containers, which Kubernetes would otherwise reject.
+//
+// It is called AFTER features run their ManageNodeAgent hooks. The model is an allowlist,
+// not a denylist, because the feature surface grows over time and a denylist is always
+// one feature behind:
+//
+//   - Containers: keep ONLY windowsAllowedContainerNames (core/trace/process agent).
+//     Everything else (system-probe, security-agent, host-profiler, flightrecorder,
+//     fips-proxy, otel-agent, …) is removed.
+//   - Init containers: keep ONLY windowsAllowedInitContainerNames (the Windows bootstrap).
+//   - Volume mounts: on each surviving container, drop any mount whose MountPath is a
+//     Linux absolute path (starts with "/"). Windows mounts use C:/... paths, so this
+//     uniformly catches hostPath mounts (/proc, /), emptyDir mounts at Linux paths
+//     (/var/run/sysprobe, /var/run/datadog/flightrecorder), and config mounts.
+//   - Volumes: drop any volume not referenced by a surviving container's mounts.
+//   - SecurityContext: clear Linux fields (capabilities, seccomp, SELinux, AppArmor,
+//     readOnlyRootFilesystem).
+//
+// Preserved: all feature env vars, Windows-path mounts/volumes added by the Windows builder.
+func StripLinuxOnlySettingsFromTemplate(tmpl *corev1.PodTemplateSpec) {
+	stripLinuxOnlyFromSpec(&tmpl.Spec, &tmpl.Annotations)
+}
+
+// isWindowsMainAgentContainer reports whether the container is the primary agent process on
+// Windows — the core agent, or the consolidated single agent under single-container strategy.
+func isWindowsMainAgentContainer(name string) bool {
+	return name == string(apicommon.CoreAgentContainerName) ||
+		name == string(apicommon.UnprivilegedSingleAgentContainerName)
+}
+
+// ApplyWindowsPodTransformation converts an already-built (Linux) node-agent pod template
+// into a Windows-compatible one, in place. It is used on the DatadogAgentProfile+provider
+// path: a profile targeting Windows nodes (annotation datadoghq.com/provider=windows) builds
+// a normal agent DaemonSet through the shared machinery — which owns naming, labels, node
+// affinity and overrides — and this function then Windows-ifies the pod contents:
+//
+//  1. Strip every Linux-only artifact (StripLinuxOnlySettingsFromTemplate): non-Windows
+//     containers, "/"-path mounts/volumes, Unix-socket + Linux-only env, container and pod
+//     securityContext, hostPID/hostIPC, and all Linux init containers.
+//  2. Re-add the Windows config bootstrap: a shared emptyDir + PowerShell init container that
+//     seeds datadog.yaml and the auth dir, mounted at C:/ProgramData/Datadog on the surviving
+//     agent containers, plus the Windows container commands and the Windows auth-token path.
+//  3. Coerce the default agent image to the -servercore variant.
+//  4. Add the Windows host-log hostPath mounts when log collection is enabled.
+//  5. Force non-local traffic so APM/DogStatsD are reachable without Unix sockets.
+//  6. Add the Windows nodeSelector + the node.kubernetes.io/os=windows:NoSchedule toleration.
+//
+// logPaths carries the configured logCollection paths (Windows defaults are applied for the
+// Linux/empty values).
+func ApplyWindowsPodTransformation(tmpl *corev1.PodTemplateSpec, dda metav1.Object, logCollectionEnabled bool, logPaths WindowsLogPaths) {
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+	spec := &tmpl.Spec
+
+	// Re-add the Windows config bootstrap (init container + shared volume + mounts/commands).
+	// The init container must use the SAME image + pull policy as the main agent container so
+	// that registry overrides / pinned tags applied to the agent (via global registry rewriting
+	// and the nodeAgent image override, both of which ran before this transformation) are also
+	// honored by the init container — otherwise it would pull the default gcr.io image and break
+	// private-registry / air-gapped installs. EnsureWindowsServercoreImage below coerces both to
+	// the -servercore variant consistently. Falls back to the default image if no agent container
+	// survives (should not happen).
+	initImage := images.GetLatestWindowsAgentImage()
+	var initPullPolicy corev1.PullPolicy
+	for i := range spec.Containers {
+		if isWindowsMainAgentContainer(spec.Containers[i].Name) {
+			initImage = spec.Containers[i].Image
+			initPullPolicy = spec.Containers[i].ImagePullPolicy
+			break
+		}
+	}
+	spec.InitContainers = windowsInitContainers(initImage)
+	if initPullPolicy != "" {
+		spec.InitContainers[0].ImagePullPolicy = initPullPolicy
+	}
+	spec.Volumes = append(spec.Volumes, volumesForWindowsAgent(dda)...)
+	for i := range spec.Containers {
+		c := &spec.Containers[i]
+		switch c.Name {
+		case string(apicommon.CoreAgentContainerName):
+			c.Command = []string{"agent", "run"}
+			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsCoreAgent()...)
+			c.Env = overrideAuthTokenPath(c.Env)
+			// DogStatsD has no Unix socket on Windows: accept UDP from other pods.
+			c.Env = setEnvVar(c.Env, "DD_DOGSTATSD_NON_LOCAL_TRAFFIC", "true")
+		case string(apicommon.TraceAgentContainerName):
+			c.Command = []string{"trace-agent", "run", "--foreground"}
+			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsTraceAgent()...)
+			c.Env = overrideAuthTokenPath(c.Env)
+			// APM receiver must accept TCP from other pods (no Unix socket on Windows).
+			c.Env = setEnvVar(c.Env, "DD_APM_NON_LOCAL_TRAFFIC", "true")
+		case string(apicommon.ProcessAgentContainerName):
+			c.Command = []string{"process-agent", "--foreground"}
+			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsProcessAgent()...)
+			c.Env = overrideAuthTokenPath(c.Env)
+		case string(apicommon.UnprivilegedSingleAgentContainerName):
+			// Single-container strategy: one consolidated agent process. Treat it as the core
+			// agent on Windows (runs `agent run`, needs the shared config + non-local traffic
+			// for the in-process APM/DogStatsD). Without this it would be stripped, leaving a
+			// container-less (invalid) pod.
+			c.Command = []string{"agent", "run"}
+			c.VolumeMounts = append(c.VolumeMounts, volumeMountsForWindowsCoreAgent()...)
+			c.Env = overrideAuthTokenPath(c.Env)
+			c.Env = setEnvVar(c.Env, "DD_DOGSTATSD_NON_LOCAL_TRAFFIC", "true")
+			c.Env = setEnvVar(c.Env, "DD_APM_NON_LOCAL_TRAFFIC", "true")
+		}
+	}
+
+	EnsureWindowsServercoreImage(spec)
+
+	if logCollectionEnabled {
+		AddWindowsLogCollectionVolumes(spec, logPaths)
+	}
+
+	// Node scheduling: target Windows nodes and tolerate the automatic Windows taint. The
+	// profile's node affinity also targets Windows nodes; the nodeSelector is belt-and-braces.
+	if spec.NodeSelector == nil {
+		spec.NodeSelector = map[string]string{}
+	}
+	spec.NodeSelector["kubernetes.io/os"] = "windows"
+	windowsToleration := corev1.Toleration{
+		Key:      "node.kubernetes.io/os",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "windows",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	// Avoid a duplicate if an override already added the same toleration.
+	if !slices.Contains(spec.Tolerations, windowsToleration) {
+		spec.Tolerations = append(spec.Tolerations, windowsToleration)
+	}
+}
+
+func stripLinuxOnlyFromSpec(spec *corev1.PodSpec, annotations *map[string]string) {
+	// 0. Clear Linux pod-level namespace-sharing fields and pod-level security context.
+	//    Features can set these (e.g. DogStatsD origin detection sets hostPID=true), and a
+	//    nodeAgent securityContext override lands on the pod spec before this strip runs.
+	//    All are Linux-only (SELinux/seccomp/sysctls/fsGroup/…) and produce a
+	//    Windows-invalid PodSpec that the API server / kubelet rejects.
+	spec.HostPID = false
+	spec.HostIPC = false
+	// hostNetwork (Linux host networking) is not supported by regular Windows ServerCore
+	// containers; an override could set it, so clear it here.
+	spec.HostNetwork = false
+	spec.ShareProcessNamespace = nil
+	spec.SecurityContext = stripLinuxPodSecurityContext(spec.SecurityContext)
+
+	// Volumes backed by a Linux absolute hostPath (e.g. /var/run/docker.sock) are invalid on
+	// Windows even when a user override mounts them at a Windows-looking path (C:/...), so their
+	// mounts must be dropped too — not only mounts whose MountPath starts with "/".
+	linuxHostPathVols := make(map[string]bool)
+	for _, v := range spec.Volumes {
+		if v.HostPath != nil && strings.HasPrefix(v.HostPath.Path, "/") {
+			linuxHostPathVols[v.Name] = true
+		}
+	}
+
+	// 1. Keep only allowlisted main containers; drop their Linux mounts, Unix-socket
+	//    env vars, and security context.
+	var keepContainers []corev1.Container
+	for _, c := range spec.Containers {
+		if !windowsAllowedContainerNames[c.Name] {
+			continue
+		}
+		c.VolumeMounts = stripLinuxMounts(c.VolumeMounts, linuxHostPathVols)
+		c.Env = stripWindowsIncompatibleEnvVars(c.Env)
+		c.SecurityContext = stripLinuxSecurityContext(c.SecurityContext)
+		keepContainers = append(keepContainers, c)
+	}
+	spec.Containers = keepContainers
+
+	// 2. Keep only allowlisted init containers; drop their Linux mounts + security context.
+	var keepInits []corev1.Container
+	for _, c := range spec.InitContainers {
+		if !windowsAllowedInitContainerNames[c.Name] {
+			continue
+		}
+		c.VolumeMounts = stripLinuxMounts(c.VolumeMounts, linuxHostPathVols)
+		c.Env = stripWindowsIncompatibleEnvVars(c.Env)
+		c.SecurityContext = stripLinuxSecurityContext(c.SecurityContext)
+		keepInits = append(keepInits, c)
+	}
+	spec.InitContainers = keepInits
+
+	// 3. Drop any volume no longer referenced by a surviving container's mounts (this also
+	//    removes the Linux-hostPath volumes whose mounts were just dropped).
+	referenced := make(map[string]bool)
+	for _, c := range spec.Containers {
+		for _, m := range c.VolumeMounts {
+			referenced[m.Name] = true
+		}
+	}
+	for _, c := range spec.InitContainers {
+		for _, m := range c.VolumeMounts {
+			referenced[m.Name] = true
+		}
+	}
+	var keepVols []corev1.Volume
+	for _, v := range spec.Volumes {
+		if referenced[v.Name] {
+			keepVols = append(keepVols, v)
+		}
+	}
+	spec.Volumes = keepVols
+
+	// 4. Remove ALL AppArmor pod annotations (container.apparmor.security.beta.kubernetes.io/<name>).
+	//    AppArmor is Linux-only, so these are invalid on a Windows pod regardless of whether the
+	//    referenced container survived; Kubernetes also rejects annotations referencing removed
+	//    containers.
+	if annotations != nil && *annotations != nil {
+		for key := range *annotations {
+			if strings.HasPrefix(key, "container.apparmor.security.beta.kubernetes.io/") {
+				delete(*annotations, key)
+			}
+		}
+	}
+}
+
+// stripLinuxMounts removes any volume mount whose MountPath is a Linux absolute path
+// (starts with "/"). Windows mounts use C:/... drive-letter paths, so this is safe and
+// catches hostPath mounts, emptyDir mounts at Linux paths, and config mounts uniformly.
+// stripLinuxMounts drops mounts that are invalid on Windows: those mounted at a Linux absolute
+// path ("/..."), and those referencing a Linux-hostPath-backed volume (linuxHostPathVols) even
+// when the mount path itself looks Windows (e.g. an override mounting /var/run/docker.sock at
+// C:/somewhere) — otherwise the backing hostPath would make the Windows pod invalid.
+func stripLinuxMounts(mounts []corev1.VolumeMount, linuxHostPathVols map[string]bool) []corev1.VolumeMount {
+	var keep []corev1.VolumeMount
+	for _, m := range mounts {
+		if strings.HasPrefix(m.MountPath, "/") || linuxHostPathVols[m.Name] {
+			continue
+		}
+		keep = append(keep, m)
+	}
+	return keep
+}
+
+// linuxOnlyEnvVarNames are env vars that global settings / features inject with
+// Linux-specific path or transport values (Unix socket, host CA path, vsock) that are
+// invalid on Windows. Their backing volumes/mounts are already stripped; the env vars
+// must be removed too or the Windows agent gets fed bad paths/transports. Names mirror
+// the constants in internal/.../global/envvar.go (literals used to avoid an import cycle).
+var linuxOnlyEnvVarNames = map[string]bool{
+	"DOCKER_HOST":          true, // global.dockerSocketPath -> unix:///... (DD_CRI_SOCKET_PATH is caught by the SOCKET rule)
+	"DD_KUBELET_CLIENT_CA": true, // global.kubelet.hostCAPath -> /var/run/host-kubelet-ca.crt
+	"DD_VSOCK_ADDR":        true, // global.useVSock -> Linux vsock transport
+	// DogStatsD server-side origin detection resolves pod identity via the host PID
+	// namespace (/proc). The DogStatsD feature sets hostPID=true alongside it, but the
+	// strip clears hostPID (Windows-invalid), so this would just log errors on Windows.
+	// The client-side variant (DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT, container ID in the
+	// datagram) needs no hostPID and is preserved.
+	"DD_DOGSTATSD_ORIGIN_DETECTION": true,
+}
+
+// stripWindowsIncompatibleEnvVars removes env vars that don't work on Windows:
+//   - any name containing "SOCKET" (Unix-domain-socket config: DD_APM_RECEIVER_SOCKET,
+//     DD_DOGSTATSD_SOCKET, DD_*_HOST_SOCKET_PATH, DD_CRI_SOCKET_PATH). APM/DogStatsD
+//     default to UDS-enabled, so removing these lets them fall back to TCP/UDP.
+//   - the Linux-only global env vars in linuxOnlyEnvVarNames (docker host, kubelet CA path,
+//     vsock) whose Linux path/transport values are invalid on Windows.
+//
+// Windows named-pipe config (DD_*_WINDOWS_PIPE_NAME) does not match and is preserved.
+func stripWindowsIncompatibleEnvVars(envs []corev1.EnvVar) []corev1.EnvVar {
+	var keep []corev1.EnvVar
+	for _, e := range envs {
+		// DD_FIPS_* configure routing through a local fips-proxy container. That container is
+		// Linux-only and is removed by the allowlist strip, so leaving these set would make the
+		// Windows agent route intake at a proxy that does not exist. FIPS is not supported on
+		// Windows (no -servercore-fips image), so drop the config and talk to intake directly.
+		if strings.Contains(e.Name, "SOCKET") || strings.HasPrefix(e.Name, "DD_FIPS_") || linuxOnlyEnvVarNames[e.Name] {
+			continue
+		}
+		keep = append(keep, e)
+	}
+	return keep
+}
+
+// stripLinuxPodSecurityContext clears Linux-only pod-level security settings
+// (SELinux, seccomp, sysctls, fsGroup, supplementalGroups, runAsUser/Group/NonRoot)
+// that the Windows API server / kubelet rejects, while preserving the only
+// Windows-compatible field, WindowsOptions (runAsUserName / GMSA). Returns nil if
+// nothing Windows-relevant remains.
+func stripLinuxPodSecurityContext(sc *corev1.PodSecurityContext) *corev1.PodSecurityContext {
+	if sc == nil || sc.WindowsOptions == nil {
+		return nil
+	}
+	return &corev1.PodSecurityContext{WindowsOptions: sanitizeWindowsOptions(sc.WindowsOptions)}
+}
+
+// sanitizeWindowsOptions returns a copy of WindowsOptions with HostProcess cleared. This
+// transform builds regular ServerCore containers; HostProcess containers require the pod's
+// hostNetwork=true (which the strip clears), so preserving hostProcess would produce an invalid
+// pod. runAsUserName / GMSA are kept.
+func sanitizeWindowsOptions(opts *corev1.WindowsSecurityContextOptions) *corev1.WindowsSecurityContextOptions {
+	if opts == nil {
+		return nil
+	}
+	out := opts.DeepCopy()
+	out.HostProcess = nil
+	return out
+}
+
+// stripLinuxSecurityContext clears Linux-only container security settings, preserving only the
+// Windows-compatible field, WindowsOptions (runAsUserName / GMSA). Every other field —
+// capabilities, seccomp, SELinux, AppArmor, readOnlyRootFilesystem, and the *nix process
+// identity/privilege fields (runAsUser/Group/NonRoot, privileged, allowPrivilegeEscalation,
+// procMount) — is invalid on a Windows ServerCore container and would make the pod invalid if
+// set via an override. Returns nil when nothing Windows-relevant remains.
+func stripLinuxSecurityContext(sc *corev1.SecurityContext) *corev1.SecurityContext {
+	if sc == nil || sc.WindowsOptions == nil {
+		return nil
+	}
+	return &corev1.SecurityContext{WindowsOptions: sanitizeWindowsOptions(sc.WindowsOptions)}
+}

--- a/internal/controller/datadogagent/component/agent/windows_test.go
+++ b/internal/controller/datadogagent/component/agent/windows_test.go
@@ -1,0 +1,759 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+)
+
+// testDDA returns a minimal metav1.Object suitable for builder calls.
+func testDDA(name string) metav1.Object {
+	return &metav1.ObjectMeta{Name: name, Namespace: "datadog"}
+}
+
+// --- overrideAuthTokenPath ---
+
+func TestOverrideAuthTokenPath_ReplacesExisting(t *testing.T) {
+	envs := []corev1.EnvVar{
+		{Name: "DD_SITE", Value: "datadoghq.com"},
+		{Name: common.DDAuthTokenFilePath, Value: "/etc/datadog-agent/auth/token"},
+	}
+	original := make([]corev1.EnvVar, len(envs))
+	copy(original, envs)
+
+	out := overrideAuthTokenPath(envs)
+
+	// Input slice is not mutated.
+	assert.Equal(t, original, envs, "overrideAuthTokenPath must not mutate the input slice")
+
+	val, found := findEnvVar(out, common.DDAuthTokenFilePath)
+	assert.True(t, found)
+	assert.Equal(t, windowsAuthTokenFilePath, val)
+}
+
+func TestOverrideAuthTokenPath_AppendsWhenAbsent(t *testing.T) {
+	envs := []corev1.EnvVar{{Name: "DD_SITE", Value: "datadoghq.com"}}
+	out := overrideAuthTokenPath(envs)
+
+	val, found := findEnvVar(out, common.DDAuthTokenFilePath)
+	assert.True(t, found)
+	assert.Equal(t, windowsAuthTokenFilePath, val)
+}
+
+// --- StripLinuxOnlySettings ---
+
+// --- StripLinuxOnlySettingsFromTemplate (allowlist model) ---
+
+// Only core/trace/process agent containers survive; everything else (including
+// fips-proxy, otel-agent, system-probe, etc.) is removed regardless of denylist.
+func TestStripLinuxOnly_ContainerAllowlist(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "agent"},
+				{Name: "trace-agent"},
+				{Name: "process-agent"},
+				{Name: string(apicommon.SystemProbeContainerName)},
+				{Name: string(apicommon.SecurityAgentContainerName)},
+				{Name: string(apicommon.HostProfiler)},
+				{Name: string(apicommon.FlightRecorderContainerName)},
+				{Name: "fips-proxy"},
+				{Name: "otel-agent"},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	names := containerNames(tmpl.Spec.Containers)
+	assert.ElementsMatch(t, []string{"agent", "trace-agent", "process-agent"}, names,
+		"only core/trace/process agent should survive; fips-proxy/otel/system-probe/etc. removed")
+}
+
+// Init containers: only the Windows bootstrap survives.
+func TestStripLinuxOnly_InitContainerAllowlist(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init-config-windows"},
+				{Name: string(apicommon.SeccompSetupContainerName)},
+				{Name: string(apicommon.InitVolumeContainerName)},
+				{Name: string(apicommon.InitConfigContainerName)},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.InitContainers, 1)
+	assert.Equal(t, "init-config-windows", tmpl.Spec.InitContainers[0].Name)
+}
+
+// Any mount with a Linux absolute path is stripped from surviving containers;
+// Windows (C:/...) mounts are kept. Covers the reviewer's verified leaks:
+// hostPath / (SBOM), emptyDir /var/run/sysprobe (NPM/USM), /var/run/datadog/flightrecorder.
+func TestStripLinuxOnly_StripsLinuxMountPaths(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "hostroot", MountPath: "/host/root"},
+						{Name: "sysprobe-socket", MountPath: "/var/run/sysprobe"},
+						{Name: "runtimesocket", MountPath: "/run"},
+						{Name: "win-datadog-config", MountPath: "C:/ProgramData/Datadog"},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "hostroot", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/"}}},
+				{Name: "sysprobe-socket", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "runtimesocket", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/run"}}},
+				{Name: "win-datadog-config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	// Only the Windows mount survives on the container.
+	require.Len(t, tmpl.Spec.Containers, 1)
+	require.Len(t, tmpl.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Containers[0].VolumeMounts[0].Name)
+
+	// Only the referenced Windows volume survives; hostPath / and Linux emptyDirs are dropped.
+	require.Len(t, tmpl.Spec.Volumes, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Volumes[0].Name)
+}
+
+// Linux-only pod-level security settings (SELinux/sysctls/fsGroup/runAsUser/...) and
+// namespace-sharing fields must be cleared, while the Windows-compatible WindowsOptions
+// (runAsUserName / GMSA) is preserved. Guards against a nodeAgent securityContext
+// override producing a Windows-rejected pod.
+func TestStripLinuxOnly_PodSecurityContext(t *testing.T) {
+	runAsNonRoot := true
+	fsGroup := int64(1000)
+	shareNS := true
+	userName := "ContainerUser"
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			HostPID:               true,
+			HostIPC:               true,
+			ShareProcessNamespace: &shareNS,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   &runAsNonRoot,
+				FSGroup:        &fsGroup,
+				SELinuxOptions: &corev1.SELinuxOptions{Level: "s0"},
+				Sysctls:        []corev1.Sysctl{{Name: "net.core.somaxconn", Value: "1024"}},
+				WindowsOptions: &corev1.WindowsSecurityContextOptions{RunAsUserName: &userName},
+			},
+			Containers: []corev1.Container{{Name: "agent"}},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	assert.False(t, tmpl.Spec.HostPID, "HostPID must be cleared")
+	assert.False(t, tmpl.Spec.HostIPC, "HostIPC must be cleared")
+	assert.Nil(t, tmpl.Spec.ShareProcessNamespace, "ShareProcessNamespace must be cleared")
+	require.NotNil(t, tmpl.Spec.SecurityContext, "WindowsOptions must be preserved")
+	assert.Nil(t, tmpl.Spec.SecurityContext.RunAsNonRoot, "Linux RunAsNonRoot must be cleared")
+	assert.Nil(t, tmpl.Spec.SecurityContext.FSGroup, "Linux FSGroup must be cleared")
+	assert.Nil(t, tmpl.Spec.SecurityContext.SELinuxOptions, "SELinuxOptions must be cleared")
+	assert.Nil(t, tmpl.Spec.SecurityContext.Sysctls, "Sysctls must be cleared")
+	require.NotNil(t, tmpl.Spec.SecurityContext.WindowsOptions)
+	assert.Equal(t, "ContainerUser", *tmpl.Spec.SecurityContext.WindowsOptions.RunAsUserName)
+}
+
+// A pod SecurityContext with only Linux fields collapses to nil after stripping.
+func TestStripLinuxOnly_PodSecurityContext_NilWhenOnlyLinux(t *testing.T) {
+	fsGroup := int64(1000)
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{FSGroup: &fsGroup},
+			Containers:      []corev1.Container{{Name: "agent"}},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+	assert.Nil(t, tmpl.Spec.SecurityContext, "pod SecurityContext with only Linux fields must become nil")
+}
+
+// Volumes not referenced by any surviving container are dropped (even emptyDirs).
+func TestStripLinuxOnly_DropsUnreferencedVolumes(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "agent", VolumeMounts: []corev1.VolumeMount{{Name: "win-datadog-config", MountPath: "C:/ProgramData/Datadog"}}},
+				// system-probe gets removed; its emptyDir should then be unreferenced and dropped.
+				{Name: string(apicommon.SystemProbeContainerName), VolumeMounts: []corev1.VolumeMount{{Name: "sysprobe-only", MountPath: "C:/foo"}}},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "win-datadog-config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+				{Name: "sysprobe-only", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Volumes, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Volumes[0].Name)
+}
+
+func TestStripLinuxOnly_ClearsLinuxSecurityContext(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities:           &corev1.Capabilities{Add: []corev1.Capability{"SYS_ADMIN"}},
+						SeccompProfile:         &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeLocalhost},
+						SELinuxOptions:         &corev1.SELinuxOptions{Level: "s0"},
+						ReadOnlyRootFilesystem: ptr.To(true),
+					},
+				},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Containers, 1)
+	assert.Nil(t, tmpl.Spec.Containers[0].SecurityContext,
+		"SecurityContext should be nil after stripping all Linux fields")
+}
+
+func TestStripLinuxOnly_RemovesAllAppArmorAnnotations(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"container.apparmor.security.beta.kubernetes.io/system-probe": "localhost/system-probe",
+				"container.apparmor.security.beta.kubernetes.io/agent":        "runtime/default",
+				"ad.datadoghq.com/tags":                                       "{}",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "agent"},
+				{Name: string(apicommon.SystemProbeContainerName)},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	// AppArmor is Linux-only: ALL container.apparmor annotations are removed, even for the
+	// surviving agent container.
+	_, hasSystemProbe := tmpl.Annotations["container.apparmor.security.beta.kubernetes.io/system-probe"]
+	assert.False(t, hasSystemProbe, "AppArmor annotation for stripped system-probe must be removed")
+	_, hasAgent := tmpl.Annotations["container.apparmor.security.beta.kubernetes.io/agent"]
+	assert.False(t, hasAgent, "AppArmor annotation for surviving agent must ALSO be removed (Linux-only)")
+	_, hasTags := tmpl.Annotations["ad.datadoghq.com/tags"]
+	assert.True(t, hasTags, "unrelated annotation must be kept")
+}
+
+// Windows-incompatible env vars must be removed: Unix-domain-socket config (anything with
+// "SOCKET" in the name) and the Linux-only global env vars (DOCKER_HOST, DD_KUBELET_CLIENT_CA,
+// DD_VSOCK_ADDR). The agent then falls back to TCP/UDP. Non-matching env vars are preserved.
+func TestStripLinuxOnly_StripsWindowsIncompatibleEnvVars(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					Env: []corev1.EnvVar{
+						{Name: "DD_APM_RECEIVER_SOCKET", Value: "/var/run/datadog/apm.socket"},
+						{Name: "DD_DOGSTATSD_SOCKET", Value: "/var/run/datadog/dsd.socket"},
+						{Name: "DD_DOGSTATSD_HOST_SOCKET_PATH", Value: "/var/run/datadog"},
+						{Name: "DD_CRI_SOCKET_PATH", Value: "/var/run/containerd/containerd.sock"},
+						{Name: "DOCKER_HOST", Value: "unix:///host/var/run/docker.sock"},
+						{Name: "DD_KUBELET_CLIENT_CA", Value: "/var/run/host-kubelet-ca.crt"},
+						{Name: "DD_VSOCK_ADDR", Value: "vsock://..."},
+						// Server-side DogStatsD origin detection needs the (stripped) hostPID → drop it.
+						{Name: "DD_DOGSTATSD_ORIGIN_DETECTION", Value: "true"},
+						{Name: "DD_APM_ENABLED", Value: "true"},
+						{Name: "DD_API_KEY", Value: "x"},
+						// Client-side origin detection needs no hostPID → preserved.
+						{Name: "DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT", Value: "true"},
+					},
+				},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Containers, 1)
+	names := make(map[string]bool)
+	for _, e := range tmpl.Spec.Containers[0].Env {
+		names[e.Name] = true
+	}
+	for _, stripped := range []string{
+		"DD_APM_RECEIVER_SOCKET", "DD_DOGSTATSD_SOCKET", "DD_DOGSTATSD_HOST_SOCKET_PATH",
+		"DD_CRI_SOCKET_PATH", "DOCKER_HOST", "DD_KUBELET_CLIENT_CA", "DD_VSOCK_ADDR",
+		"DD_DOGSTATSD_ORIGIN_DETECTION",
+	} {
+		assert.False(t, names[stripped], "%s must be stripped on Windows", stripped)
+	}
+	assert.True(t, names["DD_APM_ENABLED"], "non-Linux env must be preserved")
+	assert.True(t, names["DD_API_KEY"], "non-Linux env must be preserved")
+	assert.True(t, names["DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT"], "client origin detection must be preserved")
+}
+
+func TestStripLinuxOnly_PreservesEnvVars(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "agent",
+					Env: []corev1.EnvVar{
+						{Name: "DD_APM_ENABLED", Value: "true"},
+						{Name: "DD_LOGS_ENABLED", Value: "true"},
+						{Name: "DD_TAGS", Value: "env:prod"},
+					},
+				},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Containers, 1)
+	require.Len(t, tmpl.Spec.Containers[0].Env, 3)
+}
+
+// --- helpers ---
+
+func containerNames(containers []corev1.Container) []string {
+	names := make([]string, len(containers))
+	for i, c := range containers {
+		names[i] = c.Name
+	}
+	return names
+}
+
+func findEnvVar(envs []corev1.EnvVar, name string) (string, bool) {
+	for _, e := range envs {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+// EnsureWindowsServercoreImage must re-add the -servercore suffix that the generic image
+// override drops (e.g. a user pinning image.tag=7.81.0), while leaving images that already
+// carry servercore untouched.
+func TestEnsureWindowsServercoreImage(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"gcr.io/datadoghq/agent:7.81.0", "gcr.io/datadoghq/agent:7.81.0-servercore"},
+		{"gcr.io/datadoghq/agent:7.81.0-servercore", "gcr.io/datadoghq/agent:7.81.0-servercore"},
+		{"gcr.io/datadoghq/agent:7.81.0-servercore-ltsc2022", "gcr.io/datadoghq/agent:7.81.0-servercore-ltsc2022"},
+		{"localhost:5000/agent:7.81.0", "localhost:5000/agent:7.81.0-servercore"}, // registry port not mistaken for tag
+		// Custom (non-"agent") images are the user's responsibility — left untouched.
+		{"registry.local/custom-agent:win2022", "registry.local/custom-agent:win2022"},
+	}
+	for _, c := range cases {
+		spec := &corev1.PodSpec{
+			Containers:     []corev1.Container{{Name: "agent", Image: c.in}},
+			InitContainers: []corev1.Container{{Name: "init-config-windows", Image: c.in}},
+		}
+		EnsureWindowsServercoreImage(spec)
+		assert.Equal(t, c.want, spec.Containers[0].Image, "container image for %q", c.in)
+		assert.Equal(t, c.want, spec.InitContainers[0].Image, "init image for %q", c.in)
+	}
+}
+
+// AddWindowsLogCollectionVolumes adds the three Windows host-log hostPath volumes + mounts
+// on the core agent (mirrors the Helm chart), and survives the strip because they use C:/ paths.
+func TestAddWindowsLogCollectionVolumes(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{Name: string(apicommon.CoreAgentContainerName)},
+			{Name: string(apicommon.TraceAgentContainerName)},
+		},
+	}
+	AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{}) // empty → Windows defaults
+
+	// 3 hostPath volumes with the expected default Windows paths.
+	paths := map[string]string{}
+	for _, v := range spec.Volumes {
+		require.NotNil(t, v.HostPath, "volume %q must be hostPath", v.Name)
+		paths[v.Name] = v.HostPath.Path
+	}
+	assert.Equal(t, "C:/var/log", paths[windowsPointerVolumeName])
+	assert.Equal(t, "C:/var/log/pods", paths[windowsPodLogsVolumeName])
+	assert.Equal(t, "C:/ProgramData", paths[windowsContainerLogVolumeName])
+
+	// Mounts land on the core agent only, at the same Windows paths.
+	var core, trace corev1.Container
+	for _, c := range spec.Containers {
+		if c.Name == string(apicommon.CoreAgentContainerName) {
+			core = c
+		}
+		if c.Name == string(apicommon.TraceAgentContainerName) {
+			trace = c
+		}
+	}
+	assert.Len(t, core.VolumeMounts, 3, "core agent gets the 3 log mounts")
+	assert.Empty(t, trace.VolumeMounts, "trace agent gets no log mounts")
+	for _, m := range core.VolumeMounts {
+		assert.True(t, strings.HasPrefix(m.MountPath, "C:/"), "mount %q must be a Windows path", m.MountPath)
+	}
+
+	// And they survive the strip (Windows paths, not Linux).
+	tmpl := &corev1.PodTemplateSpec{Spec: *spec}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+	surviving := 0
+	for _, v := range tmpl.Spec.Volumes {
+		if v.Name == windowsPointerVolumeName || v.Name == windowsPodLogsVolumeName || v.Name == windowsContainerLogVolumeName {
+			surviving++
+		}
+	}
+	assert.Equal(t, 3, surviving, "Windows log volumes must survive the strip")
+}
+
+// Configured logCollection paths must override the Windows defaults.
+func TestAddWindowsLogCollectionVolumes_CustomPaths(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: string(apicommon.CoreAgentContainerName)}},
+	}
+	AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{
+		TempStoragePath:   "D:/dd/run",
+		PodLogsPath:       "D:/logs/pods",
+		ContainerLogsPath: "D:/containerd",
+	})
+
+	paths := map[string]string{}
+	for _, v := range spec.Volumes {
+		paths[v.Name] = v.HostPath.Path
+	}
+	// Custom paths set the HOST path...
+	assert.Equal(t, "D:/dd/run", paths[windowsPointerVolumeName])
+	assert.Equal(t, "D:/logs/pods", paths[windowsPodLogsVolumeName])
+	assert.Equal(t, "D:/containerd", paths[windowsContainerLogVolumeName])
+
+	// ...but the in-container mount path is always the Agent's standard Windows path, so the
+	// Agent reads logs where it expects regardless of the host path (Linux model).
+	mountPaths := map[string]string{}
+	for _, m := range spec.Containers[0].VolumeMounts {
+		mountPaths[m.Name] = m.MountPath
+	}
+	assert.Equal(t, windowsVarLogPath, mountPaths[windowsPointerVolumeName])
+	assert.Equal(t, windowsPodLogsPath, mountPaths[windowsPodLogsVolumeName])
+	assert.Equal(t, windowsProgramDataPath, mountPaths[windowsContainerLogVolumeName])
+}
+
+// Linux-absolute paths (the logCollection feature's defaults, e.g. /var/log/pods) must be
+// treated as unset so the Windows defaults apply — otherwise Linux hostPaths land on Windows.
+func TestAddWindowsLogCollectionVolumes_LinuxDefaultsTreatedAsUnset(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{{Name: string(apicommon.CoreAgentContainerName)}},
+	}
+	AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{
+		TempStoragePath:   "/var/lib/datadog-agent/logs",
+		PodLogsPath:       "/var/log/pods",
+		ContainerLogsPath: "/var/lib/docker/containers",
+	})
+
+	for _, v := range spec.Volumes {
+		require.NotNil(t, v.HostPath)
+		assert.False(t, strings.HasPrefix(v.HostPath.Path, "/"),
+			"Linux default %q must be replaced by a Windows path", v.HostPath.Path)
+	}
+	paths := map[string]string{}
+	for _, v := range spec.Volumes {
+		paths[v.Name] = v.HostPath.Path
+	}
+	assert.Equal(t, "C:/var/log", paths[windowsPointerVolumeName])
+	assert.Equal(t, "C:/var/log/pods", paths[windowsPodLogsVolumeName])
+	assert.Equal(t, "C:/ProgramData", paths[windowsContainerLogVolumeName])
+}
+
+// --- ApplyWindowsPodTransformation ---
+
+// End-to-end: a Linux-built node-agent template (extra containers, Linux mounts/volumes,
+// Linux init, securityContext) is transformed into a valid Windows pod.
+func TestApplyWindowsPodTransformation(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			HostPID: true,
+			InitContainers: []corev1.Container{
+				{Name: string(apicommon.InitConfigContainerName), Command: []string{"bash"}},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  string(apicommon.CoreAgentContainerName),
+					Image: "gcr.io/datadoghq/agent:7.80.2",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "logpodpath", MountPath: "/var/log/pods"},
+						{Name: "auth", MountPath: "/etc/datadog-agent/auth"},
+					},
+					Env:             []corev1.EnvVar{{Name: "DD_DOGSTATSD_SOCKET", Value: "/var/run/dsd.socket"}},
+					SecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(true)},
+				},
+				{Name: string(apicommon.TraceAgentContainerName), Image: "gcr.io/datadoghq/agent:7.80.2"},
+				{Name: string(apicommon.SystemProbeContainerName), Image: "gcr.io/datadoghq/agent:7.80.2"},
+			},
+			Volumes: []corev1.Volume{
+				{Name: "logpodpath", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/log/pods"}}},
+				{Name: "auth", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+
+	ApplyWindowsPodTransformation(tmpl, testDDA("dd"), true, WindowsLogPaths{})
+	spec := tmpl.Spec
+
+	// Only core/trace survive (system-probe removed); Linux hostPID cleared.
+	assert.ElementsMatch(t, []string{"agent", "trace-agent"}, containerNames(spec.Containers))
+	assert.False(t, spec.HostPID)
+
+	// Windows bootstrap: only the Windows init container, servercore image everywhere.
+	require.Len(t, spec.InitContainers, 1)
+	assert.Equal(t, "init-config-windows", spec.InitContainers[0].Name)
+	for _, c := range spec.Containers {
+		assert.Contains(t, c.Image, "-servercore", "container %s image must be servercore", c.Name)
+	}
+	assert.Contains(t, spec.InitContainers[0].Image, "-servercore")
+
+	// No Linux hostPaths remain; the shared config + Windows log volumes are present.
+	for _, v := range spec.Volumes {
+		if v.HostPath != nil {
+			assert.False(t, strings.HasPrefix(v.HostPath.Path, "/"), "no Linux hostPath, got %q", v.HostPath.Path)
+		}
+	}
+	volNames := map[string]bool{}
+	for _, v := range spec.Volumes {
+		volNames[v.Name] = true
+	}
+	assert.True(t, volNames[windowsConfigVolumeName], "shared config volume present")
+	assert.True(t, volNames[windowsPodLogsVolumeName], "windows log volume present")
+
+	// Core agent: Windows command, config mount, non-local DogStatsD, no Unix-socket env.
+	core := findContainer(spec.Containers, "agent")
+	require.NotNil(t, core)
+	assert.Equal(t, []string{"agent", "run"}, core.Command)
+	assert.Nil(t, core.SecurityContext, "Linux securityContext cleared")
+	if v, ok := findEnvVar(core.Env, "DD_DOGSTATSD_NON_LOCAL_TRAFFIC"); assert.True(t, ok) {
+		assert.Equal(t, "true", v)
+	}
+	_, hasSocket := findEnvVar(core.Env, "DD_DOGSTATSD_SOCKET")
+	assert.False(t, hasSocket, "Unix-socket env stripped")
+
+	// nodeSelector + Windows taint toleration.
+	assert.Equal(t, "windows", spec.NodeSelector["kubernetes.io/os"])
+	found := false
+	for _, tol := range spec.Tolerations {
+		if tol.Key == "node.kubernetes.io/os" && tol.Value == "windows" {
+			found = true
+		}
+	}
+	assert.True(t, found, "windows taint toleration added")
+}
+
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+// Single-container strategy on Windows must yield a valid pod: the consolidated
+// unprivileged-single-agent container survives (as core) rather than being stripped.
+func TestApplyWindowsPodTransformation_SingleContainerStrategy(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: string(apicommon.UnprivilegedSingleAgentContainerName), Image: "gcr.io/datadoghq/agent:7.80.2"},
+			},
+		},
+	}
+	ApplyWindowsPodTransformation(tmpl, testDDA("dd"), false, WindowsLogPaths{})
+
+	require.Len(t, tmpl.Spec.Containers, 1, "single agent container must survive (not be stripped)")
+	c := tmpl.Spec.Containers[0]
+	assert.Equal(t, string(apicommon.UnprivilegedSingleAgentContainerName), c.Name)
+	assert.Equal(t, []string{"agent", "run"}, c.Command)
+	assert.Contains(t, c.Image, "-servercore")
+	if v, ok := findEnvVar(c.Env, "DD_APM_NON_LOCAL_TRAFFIC"); assert.True(t, ok) {
+		assert.Equal(t, "true", v)
+	}
+}
+
+// servercore coercion must place -servercore correctly for JMX and not fabricate broken
+// tags for -full/-fips (which have no Windows image variant).
+func TestEnsureServercoreTag_Flavors(t *testing.T) {
+	cases := map[string]string{
+		"gcr.io/datadoghq/agent:7.80.2":      "gcr.io/datadoghq/agent:7.80.2-servercore",
+		"gcr.io/datadoghq/agent:7.80.2-jmx":  "gcr.io/datadoghq/agent:7.80.2-servercore-jmx",
+		"gcr.io/datadoghq/agent:7.80.2-full": "gcr.io/datadoghq/agent:7.80.2-servercore",
+		"gcr.io/datadoghq/agent:7.80.2-fips": "gcr.io/datadoghq/agent:7.80.2-servercore",
+		// already servercore: unchanged
+		"gcr.io/datadoghq/agent:7.80.2-servercore": "gcr.io/datadoghq/agent:7.80.2-servercore",
+		// registry port not mistaken for tag; custom image untouched
+		"localhost:5000/custom-agent:win2022": "localhost:5000/custom-agent:win2022",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, ensureServercoreTag(in), "ensureServercoreTag(%q)", in)
+	}
+}
+
+// FIPS proxy is Linux-only and stripped on Windows; its DD_FIPS_* env must be removed too,
+// otherwise the agent routes intake at a proxy that no longer exists.
+func TestApplyWindowsPodTransformation_StripsFIPSEnv(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  string(apicommon.CoreAgentContainerName),
+				Image: "gcr.io/datadoghq/agent:7.80.2",
+				Env: []corev1.EnvVar{
+					{Name: "DD_FIPS_ENABLED", Value: "true"},
+					{Name: "DD_FIPS_PORT_RANGE_START", Value: "9803"},
+					{Name: "DD_FIPS_LOCAL_ADDRESS", Value: "127.0.0.1"},
+					{Name: "DD_API_KEY", Value: "x"},
+				},
+			}},
+		},
+	}
+	ApplyWindowsPodTransformation(tmpl, testDDA("dd"), false, WindowsLogPaths{})
+	c := findContainer(tmpl.Spec.Containers, string(apicommon.CoreAgentContainerName))
+	require.NotNil(t, c)
+	for _, n := range []string{"DD_FIPS_ENABLED", "DD_FIPS_PORT_RANGE_START", "DD_FIPS_LOCAL_ADDRESS"} {
+		_, ok := findEnvVar(c.Env, n)
+		assert.False(t, ok, "%s must be stripped on Windows", n)
+	}
+	_, ok := findEnvVar(c.Env, "DD_API_KEY")
+	assert.True(t, ok, "non-FIPS env preserved")
+}
+
+// The Windows init container must inherit the (possibly overridden) registry/image of the main
+// agent container, not the hardcoded default image.
+func TestApplyWindowsPodTransformation_InitInheritsAgentImage(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            string(apicommon.CoreAgentContainerName),
+				Image:           "myregistry.example.com/datadog/agent:7.99.9",
+				ImagePullPolicy: corev1.PullAlways,
+			}},
+		},
+	}
+	ApplyWindowsPodTransformation(tmpl, testDDA("dd"), false, WindowsLogPaths{})
+	require.Len(t, tmpl.Spec.InitContainers, 1)
+	init := tmpl.Spec.InitContainers[0]
+	assert.Equal(t, "myregistry.example.com/datadog/agent:7.99.9-servercore", init.Image,
+		"init image must inherit the agent's registry/tag + servercore")
+	assert.Equal(t, corev1.PullAlways, init.ImagePullPolicy, "init pull policy inherited from agent")
+}
+
+// Container-level Linux securityContext fields (runAsUser, privileged, …) set via override must
+// be dropped on Windows; only WindowsOptions survives.
+func TestStripLinuxSecurityContext_WindowsOptionsOnly(t *testing.T) {
+	user := "ContainerUser"
+	sc := &corev1.SecurityContext{
+		RunAsUser:                ptr.To[int64](0),
+		RunAsNonRoot:             ptr.To(true),
+		Privileged:               ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(true),
+		WindowsOptions:           &corev1.WindowsSecurityContextOptions{RunAsUserName: &user},
+	}
+	got := stripLinuxSecurityContext(sc)
+	require.NotNil(t, got)
+	assert.Nil(t, got.RunAsUser)
+	assert.Nil(t, got.RunAsNonRoot)
+	assert.Nil(t, got.Privileged)
+	assert.Nil(t, got.AllowPrivilegeEscalation)
+	require.NotNil(t, got.WindowsOptions)
+	assert.Equal(t, "ContainerUser", *got.WindowsOptions.RunAsUserName)
+
+	// Only-Linux context collapses to nil.
+	assert.Nil(t, stripLinuxSecurityContext(&corev1.SecurityContext{Privileged: ptr.To(true)}))
+}
+
+// hostNetwork (Linux host networking) is not supported by ServerCore Windows containers and
+// must be cleared even when set via an override.
+func TestStripLinuxOnly_ClearsHostNetwork(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			HostNetwork: true,
+			Containers:  []corev1.Container{{Name: "agent"}},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+	assert.False(t, tmpl.Spec.HostNetwork, "HostNetwork must be cleared on Windows")
+}
+
+// A Linux hostPath volume mounted at a Windows-looking path must still be dropped (both the
+// mount and the volume), since the backing hostPath is invalid on Windows.
+func TestStripLinuxOnly_DropsLinuxHostPathAtWindowsMountPath(t *testing.T) {
+	tmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "agent",
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "docker-sock", MountPath: "C:/docker"}, // Windows-looking mount path
+					{Name: "win-datadog-config", MountPath: "C:/ProgramData/Datadog"},
+				},
+			}},
+			Volumes: []corev1.Volume{
+				{Name: "docker-sock", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/docker.sock"}}},
+				{Name: "win-datadog-config", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+	StripLinuxOnlySettingsFromTemplate(tmpl)
+
+	require.Len(t, tmpl.Spec.Containers, 1)
+	// The docker-sock mount (Linux hostPath at a C:/ path) is dropped; only the emptyDir survives.
+	require.Len(t, tmpl.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Containers[0].VolumeMounts[0].Name)
+	require.Len(t, tmpl.Spec.Volumes, 1)
+	assert.Equal(t, "win-datadog-config", tmpl.Spec.Volumes[0].Name)
+}
+
+// HostProcess must be stripped from preserved WindowsOptions: HostProcess containers require
+// hostNetwork=true, which the Windows strip clears, so keeping it would make the pod invalid.
+func TestStripWindowsOptions_DropsHostProcess(t *testing.T) {
+	user := "ContainerUser"
+	hp := true
+	sc := &corev1.SecurityContext{
+		WindowsOptions: &corev1.WindowsSecurityContextOptions{RunAsUserName: &user, HostProcess: &hp},
+	}
+	got := stripLinuxSecurityContext(sc)
+	require.NotNil(t, got)
+	require.NotNil(t, got.WindowsOptions)
+	assert.Nil(t, got.WindowsOptions.HostProcess, "HostProcess must be stripped")
+	assert.Equal(t, "ContainerUser", *got.WindowsOptions.RunAsUserName, "runAsUserName preserved")
+
+	psc := &corev1.PodSecurityContext{
+		WindowsOptions: &corev1.WindowsSecurityContextOptions{HostProcess: &hp},
+	}
+	pgot := stripLinuxPodSecurityContext(psc)
+	require.NotNil(t, pgot)
+	assert.Nil(t, pgot.WindowsOptions.HostProcess, "pod-level HostProcess must be stripped")
+}
+
+// A -fips agent image tag must be detected (so the reconciler can reject it) rather than
+// silently rewritten to a non-FIPS -servercore image.
+func TestHasFIPSAgentImage(t *testing.T) {
+	fips := &corev1.PodSpec{Containers: []corev1.Container{{Name: "agent", Image: "gcr.io/datadoghq/agent:7.80.2-fips"}}}
+	assert.True(t, HasFIPSAgentImage(fips), "default agent image with -fips tag must be detected")
+
+	nonFips := &corev1.PodSpec{Containers: []corev1.Container{{Name: "agent", Image: "gcr.io/datadoghq/agent:7.80.2"}}}
+	assert.False(t, HasFIPSAgentImage(nonFips))
+
+	// A custom (non-"agent") image is the user's responsibility and is not rewritten, so not flagged.
+	custom := &corev1.PodSpec{Containers: []corev1.Container{{Name: "agent", Image: "registry.local/custom-agent:win-fips"}}}
+	assert.False(t, HasFIPSAgentImage(custom))
+}

--- a/internal/controller/datadogagent/component/agent/windows_test.go
+++ b/internal/controller/datadogagent/component/agent/windows_test.go
@@ -82,12 +82,12 @@ func TestStripLinuxOnly_ContainerAllowlist(t *testing.T) {
 		"only core/trace/process agent should survive; fips-proxy/otel/system-probe/etc. removed")
 }
 
-// Init containers: only the Windows bootstrap survives.
+// Init containers: all are stripped on Windows (the allowlist is empty — the Windows agent
+// needs no init container).
 func TestStripLinuxOnly_InitContainerAllowlist(t *testing.T) {
 	tmpl := &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{
 			InitContainers: []corev1.Container{
-				{Name: "init-config-windows"},
 				{Name: string(apicommon.SeccompSetupContainerName)},
 				{Name: string(apicommon.InitVolumeContainerName)},
 				{Name: string(apicommon.InitConfigContainerName)},
@@ -96,8 +96,7 @@ func TestStripLinuxOnly_InitContainerAllowlist(t *testing.T) {
 	}
 	StripLinuxOnlySettingsFromTemplate(tmpl)
 
-	require.Len(t, tmpl.Spec.InitContainers, 1)
-	assert.Equal(t, "init-config-windows", tmpl.Spec.InitContainers[0].Name)
+	assert.Empty(t, tmpl.Spec.InitContainers, "all Linux init containers must be stripped")
 }
 
 // Any mount with a Linux absolute path is stripped from surviving containers;
@@ -372,8 +371,8 @@ func TestEnsureWindowsServercoreImage(t *testing.T) {
 	}
 }
 
-// AddWindowsLogCollectionVolumes adds the three Windows host-log hostPath volumes + mounts
-// on the core agent (mirrors the Helm chart), and survives the strip because they use C:/ paths.
+// AddWindowsLogCollectionVolumes adds the two default Windows host-log hostPath volumes + mounts
+// on the core agent, which survive the strip because they use C:/ paths.
 func TestAddWindowsLogCollectionVolumes(t *testing.T) {
 	spec := &corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -383,7 +382,9 @@ func TestAddWindowsLogCollectionVolumes(t *testing.T) {
 	}
 	AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{}) // empty → Windows defaults
 
-	// 3 hostPath volumes with the expected default Windows paths.
+	// 2 hostPath volumes with the expected default Windows paths. The container-log store
+	// (C:/ProgramData) is NOT mounted by default — it would overlap the config dir and pod logs
+	// are regular files under C:/var/log/pods.
 	paths := map[string]string{}
 	for _, v := range spec.Volumes {
 		require.NotNil(t, v.HostPath, "volume %q must be hostPath", v.Name)
@@ -391,7 +392,8 @@ func TestAddWindowsLogCollectionVolumes(t *testing.T) {
 	}
 	assert.Equal(t, "C:/var/log", paths[windowsPointerVolumeName])
 	assert.Equal(t, "C:/var/log/pods", paths[windowsPodLogsVolumeName])
-	assert.Equal(t, "C:/ProgramData", paths[windowsContainerLogVolumeName])
+	_, hasContainerLog := paths[windowsContainerLogVolumeName]
+	assert.False(t, hasContainerLog, "container-log (C:/ProgramData) volume must NOT be mounted by default")
 
 	// Mounts land on the core agent only, at the same Windows paths.
 	var core, trace corev1.Container
@@ -403,10 +405,11 @@ func TestAddWindowsLogCollectionVolumes(t *testing.T) {
 			trace = c
 		}
 	}
-	assert.Len(t, core.VolumeMounts, 3, "core agent gets the 3 log mounts")
+	assert.Len(t, core.VolumeMounts, 2, "core agent gets the 2 default log mounts")
 	assert.Empty(t, trace.VolumeMounts, "trace agent gets no log mounts")
 	for _, m := range core.VolumeMounts {
 		assert.True(t, strings.HasPrefix(m.MountPath, "C:/"), "mount %q must be a Windows path", m.MountPath)
+		assert.NotEqual(t, windowsProgramDataPath, m.MountPath, "no C:/ProgramData mount (would overlap config dir)")
 	}
 
 	// And they survive the strip (Windows paths, not Linux).
@@ -414,11 +417,11 @@ func TestAddWindowsLogCollectionVolumes(t *testing.T) {
 	StripLinuxOnlySettingsFromTemplate(tmpl)
 	surviving := 0
 	for _, v := range tmpl.Spec.Volumes {
-		if v.Name == windowsPointerVolumeName || v.Name == windowsPodLogsVolumeName || v.Name == windowsContainerLogVolumeName {
+		if v.Name == windowsPointerVolumeName || v.Name == windowsPodLogsVolumeName {
 			surviving++
 		}
 	}
-	assert.Equal(t, 3, surviving, "Windows log volumes must survive the strip")
+	assert.Equal(t, 2, surviving, "Windows log volumes must survive the strip")
 }
 
 // Configured logCollection paths must override the Windows defaults.
@@ -439,17 +442,48 @@ func TestAddWindowsLogCollectionVolumes_CustomPaths(t *testing.T) {
 	// Custom paths set the HOST path...
 	assert.Equal(t, "D:/dd/run", paths[windowsPointerVolumeName])
 	assert.Equal(t, "D:/logs/pods", paths[windowsPodLogsVolumeName])
+	// An explicit, non-overlapping Windows container-log path IS mounted (D:/containerd).
 	assert.Equal(t, "D:/containerd", paths[windowsContainerLogVolumeName])
 
-	// ...but the in-container mount path is always the Agent's standard Windows path, so the
-	// Agent reads logs where it expects regardless of the host path (Linux model).
+	// The pointer + pod-log mounts use the Agent's standard Windows paths (Linux model), while the
+	// explicit container-log store is mounted at its own configured path (it has no standard path).
 	mountPaths := map[string]string{}
 	for _, m := range spec.Containers[0].VolumeMounts {
 		mountPaths[m.Name] = m.MountPath
 	}
 	assert.Equal(t, windowsVarLogPath, mountPaths[windowsPointerVolumeName])
 	assert.Equal(t, windowsPodLogsPath, mountPaths[windowsPodLogsVolumeName])
-	assert.Equal(t, windowsProgramDataPath, mountPaths[windowsContainerLogVolumeName])
+	assert.Equal(t, "D:/containerd", mountPaths[windowsContainerLogVolumeName])
+}
+
+// An explicit container-log path that OVERLAPS the config dir must be skipped (it would re-shadow
+// the seeded config via a non-guaranteed Windows nested mount) AND reported back to the caller.
+func TestAddWindowsLogCollectionVolumes_OverlappingContainerPathSkipped(t *testing.T) {
+	for _, overlap := range []string{"C:/ProgramData", "C:/ProgramData/Datadog", "C:/ProgramData/Datadog/conf.d", `C:\ProgramData`} {
+		spec := &corev1.PodSpec{Containers: []corev1.Container{{Name: string(apicommon.CoreAgentContainerName)}}}
+		skipped := AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{ContainerLogsPath: overlap})
+		for _, v := range spec.Volumes {
+			assert.NotEqual(t, windowsContainerLogVolumeName, v.Name,
+				"overlapping container-log path %q must not be mounted", overlap)
+		}
+		assert.Equal(t, overlap, skipped, "overlapping container-log path must be reported so the caller can surface it")
+	}
+}
+
+// A non-overlapping (sibling) container-log path — the supported way to serve symlink-based pod
+// logs — IS mounted and NOT reported as skipped.
+func TestAddWindowsLogCollectionVolumes_SiblingContainerPathMounted(t *testing.T) {
+	spec := &corev1.PodSpec{Containers: []corev1.Container{{Name: string(apicommon.CoreAgentContainerName)}}}
+	skipped := AddWindowsLogCollectionVolumes(spec, WindowsLogPaths{ContainerLogsPath: "C:/ProgramData/docker/containers"})
+	assert.Empty(t, skipped, "a non-overlapping container-log path must not be reported as skipped")
+	mounted := false
+	for _, v := range spec.Volumes {
+		if v.Name == windowsContainerLogVolumeName {
+			mounted = true
+			assert.Equal(t, "C:/ProgramData/docker/containers", v.HostPath.Path)
+		}
+	}
+	assert.True(t, mounted, "a non-overlapping sibling container-log path must be mounted")
 }
 
 // Linux-absolute paths (the logCollection feature's defaults, e.g. /var/log/pods) must be
@@ -475,7 +509,9 @@ func TestAddWindowsLogCollectionVolumes_LinuxDefaultsTreatedAsUnset(t *testing.T
 	}
 	assert.Equal(t, "C:/var/log", paths[windowsPointerVolumeName])
 	assert.Equal(t, "C:/var/log/pods", paths[windowsPodLogsVolumeName])
-	assert.Equal(t, "C:/ProgramData", paths[windowsContainerLogVolumeName])
+	// A Linux container-log path is treated as unset → not mounted (no C:/ProgramData default).
+	_, hasContainerLog := paths[windowsContainerLogVolumeName]
+	assert.False(t, hasContainerLog, "Linux container-log path must be treated as unset, not mounted")
 }
 
 // --- ApplyWindowsPodTransformation ---
@@ -491,8 +527,9 @@ func TestApplyWindowsPodTransformation(t *testing.T) {
 			},
 			Containers: []corev1.Container{
 				{
-					Name:  string(apicommon.CoreAgentContainerName),
-					Image: "gcr.io/datadoghq/agent:7.80.2",
+					Name:            string(apicommon.CoreAgentContainerName),
+					Image:           "gcr.io/datadoghq/agent:7.80.2",
+					ImagePullPolicy: corev1.PullAlways,
 					VolumeMounts: []corev1.VolumeMount{
 						{Name: "logpodpath", MountPath: "/var/log/pods"},
 						{Name: "auth", MountPath: "/etc/datadog-agent/auth"},
@@ -517,13 +554,21 @@ func TestApplyWindowsPodTransformation(t *testing.T) {
 	assert.ElementsMatch(t, []string{"agent", "trace-agent"}, containerNames(spec.Containers))
 	assert.False(t, spec.HostPID)
 
-	// Windows bootstrap: only the Windows init container, servercore image everywhere.
-	require.Len(t, spec.InitContainers, 1)
+	// The config-seed init container is added (copies the image's conf.d + datadog.yaml into the
+	// shared emptyDir); servercore image on all containers, including the init container.
+	require.Len(t, spec.InitContainers, 1, "config-seed init container present")
 	assert.Equal(t, "init-config-windows", spec.InitContainers[0].Name)
+	assert.Contains(t, spec.InitContainers[0].Image, "-servercore", "init container image must be servercore")
+	initMount := spec.InitContainers[0].VolumeMounts[0]
+	assert.Equal(t, windowsConfigVolumeName, initMount.Name)
+	assert.Equal(t, windowsConfigInitPath, initMount.MountPath,
+		"init must stage into the emptyDir at a path other than the config dir, so it can read the image conf.d")
+	// Init container inherits the main agent container's pull policy (it uses the same image).
+	assert.Equal(t, corev1.PullAlways, spec.InitContainers[0].ImagePullPolicy,
+		"init container must inherit the agent's ImagePullPolicy")
 	for _, c := range spec.Containers {
 		assert.Contains(t, c.Image, "-servercore", "container %s image must be servercore", c.Name)
 	}
-	assert.Contains(t, spec.InitContainers[0].Image, "-servercore")
 
 	// No Linux hostPaths remain; the shared config + Windows log volumes are present.
 	for _, v := range spec.Volumes {
@@ -548,6 +593,24 @@ func TestApplyWindowsPodTransformation(t *testing.T) {
 	}
 	_, hasSocket := findEnvVar(core.Env, "DD_DOGSTATSD_SOCKET")
 	assert.False(t, hasSocket, "Unix-socket env stripped")
+
+	// The shared config volume mounts at the whole config dir C:/ProgramData/Datadog, seeded by the
+	// init container with conf.d + datadog.yaml.
+	var sharedMount string
+	for _, m := range core.VolumeMounts {
+		if m.Name == windowsConfigVolumeName {
+			sharedMount = m.MountPath
+		}
+	}
+	assert.Equal(t, windowsDatadogConfigPath, sharedMount, "shared config vol must mount at the whole config dir")
+	// CRITICAL anti-shadowing invariant: with log collection enabled, NO host mount may overlap the
+	// config dir. In particular C:/ProgramData (the config dir's parent, the old default container-
+	// log mount) must NOT be mounted — that overlap relied on non-guaranteed Windows nested-mount
+	// overlay and could re-shadow the seeded config (the original bug).
+	for _, m := range core.VolumeMounts {
+		assert.NotEqual(t, windowsProgramDataPath, m.MountPath,
+			"C:/ProgramData must not be mounted (would overlap config dir C:/ProgramData/Datadog)")
+	}
 
 	// nodeSelector + Windows taint toleration.
 	assert.Equal(t, "windows", spec.NodeSelector["kubernetes.io/os"])
@@ -635,26 +698,6 @@ func TestApplyWindowsPodTransformation_StripsFIPSEnv(t *testing.T) {
 	}
 	_, ok := findEnvVar(c.Env, "DD_API_KEY")
 	assert.True(t, ok, "non-FIPS env preserved")
-}
-
-// The Windows init container must inherit the (possibly overridden) registry/image of the main
-// agent container, not the hardcoded default image.
-func TestApplyWindowsPodTransformation_InitInheritsAgentImage(t *testing.T) {
-	tmpl := &corev1.PodTemplateSpec{
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:            string(apicommon.CoreAgentContainerName),
-				Image:           "myregistry.example.com/datadog/agent:7.99.9",
-				ImagePullPolicy: corev1.PullAlways,
-			}},
-		},
-	}
-	ApplyWindowsPodTransformation(tmpl, testDDA("dd"), false, WindowsLogPaths{})
-	require.Len(t, tmpl.Spec.InitContainers, 1)
-	init := tmpl.Spec.InitContainers[0]
-	assert.Equal(t, "myregistry.example.com/datadog/agent:7.99.9-servercore", init.Image,
-		"init image must inherit the agent's registry/tag + servercore")
-	assert.Equal(t, corev1.PullAlways, init.ImagePullPolicy, "init pull policy inherited from agent")
 }
 
 // Container-level Linux securityContext fields (runAsUser, privileged, …) set via override must

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -50,12 +50,22 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 	agentEnabled := requiredComponents.Agent.IsEnabled()
 	singleContainerStrategyEnabled := requiredComponents.Agent.SingleContainerStrategyEnabled()
 
+	// Windows is enabled ONLY on a profile-labeled DDAI carrying provider=windows (generated from
+	// a DatadogAgentProfile that targets Windows nodes). A default DDAI must never be Windows-ified
+	// — that would turn the cluster-wide node agent Windows-only and strand Linux nodes — so a
+	// provider=windows annotation set directly on the DatadogAgent is intentionally ignored.
+	windowsProfile := provider == kubernetes.WindowsProvider && isDDAILabeledWithProfile(ddai)
+
 	// When EDS is enabled and there are profiles defined, we only create an
 	// EDS for the default profile, for the other profiles we create
 	// DaemonSets.
 	// This is to make deployments simpler. With multiple EDS there would be
 	// multiple canaries, etc.
 	if r.options.ExtendedDaemonsetOptions.Enabled && !isDDAILabeledWithProfile(ddai) {
+		// Note: Windows is only applied on profile-labeled DDAIs (see windowsProfile below), which
+		// never reach this branch. A default DDAI with a stray provider=windows annotation builds a
+		// normal Linux ExtendedDaemonSet here (the annotation is ignored) so Linux nodes keep their
+		// agent rather than being stranded.
 		// Start by creating the Default Agent extendeddaemonset
 		eds = componentagent.NewDefaultAgentExtendedDaemonset(ddai, &r.options.ExtendedDaemonsetOptions, requiredComponents.Agent)
 		objLogger := daemonsetLogger.WithValues("object.kind", "ExtendedDaemonSet", "object.namespace", eds.Namespace, "object.name", eds.Name)
@@ -138,6 +148,12 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 	// Provider capabilities are applied immediately after each feature's ManageNodeAgent
 	// so that each feature owns its provider correctness independently.
 	for _, feat := range features {
+		// On the Windows provider path, only allowlisted features run their node-agent hooks;
+		// the rest (eBPF/system-probe, etc.) are gated out so they don't inject config the
+		// Windows agent can't use. The subsequent strip is the safety net for what slips through.
+		if windowsProfile && !windowsSupportedFeatures[feat.ID()] {
+			continue
+		}
 		if singleContainerStrategyEnabled {
 			if errFeat := feat.ManageSingleContainerNodeAgent(podManagers); errFeat != nil {
 				return result, errFeat
@@ -173,6 +189,62 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 
 	if r.options.UntaintControllerEnabled {
 		componentagent.EnsureAgentNotReadyStartupToleration(objLogger, &podManagers.PodTemplateSpec().Spec)
+	}
+
+	// Windows profile (DatadogAgentProfile targeting Windows nodes): the DaemonSet was built,
+	// featured and overridden above like a Linux agent; now Windows-ify the pod contents.
+	if windowsProfile {
+		// FIPS + Windows is not supported: there is no -servercore-fips image, and the Linux
+		// fips-proxy sidecar/config is stripped on Windows. Both FIPS mechanisms must be caught —
+		// useFIPSAgent (FIPS agent flavor) AND fips.enabled (fips-proxy sidecar) — otherwise the
+		// Windows agent would silently run non-FIPS (a compliance risk). Surface a condition and
+		// remove the Windows DaemonSet instead of downgrading.
+		fipsEnabled := ddai.Spec.Global != nil &&
+			(apiutils.BoolValue(ddai.Spec.Global.UseFIPSAgent) ||
+				(ddai.Spec.Global.FIPS != nil && apiutils.BoolValue(ddai.Spec.Global.FIPS.Enabled)))
+		// Also catch FIPS requested via a -fips agent image tag override, which would otherwise be
+		// silently rewritten to a non-FIPS -servercore image.
+		if fipsEnabled || componentagent.HasFIPSAgentImage(&daemonset.Spec.Template.Spec) {
+			condition.UpdateDatadogAgentInternalStatusConditions(
+				newStatus,
+				metav1.NewTime(time.Now()),
+				"WindowsAgentReconcile",
+				metav1.ConditionFalse,
+				"WindowsFIPSUnsupported",
+				"the windows provider is not supported with FIPS (global.useFIPSAgent or global.fips.enabled): no -servercore-fips image",
+				true,
+			)
+			daemonsetLogger.Info("Removing Windows DaemonSet: FIPS (useFIPSAgent or fips.enabled) is enabled and FIPS is unsupported on Windows")
+			// Delete any existing Windows DaemonSet so a non-FIPS agent does not keep running
+			// under a FIPS-required configuration (compliance), rather than silently downgrading.
+			if err := r.deleteV2DaemonSet(ctx, ddai, daemonset, newStatus); err != nil {
+				return reconcile.Result{}, err
+			}
+			// Clear the Agent status unconditionally: deleteV2DaemonSet returns early (without
+			// clearing status) if the DaemonSet is already gone, which would otherwise leave a
+			// stale Agent status on the profile while FIPS blocks recreation.
+			newStatus.Agent = nil
+			return reconcile.Result{}, nil
+		}
+		// Windows is supported for this DDAI: clear any prior WindowsFIPSUnsupported condition
+		// (e.g. after FIPS is turned back off) so the status reflects the healthy state.
+		condition.UpdateDatadogAgentInternalStatusConditions(
+			newStatus,
+			metav1.NewTime(time.Now()),
+			"WindowsAgentReconcile",
+			metav1.ConditionTrue,
+			"WindowsAgentReconcile",
+			"windows agent reconciled",
+			false,
+		)
+		logCollectionEnabled := false
+		for _, feat := range features {
+			if feat.ID() == feature.LogCollectionIDType {
+				logCollectionEnabled = true
+				break
+			}
+		}
+		componentagent.ApplyWindowsPodTransformation(&daemonset.Spec.Template, ddai, logCollectionEnabled, windowsLogPaths(ddai))
 	}
 
 	if disabledByOverride {

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -7,6 +7,7 @@ package datadogagentinternal
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
@@ -244,7 +245,28 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 				break
 			}
 		}
-		componentagent.ApplyWindowsPodTransformation(&daemonset.Spec.Template, ddai, logCollectionEnabled, windowsLogPaths(ddai))
+		skippedContainerLogsPath := componentagent.ApplyWindowsPodTransformation(&daemonset.Spec.Template, ddai, logCollectionEnabled, windowsLogPaths(ddai))
+		// Surface a configured containerLogsPath that overlaps the agent config dir and was dropped
+		// (mounting it would re-shadow the seeded config); clear the condition otherwise so a fixed
+		// path doesn't leave a stale warning. See AddWindowsLogCollectionVolumes.
+		skipStatus := metav1.ConditionFalse
+		skipMsg := "no overlapping containerLogsPath"
+		if skippedContainerLogsPath != "" {
+			skipStatus = metav1.ConditionTrue
+			skipMsg = fmt.Sprintf("logCollection.containerLogsPath %q overlaps the Windows agent config dir C:/ProgramData/Datadog and was not mounted; set it to the container-runtime log-store subdirectory (a sibling of the config dir) instead", skippedContainerLogsPath)
+			daemonsetLogger.Info("Windows log collection: skipping overlapping containerLogsPath", "containerLogsPath", skippedContainerLogsPath)
+		}
+		condition.UpdateDatadogAgentInternalStatusConditions(
+			newStatus,
+			metav1.NewTime(time.Now()),
+			"WindowsLogCollectionPathSkipped",
+			skipStatus,
+			"OverlappingContainerLogsPath",
+			skipMsg,
+			// Only record True (a real skip) or clear an existing condition; don't create a
+			// permanent False on healthy clusters that never configured an overlapping path.
+			false,
+		)
 	}
 
 	if disabledByOverride {

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
-	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
@@ -206,7 +205,13 @@ func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1
 		}
 
 		if restartDaemonset(daemonset, currentDaemonset) {
-			if err = deleteObjectAndOrphanDependents(ctx, r.client, daemonset, constants.DefaultAgentResourceSuffix); err != nil {
+			// The DaemonSet selector changed (immutable): delete THIS DaemonSet, orphaning its
+			// pods, so it can be recreated with the new selector. Delete the specific object by
+			// name — NOT a {part-of, component}-label DeleteAllOf — because profile and Windows
+			// agent DaemonSets share the same part-of + component=agent labels as the default
+			// agent, so a label-scoped delete would also orphan-delete sibling DaemonSets.
+			orphan := metav1.DeletePropagationOrphan
+			if err = r.client.Delete(ctx, currentDaemonset, &client.DeleteOptions{PropagationPolicy: &orphan}); err != nil && !apierrors.IsNotFound(err) {
 				return result, err
 			}
 			return result, nil

--- a/internal/controller/datadogagentinternal/windows_provider.go
+++ b/internal/controller/datadogagentinternal/windows_provider.go
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Windows node-agent support (CONTP-1448).
+//
+// Windows nodes are enabled through a DatadogAgentProfile that targets Windows nodes and
+// carries the datadoghq.com/provider=windows annotation. The profile machinery generates a
+// dedicated DDAI (and therefore a dedicated DaemonSet) scoped to those nodes; reconcileV2Agent
+// then detects provider==windows and Windows-ifies the built pod template via
+// componentagent.ApplyWindowsPodTransformation. This file holds the Windows-specific inputs to
+// that path: the feature allowlist and the configured log paths.
+
+package datadogagentinternal
+
+import (
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	componentagent "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+)
+
+// windowsSupportedFeatures is the allowlist of feature IDs whose ManageNodeAgent hook runs
+// against a Windows (provider==windows) DaemonSet. Features absent here are gated out so they
+// don't inject env vars / config the Windows agent can't use (eBPF/system-probe in particular).
+// This is an allowlist (not a denylist) so new Linux-only features don't silently leak onto
+// Windows. The `default` feature is required — it configures the base agent. Expand as Windows
+// support for more features is verified.
+//
+// NOTE when adding a feature here: the Windows strip removes env vars by NAME (Unix-socket
+// names, known Linux-only globals — see stripWindowsIncompatibleEnvVars) and mounts by Linux
+// path prefix, but it does NOT inspect env-var VALUES. Verify the feature does not hand the
+// agent a Linux path/transport VALUE under an innocuous (non-SOCKET) env-var name; if it does,
+// extend the strip accordingly before allowlisting it.
+var windowsSupportedFeatures = map[feature.IDType]bool{
+	feature.DefaultIDType:              true, // base agent config (required)
+	feature.APMIDType:                  true, // trace-agent runs on Windows (TCP; see non-local-traffic)
+	feature.LogCollectionIDType:        true, // log collection — Windows host-log mounts added post-strip
+	feature.LiveContainerIDType:        true, // container collection
+	feature.LiveProcessIDType:          true, // process collection (no eBPF on Windows)
+	feature.ProcessDiscoveryIDType:     true,
+	feature.DogstatsdIDType:            true, // dogstatsd (UDP non-local; named pipe future)
+	feature.OrchestratorExplorerIDType: true, // node-side config is env-only
+	feature.RemoteConfigurationIDType:  true,
+	feature.PrometheusScrapeIDType:     true,
+	feature.EventCollectionIDType:      true,
+}
+
+// windowsLogPaths reads the configured logCollection host paths from the DDAI so custom Windows
+// log paths take effect (Windows defaults are applied for empty/Linux values downstream).
+func windowsLogPaths(ddai *datadoghqv1alpha1.DatadogAgentInternal) componentagent.WindowsLogPaths {
+	var p componentagent.WindowsLogPaths
+	if ddai.Spec.Features == nil || ddai.Spec.Features.LogCollection == nil {
+		return p
+	}
+	lc := ddai.Spec.Features.LogCollection
+	if lc.TempStoragePath != nil {
+		p.TempStoragePath = *lc.TempStoragePath
+	}
+	if lc.PodLogsPath != nil {
+		p.PodLogsPath = *lc.PodLogsPath
+	}
+	if lc.ContainerLogsPath != nil {
+		p.ContainerLogsPath = *lc.ContainerLogsPath
+	}
+	return p
+}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -54,6 +54,8 @@ const (
 	FIPSTagSuffix = "-fips"
 	// FullTagSuffix tag suffix for full agent images
 	FullTagSuffix = "-full"
+	// WindowsServerCoreTagSuffix tag suffix for Windows Server Core agent images
+	WindowsServerCoreTagSuffix = "-servercore"
 	// Default Image names
 	DefaultAgentImageName         string = "agent"
 	DefaultClusterAgentImageName  string = "cluster-agent"
@@ -161,6 +163,16 @@ func (i *Image) FIPSVersionError() error {
 // GetLatestAgentImage returns the latest stable agent release version
 func GetLatestAgentImage() string {
 	image := newImage(DefaultImageRegistry, DefaultAgentImageName, AgentLatestVersion, false, false, false)
+	return image.ToString()
+}
+
+// GetLatestWindowsAgentImage returns the Windows Server Core variant of the latest agent image.
+// Windows agent images use the "-servercore" tag suffix (e.g. 7.80.2-servercore).
+// Note: the registry is overwritten by updateContainerImages when GlobalConfig.Registry is set;
+// the tag suffix "-servercore" is also incompatible with FIPS (which would produce a non-existent
+// tag like "7.80.2-servercore-fips") — FIPS + Windows is not supported.
+func GetLatestWindowsAgentImage() string {
+	image := newImage(DefaultImageRegistry, DefaultAgentImageName, AgentLatestVersion+WindowsServerCoreTagSuffix, false, false, false)
 	return image.ToString()
 }
 

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -8,6 +8,7 @@ package images
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,26 @@ func TestGetLatestAgentImage(t *testing.T) {
 				t.Errorf("GetLatestAgentImage() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetLatestWindowsAgentImage(t *testing.T) {
+	got := GetLatestWindowsAgentImage()
+	// Must use the default registry (consistent with other sibling functions).
+	if !strings.HasPrefix(got, DefaultImageRegistry+"/") {
+		t.Errorf("GetLatestWindowsAgentImage() registry = %q, want prefix %q", got, DefaultImageRegistry+"/")
+	}
+	// Must carry the -servercore suffix.
+	if !strings.HasSuffix(got, WindowsServerCoreTagSuffix) {
+		t.Errorf("GetLatestWindowsAgentImage() = %q, want suffix %q", got, WindowsServerCoreTagSuffix)
+	}
+	// Must embed the current agent version.
+	if !strings.Contains(got, AgentLatestVersion) {
+		t.Errorf("GetLatestWindowsAgentImage() = %q, want version %q", got, AgentLatestVersion)
+	}
+	want := fmt.Sprintf("%s/agent:%s%s", DefaultImageRegistry, AgentLatestVersion, WindowsServerCoreTagSuffix)
+	if got != want {
+		t.Errorf("GetLatestWindowsAgentImage() = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -46,6 +46,12 @@ const (
 	// GKEProviderLabel is the GKE node label used to determine the node's provider
 	GKEProviderLabel = "cloud.google.com/gke-os-distribution"
 
+	// WindowsProvider marks a DatadogAgent(Internal)/DatadogAgentProfile whose node agent
+	// targets Windows nodes. Set via the datadoghq.com/provider annotation on a
+	// DatadogAgentProfile that selects Windows nodes; the node-agent reconcile then builds a
+	// Windows-compatible DaemonSet (CONTP-1448).
+	WindowsProvider = "windows"
+
 	// OpenshiftProvider is the OpenShift Provider name
 	OpenshiftProvider = "openshift"
 


### PR DESCRIPTION
## What does this PR do?

Enables the Datadog **node agent on Windows nodes**. A Windows-targeted `DatadogAgentProfile` makes the operator build a Windows-compatible agent DaemonSet alongside the existing (unchanged) Linux one.

## How it works
Windows is enabled by creating a `DatadogAgentProfile` that (a) targets Windows nodes via `profileNodeAffinity: kubernetes.io/os In [windows]` and (b) carries the annotation `datadoghq.com/provider: windows`.

The operator builds the profile's pod as a normal agent, then Windows-ifies it: Linux-only containers/mounts/securityContext are stripped, and an **`init-config-windows` init container copies the image's `conf.d` (default check configs) + a `datadog.yaml` into a shared volume mounted at `C:/ProgramData/Datadog`** — so the default system checks run and the trace agent finds the config it requires (the containers override the image entrypoint, which would otherwise generate `datadog.yaml`).

<img width="2980" height="1113" alt="image" src="https://github.com/user-attachments/assets/1f633492-90c3-4c3b-b590-9eb28ef414d5" />


## How to QA

**Prerequisites**
- A Kubernetes cluster with **both Linux and Windows nodes** (e.g. GKE with a `WINDOWS_LTSC_CONTAINERD` node pool). Windows nodes carry the automatic `node.kubernetes.io/os=windows:NoSchedule` taint.
- Operator built from this branch, running on a Linux node.
- The **DatadogAgentProfile controller enabled**: `--datadogAgentProfileEnabled=true` (Helm: `datadogAgentProfile.enabled`). The `DatadogAgentProfile` CRD and operator RBAC for `datadogagentprofiles`(+`/status`,`/finalizers`) must be present.

**1. Deploy** the DatadogAgent + Windows DatadogAgentProfile
```bash
kubectl apply -f - <<'YAML'
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata: {name: datadog, namespace: datadog}
spec:
  global: {credentials: {apiSecret: {secretName: datadog-secret, keyName: api-key}}, site: datadoghq.com}
  features:
    logCollection: {enabled: true, containerCollectAll: true}
    apm: {enabled: true}
---
apiVersion: datadoghq.com/v1alpha1
kind: DatadogAgentProfile
metadata:
  name: windows
  namespace: datadog
  annotations: {datadoghq.com/provider: windows}
spec:
  config: {}
  profileAffinity:
    profileNodeAffinity:
      - {key: kubernetes.io/os, operator: In, values: [windows]}
YAML
```

**2. Verify the Windows DaemonSet**
```bash
# A second DaemonSet 'windows-agent' (component=agent) is created alongside 'datadog-agent'.
kubectl get ds -n datadog

# Pod runs on the Windows node, reaches Running (2/2 with APM).
kubectl get pods -n datadog -o wide | grep windows-agent
```
Confirm on the `windows-agent` DaemonSet:
- Containers use the `*-servercore` image; the **init container image matches the agent image** (same registry/tag + `-servercore`).
- `nodeSelector: kubernetes.io/os=windows` and a toleration for `node.kubernetes.io/os=windows:NoSchedule`.
- **No** hostPath volume with a Linux (`/`-prefixed) path.
- Only `agent`/`trace-agent`/`process-agent` containers (no `system-probe`/`security-agent`).

**3. Verify function**
```bash
POD=$(kubectl get pods -n datadog -o name | grep windows-agent | head -1)
# core agent healthy, forwarders + logs-agent started, tailing C:\var\log\pods
kubectl logs -n datadog $POD -c agent | grep -Ei "Forwarder started|logs-agent started|Opening  C:.var.log.pods"
# trace-agent serving APM
kubectl logs -n datadog $POD -c trace-agent | grep -i "Listening for traces"
```

**4. Verify the Linux agent is unaffected**
```bash
# datadog-agent DaemonSet still Running on Linux nodes only; status unchanged.
kubectl get ds datadog-agent -n datadog
```



