### PR TITLE
[CASCL-1386] Address post-merge review fixes for evict-legacy-nodes

### DIFF
--- a/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/clients/clients.go
@@ -66,6 +66,8 @@ func Build(ctx context.Context, configFlags *genericclioptions.ConfigFlags, k8sC
 		schema.GroupVersion{Group: "karpenter.sh", Version: "v1"},
 		&karpv1.NodePool{},
 		&karpv1.NodePoolList{},
+		&karpv1.NodeClaim{},
+		&karpv1.NodeClaimList{},
 	)
 	metav1.AddToGroupVersion(sch, schema.GroupVersion{Group: "karpenter.sh", Version: "v1"})
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/asg_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/asg_test.go
@@ -118,7 +118,7 @@ func TestEvictASG(t *testing.T) {
 	}
 	stuckPod := func() *corev1.Pod {
 		return &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "blocker", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "blocker", Namespace: "default", OwnerReferences: controllerOwnerRefs()},
 			Spec:       corev1.PodSpec{NodeName: "ip-stuck"},
 		}
 	}

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/eks_mng_test.go
@@ -47,7 +47,7 @@ func TestEvictEKSManagedNodeGroup(t *testing.T) {
 		}}
 	}
 	podOnNode := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default", OwnerReferences: controllerOwnerRefs()},
 		Spec:       corev1.PodSpec{NodeName: nodeName},
 	}
 

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict.go
@@ -1,3 +1,10 @@
+// Package evict implements the `kubectl datadog autoscaling cluster
+// evict-legacy-nodes` subcommand. It drains workloads from nodes that are not
+// managed by the Datadog Karpenter NodePools (cluster-autoscaler ASGs, EKS
+// managed node groups, user-created Karpenter NodePools, standalone EC2
+// instances) and removes those node groups so that future capacity is
+// provisioned exclusively by the NodePools created by
+// `kubectl datadog autoscaling cluster install`.
 package evict
 
 import (
@@ -39,6 +46,7 @@ type options struct {
 	targets            []Target // populated by validate()
 	skipCA             bool
 	ensurePDBs         bool
+	force              bool
 	evictionTimeout    time.Duration
 	nodeTimeout        time.Duration
 	dryRun             bool
@@ -82,6 +90,7 @@ func New(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd.Flags().StringSliceVar(&o.targetSpecs, "target", nil, "Target a specific node group: <manager>/<name>, with <manager> one of asg, eksManagedNodeGroup, karpenter. Use `standalone` (no name) for standalone EC2 instances. Repeatable. Mutually exclusive with --all.")
 	cmd.Flags().BoolVar(&o.skipCA, "skip-cluster-autoscaler", false, "Do not scale the cluster-autoscaler Deployment to 0 replicas as step 1")
 	cmd.Flags().BoolVar(&o.ensurePDBs, "ensure-pdbs", true, "Create temporary PodDisruptionBudgets (maxUnavailable: 1) for workloads without one, and remove them at the end")
+	cmd.Flags().BoolVar(&o.force, "force", false, "Evict pods not managed by a controller (bare pods); without it, a node hosting such pods is left intact")
 	cmd.Flags().DurationVar(&o.evictionTimeout, "eviction-timeout", 5*time.Minute, "Time budget per pod for the Eviction API to succeed before giving up (PDB-blocked pods)")
 	cmd.Flags().DurationVar(&o.nodeTimeout, "node-timeout", 15*time.Minute, "Time budget per node for it to become empty after pods have been evicted")
 	cmd.Flags().BoolVar(&o.dryRun, "dry-run", false, "Log the actions that would be taken without performing them")
@@ -148,6 +157,7 @@ func (o *options) run() error {
 		Targets:            o.targets,
 		SkipCA:             o.skipCA,
 		EnsurePDBs:         o.ensurePDBs,
+		Force:              o.force,
 		DryRun:             o.dryRun,
 		Yes:                o.yes,
 		EvictionTimeout:    o.evictionTimeout,

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -23,6 +24,7 @@ import (
 // nodeDrainOptions captures the per-call tunables for evicting a node's pods.
 type nodeDrainOptions struct {
 	DryRun          bool
+	Force           bool          // evict pods not managed by a controller (bare pods)
 	EvictionTimeout time.Duration // per pod, bound for retries on 429
 	NodeTimeout     time.Duration // total wait for the node to become empty
 	PollInterval    time.Duration // interval between empty-checks; default 2s
@@ -36,6 +38,10 @@ type nodeDrainOptions struct {
 // Pods that cannot be evicted (PDB-blocked beyond EvictionTimeout, etc.) are
 // logged as warnings; drainNode then continues with the remaining pods rather
 // than aborting the whole run.
+//
+// A pod not managed by a controller (a "bare" pod) has no replacement once
+// evicted, so — like `kubectl drain` — drainNode refuses the whole node unless
+// opts.Force is set, leaving the node cordoned and its instance intact.
 func drainNode(ctx context.Context, clientset kubernetes.Interface, nodeName string, opts nodeDrainOptions) error {
 	if opts.DryRun {
 		log.Printf("[dry-run] would drain node %s", nodeName)
@@ -44,6 +50,17 @@ func drainNode(ctx context.Context, clientset kubernetes.Interface, nodeName str
 	pods, err := listPodsOnNode(ctx, clientset, nodeName)
 	if err != nil {
 		return fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)
+	}
+	if !opts.Force {
+		var bare []string
+		for i := range pods {
+			if p := &pods[i]; !shouldSkipEviction(p) && metav1.GetControllerOf(p) == nil {
+				bare = append(bare, p.Namespace+"/"+p.Name)
+			}
+		}
+		if len(bare) > 0 {
+			return fmt.Errorf("node %s hosts %d pod(s) not managed by a controller (%s); evicting them would delete them permanently with no replacement. Re-run with --force to evict them anyway", nodeName, len(bare), strings.Join(bare, ", "))
+		}
 	}
 	for _, p := range pods {
 		if shouldSkipEviction(&p) {

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/evict_pods_test.go
@@ -259,9 +259,21 @@ func TestListPodsOnNode(t *testing.T) {
 	assert.Equal(t, "spec.nodeName=ip-7", gotFieldSelector)
 }
 
-// occupyingPod and dsPod are the two fixtures the drain/wait tests reuse: a
-// plain pod that keeps the node busy, and a DaemonSet pod that never does.
+// controllerOwnerRefs returns the owner references of a pod managed by a
+// controller (a ReplicaSet here). It is what distinguishes a normally drainable
+// workload pod from a "bare" pod that drainNode refuses without --force.
+func controllerOwnerRefs() []metav1.OwnerReference {
+	return []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "rs", Controller: ptr.To(true)}}
+}
+
+// occupyingPod, barePod and dsPod are the fixtures the drain/wait tests reuse: a
+// controller-managed pod that keeps the node busy, a pod with no controller
+// owner, and a DaemonSet pod that never occupies the node.
 func occupyingPod(name string) corev1.Pod {
+	return corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", OwnerReferences: controllerOwnerRefs()}}
+}
+
+func barePod(name string) corev1.Pod {
 	return corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
 }
 
@@ -411,5 +423,46 @@ func TestDrainNode(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Zero(t, evictions)
+	})
+
+	t.Run("refuses a bare pod without --force", func(t *testing.T) {
+		bare := barePod("orphan")
+		client := fake.NewClientset(&bare)
+		var evictions int
+		countingEvictionReactor(client, &evictions)
+		client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			return true, &corev1.PodList{Items: []corev1.Pod{bare}}, nil
+		})
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{
+			EvictionTimeout: time.Second,
+			NodeTimeout:     time.Second,
+			PollInterval:    10 * time.Millisecond,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not managed by a controller")
+		assert.Contains(t, err.Error(), "default/orphan")
+		assert.Zero(t, evictions, "a bare pod must not be evicted without --force")
+	})
+
+	t.Run("evicts a bare pod with --force", func(t *testing.T) {
+		bare := barePod("orphan")
+		client := fake.NewClientset(&bare)
+		var evictions, lists int
+		countingEvictionReactor(client, &evictions)
+		client.PrependReactor("list", "pods", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+			lists++
+			if lists == 1 {
+				return true, &corev1.PodList{Items: []corev1.Pod{bare}}, nil
+			}
+			return true, &corev1.PodList{}, nil
+		})
+		err := drainNode(t.Context(), client, "ip-1", nodeDrainOptions{
+			Force:           true,
+			EvictionTimeout: time.Second,
+			NodeTimeout:     time.Second,
+			PollInterval:    10 * time.Millisecond,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, evictions)
 	})
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user.go
@@ -6,18 +6,92 @@ import (
 	"fmt"
 	"log"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
-func evictKarpenterUserNodePool(ctx context.Context, clientset kubernetes.Interface, nodePoolName string, nodes []string, drainOpts nodeDrainOptions) error {
+func evictKarpenterUserNodePool(ctx context.Context, clientset kubernetes.Interface, ctrlClient client.Client, nodePoolName string, nodes []string, drainOpts nodeDrainOptions) error {
 	cordoned, errs := cordonNodes(ctx, clientset, nodes, drainOpts.DryRun)
+
+	// Map each node's providerID to its Karpenter NodeClaim so the claim can be
+	// deleted once the node is drained. Deleting the NodeClaim is Karpenter's
+	// native "decommission this node" action — it terminates the underlying
+	// instance and removes the Node — and does NOT touch the user's NodePool
+	// spec, so it stays within this command's scope. Without it, an empty
+	// cordoned node lingers until Karpenter consolidation reaps it, which never
+	// happens if the user disabled consolidation on their NodePool.
+	//
+	// Claims are indexed by providerID rather than filtered by NodePool label:
+	// a target "entity" is only the NodePool name when the node carried the
+	// karpenter.sh/nodepool label; classification also falls back to the
+	// EC2NodeClass or (legacy) provisioner name, which would not match the
+	// label. providerID ties a claim to the node we actually drained regardless.
+	claimByProviderID, err := nodeClaimsByProviderID(ctx, ctrlClient)
+	if err != nil {
+		// Non-fatal: keep draining, and fall back to Karpenter consolidation for
+		// the actual node removal. The error is surfaced so the operator knows
+		// the claims may not have been deleted.
+		errs = append(errs, fmt.Errorf("list NodeClaims for NodePool %s: %w", nodePoolName, err))
+	}
+
 	for _, node := range cordoned {
 		if err := drainNode(ctx, clientset, node.Name, drainOpts); err != nil {
 			errs = append(errs, fmt.Errorf("drain node %s: %w", node.Name, err))
+			continue // do NOT delete the NodeClaim: workloads are still on it
+		}
+		if claimByProviderID == nil {
+			continue // NodeClaims unavailable (listing failed, or the CRD is absent); any error was already recorded
+		}
+		nc, ok := claimByProviderID[node.Spec.ProviderID]
+		if !ok {
+			log.Printf("Warning: no Karpenter NodeClaim found for node %s (providerID %q) in NodePool %s; Karpenter will reap it once empty", node.Name, node.Spec.ProviderID, nodePoolName)
+			continue
+		}
+		if err := deleteNodeClaim(ctx, ctrlClient, nc, drainOpts.DryRun); err != nil {
+			errs = append(errs, fmt.Errorf("delete NodeClaim %s for node %s: %w", nc.Name, node.Name, err))
 		}
 	}
-	if !drainOpts.DryRun && len(errs) == 0 {
-		log.Printf("Drained %d node(s) from user NodePool %s; Karpenter will terminate their NodeClaims once empty.", len(cordoned), nodePoolName)
-	}
 	return errors.Join(errs...)
+}
+
+// nodeClaimsByProviderID lists every Karpenter NodeClaim and indexes them by
+// their status providerID — the stable key that ties a NodeClaim to its
+// Kubernetes Node (node.spec.providerID). Claims without a providerID yet
+// (still provisioning) are omitted; they carry no drained node. A missing
+// NodeClaim CRD (e.g. legacy Karpenter v0.x with no NodeClaims) yields a nil
+// map and no error, so the caller falls back to consolidation silently.
+func nodeClaimsByProviderID(ctx context.Context, ctrlClient client.Client) (map[string]*karpv1.NodeClaim, error) {
+	list := &karpv1.NodeClaimList{}
+	if err := ctrlClient.List(ctx, list); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	byID := make(map[string]*karpv1.NodeClaim, len(list.Items))
+	for i := range list.Items {
+		nc := &list.Items[i]
+		if nc.Status.ProviderID != "" {
+			byID[nc.Status.ProviderID] = nc
+		}
+	}
+	return byID, nil
+}
+
+// deleteNodeClaim deletes a single (already drained) NodeClaim. A claim that is
+// already gone — Karpenter reaped it between the list and now — is treated as
+// success.
+func deleteNodeClaim(ctx context.Context, ctrlClient client.Client, nc *karpv1.NodeClaim, dryRun bool) error {
+	if dryRun {
+		log.Printf("[dry-run] would delete Karpenter NodeClaim %s", nc.Name)
+		return nil
+	}
+	if err := ctrlClient.Delete(ctx, nc); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	log.Printf("Deleted Karpenter NodeClaim %s; Karpenter will terminate the underlying instance.", nc.Name)
+	return nil
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
@@ -1,16 +1,21 @@
 package evict
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
@@ -70,5 +75,70 @@ func TestEvictKarpenterUserNodePool(t *testing.T) {
 
 		nc := &karpv1.NodeClaim{}
 		require.NoError(t, ctrlClient.Get(t.Context(), client.ObjectKey{Name: "nc-other"}, nc), "an unrelated NodeClaim must be left alone")
+	})
+
+	t.Run("NodeClaim list failure is surfaced; the node is still drained", func(t *testing.T) {
+		cs := fake.NewClientset(newNode())
+		ctrlClient := ctrlfake.NewClientBuilder().WithScheme(newKarpenterScheme(t)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+					return errors.New("apiserver unreachable")
+				},
+			}).Build()
+
+		err := evictKarpenterUserNodePool(t.Context(), cs, ctrlClient, nodePool, []string{"n1"}, newDrainOpts(false))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "list NodeClaims")
+
+		got, getErr := cs.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+		require.NoError(t, getErr)
+		assert.True(t, got.Spec.Unschedulable, "the node must still be cordoned and drained")
+	})
+
+	t.Run("NodeClaim delete failure is surfaced", func(t *testing.T) {
+		cs := fake.NewClientset(newNode())
+		ctrlClient := ctrlfake.NewClientBuilder().WithScheme(newKarpenterScheme(t)).WithObjects(newNodeClaim()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+					return apierrors.NewInternalError(errors.New("boom"))
+				},
+			}).Build()
+
+		err := evictKarpenterUserNodePool(t.Context(), cs, ctrlClient, nodePool, []string{"n1"}, newDrainOpts(false))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete NodeClaim")
+	})
+
+	t.Run("drain failure leaves the NodeClaim intact", func(t *testing.T) {
+		// A bare pod trips the --force gate, so the drain fails and the node's
+		// NodeClaim must NOT be deleted (its workloads are still on it).
+		bare := barePod("orphan")
+		bare.Spec.NodeName = "n1"
+		cs := fake.NewClientset(newNode(), &bare)
+		ctrlClient := ctrlfake.NewClientBuilder().WithScheme(newKarpenterScheme(t)).WithObjects(newNodeClaim()).Build()
+
+		err := evictKarpenterUserNodePool(t.Context(), cs, ctrlClient, nodePool, []string{"n1"}, newDrainOpts(false))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "drain node n1")
+
+		nc := &karpv1.NodeClaim{}
+		require.NoError(t, ctrlClient.Get(t.Context(), client.ObjectKey{Name: "nc1"}, nc), "the NodeClaim must be left intact when the drain fails")
+	})
+
+	t.Run("missing NodeClaim CRD falls back to consolidation", func(t *testing.T) {
+		cs := fake.NewClientset(newNode())
+		ctrlClient := ctrlfake.NewClientBuilder().WithScheme(newKarpenterScheme(t)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+					return &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "karpenter.sh", Kind: "NodeClaim"}}
+				},
+			}).Build()
+
+		err := evictKarpenterUserNodePool(t.Context(), cs, ctrlClient, nodePool, []string{"n1"}, newDrainOpts(false))
+		require.NoError(t, err, "an absent NodeClaim CRD must not fail the eviction")
+
+		got, getErr := cs.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+		require.NoError(t, getErr)
+		assert.True(t, got.Spec.Unschedulable, "the node is still cordoned and drained")
 	})
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/karpenter_user_test.go
@@ -6,28 +6,69 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
 func TestEvictKarpenterUserNodePool(t *testing.T) {
-	for _, tc := range []struct {
-		name              string
-		dryRun            bool
-		wantUnschedulable bool
-	}{
-		{name: "cordons and drains", dryRun: false, wantUnschedulable: true},
-		{name: "dry-run touches nothing", dryRun: true, wantUnschedulable: false},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1"}}
-			client := fake.NewClientset(node)
-
-			require.NoError(t, evictKarpenterUserNodePool(t.Context(), client, "user-np", []string{"n1"}, newDrainOpts(tc.dryRun)))
-
-			got, err := client.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
-			require.NoError(t, err)
-			assert.Equal(t, tc.wantUnschedulable, got.Spec.Unschedulable)
-		})
+	const nodePool, providerID = "user-np", "aws:///eu-west-3a/i-abc"
+	newNode := func() *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+			Spec:       corev1.NodeSpec{ProviderID: providerID},
+		}
 	}
+	newNodeClaim := func() *karpv1.NodeClaim {
+		return &karpv1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "nc1", Labels: map[string]string{karpv1.NodePoolLabelKey: nodePool}},
+			Status:     karpv1.NodeClaimStatus{ProviderID: providerID, NodeName: "n1"},
+		}
+	}
+
+	t.Run("cordons, drains, then deletes the NodeClaim", func(t *testing.T) {
+		cs := fake.NewClientset(newNode())
+		ctrlClient := ctrlfake.NewClientBuilder().WithScheme(newKarpenterScheme(t)).WithObjects(newNodeClaim()).Build()
+
+		require.NoError(t, evictKarpenterUserNodePool(t.Context(), cs, ctrlClient, nodePool, []string{"n1"}, newDrainOpts(false)))
+
+		got, err := cs.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.True(t, got.Spec.Unschedulable, "the node must be cordoned")
+
+		nc := &karpv1.NodeClaim{}
+		err = ctrlClient.Get(t.Context(), client.ObjectKey{Name: "nc1"}, nc)
+		assert.True(t, apierrors.IsNotFound(err), "the NodeClaim must be deleted, got err=%v", err)
+	})
+
+	t.Run("dry-run touches nothing", func(t *testing.T) {
+		cs := fake.NewClientset(newNode())
+		ctrlClient := ctrlfake.NewClientBuilder().WithScheme(newKarpenterScheme(t)).WithObjects(newNodeClaim()).Build()
+
+		require.NoError(t, evictKarpenterUserNodePool(t.Context(), cs, ctrlClient, nodePool, []string{"n1"}, newDrainOpts(true)))
+
+		got, err := cs.CoreV1().Nodes().Get(t.Context(), "n1", metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.False(t, got.Spec.Unschedulable, "dry-run must not cordon")
+
+		nc := &karpv1.NodeClaim{}
+		require.NoError(t, ctrlClient.Get(t.Context(), client.ObjectKey{Name: "nc1"}, nc), "dry-run must not delete the NodeClaim")
+	})
+
+	t.Run("no matching NodeClaim: drains and warns, no error", func(t *testing.T) {
+		cs := fake.NewClientset(newNode())
+		// A NodeClaim for a different providerID: nothing matches node n1.
+		other := newNodeClaim()
+		other.Name = "nc-other"
+		other.Status.ProviderID = "aws:///eu-west-3a/i-other"
+		ctrlClient := ctrlfake.NewClientBuilder().WithScheme(newKarpenterScheme(t)).WithObjects(other).Build()
+
+		require.NoError(t, evictKarpenterUserNodePool(t.Context(), cs, ctrlClient, nodePool, []string{"n1"}, newDrainOpts(false)))
+
+		nc := &karpv1.NodeClaim{}
+		require.NoError(t, ctrlClient.Get(t.Context(), client.ObjectKey{Name: "nc-other"}, nc), "an unrelated NodeClaim must be left alone")
+	})
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/preflight_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/preflight_test.go
@@ -21,7 +21,7 @@ func newKarpenterScheme(t *testing.T) *runtime.Scheme {
 	sch := runtime.NewScheme()
 	require.NoError(t, scheme.AddToScheme(sch))
 	gv := schema.GroupVersion{Group: "karpenter.sh", Version: "v1"}
-	sch.AddKnownTypes(gv, &karpv1.NodePool{}, &karpv1.NodePoolList{})
+	sch.AddKnownTypes(gv, &karpv1.NodePool{}, &karpv1.NodePoolList{}, &karpv1.NodeClaim{}, &karpv1.NodeClaimList{})
 	metav1.AddToGroupVersion(sch, gv)
 	return sch
 }

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/run.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/run.go
@@ -25,6 +25,7 @@ type RunOptions struct {
 	Targets            []Target // parsed --target=<type>/<name>
 	SkipCA             bool
 	EnsurePDBs         bool
+	Force              bool
 	DryRun             bool
 	Yes                bool
 	EvictionTimeout    time.Duration
@@ -37,7 +38,7 @@ type RunOptions struct {
 // killed run leaves no permanently corrupting state — re-running cleans up.
 func Run(ctx context.Context, streams genericclioptions.IOStreams, configFlags *genericclioptions.ConfigFlags, clientset *kubernetes.Clientset, opts RunOptions) error {
 	log.SetOutput(streams.ErrOut)
-	ctrl.SetLogger(zap.New(zap.UseDevMode(false), zap.WriteTo(streams.ErrOut)))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(opts.Debug), zap.WriteTo(streams.ErrOut)))
 
 	cli, err := clients.Build(ctx, configFlags, clientset)
 	if err != nil {
@@ -121,6 +122,16 @@ func Run(ctx context.Context, streams genericclioptions.IOStreams, configFlags *
 	// label-based cleanup picks them up. On a SIGINT mid-flight the temp
 	// PDBs may leak; a subsequent run cleans them up via the same label.
 	if opts.EnsurePDBs {
+		// Reclaim any temp PDB leaked by a prior interrupted run before creating
+		// fresh ones. Otherwise, if the user has since added their own PDB for
+		// the same workload, the pod would be covered by both PDBs and the
+		// Eviction API refuses pods matched by more than one PDB, deadlocking
+		// the drain below. Unlike the no-op exit path, this is not best-effort:
+		// a failed cleanup here must abort before draining, since a surviving
+		// leaked PDB is exactly what would deadlock the drain.
+		if err := cleanupTempPDBs(ctx, cli.K8sClient, opts.DryRun); err != nil {
+			return fmt.Errorf("failed to reclaim leaked temporary PDBs: %w", err)
+		}
 		if err := ensureTempPDBs(ctx, clientset, cli.K8sClient, targets, opts.DryRun); err != nil {
 			if cleanupErr := cleanupTempPDBs(ctx, cli.K8sClient, opts.DryRun); cleanupErr != nil {
 				log.Printf("Warning: failed to cleanup partial temporary PDBs: %v", cleanupErr)
@@ -129,8 +140,10 @@ func Run(ctx context.Context, streams genericclioptions.IOStreams, configFlags *
 		}
 	}
 
+	// Step 3: drain and remove every target's nodes.
 	drainOpts := nodeDrainOptions{
 		DryRun:          opts.DryRun,
+		Force:           opts.Force,
 		EvictionTimeout: opts.EvictionTimeout,
 		NodeTimeout:     opts.NodeTimeout,
 		PollInterval:    2 * time.Second,
@@ -218,7 +231,7 @@ func evictTarget(ctx context.Context, clientset kubernetes.Interface, cli *clien
 	case clusterinfo.NodeManagerEKSManagedNodeGroup:
 		return evictEKSManagedNodeGroup(ctx, cli.EKS, clientset, clusterName, t.Entity, t.Nodes, drainOpts)
 	case clusterinfo.NodeManagerKarpenter:
-		return evictKarpenterUserNodePool(ctx, clientset, t.Entity, t.Nodes, drainOpts)
+		return evictKarpenterUserNodePool(ctx, clientset, cli.K8sClient, t.Entity, t.Nodes, drainOpts)
 	case clusterinfo.NodeManagerStandalone:
 		return evictStandalone(ctx, clientset, cli.EC2, t.Nodes, drainOpts)
 	default:

--- a/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone_test.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/evict/standalone_test.go
@@ -36,7 +36,7 @@ func TestEvictStandalone(t *testing.T) {
 	}
 	stuckPod := func() *corev1.Pod {
 		return &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: "blocker", Namespace: "default"},
+			ObjectMeta: metav1.ObjectMeta{Name: "blocker", Namespace: "default", OwnerReferences: controllerOwnerRefs()},
 			Spec:       corev1.PodSpec{NodeName: "ip-stuck"},
 		}
 	}
@@ -160,7 +160,7 @@ func TestEvictStandaloneCordonsAllBeforeDraining(t *testing.T) {
 		}
 	}
 	pod1 := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: "default", OwnerReferences: controllerOwnerRefs()},
 		Spec:       corev1.PodSpec{NodeName: "ip-1"},
 	}
 	client := fake.NewClientset(ec2Node("ip-1", "eu-west-3a", "i-aaa"), ec2Node("ip-2", "eu-west-3b", "i-bbb"), pod1)


### PR DESCRIPTION
### What does this PR do?

Follow-up correctness and consistency fixes surfaced by a deep post-merge review of the `kubectl datadog autoscaling cluster evict-legacy-nodes` command (originally landed via #3160–#3178):

- **Karpenter user NodePools now actively remove nodes.** `evictKarpenterUserNodePool` deletes the `NodeClaim` backing each drained node (matched by `providerID`) instead of relying on Karpenter consolidation, which never reaps the empty cordoned node when the user has consolidation disabled. This makes step 3 (remove the underlying instance) consistent across all four node-group types (ASG terminates instances, standalone terminates instances, EKS MNG scales to 0, Karpenter deletes NodeClaims). Matching by `providerID` rather than the `karpenter.sh/nodepool` label is deliberate: `classifyNodeByLabel` also buckets Karpenter nodes by `karpenter.k8s.aws/ec2nodeclass` or the legacy `karpenter.sh/provisioner-name`, so the target entity is not always the NodePool name. A missing NodeClaim CRD (legacy Karpenter v0.x) falls back to consolidation.
- **Bare pods are no longer silently destroyed.** `drainNode` refuses a node hosting pods not managed by a controller unless the new `--force` flag is set, mirroring `kubectl drain`. Without it such a pod would be evicted with no replacement and lost.
- **Leaked temporary PDBs can no longer deadlock the drain.** On the eviction path, `Run` now reclaims leaked temp PDBs (fail-fast) before creating fresh ones. Otherwise a temp PDB left by an interrupted run plus a user-added PDB for the same workload would double-cover a pod, and the Eviction API refuses pods matched by more than one PDB.
- **Misc:** the previously-dead `--debug` flag is wired (`zap.UseDevMode(opts.Debug)`), the `evict` package gets a doc comment (all sibling packages have one), and the eviction step is labeled "Step 3".

### Motivation

A thorough review of the merged implementation (comparing the reference PR #3026 against what landed across the ~13 split PRs, and re-checking every review comment) turned up a handful of genuine gaps: the Karpenter type was the odd one out for actively removing capacity, bare pods were evicted unconditionally, an interrupted run could leave a state that deadlocks the next drain, and `--debug` did nothing.

### Additional Notes

- Known limitation: `--dry-run` does not preview the `--force` bare-pod refusal, because dry-run short-circuits before listing per-pod state (as it already does for all per-pod details). Low impact — a real run without `--force` still refuses the node safely.
- Deliberately **not** changed: a drained Karpenter node with no matching NodeClaim logs a warning and continues rather than erroring. The unmatched case is either a legacy v0.x node this command cannot remove via a v1 NodeClaim anyway, or a node already being torn down (where success is correct); the reap-between-list-and-delete race is already handled by tolerating `IsNotFound` on delete.

### Minimum Agent Versions

None — this is a `kubectl-datadog` plugin change with no Datadog Agent or Cluster Agent version dependency.

### Describe your test plan

- `go test -race ./cmd/kubectl-datadog/autoscaling/cluster/evict/...` — new subtests cover the bare-pod `--force` gate (refuse without, evict with) and NodeClaim deletion (deleted after drain, dry-run leaves it, unrelated claim untouched); existing drain fixtures updated to be controller-managed so they exercise the default no-`--force` path.
- `go test ./cmd/kubectl-datadog/autoscaling/cluster/...` — full command tree green (clients scheme change included).
- `golangci-lint run` — 0 issues.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
