### PR TITLE
Drop empty provider label from DDAI agent override

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -2015,7 +2015,6 @@ func Test_DDAI_ReconcileV3(t *testing.T) {
 					v2alpha1.NodeAgentComponentName: {
 						Labels: map[string]string{
 							"custom-label": "custom-value",
-							constants.MD5AgentDeploymentProviderLabelKey: "",
 						},
 						Annotations: map[string]string{
 							"checksum/dca-token-custom-config": "0c85492446fadac292912bb6d5fc3efd",
@@ -2113,7 +2112,6 @@ func Test_DDAI_ReconcileV3(t *testing.T) {
 					v2alpha1.NodeAgentComponentName: {
 						Name: ptr.To("foo-profile-agent"),
 						Labels: map[string]string{
-							constants.MD5AgentDeploymentProviderLabelKey: "",
 							"foo":                     "bar",
 							constants.ProfileLabelKey: "foo-profile",
 						},
@@ -2320,11 +2318,7 @@ func getBaseDDAI(dda *v2alpha1.DatadogAgent) v1alpha1.DatadogAgentInternal {
 			Features: features,
 			Global:   globalConfig,
 			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
-				v2alpha1.NodeAgentComponentName: {
-					Labels: map[string]string{
-						constants.MD5AgentDeploymentProviderLabelKey: "",
-					},
-				},
+				v2alpha1.NodeAgentComponentName: {},
 			},
 		},
 	}
@@ -2351,9 +2345,6 @@ func getDefaultDDAI(dda *v2alpha1.DatadogAgent) v1alpha1.DatadogAgentInternal {
 	expectedDDAI := getBaseDDAI(dda)
 	expectedDDAI.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 		v2alpha1.NodeAgentComponentName: {
-			Labels: map[string]string{
-				constants.MD5AgentDeploymentProviderLabelKey: "",
-			},
 			Affinity: &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/internal/controller/datadogagent/ddai_test.go
+++ b/internal/controller/datadogagent/ddai_test.go
@@ -139,11 +139,7 @@ func Test_generateSpecFromDDA(t *testing.T) {
 						},
 					},
 					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
-						v2alpha1.NodeAgentComponentName: {
-							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
-							},
-						},
+						v2alpha1.NodeAgentComponentName: {},
 					},
 				},
 			},
@@ -206,7 +202,6 @@ func Test_generateSpecFromDDA(t *testing.T) {
 					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 						v2alpha1.NodeAgentComponentName: {
 							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
 								"foo": "bar",
 							},
 							PriorityClassName: ptr.To("foo-priority-class"),

--- a/internal/controller/datadogagent/override/ddai_utils.go
+++ b/internal/controller/datadogagent/override/ddai_utils.go
@@ -24,11 +24,6 @@ func SetOverrideFromDDA(dda *v2alpha1.DatadogAgent, ddaiSpec *v2alpha1.DatadogAg
 	if _, ok := ddaiSpec.Override[v2alpha1.NodeAgentComponentName]; !ok {
 		ddaiSpec.Override[v2alpha1.NodeAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{}
 	}
-	if ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels == nil {
-		ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels = make(map[string]string)
-	}
-	// Set empty provider label
-	ddaiSpec.Override[v2alpha1.NodeAgentComponentName].Labels[constants.MD5AgentDeploymentProviderLabelKey] = ""
 
 	// Add checksum annotation to the components (nodeAgent, clusterAgent, clusterChecksRunner) pod templates if the cluster agent token is set in DDA spec
 	// This is used to trigger a redeployment of the components when the cluster agent token is changed

--- a/internal/controller/datadogagent/override/ddai_utils_test.go
+++ b/internal/controller/datadogagent/override/ddai_utils_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/global"
-	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/stretchr/testify/assert"
 )
@@ -115,9 +114,6 @@ func TestSetOverrideFromDDA(t *testing.T) {
 				},
 				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 					v2alpha1.NodeAgentComponentName: {
-						Labels: map[string]string{
-							constants.MD5AgentDeploymentProviderLabelKey: "",
-						},
 						Annotations: map[string]string{
 							dcaTokenChecksumAnnotationKey: tokenHash,
 						},
@@ -155,9 +151,6 @@ func TestSetOverrideFromDDA(t *testing.T) {
 				},
 				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 					v2alpha1.NodeAgentComponentName: {
-						Labels: map[string]string{
-							constants.MD5AgentDeploymentProviderLabelKey: "",
-						},
 						Annotations: map[string]string{
 							dcaTokenChecksumAnnotationKey: tokenHash,
 						},
@@ -193,11 +186,7 @@ func TestSetOverrideFromDDA(t *testing.T) {
 					},
 				},
 				Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
-					v2alpha1.NodeAgentComponentName: {
-						Labels: map[string]string{
-							constants.MD5AgentDeploymentProviderLabelKey: "",
-						},
-					},
+					v2alpha1.NodeAgentComponentName: {},
 				},
 			},
 		},
@@ -237,7 +226,6 @@ func TestSetOverrideFromDDA(t *testing.T) {
 					v2alpha1.NodeAgentComponentName: {
 						Labels: map[string]string{
 							existingLabel: existingValue,
-							constants.MD5AgentDeploymentProviderLabelKey: "",
 						},
 						Annotations: map[string]string{
 							existingAnnotation:            existingValue,
@@ -293,7 +281,6 @@ func TestSetOverrideFromDDA(t *testing.T) {
 					v2alpha1.NodeAgentComponentName: {
 						Labels: map[string]string{
 							existingLabel: existingValue,
-							constants.MD5AgentDeploymentProviderLabelKey: "",
 						},
 					},
 				},

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -65,9 +65,6 @@ func Test_computeProfileMerge(t *testing.T) {
 									Value: "value",
 								},
 							},
-							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
-							},
 						},
 					},
 				},
@@ -82,7 +79,7 @@ func Test_computeProfileMerge(t *testing.T) {
 					Name:      "foo",
 					Namespace: "bar",
 					Annotations: map[string]string{
-						constants.MD5DDAIDeploymentAnnotationKey: "cf36f429dc3cdc72527e13ab7c602dec",
+						constants.MD5DDAIDeploymentAnnotationKey: "10394c6b4f1e5029544f602ecb5a557b",
 					},
 				},
 				Spec: v2alpha1.DatadogAgentSpec{
@@ -131,9 +128,6 @@ func Test_computeProfileMerge(t *testing.T) {
 									Value: "value",
 								},
 							},
-							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
-							},
 						},
 					},
 				},
@@ -159,9 +153,6 @@ func Test_computeProfileMerge(t *testing.T) {
 									Name:  "EXISTING",
 									Value: "value",
 								},
-							},
-							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
 							},
 						},
 					},
@@ -201,7 +192,7 @@ func Test_computeProfileMerge(t *testing.T) {
 					Name:      "foo-profile",
 					Namespace: "bar",
 					Annotations: map[string]string{
-						constants.MD5DDAIDeploymentAnnotationKey: "e160cdf078da13507876397e80bbe4e0",
+						constants.MD5DDAIDeploymentAnnotationKey: "a9033f6ffba89ddf862136d39a5db466",
 					},
 				},
 				Spec: v2alpha1.DatadogAgentSpec{
@@ -258,8 +249,7 @@ func Test_computeProfileMerge(t *testing.T) {
 								},
 							},
 							Labels: map[string]string{
-								constants.ProfileLabelKey:                    "foo-profile",
-								constants.MD5AgentDeploymentProviderLabelKey: "",
+								constants.ProfileLabelKey: "foo-profile",
 							},
 						},
 						v2alpha1.ClusterAgentComponentName: {
@@ -332,9 +322,6 @@ func Test_setProfileSpec(t *testing.T) {
 				Spec: v2alpha1.DatadogAgentSpec{
 					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 						v2alpha1.NodeAgentComponentName: {
-							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
-							},
 							Affinity: &corev1.Affinity{
 								NodeAffinity: &corev1.NodeAffinity{
 									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -406,9 +393,6 @@ func Test_setProfileSpec(t *testing.T) {
 									},
 								},
 							},
-							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
-							},
 						},
 					},
 				},
@@ -421,15 +405,9 @@ func Test_setProfileSpec(t *testing.T) {
 					Name:      "foo",
 					Namespace: "bar",
 				},
-				// DDAI spec is overridden to create the profile DDAI
-				// Therefore, the provider label will not be in the final profile DDAI spec
-				// This config will be merged with a copy of the original DDAI
 				Spec: v2alpha1.DatadogAgentSpec{
 					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 						v2alpha1.NodeAgentComponentName: {
-							Labels: map[string]string{
-								constants.MD5AgentDeploymentProviderLabelKey: "",
-							},
 							Affinity: &corev1.Affinity{
 								NodeAffinity: &corev1.NodeAffinity{
 									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{


### PR DESCRIPTION
### What does this PR do?

DDAI is created with an empty provider label override, which is confusing or redundant at least.
```yaml
  override:
    nodeAgent:
      labels:
        agent.datadoghq.com/provider: ""
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Apply DDA with provider annotation 
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  annotations:
    datadoghq.com/provider: aks
...
...
```
and observe DDAI is created without 
```yaml
  override:
    nodeAgent:
      labels:
        agent.datadoghq.com/provider: ""
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits