### PR TITLE
Add apm non local traffic env var to local service

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -94,11 +94,6 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 		}
 	}
 
-	// Manage dependencies
-	if err := r.manageDDADependenciesWithDDAI(ctx, logger, instance, newDDAStatus); err != nil {
-		return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, err, now)
-	}
-
 	// Generate default DDAI object from DDA
 	ddai, err := r.generateDDAIFromDDA(instance, provider)
 	if err != nil {
@@ -129,6 +124,12 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
 		}
 		ddais = profileDDAIs
+	}
+
+	// Manage dependencies after DDAIs are computed to include profile changes
+	err = r.manageDDADependenciesWithDDAI(ctx, logger, instance, newDDAStatus, ddais)
+	if err != nil {
+		return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, err, now)
 	}
 
 	// Create or update the DDAI object in k8s

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal"
+	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
@@ -1939,7 +1940,7 @@ func Test_ProfileAPMOverrideAddsDDAOwnedLocalAgentServicePort(t *testing.T) {
 			},
 		},
 		{
-			name: "conflicting profile APM override keeps first trace port",
+			name: "conflicting profile APM override rejects conflicting profile and reconciles accepted profile",
 			clientBuilder: fake.NewClientBuilder().
 				WithStatusSubresource(&v2alpha1.DatadogAgent{}, &v1alpha1.DatadogAgentProfile{}, &v1alpha1.DatadogAgentInternal{}).
 				WithObjects(conflictingProfileA, conflictingProfileB),
@@ -1962,11 +1963,39 @@ func Test_ProfileAPMOverrideAddsDDAOwnedLocalAgentServicePort(t *testing.T) {
 				assert.NotNil(t, apmPort)
 				assert.Equal(t, int32(8126), apmPort.Port)
 				assert.Equal(t, intstr.FromInt(int(constants.DefaultApmPort)), apmPort.TargetPort)
+
+				appliedProfile := &v1alpha1.DatadogAgentProfile{}
+				err = c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: "apm-profile-a"}, appliedProfile)
+				assert.NoError(t, err)
+				assert.Equal(t, metav1.ConditionTrue, appliedProfile.Status.Applied)
+
+				conflictingProfile := &v1alpha1.DatadogAgentProfile{}
+				err = c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: "apm-profile-b"}, conflictingProfile)
+				assert.NoError(t, err)
+				assert.Equal(t, metav1.ConditionFalse, conflictingProfile.Status.Applied)
+				assert.Contains(t, profileConditionMessage(conflictingProfile.Status.Conditions, agentprofile.AppliedConditionType), "port \"traceport\" conflicts")
+
+				appliedDDAI := &v1alpha1.DatadogAgentInternal{}
+				err = c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: "apm-profile-a"}, appliedDDAI)
+				assert.NoError(t, err)
+
+				conflictingDDAI := &v1alpha1.DatadogAgentInternal{}
+				err = c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: "apm-profile-b"}, conflictingDDAI)
+				assert.True(t, apierrors.IsNotFound(err), "conflicting profile DDAI should not be rendered")
 			},
 		},
 	}
 
 	runTestCases(t, tests, runFullReconcilerTest)
+}
+
+func profileConditionMessage(conditions []metav1.Condition, conditionType string) string {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Message
+		}
+	}
+	return ""
 }
 
 func verifyDaemonsetContainers(t *testing.T, c client.Client, resourcesNamespace, dsName string, expectedContainers []string) {

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal"
 	"github.com/DataDog/datadog-operator/pkg/condition"
@@ -62,6 +64,7 @@ type testCase struct {
 	profilesEnabled      bool                          // For DDAI tests
 	introspectionEnabled bool                          // For introspection tests
 	clusterProvider      string                        // For control plane monitoring tests: provider returned by the injected detector
+	platformInfo         *kubernetes.PlatformInfo
 }
 
 // ddaiReconcilerOptionsFromDDA mirrors setup.go wiring so DDAI tests behave like production
@@ -73,6 +76,13 @@ func ddaiReconcilerOptionsFromDDA(opts ReconcilerOptions) datadogagentinternal.R
 		OperatorMetricsEnabled:   opts.OperatorMetricsEnabled,
 		UntaintControllerEnabled: opts.UntaintControllerEnabled,
 	}
+}
+
+func platformInfoForTest(tt testCase) kubernetes.PlatformInfo {
+	if tt.platformInfo != nil {
+		return *tt.platformInfo
+	}
+	return kubernetes.PlatformInfo{}
 }
 
 // runTestCases runs test cases
@@ -111,12 +121,13 @@ func runDDAReconcilerTest(t *testing.T, tt testCase, opts ReconcilerOptions) {
 	forwarders := dummyManager{}
 
 	c := buildClient(t, tt, s)
+	platformInfo := platformInfoForTest(tt)
 
 	// Create reconciler
 	r := &Reconciler{
 		client:       c,
 		scheme:       s,
-		platformInfo: kubernetes.PlatformInfo{},
+		platformInfo: platformInfo,
 		recorder:     recorder,
 		log:          logf.Log.WithName(tt.name),
 		forwarders:   forwarders,
@@ -127,7 +138,7 @@ func runDDAReconcilerTest(t *testing.T, tt testCase, opts ReconcilerOptions) {
 	ri := datadogagentinternal.NewReconciler(
 		ddaiReconcilerOptionsFromDDA(opts),
 		c,
-		kubernetes.PlatformInfo{},
+		platformInfo,
 		s,
 		recorder,
 		forwarders)
@@ -184,12 +195,13 @@ func runFullReconcilerTest(t *testing.T, tt testCase, opts ReconcilerOptions) {
 	forwarders := dummyManager{}
 
 	c := buildClient(t, tt, s)
+	platformInfo := platformInfoForTest(tt)
 
 	// Create reconciler
 	r := &Reconciler{
 		client:       c,
 		scheme:       s,
-		platformInfo: kubernetes.PlatformInfo{},
+		platformInfo: platformInfo,
 		recorder:     recorder,
 		log:          logf.Log.WithName(tt.name),
 		forwarders:   forwarders,
@@ -200,7 +212,7 @@ func runFullReconcilerTest(t *testing.T, tt testCase, opts ReconcilerOptions) {
 	ri := datadogagentinternal.NewReconciler(
 		ddaiReconcilerOptionsFromDDA(opts),
 		c,
-		kubernetes.PlatformInfo{},
+		platformInfo,
 		s,
 		recorder,
 		forwarders)
@@ -1827,6 +1839,129 @@ func Test_COSProviderOverrides(t *testing.T) {
 				assertVolumes(t, c, resourcesNamespace, profileDsName, false)
 				// Default DDAI has no provider annotation → src present.
 				assertVolumes(t, c, resourcesNamespace, defaultDsName, true)
+			},
+		},
+	}
+
+	runTestCases(t, tests, runFullReconcilerTest)
+}
+
+func Test_ProfileAPMOverrideAddsDDAOwnedLocalAgentServicePort(t *testing.T) {
+	const resourcesName = "foo"
+	const resourcesNamespace = "bar"
+	const profileName = "apm-profile"
+	defaultRequeueDuration := 15 * time.Second
+
+	dda := testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+		WithAPMEnabled(false).
+		BuildWithDefaults()
+	localAgentServiceName := constants.GetLocalAgentServiceName(resourcesName, &dda.Spec)
+	platformInfo := kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.32.0"}, nil, nil)
+
+	newAPMProfile := func(name string, apm *v2alpha1.APMFeatureConfig) *v1alpha1.DatadogAgentProfile {
+		return &v1alpha1.DatadogAgentProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: resourcesNamespace,
+			},
+			Spec: v1alpha1.DatadogAgentProfileSpec{
+				ProfileAffinity: &v1alpha1.ProfileAffinity{
+					ProfileNodeAffinity: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "profile",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{name},
+						},
+					},
+				},
+				Config: &v2alpha1.DatadogAgentSpec{
+					Features: &v2alpha1.DatadogFeatures{
+						APM: apm,
+					},
+				},
+			},
+		}
+	}
+	profile := newAPMProfile(profileName, &v2alpha1.APMFeatureConfig{
+		Enabled: ptr.To(true),
+	})
+	conflictingProfileA := newAPMProfile("apm-profile-a", &v2alpha1.APMFeatureConfig{
+		Enabled: ptr.To(true),
+		HostPortConfig: &v2alpha1.HostPortConfig{
+			Enabled: ptr.To(true),
+			Port:    ptr.To[int32](8126),
+		},
+	})
+	conflictingProfileB := newAPMProfile("apm-profile-b", &v2alpha1.APMFeatureConfig{
+		Enabled: ptr.To(true),
+		HostPortConfig: &v2alpha1.HostPortConfig{
+			Enabled: ptr.To(true),
+			Port:    ptr.To[int32](9126),
+		},
+	})
+
+	tests := []testCase{
+		{
+			name: "profile APM override adds trace port to DDA-owned local Agent Service",
+			clientBuilder: fake.NewClientBuilder().
+				WithStatusSubresource(&v2alpha1.DatadogAgent{}, &v1alpha1.DatadogAgentProfile{}, &v1alpha1.DatadogAgentInternal{}).
+				WithObjects(profile),
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				ddaCopy := dda.DeepCopy()
+				_ = c.Create(context.TODO(), ddaCopy)
+				return ddaCopy
+			},
+			profilesEnabled: true,
+			platformInfo:    &platformInfo,
+			want:            reconcile.Result{RequeueAfter: defaultRequeueDuration},
+			wantErr:         false,
+			wantFunc: func(t *testing.T, c client.Client) {
+				service := &corev1.Service{}
+				err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: localAgentServiceName}, service)
+				assert.NoError(t, err)
+				assert.Equal(t, "true", service.Labels[store.ManagedByDDAControllerLabelKey])
+
+				apmPort := findServicePortByName(service.Spec.Ports, constants.DefaultApmPortName)
+				assert.NotNil(t, apmPort)
+				assert.Equal(t, corev1.ProtocolTCP, apmPort.Protocol)
+				assert.Equal(t, int32(constants.DefaultApmPort), apmPort.Port)
+				assert.Equal(t, intstr.FromInt(int(constants.DefaultApmPort)), apmPort.TargetPort)
+
+				defaultDDAI := &v1alpha1.DatadogAgentInternal{}
+				err = c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: resourcesName}, defaultDDAI)
+				assert.NoError(t, err)
+				assert.False(t, ptr.Deref(defaultDDAI.Spec.Features.APM.Enabled, true))
+
+				profileDDAI := &v1alpha1.DatadogAgentInternal{}
+				err = c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: profileName}, profileDDAI)
+				assert.NoError(t, err)
+				assert.True(t, ptr.Deref(profileDDAI.Spec.Features.APM.Enabled, false))
+			},
+		},
+		{
+			name: "conflicting profile APM override keeps first trace port",
+			clientBuilder: fake.NewClientBuilder().
+				WithStatusSubresource(&v2alpha1.DatadogAgent{}, &v1alpha1.DatadogAgentProfile{}, &v1alpha1.DatadogAgentInternal{}).
+				WithObjects(conflictingProfileA, conflictingProfileB),
+			loadFunc: func(c client.Client) *v2alpha1.DatadogAgent {
+				ddaCopy := dda.DeepCopy()
+				_ = c.Create(context.TODO(), ddaCopy)
+				return ddaCopy
+			},
+			profilesEnabled: true,
+			platformInfo:    &platformInfo,
+			want:            reconcile.Result{RequeueAfter: defaultRequeueDuration},
+			wantErr:         false,
+			wantFunc: func(t *testing.T, c client.Client) {
+				service := &corev1.Service{}
+				err := c.Get(context.TODO(), types.NamespacedName{Namespace: resourcesNamespace, Name: localAgentServiceName}, service)
+				assert.NoError(t, err)
+				assert.Equal(t, "true", service.Labels[store.ManagedByDDAControllerLabelKey])
+
+				apmPort := findServicePortByName(service.Spec.Ports, constants.DefaultApmPortName)
+				assert.NotNil(t, apmPort)
+				assert.Equal(t, int32(8126), apmPort.Port)
+				assert.Equal(t, intstr.FromInt(int(constants.DefaultApmPort)), apmPort.TargetPort)
 			},
 		},
 	}

--- a/internal/controller/datadogagent/dependencies.go
+++ b/internal/controller/datadogagent/dependencies.go
@@ -7,13 +7,11 @@ package datadogagent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -21,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
@@ -78,7 +75,7 @@ func (r *Reconciler) manageDDADependenciesWithDDAI(ctx context.Context, logger l
 
 	// Dependencies that can get configs from DDA and DDAI
 	// Example: agent local service for APM, DSD, and OTLP
-	if err := r.addDDASharedDependencies(ctx, instance, ddais, resourceManagers); err != nil {
+	if err := r.addDDASharedDependencies(instance, ddais, resourceManagers); err != nil {
 		return err
 	}
 
@@ -104,21 +101,11 @@ func (r *Reconciler) manageDDADependenciesWithDDAI(ctx context.Context, logger l
 	return nil
 }
 
-func (r *Reconciler) addDDASharedDependencies(ctx context.Context, dda *v2alpha1.DatadogAgent, ddais []*v1alpha1.DatadogAgentInternal, managers feature.ResourceManagers) error {
-	logger := ctrl.LoggerFrom(ctx)
+func (r *Reconciler) addDDASharedDependencies(dda *v2alpha1.DatadogAgent, ddais []*v1alpha1.DatadogAgentInternal, managers feature.ResourceManagers) error {
 	var errs []error
 
 	for _, ddai := range ddais {
 		if err := feature.ApplyDDASharedDependencies(dda, &dda.Spec, ddai, &ddai.Spec, managers); err != nil {
-			if errors.Is(err, merger.ErrServicePortConflict) {
-				logger.Info(
-					"Ignoring conflicting DDA shared Service port",
-					"datadogagentinternal_namespace", ddai.Namespace,
-					"datadogagentinternal_name", ddai.Name,
-					"reason", err.Error(),
-				)
-				continue
-			}
 			errs = append(errs, fmt.Errorf("%s/%s DDA shared dependencies failed: %w", ddai.Namespace, ddai.Name, err))
 		}
 	}

--- a/internal/controller/datadogagent/dependencies.go
+++ b/internal/controller/datadogagent/dependencies.go
@@ -7,16 +7,21 @@ package datadogagent
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
 
+	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusteragent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
@@ -38,7 +43,7 @@ func (r *Reconciler) setupDDADependenciesStore(instance *v2alpha1.DatadogAgent, 
 	return depsStore, resourceManagers
 }
 
-func (r *Reconciler) manageDDADependenciesWithDDAI(ctx context.Context, logger logr.Logger, instance *v2alpha1.DatadogAgent, newDDAStatus *v2alpha1.DatadogAgentStatus) error {
+func (r *Reconciler) manageDDADependenciesWithDDAI(ctx context.Context, logger logr.Logger, instance *v2alpha1.DatadogAgent, newDDAStatus *v2alpha1.DatadogAgentStatus, ddais []*v1alpha1.DatadogAgentInternal) error {
 	// Use a store marked as DDA controller store so resources are labeled
 	// with ManagedByDDAControllerLabelKey and won't be cleaned up by DDAI controller.
 	depsStore, resourceManagers := r.setupDDADependenciesStore(instance, logger)
@@ -71,16 +76,22 @@ func (r *Reconciler) manageDDADependenciesWithDDAI(ctx context.Context, logger l
 		return err
 	}
 
+	// Dependencies that can get configs from DDA and DDAI
+	// Example: agent local service for APM, DSD, and OTLP
+	if err := r.addDDASharedDependencies(ctx, instance, ddais, resourceManagers); err != nil {
+		return err
+	}
+
 	// Apply dependencies
 	if err := depsStore.Apply(ctx, r.client); err != nil {
-		return errors.NewAggregate(err)
+		return utilerrors.NewAggregate(err)
 	}
 
 	// Cleanup unused DDA controller dependencies.
 	// Pass false since we want to clean up DDA-managed resources (this is the DDA controller).
 	// Note that we don't really need to clean these dependencies as they're all ownerRef'ed by the DDA, so they will be cleaned if the DDA is deleted.
 	if err := depsStore.Cleanup(ctx, r.client, false); err != nil {
-		return errors.NewAggregate(err)
+		return utilerrors.NewAggregate(err)
 	}
 
 	// DatadogCSIDriver: create or delete based on spec.global.csi configuration.
@@ -90,6 +101,31 @@ func (r *Reconciler) manageDDADependenciesWithDDAI(ctx context.Context, logger l
 		return err
 	}
 
+	return nil
+}
+
+func (r *Reconciler) addDDASharedDependencies(ctx context.Context, dda *v2alpha1.DatadogAgent, ddais []*v1alpha1.DatadogAgentInternal, managers feature.ResourceManagers) error {
+	logger := ctrl.LoggerFrom(ctx)
+	var errs []error
+
+	for _, ddai := range ddais {
+		if err := feature.ApplyDDASharedDependencies(dda, &dda.Spec, ddai, &ddai.Spec, managers); err != nil {
+			if errors.Is(err, merger.ErrServicePortConflict) {
+				logger.Info(
+					"Ignoring conflicting DDA shared Service port",
+					"datadogagentinternal_namespace", ddai.Namespace,
+					"datadogagentinternal_name", ddai.Name,
+					"reason", err.Error(),
+				)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("%s/%s DDA shared dependencies failed: %w", ddai.Namespace, ddai.Name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
+	}
 	return nil
 }
 

--- a/internal/controller/datadogagent/dependencies_test.go
+++ b/internal/controller/datadogagent/dependencies_test.go
@@ -1,0 +1,140 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/utils/ptr"
+
+	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	"github.com/DataDog/datadog-operator/pkg/testutils"
+)
+
+func TestAddDDASharedDependenciesIncludesProfileAPMPort(t *testing.T) {
+	dda := testutils.NewInitializedDatadogAgentBuilder("default", "datadog").WithAPMEnabled(false).BuildWithDefaults()
+	baseDDAI := testDDAIWithSpec("datadog", dda.Namespace, &dda.Spec)
+
+	profileSpec := dda.Spec.DeepCopy()
+	enableAPMForDependencyTest(profileSpec, nil)
+	profileDDAI := testDDAIWithSpec("datadog-profile", dda.Namespace, profileSpec)
+
+	depsStore := newDependencyTestStore(dda)
+	managers := feature.NewResourceManagers(depsStore)
+
+	err := (&Reconciler{}).addDDASharedDependencies(context.Background(), dda, []*v1alpha1.DatadogAgentInternal{baseDDAI, profileDDAI}, managers)
+	require.NoError(t, err)
+
+	obj, found := depsStore.Get(kubernetes.ServicesKind, "default", "datadog-agent")
+	require.True(t, found)
+	service := obj.(*corev1.Service)
+
+	apmPort := findServicePortByName(service.Spec.Ports, constants.DefaultApmPortName)
+	require.NotNil(t, apmPort)
+	assert.Equal(t, corev1.ProtocolTCP, apmPort.Protocol)
+	assert.Equal(t, int32(constants.DefaultApmPort), apmPort.Port)
+	assert.Equal(t, intstr.FromInt(int(constants.DefaultApmPort)), apmPort.TargetPort)
+}
+
+func TestAddDDASharedDependenciesKeepsFirstConflictingProfilePort(t *testing.T) {
+	dda := testutils.NewInitializedDatadogAgentBuilder("default", "datadog").WithAPMEnabled(false).BuildWithDefaults()
+
+	profileSpecA := dda.Spec.DeepCopy()
+	enableAPMForDependencyTest(profileSpecA, ptr.To[int32](8126))
+
+	profileSpecB := dda.Spec.DeepCopy()
+	enableAPMForDependencyTest(profileSpecB, ptr.To[int32](9126))
+
+	depsStore := newDependencyTestStore(dda)
+	managers := feature.NewResourceManagers(depsStore)
+
+	err := (&Reconciler{}).addDDASharedDependencies(context.Background(), dda, []*v1alpha1.DatadogAgentInternal{
+		testDDAIWithSpec("datadog-profile-a", dda.Namespace, profileSpecA),
+		testDDAIWithSpec("datadog-profile-b", dda.Namespace, profileSpecB),
+	}, managers)
+
+	require.NoError(t, err)
+
+	obj, found := depsStore.Get(kubernetes.ServicesKind, "default", "datadog-agent")
+	require.True(t, found)
+	service := obj.(*corev1.Service)
+
+	apmPort := findServicePortByName(service.Spec.Ports, constants.DefaultApmPortName)
+	require.NotNil(t, apmPort)
+	assert.Equal(t, int32(8126), apmPort.Port)
+	assert.Equal(t, intstr.FromInt(8126), apmPort.TargetPort)
+}
+
+func TestAddDDASharedDependenciesDoesNotMutateDDAISpec(t *testing.T) {
+	dda := testutils.NewInitializedDatadogAgentBuilder("default", "datadog").BuildWithDefaults()
+	ddai := testDDAIWithSpec("datadog", dda.Namespace, &dda.Spec)
+
+	require.NotNil(t, ddai.Spec.Features.ServiceDiscovery)
+	require.Nil(t, ddai.Spec.Features.ServiceDiscovery.Enabled)
+
+	depsStore := newDependencyTestStore(dda)
+	managers := feature.NewResourceManagers(depsStore)
+
+	err := (&Reconciler{}).addDDASharedDependencies(context.Background(), dda, []*v1alpha1.DatadogAgentInternal{ddai}, managers)
+	require.NoError(t, err)
+
+	assert.Nil(t, ddai.Spec.Features.ServiceDiscovery.Enabled)
+}
+
+func newDependencyTestStore(dda *v2alpha1.DatadogAgent) *store.Store {
+	return store.NewStore(dda, &store.StoreOptions{
+		PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.32.0"}, nil, nil),
+		Scheme:       agenttestutils.TestScheme(),
+	})
+}
+
+func enableAPMForDependencyTest(spec *v2alpha1.DatadogAgentSpec, hostPort *int32) {
+	spec.Features.APM.Enabled = ptr.To(true)
+	spec.Features.APM.HostPortConfig = &v2alpha1.HostPortConfig{
+		Enabled: ptr.To(hostPort != nil),
+		Port:    ptr.To[int32](constants.DefaultApmPort),
+	}
+	if hostPort != nil {
+		spec.Features.APM.HostPortConfig.Port = hostPort
+	}
+	spec.Features.APM.UnixDomainSocketConfig = &v2alpha1.UnixDomainSocketConfig{
+		Enabled: ptr.To(false),
+		Path:    ptr.To(common.DogstatsdAPMSocketHostPath + "/" + common.APMSocketName),
+	}
+}
+
+func testDDAIWithSpec(name, namespace string, spec *v2alpha1.DatadogAgentSpec) *v1alpha1.DatadogAgentInternal {
+	return &v1alpha1.DatadogAgentInternal{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: *spec.DeepCopy(),
+	}
+}
+
+func findServicePortByName(ports []corev1.ServicePort, name string) *corev1.ServicePort {
+	for i := range ports {
+		if ports[i].Name == name {
+			return &ports[i]
+		}
+	}
+	return nil
+}

--- a/internal/controller/datadogagent/dependencies_test.go
+++ b/internal/controller/datadogagent/dependencies_test.go
@@ -6,7 +6,6 @@
 package datadogagent
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +38,7 @@ func TestAddDDASharedDependenciesIncludesProfileAPMPort(t *testing.T) {
 	depsStore := newDependencyTestStore(dda)
 	managers := feature.NewResourceManagers(depsStore)
 
-	err := (&Reconciler{}).addDDASharedDependencies(context.Background(), dda, []*v1alpha1.DatadogAgentInternal{baseDDAI, profileDDAI}, managers)
+	err := (&Reconciler{}).addDDASharedDependencies(dda, []*v1alpha1.DatadogAgentInternal{baseDDAI, profileDDAI}, managers)
 	require.NoError(t, err)
 
 	obj, found := depsStore.Get(kubernetes.ServicesKind, "default", "datadog-agent")
@@ -53,7 +52,7 @@ func TestAddDDASharedDependenciesIncludesProfileAPMPort(t *testing.T) {
 	assert.Equal(t, intstr.FromInt(int(constants.DefaultApmPort)), apmPort.TargetPort)
 }
 
-func TestAddDDASharedDependenciesKeepsFirstConflictingProfilePort(t *testing.T) {
+func TestAddDDASharedDependenciesRejectsConflictingProfilePorts(t *testing.T) {
 	dda := testutils.NewInitializedDatadogAgentBuilder("default", "datadog").WithAPMEnabled(false).BuildWithDefaults()
 
 	profileSpecA := dda.Spec.DeepCopy()
@@ -65,21 +64,15 @@ func TestAddDDASharedDependenciesKeepsFirstConflictingProfilePort(t *testing.T) 
 	depsStore := newDependencyTestStore(dda)
 	managers := feature.NewResourceManagers(depsStore)
 
-	err := (&Reconciler{}).addDDASharedDependencies(context.Background(), dda, []*v1alpha1.DatadogAgentInternal{
+	err := (&Reconciler{}).addDDASharedDependencies(dda, []*v1alpha1.DatadogAgentInternal{
 		testDDAIWithSpec("datadog-profile-a", dda.Namespace, profileSpecA),
 		testDDAIWithSpec("datadog-profile-b", dda.Namespace, profileSpecB),
 	}, managers)
 
-	require.NoError(t, err)
-
-	obj, found := depsStore.Get(kubernetes.ServicesKind, "default", "datadog-agent")
-	require.True(t, found)
-	service := obj.(*corev1.Service)
-
-	apmPort := findServicePortByName(service.Spec.Ports, constants.DefaultApmPortName)
-	require.NotNil(t, apmPort)
-	assert.Equal(t, int32(8126), apmPort.Port)
-	assert.Equal(t, intstr.FromInt(8126), apmPort.TargetPort)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default/datadog-profile-b DDA shared dependencies failed")
+	assert.Contains(t, err.Error(), "port \"traceport\" conflicts")
+	assert.Contains(t, err.Error(), "service port conflict")
 }
 
 func TestAddDDASharedDependenciesDoesNotMutateDDAISpec(t *testing.T) {
@@ -92,7 +85,7 @@ func TestAddDDASharedDependenciesDoesNotMutateDDAISpec(t *testing.T) {
 	depsStore := newDependencyTestStore(dda)
 	managers := feature.NewResourceManagers(depsStore)
 
-	err := (&Reconciler{}).addDDASharedDependencies(context.Background(), dda, []*v1alpha1.DatadogAgentInternal{ddai}, managers)
+	err := (&Reconciler{}).addDDASharedDependencies(dda, []*v1alpha1.DatadogAgentInternal{ddai}, managers)
 	require.NoError(t, err)
 
 	assert.Nil(t, ddai.Spec.Features.ServiceDiscovery.Enabled)

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -45,6 +45,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	err = feature.RegisterDDASharedDependencies(feature.APMIDType, applyAPMDDASharedDependencies)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func buildAPMFeature(options *feature.Options) feature.Feature {
@@ -72,9 +76,6 @@ type apmFeature struct {
 	udsHostFilepath string
 
 	owner metav1.Object
-
-	forceEnableLocalService bool
-	localServiceName        string
 
 	createKubernetesNetworkPolicy bool
 	createCiliumNetworkPolicy     bool
@@ -180,11 +181,6 @@ func (f *apmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 		}
 		f.udsHostFilepath = *apm.UnixDomainSocketConfig.Path
 
-		if ddaSpec.Global.LocalService != nil {
-			f.forceEnableLocalService = apiutils.BoolValue(ddaSpec.Global.LocalService.ForceEnableLocalService)
-		}
-		f.localServiceName = constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec)
-
 		reqComp.Agent = feature.RequiredComponent{
 			IsRequired: ptr.To(true),
 			Containers: []apicommon.AgentContainerName{
@@ -262,82 +258,57 @@ func (f *apmFeature) shouldEnableLanguageDetection() bool {
 // ManageDependencies allows a feature to manage its dependencies.
 // Feature's dependencies should be added in the store.
 func (f *apmFeature) ManageDependencies(managers feature.ResourceManagers) error {
-	if f.nodeAPMEnabled {
-		platformInfo := managers.Store().GetPlatformInfo()
-		// agent local service
-		if common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), f.forceEnableLocalService) {
-			apmPort := &corev1.ServicePort{
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(int(constants.DefaultApmPort)),
-				Port:       constants.DefaultApmPort,
-				Name:       constants.DefaultApmPortName,
-			}
-			if f.hostPortEnabled {
-				apmPort.Port = f.hostPortHostPort
-				apmPort.Name = apmHostPortName
-				if f.useHostNetwork {
-					apmPort.TargetPort = intstr.FromInt(int(f.hostPortHostPort))
-				}
-			}
-
-			serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-			if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), common.GetAgentLocalServiceSelector(f.owner), []corev1.ServicePort{*apmPort}, &serviceInternalTrafficPolicy); err != nil {
-				return err
-			}
-		}
-
-		// network policies
-		if f.hostPortEnabled {
-			policyName, podSelector := objects.GetNetworkPolicyMetadata(f.owner, v2alpha1.NodeAgentComponentName)
-			if f.createKubernetesNetworkPolicy {
-				protocolTCP := corev1.ProtocolTCP
-				ingressRules := []netv1.NetworkPolicyIngressRule{
-					{
-						Ports: []netv1.NetworkPolicyPort{
-							{
-								Port: &intstr.IntOrString{
-									Type:   intstr.Int,
-									IntVal: f.hostPortHostPort,
-								},
-								Protocol: &protocolTCP,
+	// network policies
+	if f.nodeAPMEnabled && f.hostPortEnabled {
+		policyName, podSelector := objects.GetNetworkPolicyMetadata(f.owner, v2alpha1.NodeAgentComponentName)
+		if f.createKubernetesNetworkPolicy {
+			protocolTCP := corev1.ProtocolTCP
+			ingressRules := []netv1.NetworkPolicyIngressRule{
+				{
+					Ports: []netv1.NetworkPolicyPort{
+						{
+							Port: &intstr.IntOrString{
+								Type:   intstr.Int,
+								IntVal: f.hostPortHostPort,
 							},
+							Protocol: &protocolTCP,
 						},
 					},
-				}
-				return managers.NetworkPolicyManager().AddKubernetesNetworkPolicy(
-					policyName,
-					f.owner.GetNamespace(),
-					podSelector,
-					nil,
-					ingressRules,
-					nil,
-				)
-			} else if f.createCiliumNetworkPolicy {
-				policySpecs := []cilium.NetworkPolicySpec{
-					{
-						Description:      "Ingress for APM trace",
-						EndpointSelector: podSelector,
-						Ingress: []cilium.IngressRule{
-							{
-								FromEndpoints: []metav1.LabelSelector{
-									{},
-								},
-								ToPorts: []cilium.PortRule{
-									{
-										Ports: []cilium.PortProtocol{
-											{
-												Port:     strconv.Itoa(int(f.hostPortHostPort)),
-												Protocol: cilium.ProtocolTCP,
-											},
+				},
+			}
+			return managers.NetworkPolicyManager().AddKubernetesNetworkPolicy(
+				policyName,
+				f.owner.GetNamespace(),
+				podSelector,
+				nil,
+				ingressRules,
+				nil,
+			)
+		} else if f.createCiliumNetworkPolicy {
+			policySpecs := []cilium.NetworkPolicySpec{
+				{
+					Description:      "Ingress for APM trace",
+					EndpointSelector: podSelector,
+					Ingress: []cilium.IngressRule{
+						{
+							FromEndpoints: []metav1.LabelSelector{
+								{},
+							},
+							ToPorts: []cilium.PortRule{
+								{
+									Ports: []cilium.PortProtocol{
+										{
+											Port:     strconv.Itoa(int(f.hostPortHostPort)),
+											Protocol: cilium.ProtocolTCP,
 										},
 									},
 								},
 							},
 						},
 					},
-				}
-				return managers.CiliumPolicyManager().AddCiliumPolicy(policyName, f.owner.GetNamespace(), policySpecs)
+				},
 			}
+			return managers.CiliumPolicyManager().AddCiliumPolicy(policyName, f.owner.GetNamespace(), policySpecs)
 		}
 	}
 
@@ -348,6 +319,57 @@ func (f *apmFeature) ManageDependencies(managers feature.ResourceManagers) error
 	}
 
 	return nil
+}
+
+func applyAPMDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) error {
+	ports := apmLocalAgentServicePorts(ddai, ddaiSpec)
+	if len(ports) == 0 || !featutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+		return nil
+	}
+
+	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
+	return managers.ServiceManager().AddService(
+		constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec),
+		dda.GetNamespace(),
+		common.GetAgentLocalServiceSelector(dda),
+		ports,
+		&serviceInternalTrafficPolicy,
+	)
+}
+
+func apmLocalAgentServicePorts(ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec) []corev1.ServicePort {
+	if ddaiSpec == nil || ddaiSpec.Features == nil || !shouldEnableAPM(ddaiSpec.Features.APM) {
+		return nil
+	}
+
+	apm := ddaiSpec.Features.APM
+	hostPortEnabled := false
+	hostPortHostPort := int32(constants.DefaultApmPort)
+	if apm.HostPortConfig != nil {
+		hostPortEnabled = apiutils.BoolValue(apm.HostPortConfig.Enabled)
+		if apm.HostPortConfig.Port != nil {
+			hostPortHostPort = *apm.HostPortConfig.Port
+		}
+	}
+	if experimental.IsAutopilotEnabled(ddai) {
+		hostPortEnabled = true
+	}
+
+	apmPort := corev1.ServicePort{
+		Protocol:   corev1.ProtocolTCP,
+		TargetPort: intstr.FromInt(int(constants.DefaultApmPort)),
+		Port:       constants.DefaultApmPort,
+		Name:       constants.DefaultApmPortName,
+	}
+	if hostPortEnabled {
+		apmPort.Port = hostPortHostPort
+		apmPort.Name = apmHostPortName
+		if constants.IsHostNetworkEnabled(ddaiSpec, v2alpha1.NodeAgentComponentName) {
+			apmPort.TargetPort = intstr.FromInt(int(hostPortHostPort))
+		}
+	}
+
+	return []corev1.ServicePort{apmPort}
 }
 
 // ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -31,6 +31,7 @@ import (
 	cilium "github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/images"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/utils"
 )
 
@@ -56,6 +57,7 @@ func buildAPMFeature(options *feature.Options) feature.Feature {
 
 	if options != nil {
 		apmFeat.logger = options.Logger
+		apmFeat.platformInfo = options.PlatformInfo
 	}
 
 	return apmFeat
@@ -65,10 +67,11 @@ type apmFeature struct {
 	// nodeAPMEnabled tracks the node-agent side of APM separately from SSI.
 	// Profiles can contribute SSI Cluster Agent config without enabling trace
 	// agent configuration on the default DDAI.
-	nodeAPMEnabled   bool
-	hostPortEnabled  bool
-	hostPortHostPort int32
-	useHostNetwork   bool
+	nodeAPMEnabled      bool
+	hostPortEnabled     bool
+	hostPortHostPort    int32
+	localServiceEnabled bool
+	useHostNetwork      bool
 
 	serviceAccountName string
 
@@ -86,7 +89,8 @@ type apmFeature struct {
 
 	errorTrackingStandalone bool
 
-	logger logr.Logger
+	logger       logr.Logger
+	platformInfo kubernetes.PlatformInfo
 }
 
 type instrumentationConfig struct {
@@ -168,6 +172,7 @@ func (f *apmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 			f.hostPortEnabled = apiutils.BoolValue(apm.HostPortConfig.Enabled)
 			f.udsEnabled = apiutils.BoolValue(apm.UnixDomainSocketConfig.Enabled)
 		}
+		f.localServiceEnabled = featutils.ShouldCreateLocalAgentService(ddaSpec, f.platformInfo)
 
 		f.hostPortHostPort = *apm.HostPortConfig.Port
 		if f.hostPortEnabled {
@@ -323,7 +328,7 @@ func (f *apmFeature) ManageDependencies(managers feature.ResourceManagers) error
 
 func applyAPMDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) error {
 	ports := apmLocalAgentServicePorts(ddai, ddaiSpec)
-	if len(ports) == 0 || !featutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+	if len(ports) == 0 || !featutils.ShouldCreateLocalAgentService(ddaSpec, managers.Store().GetPlatformInfo()) {
 		return nil
 	}
 
@@ -511,6 +516,14 @@ func (f *apmFeature) manageNodeAgent(agentContainerName apicommon.AgentContainer
 		ContainerPort: constants.DefaultApmPort,
 		Protocol:      corev1.ProtocolTCP,
 	}
+	// APM has no CRD non-local-traffic knob, so derive it from exposure modes.
+	// DogStatsD intentionally uses the defaulted/user-set CRD value instead.
+	if f.hostPortEnabled || f.localServiceEnabled {
+		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
+			Name:  DDAPMNonLocalTraffic,
+			Value: "true",
+		})
+	}
 	if f.hostPortEnabled {
 		apmPort.HostPort = f.hostPortHostPort
 		receiverPortEnvVarValue := constants.DefaultApmPort
@@ -519,10 +532,6 @@ func (f *apmFeature) manageNodeAgent(agentContainerName apicommon.AgentContainer
 			apmPort.ContainerPort = f.hostPortHostPort
 			receiverPortEnvVarValue = int(f.hostPortHostPort)
 		}
-		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
-			Name:  DDAPMNonLocalTraffic,
-			Value: "true",
-		})
 		managers.EnvVar().AddEnvVarToContainer(agentContainerName, &corev1.EnvVar{
 			Name:  DDAPMReceiverPort,
 			Value: strconv.Itoa(receiverPortEnvVarValue),

--- a/internal/controller/datadogagent/feature/apm/feature_test.go
+++ b/internal/controller/datadogagent/feature/apm/feature_test.go
@@ -9,6 +9,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -22,11 +27,6 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -130,8 +130,38 @@ func TestAPMFeature(t *testing.T) {
 				WithAPMHostPortEnabled(false, ptr.To[int32](8126)).
 				WithAPMUDSEnabled(true, apmSocketHostPath).
 				Build(),
+			FeatureOptions: &feature.Options{
+				PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.20.0"}, nil, nil),
+			},
 			WantConfigure: true,
 			Agent:         testAgentUDSOnly(apicommon.TraceAgentContainerName),
+		},
+		{
+			Name: "apm enabled, use uds and local service",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithAPMEnabled(true).
+				WithAPMHostPortEnabled(false, ptr.To[int32](8126)).
+				WithAPMUDSEnabled(true, apmSocketHostPath).
+				Build(),
+			FeatureOptions: &feature.Options{
+				PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.32.0"}, nil, nil),
+			},
+			WantConfigure: true,
+			Agent:         testAgentUDSWithNonLocalTraffic(apicommon.TraceAgentContainerName),
+		},
+		{
+			Name: "apm enabled, use uds, force local service on old k8s",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithAPMEnabled(true).
+				WithAPMHostPortEnabled(false, ptr.To[int32](8126)).
+				WithAPMUDSEnabled(true, apmSocketHostPath).
+				WithForceEnableLocalService(true).
+				Build(),
+			FeatureOptions: &feature.Options{
+				PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.21.0"}, nil, nil),
+			},
+			WantConfigure: true,
+			Agent:         testAgentUDSWithNonLocalTraffic(apicommon.TraceAgentContainerName),
 		},
 		{
 			Name: "apm enabled, use uds with single container strategy",
@@ -141,8 +171,55 @@ func TestAPMFeature(t *testing.T) {
 				WithAPMUDSEnabled(true, apmSocketHostPath).
 				WithSingleContainerStrategy(true).
 				Build(),
+			FeatureOptions: &feature.Options{
+				PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.20.0"}, nil, nil),
+			},
 			WantConfigure: true,
 			Agent:         testAgentUDSOnly(apicommon.UnprivilegedSingleAgentContainerName),
+		},
+		{
+			Name: "apm enabled, use uds and local service with single container strategy",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithAPMEnabled(true).
+				WithAPMHostPortEnabled(false, ptr.To[int32](8126)).
+				WithAPMUDSEnabled(true, apmSocketHostPath).
+				WithSingleContainerStrategy(true).
+				Build(),
+			FeatureOptions: &feature.Options{
+				PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.32.0"}, nil, nil),
+			},
+			WantConfigure: true,
+			Agent:         testAgentUDSWithNonLocalTraffic(apicommon.UnprivilegedSingleAgentContainerName),
+		},
+		{
+			Name: "apm enabled, tcp only with local service",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithAPMEnabled(true).
+				WithAPMHostPortEnabled(false, ptr.To[int32](8126)).
+				// WithAPMUDSEnabled is called with enabled=false to initialize the
+				// UnixDomainSocketConfig struct; Configure unconditionally dereferences
+				// its Path field, so the struct must be non-nil even when UDS is off.
+				WithAPMUDSEnabled(false, apmSocketHostPath).
+				Build(),
+			FeatureOptions: &feature.Options{
+				PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.32.0"}, nil, nil),
+			},
+			WantConfigure: true,
+			Agent:         testAgentTCPOnlyWithNonLocalTraffic(apicommon.TraceAgentContainerName),
+		},
+		{
+			Name: "apm enabled, tcp only, force local service on old k8s",
+			DDA: testutils.NewDatadogAgentBuilder().
+				WithAPMEnabled(true).
+				WithAPMHostPortEnabled(false, ptr.To[int32](8126)).
+				WithAPMUDSEnabled(false, apmSocketHostPath).
+				WithForceEnableLocalService(true).
+				Build(),
+			FeatureOptions: &feature.Options{
+				PlatformInfo: kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "1.21.0"}, nil, nil),
+			},
+			WantConfigure: true,
+			Agent:         testAgentTCPOnlyWithNonLocalTraffic(apicommon.TraceAgentContainerName),
 		},
 		{
 			Name: "apm enabled, use uds and host port",
@@ -594,7 +671,7 @@ func testAgentErrorTrackingStandalone() *test.ComponentTest {
 	)
 }
 
-func testAgentUDSOnly(agentContainerName apicommon.AgentContainerName) *test.ComponentTest {
+func testAgentTCPOnlyWithNonLocalTraffic(agentContainerName apicommon.AgentContainerName) *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -606,10 +683,72 @@ func testAgentUDSOnly(agentContainerName apicommon.AgentContainerName) *test.Com
 					Value: "true",
 				},
 				{
+					Name:  DDAPMNonLocalTraffic,
+					Value: "true",
+				},
+			}
+			assert.True(
+				t,
+				apiutils.IsEqualStruct(agentEnvs, expectedAgentEnvs),
+				"Trace Agent ENVs \ndiff = %s", cmp.Diff(agentEnvs, expectedAgentEnvs),
+			)
+
+			agentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[agentContainerName]
+			assert.Empty(t, agentVolumeMounts, "Trace Agent VolumeMounts should be empty for TCP-only")
+
+			agentVolumes := mgr.VolumeMgr.Volumes
+			assert.Empty(t, agentVolumes, "Trace Agent Volumes should be empty for TCP-only")
+
+			agentPorts := mgr.PortMgr.PortsByC[agentContainerName]
+			expectedPorts := []*corev1.ContainerPort{
+				{
+					Name:          constants.DefaultApmPortName,
+					ContainerPort: constants.DefaultApmPort,
+					Protocol:      corev1.ProtocolTCP,
+				},
+			}
+			assert.True(
+				t,
+				apiutils.IsEqualStruct(agentPorts, expectedPorts),
+				"Trace Agent Ports \ndiff = %s", cmp.Diff(agentPorts, expectedPorts),
+			)
+		},
+	)
+}
+
+func testAgentUDSOnly(agentContainerName apicommon.AgentContainerName) *test.ComponentTest {
+	return testAgentUDS(agentContainerName, false)
+}
+
+func testAgentUDSWithNonLocalTraffic(agentContainerName apicommon.AgentContainerName) *test.ComponentTest {
+	return testAgentUDS(agentContainerName, true)
+}
+
+func testAgentUDS(agentContainerName apicommon.AgentContainerName, nonLocalTraffic bool) *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+			expectedAgentEnvs := []*corev1.EnvVar{
+				{
+					Name:  constants.DDAPMEnabled,
+					Value: "true",
+				},
+			}
+			if nonLocalTraffic {
+				expectedAgentEnvs = append(expectedAgentEnvs, &corev1.EnvVar{
+					Name:  DDAPMNonLocalTraffic,
+					Value: "true",
+				})
+			}
+			expectedAgentEnvs = append(expectedAgentEnvs,
+				&corev1.EnvVar{
 					Name:  DDAPMReceiverSocket,
 					Value: apmSocketLocalPath,
 				},
-			}
+			)
+
+			agentEnvs := mgr.EnvVarMgr.EnvVarsByC[agentContainerName]
 			assert.True(
 				t,
 				apiutils.IsEqualStruct(agentEnvs, expectedAgentEnvs),

--- a/internal/controller/datadogagent/feature/apm/profile_overlay.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay.go
@@ -12,9 +12,14 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
-func applyAPMProfileSharedConfigOverlay(dst, _ *v2alpha1.DatadogAgentSpec, profileSpec *v2alpha1.DatadogAgentSpec) error {
+func applyAPMProfileSharedConfigOverlay(dst, base *v2alpha1.DatadogAgentSpec, profileSpec *v2alpha1.DatadogAgentSpec) error {
+	if err := applyProfileLocalAgentServicePort(dst, base, profileSpec); err != nil {
+		return err
+	}
+
 	// Only profiles that explicitly enable SSI contribute shared Cluster Agent
 	// config. SSI enabled=false is treated as "no shared overlay".
 	profileSSI, ok := profileSSIOverlayConfig(profileSpec)
@@ -40,6 +45,47 @@ func applyAPMProfileSharedConfigOverlay(dst, _ *v2alpha1.DatadogAgentSpec, profi
 	defaultLanguageDetection(dstSSI)
 
 	return nil
+}
+
+func applyProfileLocalAgentServicePort(dst, base, profileSpec *v2alpha1.DatadogAgentSpec) error {
+	profilePort, ok := profileLocalAgentServicePort(profileSpec)
+	if !ok {
+		return nil
+	}
+
+	existingPort, ok := profileLocalAgentServicePort(base)
+	if !ok {
+		if dst != nil && dst.Features != nil && dst.Features.APM != nil {
+			hostPort := dst.Features.APM.HostPortConfig
+			if hostPort != nil && ptr.Deref(hostPort.Enabled, false) && hostPort.Port != nil {
+				existingPort = *hostPort.Port
+				ok = true
+			}
+		}
+	}
+	if ok && existingPort != profilePort {
+		return fmt.Errorf("local Agent Service port %q conflicts with existing port", constants.DefaultApmPortName)
+	}
+
+	if dst.Features == nil {
+		dst.Features = &v2alpha1.DatadogFeatures{}
+	}
+	if dst.Features.APM == nil {
+		dst.Features.APM = &v2alpha1.APMFeatureConfig{}
+	}
+	dst.Features.APM.HostPortConfig = &v2alpha1.HostPortConfig{
+		Enabled: ptr.To(true),
+		Port:    ptr.To(profilePort),
+	}
+	return nil
+}
+
+func profileLocalAgentServicePort(spec *v2alpha1.DatadogAgentSpec) (int32, bool) {
+	ports := apmLocalAgentServicePorts(nil, spec)
+	if len(ports) == 0 {
+		return 0, false
+	}
+	return ports[0].Port, true
 }
 
 // profileSSIOverlayConfig extracts the only APM profile config that affects a

--- a/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
@@ -475,6 +475,20 @@ func TestAPMProfileSharedConfigOverlay(t *testing.T) {
 	}
 }
 
+func TestAPMProfileSharedConfigOverlayLocalAgentServicePortConflict(t *testing.T) {
+	base := testProfileOverlayBaseSpec(false)
+	dst := base.DeepCopy()
+
+	require.NoError(t, applyAPMProfileSharedConfigOverlay(dst, base, testProfileOverlayProfileAPMSpec(8126)))
+	assert.Equal(t, int32(8126), ptr.Deref(dst.Features.APM.HostPortConfig.Port, 0))
+
+	require.NoError(t, applyAPMProfileSharedConfigOverlay(dst, base, testProfileOverlayProfileAPMSpec(8126)))
+
+	err := applyAPMProfileSharedConfigOverlay(dst, base, testProfileOverlayProfileAPMSpec(9126))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `local Agent Service port "traceport" conflicts`)
+}
+
 // Profile SSI overlays should render the same Cluster Agent config as direct
 // base-DDA SSI config. Node Agent config is intentionally out of scope because
 // profile-owned APM config renders on the profile DDAI instead of the default
@@ -578,6 +592,16 @@ func testProfileOverlayProfileSpec(ssi *v2alpha1.SingleStepInstrumentation) *v2a
 				SingleStepInstrumentation: ssi,
 			},
 		},
+	}
+	return spec
+}
+
+func testProfileOverlayProfileAPMSpec(port int32) *v2alpha1.DatadogAgentSpec {
+	spec := testProfileOverlayProfileSpec(nil)
+	spec.Features.APM.Enabled = ptr.To(true)
+	spec.Features.APM.HostPortConfig = &v2alpha1.HostPortConfig{
+		Enabled: ptr.To(true),
+		Port:    ptr.To(port),
 	}
 	return spec
 }

--- a/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
@@ -458,7 +458,8 @@ func TestAPMProfileSharedConfigOverlay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := applyAPMProfileSharedConfigOverlay(tt.dst, tt.dst.DeepCopy(), tt.profile)
+			dst := tt.dst.DeepCopy()
+			err := applyAPMProfileSharedConfigOverlay(dst, dst.DeepCopy(), tt.profile)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -466,10 +467,10 @@ func TestAPMProfileSharedConfigOverlay(t *testing.T) {
 			}
 			require.NoError(t, err)
 			if tt.wantNoApply {
-				assert.False(t, *tt.dst.Features.APM.SingleStepInstrumentation.Enabled)
+				assert.False(t, *dst.Features.APM.SingleStepInstrumentation.Enabled)
 				return
 			}
-			assert.Equal(t, tt.want, tt.dst.Features.APM.SingleStepInstrumentation)
+			assert.Equal(t, tt.want, dst.Features.APM.SingleStepInstrumentation)
 		})
 	}
 }

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -109,6 +109,8 @@ func (f *dogstatsdFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 		f.mapperProfiles = dogstatsd.MapperProfiles
 	}
 
+	// DogStatsD keeps using the defaulted/user-set CRD value rather than deriving
+	// non-local traffic from hostPort/local-service exposure like APM.
 	f.nonLocalTraffic = apiutils.BoolValue(dogstatsd.NonLocalTraffic)
 
 	f.dataPlaneEnabled = featureutils.IsDataPlaneEnabled(dda, ddaSpec)
@@ -134,7 +136,7 @@ func (f *dogstatsdFeature) ManageDependencies(managers feature.ResourceManagers)
 
 func applyDogstatsdDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) error {
 	ports := dogstatsdLocalAgentServicePorts(ddai, ddaiSpec)
-	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers.Store().GetPlatformInfo()) {
 		return nil
 	}
 

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -32,6 +32,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	err = feature.RegisterDDASharedDependencies(feature.DogstatsdIDType, applyDogstatsdDDASharedDependencies)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func buildDogstatsdFeature(options *feature.Options) feature.Feature {
@@ -55,9 +59,6 @@ type dogstatsdFeature struct {
 	originDetectionEnabled bool
 	tagCardinality         string
 	mapperProfiles         *v2alpha1.CustomConfig
-
-	forceEnableLocalService bool
-	localServiceName        string
 
 	dataPlaneEnabled           bool
 	dataPlaneDogstatsdEnabled  bool
@@ -108,11 +109,6 @@ func (f *dogstatsdFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 		f.mapperProfiles = dogstatsd.MapperProfiles
 	}
 
-	if ddaSpec.Global.LocalService != nil {
-		f.forceEnableLocalService = apiutils.BoolValue(ddaSpec.Global.LocalService.ForceEnableLocalService)
-	}
-	f.localServiceName = constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec)
-
 	f.nonLocalTraffic = apiutils.BoolValue(dogstatsd.NonLocalTraffic)
 
 	f.dataPlaneEnabled = featureutils.IsDataPlaneEnabled(dda, ddaSpec)
@@ -133,29 +129,58 @@ func (f *dogstatsdFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 // ManageDependencies allows a feature to manage its dependencies.
 // Feature's dependencies should be added in the store.
 func (f *dogstatsdFeature) ManageDependencies(managers feature.ResourceManagers) error {
-	platformInfo := managers.Store().GetPlatformInfo()
-	// agent local service
-	if common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), f.forceEnableLocalService) {
-		dsdPort := &corev1.ServicePort{
-			Protocol:   corev1.ProtocolUDP,
-			TargetPort: intstr.FromInt(int(common.DefaultDogstatsdPort)),
-			Port:       common.DefaultDogstatsdPort,
-			Name:       defaultDogstatsdPortName,
+	return nil
+}
+
+func applyDogstatsdDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) error {
+	ports := dogstatsdLocalAgentServicePorts(ddai, ddaiSpec)
+	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+		return nil
+	}
+
+	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
+	return managers.ServiceManager().AddService(
+		constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec),
+		dda.GetNamespace(),
+		common.GetAgentLocalServiceSelector(dda),
+		ports,
+		&serviceInternalTrafficPolicy,
+	)
+}
+
+func dogstatsdLocalAgentServicePorts(ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec) []corev1.ServicePort {
+	if ddaiSpec == nil || ddaiSpec.Features == nil || ddaiSpec.Features.Dogstatsd == nil {
+		return nil
+	}
+
+	dogstatsd := ddaiSpec.Features.Dogstatsd
+	hostPortEnabled := false
+	hostPortHostPort := int32(common.DefaultDogstatsdPort)
+	if dogstatsd.HostPortConfig != nil {
+		hostPortEnabled = apiutils.BoolValue(dogstatsd.HostPortConfig.Enabled)
+		if dogstatsd.HostPortConfig.Port != nil {
+			hostPortHostPort = *dogstatsd.HostPortConfig.Port
 		}
-		if f.hostPortEnabled {
-			dsdPort.Port = f.hostPortHostPort
-			dsdPort.Name = dogstatsdHostPortName
-			if f.useHostNetwork {
-				dsdPort.TargetPort = intstr.FromInt(int(f.hostPortHostPort))
-			}
-		}
-		serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-		if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), common.GetAgentLocalServiceSelector(f.owner), []corev1.ServicePort{*dsdPort}, &serviceInternalTrafficPolicy); err != nil {
-			return err
+	}
+	if experimental.IsAutopilotEnabled(ddai) {
+		hostPortEnabled = true
+	}
+
+	dsdPort := corev1.ServicePort{
+		Protocol:   corev1.ProtocolUDP,
+		TargetPort: intstr.FromInt(int(common.DefaultDogstatsdPort)),
+		Port:       common.DefaultDogstatsdPort,
+		Name:       defaultDogstatsdPortName,
+	}
+	if hostPortEnabled {
+		dsdPort.Port = hostPortHostPort
+		dsdPort.Name = dogstatsdHostPortName
+		if constants.IsHostNetworkEnabled(ddaiSpec, v2alpha1.NodeAgentComponentName) {
+			dsdPort.TargetPort = intstr.FromInt(int(hostPortHostPort))
 		}
 	}
 
-	return nil
+	return []corev1.ServicePort{dsdPort}
 }
 
 // ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec

--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/otelcollector/defaultconfig"
+	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
@@ -44,6 +45,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	err = feature.RegisterDDASharedDependencies(feature.OtelAgentIDType, applyOTelCollectorDDASharedDependencies)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func buildOtelCollectorFeature(options *feature.Options) feature.Feature {
@@ -66,9 +71,6 @@ type otelCollectorFeature struct {
 	customConfigAnnotationKey   string
 	customConfigAnnotationValue string
 
-	forceEnableLocalService bool
-	localServiceName        string
-
 	incompatibleImage bool
 
 	otelGatewayEnabled bool
@@ -87,16 +89,8 @@ func (o *otelCollectorFeature) ID() feature.IDType {
 }
 
 func (o *otelCollectorFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) feature.RequiredComponents {
-	var agentImageName string
-	agentVersion := images.AgentLatestVersion
-	if nodeAgent, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok {
-		if nodeAgent.Image != nil {
-			agentImageName = nodeAgent.Image.Name
-			agentVersion = common.GetAgentVersionFromImage(*nodeAgent.Image)
-		}
-	}
-	supportedVersion := utils.IsAboveMinVersion(agentVersion, otelAgentMinVersion, ptr.To(true))
-	if !supportedVersion && agentImageName == "" {
+	agentImageName, agentVersion := otelCollectorAgentImage(ddaSpec)
+	if otelCollectorRequiresNewerAgent(agentImageName, agentVersion) {
 		o.incompatibleImage = true
 		o.logger.Error(errIncompatibleImage,
 			fmt.Sprintf("OTel Agent Standalone requires Agent version %s or higher. Either update the Agent version to %s+, or override the Agent image by setting %s to a fully qualified image name with the -full tag (e.g., %s)",
@@ -105,7 +99,7 @@ func (o *otelCollectorFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Da
 		return feature.RequiredComponents{}
 	}
 
-	if strings.HasSuffix(agentVersion, "-full") && agentImageName == "" {
+	if otelCollectorRejectsFullTag(agentImageName, agentVersion) {
 		o.incompatibleImage = true
 		o.logger.Error(errIncompatibleImage,
 			fmt.Sprintf("OTel Agent Standalone does not support the -full tag. Either remove the -full suffix from the Agent tag (e.g., use %s instead of %s), or override the Agent image by setting %s to a fully qualified image name (e.g., %s)",
@@ -119,11 +113,6 @@ func (o *otelCollectorFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Da
 		o.customConfig = ddaSpec.Features.OtelCollector.Conf
 	}
 	o.configMapName = constants.GetConfName(dda, o.customConfig, defaultOTelAgentConf)
-
-	if ddaSpec.Global.LocalService != nil {
-		o.forceEnableLocalService = apiutils.BoolValue(ddaSpec.Global.LocalService.ForceEnableLocalService)
-	}
-	o.localServiceName = constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec)
 
 	if ddaSpec.Features.OtelCollector.CoreConfig != nil {
 		o.coreAgentConfig.enabled = ddaSpec.Features.OtelCollector.CoreConfig.Enabled
@@ -243,33 +232,83 @@ func (o *otelCollectorFeature) ManageDependencies(managers feature.ResourceManag
 		}
 	}
 
-	platformInfo := managers.Store().GetPlatformInfo()
-	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-	if common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), o.forceEnableLocalService) {
-		otlpGrpcPort := &corev1.ServicePort{
+	return nil
+}
+
+func applyOTelCollectorDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) error {
+	ports := otelCollectorLocalAgentServicePorts(ddaiSpec)
+	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+		return nil
+	}
+
+	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
+	return managers.ServiceManager().AddService(
+		constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec),
+		dda.GetNamespace(),
+		common.GetAgentLocalServiceSelector(dda),
+		ports,
+		&serviceInternalTrafficPolicy,
+	)
+}
+
+func otelCollectorLocalAgentServicePorts(ddaiSpec *v2alpha1.DatadogAgentSpec) []corev1.ServicePort {
+	if ddaiSpec == nil ||
+		ddaiSpec.Features == nil ||
+		ddaiSpec.Features.OtelCollector == nil ||
+		!apiutils.BoolValue(ddaiSpec.Features.OtelCollector.Enabled) ||
+		!otelCollectorSupportsAgentImage(ddaiSpec) {
+		return nil
+	}
+
+	grpcPort := 4317
+	httpPort := 4318
+	for _, port := range ddaiSpec.Features.OtelCollector.Ports {
+		if port.Name == "otel-grpc" {
+			grpcPort = int(port.ContainerPort)
+		}
+		if port.Name == "otel-http" {
+			httpPort = int(port.ContainerPort)
+		}
+	}
+
+	return []corev1.ServicePort{
+		{
 			Name:       "otlpgrpcport",
 			Port:       int32(grpcPort),
 			Protocol:   corev1.ProtocolTCP,
 			TargetPort: intstr.FromInt(grpcPort),
-		}
-		otlpHttpPort := &corev1.ServicePort{
+		},
+		{
 			Name:       "otlphttpport",
 			Port:       int32(httpPort),
 			Protocol:   corev1.ProtocolTCP,
 			TargetPort: intstr.FromInt(httpPort),
-		}
-		if err := managers.ServiceManager().AddService(
-			o.localServiceName,
-			o.owner.GetNamespace(),
-			common.GetAgentLocalServiceSelector(o.owner),
-			[]corev1.ServicePort{*otlpGrpcPort, *otlpHttpPort},
-			&internalTrafficPolicy,
-		); err != nil {
-			return err
-		}
+		},
 	}
+}
 
-	return nil
+func otelCollectorSupportsAgentImage(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
+	agentImageName, agentVersion := otelCollectorAgentImage(ddaSpec)
+	return !otelCollectorRequiresNewerAgent(agentImageName, agentVersion) &&
+		!otelCollectorRejectsFullTag(agentImageName, agentVersion)
+}
+
+func otelCollectorRequiresNewerAgent(agentImageName, agentVersion string) bool {
+	return !utils.IsAboveMinVersion(agentVersion, otelAgentMinVersion, ptr.To(true)) && agentImageName == ""
+}
+
+func otelCollectorRejectsFullTag(agentImageName, agentVersion string) bool {
+	return strings.HasSuffix(agentVersion, "-full") && agentImageName == ""
+}
+
+func otelCollectorAgentImage(ddaSpec *v2alpha1.DatadogAgentSpec) (string, string) {
+	var agentImageName string
+	agentVersion := images.AgentLatestVersion
+	if nodeAgent, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok && nodeAgent.Image != nil {
+		agentImageName = nodeAgent.Image.Name
+		agentVersion = common.GetAgentVersionFromImage(*nodeAgent.Image)
+	}
+	return agentImageName, agentVersion
 }
 
 func (o *otelCollectorFeature) ManageClusterAgent(managers feature.PodTemplateManagers) error {

--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -237,7 +237,7 @@ func (o *otelCollectorFeature) ManageDependencies(managers feature.ResourceManag
 
 func applyOTelCollectorDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) error {
 	ports := otelCollectorLocalAgentServicePorts(ddaiSpec)
-	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers.Store().GetPlatformInfo()) {
 		return nil
 	}
 

--- a/internal/controller/datadogagent/feature/otelcollector/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature_test.go
@@ -4,6 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/version"
+
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
@@ -15,12 +20,6 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/version"
 )
 
 type expectedPorts struct {
@@ -701,43 +700,6 @@ func testExpectedDepsCreatedCM(t testing.TB, store store.StoreClient) {
 		"ConfigMap \ndiff = %s", cmp.Diff(configMap.Data, expectedCM),
 	)
 
-	serviceObject, found := store.Get(kubernetes.ServicesKind, "", "-agent")
-	switch t.Name() {
-	case "Test_otelCollectorFeature_Configure/otel_agent_enabled_with_service_ports_default":
-		assert.True(t, found)
-		service := serviceObject.(*corev1.Service)
-		assert.Equal(t, []corev1.ServicePort{
-			{
-				Name:       "otlpgrpcport",
-				Port:       4317,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(4317),
-			},
-			{
-				Name:       "otlphttpport",
-				Port:       4318,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(4318),
-			},
-		}, service.Spec.Ports)
-	case "Test_otelCollectorFeature_Configure/otel_agent_enabled_with_service_ports_override":
-		assert.True(t, found)
-		service := serviceObject.(*corev1.Service)
-		assert.Equal(t, []corev1.ServicePort{
-			{
-				Name:       "otlpgrpcport",
-				Port:       4444,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(4444),
-			},
-			{
-				Name:       "otlphttpport",
-				Port:       5555,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromInt(5555),
-			},
-		}, service.Spec.Ports)
-	default:
-		assert.False(t, found)
-	}
+	_, found = store.Get(kubernetes.ServicesKind, "", "-agent")
+	assert.False(t, found)
 }

--- a/internal/controller/datadogagent/feature/otlp/feature.go
+++ b/internal/controller/datadogagent/feature/otlp/feature.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/objects"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
+	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 	"github.com/DataDog/datadog-operator/pkg/cilium/v1"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 )
@@ -34,6 +35,10 @@ var (
 
 func init() {
 	err := feature.Register(feature.OTLPIDType, buildOTLPFeature)
+	if err != nil {
+		panic(err)
+	}
+	err = feature.RegisterDDASharedDependencies(feature.OTLPIDType, applyOTLPDDASharedDependencies)
 	if err != nil {
 		panic(err)
 	}
@@ -59,9 +64,6 @@ type otlpFeature struct {
 	httpEndpoint        string
 
 	usingAPM bool
-
-	forceEnableLocalService bool
-	localServiceName        string
 
 	createKubernetesNetworkPolicy bool
 	createCiliumNetworkPolicy     bool
@@ -109,11 +111,6 @@ func (f *otlpFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgen
 		f.usingAPM = apiutils.BoolValue(apm.Enabled)
 	}
 
-	if ddaSpec.Global.LocalService != nil {
-		f.forceEnableLocalService = apiutils.BoolValue(ddaSpec.Global.LocalService.ForceEnableLocalService)
-	}
-	f.localServiceName = constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec)
-
 	if f.grpcEnabled || f.httpEnabled {
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
@@ -144,31 +141,10 @@ func (f *otlpFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgen
 // ManageDependencies allows a feature to manage its dependencies.
 // Feature's dependencies should be added in the store.
 func (f *otlpFeature) ManageDependencies(managers feature.ResourceManagers) error {
-	platformInfo := managers.Store().GetPlatformInfo()
-	versionInfo := platformInfo.GetVersionInfo()
-
 	if f.grpcEnabled {
-		port, err := extractPortEndpoint(f.grpcEndpoint)
+		port, err := f.grpcServicePort()
 		if err != nil {
-			f.logger.Error(err, "failed to extract port from OTLP/gRPC endpoint")
-			return fmt.Errorf("failed to extract port from OTLP/gRPC endpoint: %w", err)
-		}
-		if f.grpcHostPortEnabled && f.grpcCustomHostPort != 0 {
-			port = f.grpcCustomHostPort
-		}
-		if common.ShouldCreateAgentLocalService(versionInfo, f.forceEnableLocalService) {
-			servicePort := []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(int(port)),
-					Port:       port,
-					Name:       otlpGRPCPortName,
-				},
-			}
-			serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-			if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), common.GetAgentLocalServiceSelector(f.owner), servicePort, &serviceInternalTrafficPolicy); err != nil {
-				return err
-			}
+			return err
 		}
 		//network policies for gRPC OTLP
 		policyName, podSelector := objects.GetNetworkPolicyMetadata(f.owner, v2alpha1.NodeAgentComponentName)
@@ -227,27 +203,9 @@ func (f *otlpFeature) ManageDependencies(managers feature.ResourceManagers) erro
 		}
 	}
 	if f.httpEnabled {
-		port, err := extractPortEndpoint(f.httpEndpoint)
+		port, err := f.httpServicePort()
 		if err != nil {
-			f.logger.Error(err, "failed to extract port from OTLP/HTTP endpoint")
-			return fmt.Errorf("failed to extract port from OTLP/HTTP endpoint: %w", err)
-		}
-		if f.httpHostPortEnabled && f.httpCustomHostPort != 0 {
-			port = f.httpCustomHostPort
-		}
-		if common.ShouldCreateAgentLocalService(versionInfo, f.forceEnableLocalService) {
-			servicePort := []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: intstr.FromInt(int(port)),
-					Port:       port,
-					Name:       otlpHTTPPortName,
-				},
-			}
-			serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
-			if err := managers.ServiceManager().AddService(f.localServiceName, f.owner.GetNamespace(), nil, servicePort, &serviceInternalTrafficPolicy); err != nil {
-				return err
-			}
+			return err
 		}
 		//network policies for HTTP OTLP
 		policyName, podSelector := objects.GetNetworkPolicyMetadata(f.owner, v2alpha1.NodeAgentComponentName)
@@ -306,6 +264,113 @@ func (f *otlpFeature) ManageDependencies(managers feature.ResourceManagers) erro
 		}
 	}
 	return nil
+}
+
+func applyOTLPDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) error {
+	ports, err := otlpLocalAgentServicePorts(ddaiSpec)
+	if err != nil {
+		return err
+	}
+	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+		return nil
+	}
+
+	serviceInternalTrafficPolicy := corev1.ServiceInternalTrafficPolicyLocal
+	return managers.ServiceManager().AddService(
+		constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec),
+		dda.GetNamespace(),
+		common.GetAgentLocalServiceSelector(dda),
+		ports,
+		&serviceInternalTrafficPolicy,
+	)
+}
+
+func otlpLocalAgentServicePorts(ddaiSpec *v2alpha1.DatadogAgentSpec) ([]corev1.ServicePort, error) {
+	if ddaiSpec == nil || ddaiSpec.Features == nil || ddaiSpec.Features.OTLP == nil {
+		return nil, nil
+	}
+
+	ports := []corev1.ServicePort{}
+	protocols := ddaiSpec.Features.OTLP.Receiver.Protocols
+	if protocols.GRPC != nil && apiutils.BoolValue(protocols.GRPC.Enabled) {
+		port, err := otlpGRPCServicePort(protocols.GRPC)
+		if err != nil {
+			return nil, err
+		}
+		ports = append(ports, corev1.ServicePort{
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(int(port)),
+			Port:       port,
+			Name:       otlpGRPCPortName,
+		})
+	}
+	if protocols.HTTP != nil && apiutils.BoolValue(protocols.HTTP.Enabled) {
+		port, err := otlpHTTPServicePort(protocols.HTTP)
+		if err != nil {
+			return nil, err
+		}
+		ports = append(ports, corev1.ServicePort{
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(int(port)),
+			Port:       port,
+			Name:       otlpHTTPPortName,
+		})
+	}
+	return ports, nil
+}
+
+func otlpGRPCServicePort(config *v2alpha1.OTLPGRPCConfig) (int32, error) {
+	endpoint := ""
+	if config.Endpoint != nil {
+		endpoint = *config.Endpoint
+	}
+	port, err := extractPortEndpoint(endpoint)
+	if err != nil {
+		return 0, fmt.Errorf("failed to extract port from OTLP/gRPC endpoint: %w", err)
+	}
+	if config.HostPortConfig != nil && apiutils.BoolValue(config.HostPortConfig.Enabled) && config.HostPortConfig.Port != nil && *config.HostPortConfig.Port != 0 {
+		port = *config.HostPortConfig.Port
+	}
+	return port, nil
+}
+
+func otlpHTTPServicePort(config *v2alpha1.OTLPHTTPConfig) (int32, error) {
+	endpoint := ""
+	if config.Endpoint != nil {
+		endpoint = *config.Endpoint
+	}
+	port, err := extractPortEndpoint(endpoint)
+	if err != nil {
+		return 0, fmt.Errorf("failed to extract port from OTLP/HTTP endpoint: %w", err)
+	}
+	if config.HostPortConfig != nil && apiutils.BoolValue(config.HostPortConfig.Enabled) && config.HostPortConfig.Port != nil && *config.HostPortConfig.Port != 0 {
+		port = *config.HostPortConfig.Port
+	}
+	return port, nil
+}
+
+func (f *otlpFeature) grpcServicePort() (int32, error) {
+	port, err := extractPortEndpoint(f.grpcEndpoint)
+	if err != nil {
+		f.logger.Error(err, "failed to extract port from OTLP/gRPC endpoint")
+		return 0, fmt.Errorf("failed to extract port from OTLP/gRPC endpoint: %w", err)
+	}
+	if f.grpcHostPortEnabled && f.grpcCustomHostPort != 0 {
+		port = f.grpcCustomHostPort
+	}
+	return port, nil
+}
+
+func (f *otlpFeature) httpServicePort() (int32, error) {
+	port, err := extractPortEndpoint(f.httpEndpoint)
+	if err != nil {
+		f.logger.Error(err, "failed to extract port from OTLP/HTTP endpoint")
+		return 0, fmt.Errorf("failed to extract port from OTLP/HTTP endpoint: %w", err)
+	}
+	if f.httpHostPortEnabled && f.httpCustomHostPort != 0 {
+		port = f.httpCustomHostPort
+	}
+	return port, nil
 }
 
 // ManageClusterAgent allows a feature to configure the ClusterAgent's corev1.PodTemplateSpec

--- a/internal/controller/datadogagent/feature/otlp/feature.go
+++ b/internal/controller/datadogagent/feature/otlp/feature.go
@@ -271,7 +271,7 @@ func applyOTLPDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.Datadog
 	if err != nil {
 		return err
 	}
-	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers) {
+	if len(ports) == 0 || !featureutils.ShouldCreateLocalAgentService(ddaSpec, managers.Store().GetPlatformInfo()) {
 		return nil
 	}
 

--- a/internal/controller/datadogagent/feature/overlay.go
+++ b/internal/controller/datadogagent/feature/overlay.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"slices"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 )
 
@@ -28,9 +30,18 @@ import (
 // profile DDAI.
 type ProfileSharedConfigOverlayFunc func(dst, base, profile *v2alpha1.DatadogAgentSpec) error
 
+// DDASharedDependenciesFunc lets a feature contribute DDA-owned dependencies
+// that have one desired instance shared by all rendered DDAIs. The ddai/ddaiSpec
+// arguments are read-only inputs.
+type DDASharedDependenciesFunc func(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers ResourceManagers) error
+
 // profileSharedConfigOverlays is populated by feature package init functions
 // through RegisterProfileSharedConfigOverlay.
 var profileSharedConfigOverlays = map[IDType]ProfileSharedConfigOverlayFunc{}
+
+// ddaSharedDependencies is populated by feature package init functions through
+// RegisterDDASharedDependencies.
+var ddaSharedDependencies = map[IDType]DDASharedDependenciesFunc{}
 
 // RegisterProfileSharedConfigOverlay registers profile shared-component merge
 // logic for a feature.
@@ -39,6 +50,15 @@ func RegisterProfileSharedConfigOverlay(id IDType, overlay ProfileSharedConfigOv
 		return fmt.Errorf("the profile shared config overlay %s is registered already", id)
 	}
 	profileSharedConfigOverlays[id] = overlay
+	return nil
+}
+
+// RegisterDDASharedDependencies registers DDA shared dependency logic for a feature.
+func RegisterDDASharedDependencies(id IDType, dependency DDASharedDependenciesFunc) error {
+	if _, found := ddaSharedDependencies[id]; found {
+		return fmt.Errorf("DDA shared dependencies %s is registered already", id)
+	}
+	ddaSharedDependencies[id] = dependency
 	return nil
 }
 
@@ -57,6 +77,26 @@ func ApplyProfileSharedConfigOverlays(dst, base, profile *v2alpha1.DatadogAgentS
 	for _, id := range sortedKeys {
 		if err := profileSharedConfigOverlays[id](dst, base, profile); err != nil {
 			return fmt.Errorf("%s profile shared config overlay failed: %w", id, err)
+		}
+	}
+
+	return nil
+}
+
+// ApplyDDASharedDependencies applies all registered DDA shared dependency hooks
+// for one rendered DDAI spec.
+func ApplyDDASharedDependencies(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, ddai metav1.Object, ddaiSpec *v2alpha1.DatadogAgentSpec, managers ResourceManagers) error {
+	// Registration happens from feature package init functions, so sort IDs to
+	// keep DDA shared dependency behavior deterministic regardless of init order.
+	sortedKeys := make([]IDType, 0, len(ddaSharedDependencies))
+	for key := range ddaSharedDependencies {
+		sortedKeys = append(sortedKeys, key)
+	}
+	slices.Sort(sortedKeys)
+
+	for _, id := range sortedKeys {
+		if err := ddaSharedDependencies[id](dda, ddaSpec, ddai, ddaiSpec, managers); err != nil {
+			return fmt.Errorf("%s DDA shared dependencies failed: %w", id, err)
 		}
 	}
 

--- a/internal/controller/datadogagent/feature/types.go
+++ b/internal/controller/datadogagent/feature/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/providercaps"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 // RequiredComponents use to know which component need to be enabled for the feature
@@ -185,6 +186,9 @@ type Options struct {
 	// cluster state while building dependencies. Callers should pass an uncached
 	// reader when the feature may read outside the controller cache scope.
 	Client client.Reader
+	// PlatformInfo contains Kubernetes version and API discovery data for feature
+	// code that needs cluster capabilities while configuring pod templates.
+	PlatformInfo kubernetes.PlatformInfo
 }
 
 // BuildFunc function type used by each Feature during its factory registration.

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -11,8 +11,8 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/images"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/utils"
 )
 
@@ -111,12 +111,11 @@ func IsDataPlaneDogstatsdEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 	return true
 }
 
-func ShouldCreateLocalAgentService(ddaSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) bool {
+func ShouldCreateLocalAgentService(ddaSpec *v2alpha1.DatadogAgentSpec, platformInfo kubernetes.PlatformInfo) bool {
 	forceEnableLocalService := false
 	if ddaSpec != nil && ddaSpec.Global != nil && ddaSpec.Global.LocalService != nil {
 		forceEnableLocalService = apiutils.BoolValue(ddaSpec.Global.LocalService.ForceEnableLocalService)
 	}
 
-	platformInfo := managers.Store().GetPlatformInfo()
 	return common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), forceEnableLocalService)
 }

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -9,7 +9,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/utils"
 )
@@ -107,4 +109,14 @@ func IsDataPlaneDogstatsdEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 		return *ddaSpec.Features.DataPlane.Dogstatsd.Enabled
 	}
 	return true
+}
+
+func ShouldCreateLocalAgentService(ddaSpec *v2alpha1.DatadogAgentSpec, managers feature.ResourceManagers) bool {
+	forceEnableLocalService := false
+	if ddaSpec != nil && ddaSpec.Global != nil && ddaSpec.Global.LocalService != nil {
+		forceEnableLocalService = apiutils.BoolValue(ddaSpec.Global.LocalService.ForceEnableLocalService)
+	}
+
+	platformInfo := managers.Store().GetPlatformInfo()
+	return common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), forceEnableLocalService)
 }

--- a/internal/controller/datadogagent/merger/service.go
+++ b/internal/controller/datadogagent/merger/service.go
@@ -6,7 +6,9 @@
 package merger
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -18,6 +20,9 @@ import (
 type ServiceManager interface {
 	AddService(name, namespace string, selector map[string]string, ports []corev1.ServicePort, internalTrafficPolicy *corev1.ServiceInternalTrafficPolicy) error
 }
+
+// ErrServicePortConflict reports a same-name Service port with a different spec.
+var ErrServicePortConflict = errors.New("service port conflict")
 
 // NewServiceManager returns a new ServiceManager instance
 func NewServiceManager(store store.StoreClient) ServiceManager {
@@ -42,7 +47,11 @@ func (m *serviceManagerImpl) AddService(name, namespace string, selector map[str
 	}
 
 	if len(ports) > 0 {
-		service.Spec.Ports = append(service.Spec.Ports, ports...)
+		mergedPorts, err := mergeServicePorts(service.Spec.Ports, ports)
+		if err != nil {
+			return fmt.Errorf("unable to add ports to Service %s: %w", name, err)
+		}
+		service.Spec.Ports = mergedPorts
 	}
 	if selector != nil {
 		service.Spec.Selector = selector
@@ -55,4 +64,31 @@ func (m *serviceManagerImpl) AddService(name, namespace string, selector map[str
 		service.Spec.InternalTrafficPolicy = internalTrafficPolicy
 	}
 	return m.store.AddOrUpdate(kubernetes.ServicesKind, service)
+}
+
+func mergeServicePorts(existingPorts, newPorts []corev1.ServicePort) ([]corev1.ServicePort, error) {
+	ports := append([]corev1.ServicePort{}, existingPorts...)
+	portsByName := map[string]int{}
+	for i, port := range ports {
+		if port.Name != "" {
+			portsByName[port.Name] = i
+		}
+	}
+
+	for _, port := range newPorts {
+		if port.Name == "" {
+			ports = append(ports, port)
+			continue
+		}
+		if existingIndex, found := portsByName[port.Name]; found {
+			if !reflect.DeepEqual(ports[existingIndex], port) {
+				return nil, fmt.Errorf("port %q conflicts with existing port: %w", port.Name, ErrServicePortConflict)
+			}
+			continue
+		}
+		portsByName[port.Name] = len(ports)
+		ports = append(ports, port)
+	}
+
+	return ports, nil
 }

--- a/internal/controller/datadogagent/merger/service_test.go
+++ b/internal/controller/datadogagent/merger/service_test.go
@@ -6,17 +6,18 @@
 package merger
 
 import (
+	"errors"
 	"testing"
-
-	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
-	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
-	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 func TestServiceManager_AddService(t *testing.T) {
@@ -44,6 +45,14 @@ func TestServiceManager_AddService(t *testing.T) {
 			TargetPort: intstr.FromInt(portNumber2),
 			Port:       int32(portNumber2),
 			Name:       name2,
+		},
+	}
+	conflictingPorts := []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			TargetPort: intstr.FromInt(portNumber2),
+			Port:       int32(portNumber2),
+			Name:       name1,
 		},
 	}
 	existingService := corev1.Service{
@@ -77,11 +86,12 @@ func TestServiceManager_AddService(t *testing.T) {
 		itp       *corev1.ServiceInternalTrafficPolicy
 	}
 	tests := []struct {
-		name         string
-		store        *store.Store
-		args         args
-		wantErr      bool
-		validateFunc func(*testing.T, *store.Store)
+		name             string
+		store            *store.Store
+		args             args
+		wantErr          bool
+		wantPortConflict bool
+		validateFunc     func(*testing.T, *store.Store)
 	}{
 		{
 			name:  "empty store",
@@ -102,7 +112,7 @@ func TestServiceManager_AddService(t *testing.T) {
 		},
 		{
 			name:  "another Service already exists",
-			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ServicesKind, &existingService),
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ServicesKind, existingService.DeepCopy()),
 			args: args{
 				namespace: ns,
 				name:      name1,
@@ -118,8 +128,8 @@ func TestServiceManager_AddService(t *testing.T) {
 			},
 		},
 		{
-			name:  "update existing NetworkPolicy",
-			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ServicesKind, &existingService),
+			name:  "update existing Service",
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ServicesKind, existingService.DeepCopy()),
 			args: args{
 				namespace: ns,
 				name:      name2,
@@ -139,14 +149,55 @@ func TestServiceManager_AddService(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:  "dedupe identical named port",
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ServicesKind, existingService.DeepCopy()),
+			args: args{
+				namespace: ns,
+				name:      name2,
+				selector:  selector,
+				ports:     ports1,
+				itp:       &serviceInternalTrafficPolicy,
+			},
+			wantErr: false,
+			validateFunc: func(t *testing.T, store *store.Store) {
+				obj, found := store.Get(kubernetes.ServicesKind, ns, name2)
+				if !found {
+					t.Errorf("missing Service %s/%s", ns, name2)
+				}
+				service, ok := obj.(*corev1.Service)
+				if !ok || len(service.Spec.Ports) != 1 {
+					t.Errorf("unexpected Ports in Service %s/%s", ns, name2)
+				}
+			},
+		},
+		{
+			name:  "reject conflicting named port",
+			store: store.NewStore(owner, storeOptions).AddOrUpdateStore(kubernetes.ServicesKind, existingService.DeepCopy()),
+			args: args{
+				namespace: ns,
+				name:      name2,
+				selector:  selector,
+				ports:     conflictingPorts,
+				itp:       &serviceInternalTrafficPolicy,
+			},
+			wantErr:          true,
+			wantPortConflict: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &serviceManagerImpl{
 				store: tt.store,
 			}
-			if err := m.AddService(tt.args.name, tt.args.namespace, tt.args.selector, tt.args.ports, tt.args.itp); (err != nil) != tt.wantErr {
+			err := m.AddService(tt.args.name, tt.args.namespace, tt.args.selector, tt.args.ports, tt.args.itp)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("ServiceManager.AddService() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantPortConflict {
+				if !errors.Is(err, ErrServicePortConflict) {
+					t.Errorf("ServiceManager.AddService() error = %v, want ErrServicePortConflict", err)
+				}
 			}
 			if tt.validateFunc != nil {
 				tt.validateFunc(t, tt.store)

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/utils/ptr"
-
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -25,8 +26,6 @@ import (
 	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_computeProfileMerge(t *testing.T) {
@@ -1366,6 +1365,21 @@ func Test_reconcileProfiles_APMSharedOverlayMatrix(t *testing.T) {
 				assert.Equal(t, "1.43.0", ssi.LibVersions["java"])
 				assert.True(t, ptr.Deref(ssi.LanguageDetection.Enabled, false))
 			},
+		},
+		{
+			name:        "base APM off DAP APM on applies without enabling default DDAI APM",
+			description: "Expect the DAP to apply while leaving the default DDAI node APM disabled.",
+			profiles: []*v1alpha1.DatadogAgentProfile{
+				testAPMMatrixProfile(namespace, "dap-case-apm-only", baseTime, noMatchProfileRequirement("dap-case-apm-only"), &v2alpha1.APMFeatureConfig{
+					Enabled: ptr.To(true),
+				}),
+			},
+			wantProfileApplied: map[string]metav1.ConditionStatus{"dap-case-apm-only": metav1.ConditionTrue},
+			assertAPM: func(t *testing.T, apm *v2alpha1.APMFeatureConfig) {
+				require.NotNil(t, apm)
+				assert.False(t, ptr.Deref(apm.Enabled, true))
+			},
+			assertSSI: assertSSIEnabled(false),
 		},
 		{
 			name:        "DAP apm enabled false with SSI enabled",

--- a/internal/controller/datadogagentinternal/controller.go
+++ b/internal/controller/datadogagentinternal/controller.go
@@ -127,10 +127,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, ddai *v1alpha1.DatadogAgentI
 	return resp, err
 }
 
-func reconcilerOptionsToFeatureOptions(ctx context.Context, reader client.Reader) *feature.Options {
+func reconcilerOptionsToFeatureOptions(ctx context.Context, reader client.Reader, platformInfo kubernetes.PlatformInfo) *feature.Options {
 	return &feature.Options{
-		Logger: ctrl.LoggerFrom(ctx),
-		Client: reader,
+		Logger:       ctrl.LoggerFrom(ctx),
+		Client:       reader,
+		PlatformInfo: platformInfo,
 	}
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -56,7 +56,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	newStatus := instance.Status.DeepCopy()
 	now := metav1.NewTime(time.Now())
 
-	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instance, &instance.Spec, instance.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(ctx, r.apiReader))
+	configuredFeatures, enabledFeatures, requiredComponents := feature.BuildFeatures(instance, &instance.Spec, instance.Status.RemoteConfigConfiguration, reconcilerOptionsToFeatureOptions(ctx, r.apiReader, r.platformInfo))
 	// update list of enabled features for metrics forwarder
 	r.updateMetricsForwardersFeatures(instance, enabledFeatures)
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_helpers.go
@@ -152,8 +152,9 @@ func (r *Reconciler) applyAndCleanupDependencies(ctx context.Context, depsStore 
 
 	// Cleanup unused dependencies, excluding resources managed by the DDA controller.
 	// The DDA controller manages certain dependencies (like credentials, DCA token,
-	// DCA service) and labels them with ManagedByDDAControllerLabelKey. We exclude
-	// these from cleanup to prevent the DDAI controller from deleting them.
+	// DCA service, and local Agent Service) and labels them with
+	// ManagedByDDAControllerLabelKey. We exclude these from cleanup to prevent the
+	// DDAI controller from deleting them.
 	if errs = depsStore.Cleanup(ctx, r.client, true); len(errs) > 0 {
 		logger.V(2).Info("Dependencies cleanup error", "errs", errs)
 		return errors.NewAggregate(errs)

--- a/pkg/testutils/builder.go
+++ b/pkg/testutils/builder.go
@@ -1019,6 +1019,16 @@ func (builder *DatadogAgentBuilder) WithKubernetesActionsEnabled(enabled bool) *
 	return builder
 }
 
+// Global LocalService
+
+func (builder *DatadogAgentBuilder) WithForceEnableLocalService(force bool) *DatadogAgentBuilder {
+	if builder.datadogAgent.Spec.Global.LocalService == nil {
+		builder.datadogAgent.Spec.Global.LocalService = &v2alpha1.LocalService{}
+	}
+	builder.datadogAgent.Spec.Global.LocalService.ForceEnableLocalService = ptr.To(force)
+	return builder
+}
+
 // Global Kubelet
 
 func (builder *DatadogAgentBuilder) WithGlobalKubeletConfig(hostCAPath, agentCAPath string, tlsVerify bool, podResourcesSocketDir string) *DatadogAgentBuilder {


### PR DESCRIPTION
### What does this PR do?

Merge after https://github.com/DataDog/datadog-operator/pull/3183

Add `DD_APM_NON_LOCAL_TRAFFIC` env var to local service. Ensures the config is there even if the agent image's default `datadog.yaml` from k8s is overridden with a custom file

### Motivation

https://datadoghq.atlassian.net/browse/CONTP-1756

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits