### PR TITLE
Enable hostPID for the GPU feature

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -200,6 +200,11 @@ func (f *gpuFeature) configureCgroupPermissions(managers feature.PodTemplateMana
 // ManageNodeAgent allows a feature to configure the Node Agent's corev1.PodTemplateSpec
 // It should do nothing if the feature doesn't need to configure it.
 func (f *gpuFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error {
+	// GPU monitoring watches host processes, so it needs the host PID namespace.
+	// It is also required when patchCgroupPermissions is enabled, as the cgroup
+	// permissions patch resolves the host pid 1 cgroup.
+	managers.PodTemplateSpec().Spec.HostPID = true
+
 	// env var to enable the GPU core check
 	enableCoreCheckEnvVar := &corev1.EnvVar{
 		Name:  DDEnableGPUMonitoringCheckEnvVar,

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -230,6 +230,9 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 		systemProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
 		assert.ElementsMatch(t, systemProbeEnvVars, wantSystemProbeEnvVars)
 
+		// GPU monitoring requires the host PID namespace
+		assert.True(t, mgr.PodTemplateSpec().Spec.HostPID, "HostPID should be enabled for GPU monitoring")
+
 		// Check runtime class
 		if expectedRuntimeClass == "" {
 			assert.Nil(t, mgr.PodTemplateSpec().Spec.RuntimeClassName)
@@ -313,6 +316,9 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 		// check that system probe has NO env vars for core-check only
 		systemProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
 		assert.Empty(t, systemProbeEnvVars, "System Probe should not have env vars when privileged mode is disabled")
+
+		// GPU monitoring requires the host PID namespace, even in core-check only mode
+		assert.True(t, mgr.PodTemplateSpec().Spec.HostPID, "HostPID should be enabled for GPU monitoring")
 
 		// Check runtime class
 		if expectedRuntimeClass == "" {


### PR DESCRIPTION
### What does this PR do?

The Node Agent pod now runs in the host PID namespace when the GPU feature is enabled.

### Motivation

GPU monitoring watches host processes, which requires the host PID namespace. It is also a prerequisite for `patchCgroupPermissions`: the cgroup permissions patch resolves the host pid 1 cgroup and is a no-op without it. Unlike the Helm chart, the operator does not enable `hostPID` by default, so this was previously missing.

### Additional Notes

### Minimum Agent Versions

- Agent: N/A
- Cluster Agent: N/A

### Describe your test plan

1. Deploy DDA with gpuM enabled
2. Verify hostPID is set for Agent pod

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits))