### PR TITLE
Add GKE COS NVIDIA library mounts

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/const.go
+++ b/internal/controller/datadogagent/feature/gpu/const.go
@@ -10,6 +10,14 @@ const (
 	nvidiaDevicesVolumeName = "nvidia-devices"
 	devNullPath             = "/dev/null" // used to mount the NVIDIADevicesHostPath to /dev/null in the container, it's just used as a "signal" to the nvidia runtime to use the nvidia devices
 
+	// On GKE COS nodes the NVIDIA driver libraries live under
+	// /home/kubernetes/bin/nvidia/lib64 on the host. They are mounted into the
+	// path where the nvidia-container-runtime expects the driver libraries so
+	// that the agent and system-probe can load them.
+	gkeCOSNVIDIADriverLib64VolumeName = "gke-nvidia-driver-lib64"
+	gkeCOSNVIDIADriverLib64HostPath   = "/home/kubernetes/bin/nvidia/lib64"
+	gkeCOSNVIDIADriverLib64MountPath  = "/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
+
 	// defaultGPURuntimeClass default runtime class for GPU pods
 	defaultGPURuntimeClass = "nvidia"
 )

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -15,6 +15,8 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/providercaps"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 func init() {
@@ -40,6 +42,33 @@ type gpuFeature struct {
 // ID returns the ID of the Feature
 func (f *gpuFeature) ID() feature.IDType {
 	return feature.GPUIDType
+}
+
+// NodeAgentProviderCapabilities returns provider-conditional pod-template
+// mutations for the node agent. On GKE COS, the NVIDIA driver libraries are not
+// available at the standard path used by the nvidia-container-runtime; mount
+// them from the host location (/home/kubernetes/bin/nvidia/lib64) so the agent
+// (and system-probe, when privileged) can load them.
+func (f *gpuFeature) NodeAgentProviderCapabilities() providercaps.ProviderCapabilityMap {
+	containers := []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
+	if f.isPrivilegedModeEnabled {
+		containers = append(containers, apicommon.SystemProbeContainerName)
+	}
+
+	vol, volMount := volume.GetVolumes(gkeCOSNVIDIADriverLib64VolumeName, gkeCOSNVIDIADriverLib64HostPath, gkeCOSNVIDIADriverLib64MountPath, true)
+	vol.VolumeSource.HostPath.Type = ptr.To(corev1.HostPathDirectoryOrCreate)
+
+	return providercaps.ProviderCapabilityMap{
+		kubernetes.GKECosProvider: {
+			Volumes: []providercaps.VolumeAndMount{
+				{
+					Volume:     vol,
+					Mount:      volMount,
+					Containers: containers,
+				},
+			},
+		},
+	}
 }
 
 // Configure is used to configure the feature from a v2alpha1.DatadogAgent instance.

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/providercaps"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 const alternativeRuntimeClass = "nvidia-like"
@@ -409,4 +411,81 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 	}
 
 	tests.Run(t, buildFeature)
+}
+
+// Test_GPUFeature_NodeAgentProviderCapabilities verifies that the GKE COS
+// NVIDIA driver lib64 host mount is injected only on the gke-cos provider, and
+// only into system-probe when privileged mode is enabled.
+func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
+	wantVolume := corev1.Volume{
+		Name: gkeCOSNVIDIADriverLib64VolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: gkeCOSNVIDIADriverLib64HostPath,
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	}
+	wantMount := corev1.VolumeMount{
+		Name:      gkeCOSNVIDIADriverLib64VolumeName,
+		MountPath: gkeCOSNVIDIADriverLib64MountPath,
+		ReadOnly:  true,
+	}
+
+	newPodTemplate := func() *corev1.PodTemplateSpec {
+		return &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: string(apicommon.CoreAgentContainerName)},
+					{Name: string(apicommon.SystemProbeContainerName)},
+				},
+			},
+		}
+	}
+
+	getContainer := func(tmpl *corev1.PodTemplateSpec, name apicommon.AgentContainerName) corev1.Container {
+		for _, c := range tmpl.Spec.Containers {
+			if c.Name == string(name) {
+				return c
+			}
+		}
+		t.Fatalf("container %q not found", name)
+		return corev1.Container{}
+	}
+
+	t.Run("gke-cos privileged mounts into core agent and system-probe", func(t *testing.T) {
+		f := &gpuFeature{isPrivilegedModeEnabled: true}
+		tmpl := newPodTemplate()
+		mgr := feature.NewPodTemplateManagers(tmpl)
+
+		providercaps.ApplyProviderCapabilities(mgr, kubernetes.GKECosProvider, f.NodeAgentProviderCapabilities())
+
+		assert.Contains(t, tmpl.Spec.Volumes, wantVolume)
+		assert.Contains(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts, wantMount)
+		assert.Contains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantMount)
+	})
+
+	t.Run("gke-cos non-privileged mounts into core agent only", func(t *testing.T) {
+		f := &gpuFeature{isPrivilegedModeEnabled: false}
+		tmpl := newPodTemplate()
+		mgr := feature.NewPodTemplateManagers(tmpl)
+
+		providercaps.ApplyProviderCapabilities(mgr, kubernetes.GKECosProvider, f.NodeAgentProviderCapabilities())
+
+		assert.Contains(t, tmpl.Spec.Volumes, wantVolume)
+		assert.Contains(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts, wantMount)
+		assert.NotContains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantMount)
+	})
+
+	t.Run("non-gke-cos provider adds nothing", func(t *testing.T) {
+		f := &gpuFeature{isPrivilegedModeEnabled: true}
+		tmpl := newPodTemplate()
+		mgr := feature.NewPodTemplateManagers(tmpl)
+
+		providercaps.ApplyProviderCapabilities(mgr, kubernetes.DefaultProvider, f.NodeAgentProviderCapabilities())
+
+		assert.Empty(t, tmpl.Spec.Volumes)
+		assert.Empty(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts)
+		assert.Empty(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts)
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Mounts GKE COS NVIDIA driver libraries into the Agent containers when GPU monitoring runs on GKE COS nodes.

### Motivation

GPU monitoring needs these libraries on GKE COS, where NVIDIA driver libraries live under `/home/kubernetes/bin/nvidia/lib64`.

### Additional Notes

Mirrors DataDog/helm-charts#2764 for the Operator.

The mount is applied for the `gke-cos` provider. The operator auto-detects this from the node label `cloud.google.com/gke-os-distribution=cos`, but it can also be forced with the annotation on the DatadogAgent:

```yaml
metadata:
  annotations:
    datadoghq.com/provider: gke-cos
```

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

`go test ./internal/controller/datadogagent/feature/gpu`

Validated end-to-end on a GKE COS test cluster with a Tesla T4 node:
- provider forced via the `datadoghq.com/provider: gke-cos` annotation
- generated DaemonSet mounts `/home/kubernetes/bin/nvidia/lib64` at `/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu` on the core-agent and system-probe containers
- system-probe finds the NVML library at the mounted path
- with `features.gpu.privilegedMode: true`, `features.gpu.patchCgroupPermissions: true` and `override.nodeAgent.hostPID: true` (which should be there by default with GPU monitoring enabled, will be addressed in a separate PR), the core-agent `gpu` check reports `[OK]` and discovers `GPU 0: Tesla T4`

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits