### PR TITLE
chore(instrumentationCrd): bump minimum version to 7.82

### DIFF
--- a/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
+++ b/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
@@ -21,8 +21,8 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/utils"
 )
 
-// clusterAgentMinVersion is the minimum Cluster Agent version that supports the instrumentation CRD controller.
-const clusterAgentMinVersion = "7.81.0-0"
+// minVersion is the minimum agent version that supports the instrumentation CRD controller.
+const minVersion = "7.82.0-0"
 
 func init() {
 	err := feature.Register(feature.InstrumentationCRDIDType, buildInstrumentationCRDFeature)
@@ -60,10 +60,20 @@ func (f *instrumentationCRDFeature) Configure(dda metav1.Object, ddaSpec *v2alph
 	// If the cluster agent version is explicitly set and below the minimum, skip enabling.
 	if clusterAgent, ok := ddaSpec.Override[v2alpha1.ClusterAgentComponentName]; ok && clusterAgent.Image != nil {
 		version := common.GetAgentVersionFromImage(*clusterAgent.Image)
-		if !utils.IsAboveMinVersion(version, clusterAgentMinVersion, nil) {
+		if !utils.IsAboveMinVersion(version, minVersion, nil) {
 			return feature.RequiredComponents{}
 		}
-	} else if !utils.IsAboveMinVersion(images.ClusterAgentLatestVersion, clusterAgentMinVersion, nil) {
+	} else if !utils.IsAboveMinVersion(images.ClusterAgentLatestVersion, minVersion, nil) {
+		return feature.RequiredComponents{}
+	}
+
+	// If the node agent version is explicitly set and below the minimum, skip enabling.
+	if nodeAgent, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok && nodeAgent.Image != nil {
+		version := common.GetAgentVersionFromImage(*nodeAgent.Image)
+		if !utils.IsAboveMinVersion(version, minVersion, nil) {
+			return feature.RequiredComponents{}
+		}
+	} else if !utils.IsAboveMinVersion(images.AgentLatestVersion, minVersion, nil) {
 		return feature.RequiredComponents{}
 	}
 

--- a/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
+++ b/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
@@ -88,6 +88,10 @@ func (f *instrumentationCRDFeature) Configure(dda metav1.Object, ddaSpec *v2alph
 			IsRequired: ptr.To(true),
 			Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 		},
+		Agent: feature.RequiredComponent{
+			IsRequired: ptr.To(true),
+			Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
+		},
 	}
 }
 

--- a/internal/controller/datadogagent/feature/instrumentationcrd/feature_test.go
+++ b/internal/controller/datadogagent/feature/instrumentationcrd/feature_test.go
@@ -35,34 +35,56 @@ func Test_instrumentationCRDFeature_Configure(t *testing.T) {
 			Name: "InstrumentationCRD disabled via annotation",
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithAnnotations(map[string]string{featureutils.EnableInstrumentationCRDAnnotation: "false"}).
-				WithClusterAgentImage("cluster-agent:7.81.0").
+				WithClusterAgentImage("cluster-agent:7.82.0").
+				WithNodeAgentImage("agent:7.82.0").
 				Build(),
 			WantConfigure: false,
+			ClusterAgent:  instrumentationCRDClusterAgentFunc(false),
+			Agent:         instrumentationCRDAgentFunc(false),
 		},
 		{
 			Name: "InstrumentationCRD disabled by default",
 			DDA: testutils.NewDatadogAgentBuilder().
-				WithClusterAgentImage("cluster-agent:7.81.0").
+				WithClusterAgentImage("cluster-agent:7.82.0").
+				WithNodeAgentImage("agent:7.82.0").
 				Build(),
 			WantConfigure: false,
+			ClusterAgent:  instrumentationCRDClusterAgentFunc(false),
+			Agent:         instrumentationCRDAgentFunc(false),
 		},
 		{
-			Name: "InstrumentationCRD enabled via annotation when CA version meets minimum",
+			Name: "InstrumentationCRD enabled via annotation when both agent versions meet minimum",
 			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
 				WithAnnotations(map[string]string{featureutils.EnableInstrumentationCRDAnnotation: "true"}).
-				WithClusterAgentImage("cluster-agent:7.81.0").
+				WithClusterAgentImage("cluster-agent:7.82.0").
+				WithNodeAgentImage("agent:7.82.0").
 				Build(),
 			WantConfigure:        true,
 			WantDependenciesFunc: instrumentationCRDWantDepsFunc(),
-			ClusterAgent:         instrumentationCRDWantClusterAgentFunc(),
+			ClusterAgent:         instrumentationCRDClusterAgentFunc(true),
+			Agent:                instrumentationCRDAgentFunc(true),
 		},
 		{
-			Name: "InstrumentationCRD disabled when version below minimum",
+			Name: "InstrumentationCRD disabled when cluster agent version below minimum",
 			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
 				WithAnnotations(map[string]string{featureutils.EnableInstrumentationCRDAnnotation: "true"}).
 				WithClusterAgentImage("cluster-agent:7.79.0").
+				WithNodeAgentImage("agent:7.82.0").
 				Build(),
 			WantConfigure: false,
+			ClusterAgent:  instrumentationCRDClusterAgentFunc(false),
+			Agent:         instrumentationCRDAgentFunc(false),
+		},
+		{
+			Name: "InstrumentationCRD disabled when node agent version below minimum",
+			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+				WithAnnotations(map[string]string{featureutils.EnableInstrumentationCRDAnnotation: "true"}).
+				WithClusterAgentImage("cluster-agent:7.82.0").
+				WithNodeAgentImage("agent:7.81.0").
+				Build(),
+			WantConfigure: false,
+			ClusterAgent:  instrumentationCRDClusterAgentFunc(false),
+			Agent:         instrumentationCRDAgentFunc(false),
 		},
 	}
 
@@ -108,25 +130,30 @@ func instrumentationCRDWantDepsFunc() func(t testing.TB, store store.StoreClient
 	}
 }
 
-func instrumentationCRDWantClusterAgentFunc() *test.ComponentTest {
+func instrumentationCRDClusterAgentFunc(wantEnvVars bool) *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
-
-			// validate env vars
-			clusterAgentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
-
-			expectedEnvVars := []*corev1.EnvVar{
-				{
-					Name:  DDInstrumentationCRDControllerEnabled,
-					Value: "true",
-				},
-			}
-
-			assert.True(
-				t,
-				apiutils.IsEqualStruct(clusterAgentEnvs, expectedEnvVars),
-				"Cluster Agent EnvVars \ndiff = %s", cmp.Diff(clusterAgentEnvs, expectedEnvVars),
-			)
+			envVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
+			assertContainsEnvVar(t, envVars, DDInstrumentationCRDControllerEnabled, "true", wantEnvVars)
 		})
+}
+
+func instrumentationCRDAgentFunc(wantEnvVars bool) *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+			envVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+			assertContainsEnvVar(t, envVars, DDInstrumentationCRDControllerEnabled, "true", wantEnvVars)
+		})
+}
+
+func assertContainsEnvVar(t testing.TB, envVars []*corev1.EnvVar, name, value string, want bool) {
+	t.Helper()
+	expected := &corev1.EnvVar{Name: name, Value: value}
+	if want {
+		assert.Contains(t, envVars, expected)
+	} else {
+		assert.NotContains(t, envVars, expected)
+	}
 }

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -1017,8 +1017,8 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
+    agent.datadoghq.com/cluster-provider: gke-autopilot
     agent.datadoghq.com/ddaispechash: 948422f2156abec1b0120dc8b6b8454c
-    datadoghq.com/provider: gke-autopilot
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -1017,8 +1017,8 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
+    agent.datadoghq.com/cluster-provider: gke-autopilot
     agent.datadoghq.com/ddaispechash: d32d3ca2ec26a993fed2b5efe7acb197
-    datadoghq.com/provider: gke-autopilot
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -1017,8 +1017,8 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
+    agent.datadoghq.com/cluster-provider: gke-autopilot
     agent.datadoghq.com/ddaispechash: 01851726b1d9a6fb95bbbd3a451be02f
-    datadoghq.com/provider: gke-autopilot
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal

--- a/pkg/testutils/builder.go
+++ b/pkg/testutils/builder.go
@@ -1198,6 +1198,21 @@ func (builder *DatadogAgentBuilder) WithClusterAgentDisabled(disabled bool) *Dat
 	return builder
 }
 
+func (builder *DatadogAgentBuilder) WithNodeAgentImage(image string) *DatadogAgentBuilder {
+	if builder.datadogAgent.Spec.Override == nil {
+		builder.datadogAgent.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{}
+	}
+
+	if builder.datadogAgent.Spec.Override[v2alpha1.NodeAgentComponentName] == nil {
+		builder.datadogAgent.Spec.Override[v2alpha1.NodeAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{}
+	}
+
+	builder.datadogAgent.Spec.Override[v2alpha1.NodeAgentComponentName].Image = &v2alpha1.AgentImageConfig{
+		Name: image,
+	}
+	return builder
+}
+
 func (builder *DatadogAgentBuilder) WithClusterChecksRunnerImage(image string) *DatadogAgentBuilder {
 	if builder.datadogAgent.Spec.Override == nil {
 		builder.datadogAgent.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{}


### PR DESCRIPTION
### What does this PR do?

- Bumps the minimum agent version required for Instrumentation CRD to `7.82.x`.
- Adds node agent version check for instrumentation CRD feature enablement.

### Motivation

A breaking change has been made to the instrumentation CRD controller starting in `7.82.x`, which means this unreleased feature now requires `7.82.x` to properly function. The operator should disable the feature if the deployed agent & cluster agent are below 7.82

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.82.x
* Cluster Agent: v7.82.x

### Describe your test plan

- Added unit tests ✅ 

#### Manual QA.

1. Deploy agent with version >= `7.82.0`
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  annotations:
    agent.datadoghq.com/instrumentation-crd-enabled: "true" # annotation enabling the feature
spec:
  global:
    logLevel: "info"
    clusterName: mathewe-inst-controller
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
    kubelet:
      tlsVerify: false
```

2. Confirm both cluster and core agent have `DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED: "true"` env var set.
3. Drop agent image below `7.82`
4. Confirm both cluster and core agent do not have `DD_INSTRUMENTATION_CRD_CONTROLLER_ENABLED` set to true.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits