### PR TITLE
Rename provider annotation key to agent.datadoghq.com/cluster-provider

### DIFF
--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -1686,7 +1686,7 @@ func verifyEtcdMountsOpenshift(t *testing.T, c client.Client, resourcesNamespace
 // Test_COSProviderOverrides verifies that the GKE COS provider strips the
 // `src` HostPath volume (and its system-probe mount) that oomkill and
 // tcpqueuelength would otherwise add — the host has no /usr/src on COS nodes.
-// The provider value flows from the DDA's `datadoghq.com/provider` annotation,
+// The provider value flows from the DDA's `agent.datadoghq.com/cluster-provider` annotation,
 // or from the DAP's annotation propagated onto the per-profile DDAI.
 func Test_COSProviderOverrides(t *testing.T) {
 	const resourcesName, resourcesNamespace = "foo", "bar"

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// DDA/DDAI annotation key for provider used in reconciler to apply provider-specific configs
-	ProviderAnnotationKey = "datadoghq.com/provider"
+	ProviderAnnotationKey = "agent.datadoghq.com/cluster-provider"
 
 	// LegacyProvider Legacy Provider (empty name)
 	LegacyProvider = ""


### PR DESCRIPTION
### What does this PR do?

Aligns the DDA/DDAI provider annotation with the agent.datadoghq.com namespace used by other provider-related keys, and disambiguates it from the per-daemonset agent.datadoghq.com/provider override label.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits