### PR TITLE
Add AKS cluster provider detection

### DIFF
--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -63,6 +63,13 @@ const (
 	// EKS label prefixes for provider detection
 	eksLabelPrefix    = "eks.amazonaws.com/"
 	eksctlLabelPrefix = "alpha.eksctl.io/"
+
+	// aksLabelPrefix is AKS's reserved node-label prefix (nodes outside AKS
+	// cannot set it: https://learn.microsoft.com/en-us/azure/aks/use-labels#reserved-prefixes).
+	// kubernetes.azure.com/cluster in particular is applied to every node in an
+	// AKS cluster, including virtual (ACI) nodes, so any label under this
+	// prefix is a reliable cluster-level AKS signal.
+	aksLabelPrefix = "kubernetes.azure.com/"
 )
 
 // ProviderValue allowlist
@@ -99,6 +106,18 @@ func isEKSProvider(labels map[string]string) bool {
 	// Check for any eks.amazonaws.com/* or eksctl labels
 	for key := range labels {
 		if strings.HasPrefix(key, eksLabelPrefix) || strings.HasPrefix(key, eksctlLabelPrefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isAKSProvider checks if a node is an AKS node by looking for labels under
+// AKS's reserved kubernetes.azure.com/ prefix.
+func isAKSProvider(labels map[string]string) bool {
+	for key := range labels {
+		if strings.HasPrefix(key, aksLabelPrefix) {
 			return true
 		}
 	}
@@ -276,7 +295,7 @@ func IsSpecificProvider(p string) bool {
 }
 
 // ClusterProviderFromNodeLabels maps a single node's labels to the cluster-level
-// provider (eks, openshift-<os>, or default). It is the node-label signal for the
+// provider (eks, aks, openshift-<os>, or default). It is the node-label signal for the
 // cluster dimension.
 //
 // Node-OS distinctions such as gke-cos belong to the node
@@ -292,6 +311,9 @@ func ClusterProviderFromNodeLabels(labels map[string]string) string {
 		}
 		if isEKSProvider(labels) {
 			return EKSCloudProvider
+		}
+		if isAKSProvider(labels) {
+			return AKSProvider
 		}
 	}
 	return DefaultProvider

--- a/pkg/kubernetes/provider_test.go
+++ b/pkg/kubernetes/provider_test.go
@@ -689,6 +689,7 @@ func TestClusterProviderFromNodeLabels(t *testing.T) {
 		want   string
 	}{
 		{name: "eks", labels: map[string]string{EKSProviderLabel: "ami-x"}, want: EKSCloudProvider},
+		{name: "aks", labels: map[string]string{"kubernetes.azure.com/cluster": "MC_rg_aks_westus2"}, want: AKSProvider},
 		{name: "openshift keeps os suffix", labels: map[string]string{OpenShiftProviderLabel: "rhcos"}, want: "openshift-rhcos"},
 		{
 			name:   "gke node-OS does not leak to cluster scope",


### PR DESCRIPTION
### What does this PR do?

CONTP-1799

Adds detection of AKS cluster, which leads to configuring DCA with `DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS` env.

AKS system labels doc https://learn.microsoft.com/en-us/azure/aks/use-labels#reserved-system-labels 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

On kind cluster label worker node(s) with a AKS prefixed label
```sh
k label node kind-worker kubernetes.azure.com/cluster=kind
```
Observe DCA is created with
```yaml
    - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
      value: "true"
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits