### PR TITLE
Publish internal latest image tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -682,6 +682,33 @@ trigger_internal_operator_image_fips_rc_latest:
     RELEASE_TAG: rc-latest-fips
     BUILD_TAG: rc-latest-fips
 
+trigger_internal_operator_image_latest:
+  stage: release-latest
+  rules:
+    # Skip latest jobs for vX.Y.Z-rc.W tags
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
+      when: never
+    - if: $CI_COMMIT_TAG
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_NAME: $PROJECTNAME
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_TAG: latest
+    BUILD_TAG: latest
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"
+
+trigger_internal_operator_image_fips_latest:
+  extends: trigger_internal_operator_image_latest
+  variables:
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
+    RELEASE_TAG: latest-fips
+    BUILD_TAG: latest-fips
+
 trigger_internal_operator_nightly_image:
   stage: release
   rules:


### PR DESCRIPTION
## What changed

Adds internal `latest` and `latest-fips` image publication jobs to `.gitlab-ci.yml`, mirroring the existing internal `rc-latest` jobs and skipping release-candidate tags.

## Why

Stable release tag pipelines currently publish versioned internal tags and public `latest` tags, but do not publish an internal `latest` tag. These jobs let stable releases update the internal latest aliases in `DataDog/images`.

## Validation

- Parsed `.gitlab-ci.yml` with Ruby YAML loader.