### PR TITLE
[ACTP] Extend PAR k8s RBAC in DCA for kubetray use cases

### DIFF
--- a/internal/controller/datadogagent/feature/privateactionrunner/rbac.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/rbac.go
@@ -38,7 +38,7 @@ func getK8sRemediationPolicyRules() []rbacv1.PolicyRule {
 		// Read to some workload types
 		{
 			APIGroups: []string{rbac.AppsAPIGroup},
-			Resources: []string{rbac.DeploymentsResource, rbac.DaemonsetsResource, rbac.ReplicasetsResource, rbac.StatefulsetsResource},
+			Resources: []string{rbac.DeploymentsResource, rbac.DaemonsetsResource, rbac.StatefulsetsResource, rbac.ReplicasetsResource},
 			Verbs:     []string{rbac.GetVerb, rbac.ListVerb, rbac.WatchVerb},
 		},
 		{
@@ -46,13 +46,13 @@ func getK8sRemediationPolicyRules() []rbacv1.PolicyRule {
 			Resources: []string{rbac.PodsResource, rbac.EventsResource, rbac.ConfigMapsResource},
 			Verbs:     []string{rbac.GetVerb, rbac.ListVerb, rbac.WatchVerb},
 		},
-		// Write deployments (patch/restart)
+		// Deployment patch
 		{
 			APIGroups: []string{rbac.AppsAPIGroup},
 			Resources: []string{rbac.DeploymentsResource},
 			Verbs:     []string{rbac.PatchVerb},
 		},
-		// StatefulSet write
+		// StatefulSet patch
 		{
 			APIGroups: []string{rbac.AppsAPIGroup},
 			Resources: []string{rbac.StatefulsetsResource},

--- a/internal/controller/datadogagent/feature/privateactionrunner/rbac.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/rbac.go
@@ -38,7 +38,7 @@ func getK8sRemediationPolicyRules() []rbacv1.PolicyRule {
 		// Read to some workload types
 		{
 			APIGroups: []string{rbac.AppsAPIGroup},
-			Resources: []string{rbac.DeploymentsResource, rbac.DaemonsetsResource, rbac.StatefulsetsResource, rbac.ReplicasetsResource},
+			Resources: []string{rbac.DeploymentsResource, rbac.DaemonsetsResource, rbac.ReplicasetsResource, rbac.StatefulsetsResource},
 			Verbs:     []string{rbac.GetVerb, rbac.ListVerb, rbac.WatchVerb},
 		},
 		{
@@ -52,11 +52,17 @@ func getK8sRemediationPolicyRules() []rbacv1.PolicyRule {
 			Resources: []string{rbac.DeploymentsResource},
 			Verbs:     []string{rbac.PatchVerb},
 		},
-		// Patch pods
+		// StatefulSet write
+		{
+			APIGroups: []string{rbac.AppsAPIGroup},
+			Resources: []string{rbac.StatefulsetsResource},
+			Verbs:     []string{rbac.PatchVerb},
+		},
+		// Patch and delete pods
 		{
 			APIGroups: []string{rbac.CoreAPIGroup},
 			Resources: []string{rbac.PodsResource},
-			Verbs:     []string{rbac.PatchVerb},
+			Verbs:     []string{rbac.PatchVerb, rbac.DeleteVerb},
 		},
 		// Full write access to configmaps
 		{

--- a/internal/controller/datadogagent/feature/privateactionrunner/rbac_test.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/rbac_test.go
@@ -6,12 +6,61 @@
 package privateactionrunner
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/DataDog/datadog-operator/pkg/kubernetes/rbac"
 )
+
+func hasPermission(rules []rbacv1.PolicyRule, apiGroup, resource, verb string) bool {
+	for _, rule := range rules {
+		if slices.Contains(rule.APIGroups, apiGroup) &&
+			slices.Contains(rule.Resources, resource) &&
+			slices.Contains(rule.Verbs, verb) {
+			return true
+		}
+	}
+	return false
+}
+
+func assertPermission(t *testing.T, rules []rbacv1.PolicyRule, apiGroup, resource, verb string) {
+	t.Helper()
+	if !hasPermission(rules, apiGroup, resource, verb) {
+		t.Errorf("expected %s %s/%s to be granted but it was not", verb, apiGroup, resource)
+	}
+}
+
+func assertNoPermission(t *testing.T, rules []rbacv1.PolicyRule, apiGroup, resource, verb string) {
+	t.Helper()
+	if hasPermission(rules, apiGroup, resource, verb) {
+		t.Errorf("expected %s %s/%s NOT to be granted but it was", verb, apiGroup, resource)
+	}
+}
+
+func TestGetK8sRemediationPolicyRules(t *testing.T) {
+	rules := getK8sRemediationPolicyRules()
+
+	// reads
+	assertPermission(t, rules, rbac.AppsAPIGroup, rbac.DeploymentsResource, rbac.GetVerb)
+	assertPermission(t, rules, rbac.AppsAPIGroup, rbac.StatefulsetsResource, rbac.ListVerb)
+	assertPermission(t, rules, rbac.CoreAPIGroup, rbac.PodsResource, rbac.WatchVerb)
+
+	// writes
+	assertPermission(t, rules, rbac.AppsAPIGroup, rbac.DeploymentsResource, rbac.PatchVerb)
+	assertPermission(t, rules, rbac.AppsAPIGroup, rbac.StatefulsetsResource, rbac.PatchVerb)
+	assertPermission(t, rules, rbac.CoreAPIGroup, rbac.PodsResource, rbac.DeleteVerb)
+	assertPermission(t, rules, rbac.CoreAPIGroup, rbac.ConfigMapsResource, rbac.CreateVerb)
+	assertPermission(t, rules, rbac.CoreAPIGroup, rbac.EventsResource, rbac.CreateVerb)
+
+	// not granted
+	assertNoPermission(t, rules, rbac.AppsAPIGroup, rbac.DeploymentsResource, rbac.DeleteVerb)
+	assertNoPermission(t, rules, rbac.AppsAPIGroup, rbac.StatefulsetsResource, rbac.DeleteVerb)
+	assertNoPermission(t, rules, rbac.CoreAPIGroup, rbac.PodsResource, rbac.CreateVerb)
+	assertNoPermission(t, rules, rbac.CoreAPIGroup, rbac.ConfigMapsResource, rbac.DeleteVerb)
+}
 
 func TestGetClusterAgentRBACPolicyRules(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### What does this PR do?

Extends the Kubernetes RBAC permissions for the Private Action Runner (PAR) running inside the Datadog Cluster Agent (DCA) to unblock kubetray use cases.

### Motivation

Kubetray requires two operations not previously supported by PAR-in-DCA:
- **Pod `delete`**: needed for pod restart flows; safe because pods managed by a Deployment/StatefulSet are recreated automatically by their controller.
- **StatefulSet `patch`**: enables restart, rollback, and scale operations on StatefulSets (analogous to how Deployment restart/scale is already done via patch).

### Additional Notes

StatefulSet `get`/`list`/`watch` was already present in the read rule; this PR adds `patch` in a separate write rule, keeping read and write rules distinct. The permissions are within the maximum set the DCA itself can have when all features are enabled.

### Minimum Agent Versions

N/A — operator-side RBAC change only.

### Describe your test plan
Deployed the operator on a local cluster and then ran `k get clusterrole datadog-private-action-runner -o yaml` and verified we have the new permissions.
```bash
cd ~/dd/datadog-operator
# Make sure you are using the right ns
kubens datadog-operator-test

# Build the operator image
make docker-build IMG=datadog-test/operator:local

# Install the operator
helm install datadog-operator datadog/datadog-operator \
    --set image.repository=datadog-test/operator \
    --set image.tag=local \
    --set image.doNotCheckTag=true

# Install the DatadogAgent crd
kubectl apply -k ./manifests

kubectl get clusterrole datadog-private-action-runner -o yaml
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits