### PR TITLE
[PROF-15317] allow operator to use logging seccomp

### DIFF
--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -139,7 +139,7 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 	if o.seccompEnabled {
 		sc.SeccompProfile = &corev1.SeccompProfile{
 			Type:             corev1.SeccompProfileTypeLocalhost,
-			LocalhostProfile: new(seccompProfileName(hostProfilerImage)),
+			LocalhostProfile: new(seccompProfileName(hostProfilerImage, o.loggingSeccomp)),
 		}
 
 		// seccomp-root EmptyDir volume (shared with system-probe when both are enabled; VolumeManager deduplicates)

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -69,7 +69,7 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, _ *v2alpha1.DatadogAg
 
 	o.loggingSeccomp = featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnableHostProfilerLoggingSeccompAnnotation)
 	if o.loggingSeccomp && !o.seccompEnabled {
-		o.logger.Info("host profiler: logging-seccomp annotation has no effect when seccomp is disabled")
+		o.logger.V(1).Info("host profiler: logging-seccomp annotation has no effect when seccomp is disabled")
 	}
 
 	return feature.RequiredComponents{

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -23,6 +23,7 @@ type hostProfilerFeature struct {
 	owner                   metav1.Object
 	hostPIDDisabledManually bool
 	seccompEnabled          bool
+	loggingSeccomp          bool
 
 	logger logr.Logger
 }
@@ -65,6 +66,8 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, _ *v2alpha1.DatadogAg
 			o.seccompEnabled = value
 		}
 	}
+
+	o.loggingSeccomp = featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnableHostProfilerLoggingSeccompAnnotation)
 
 	return feature.RequiredComponents{
 		Agent: feature.RequiredComponent{
@@ -142,7 +145,7 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 
 		// Init container: copy seccomp profile JSON to the kubelet seccomp directory on the host.
 		// Appended after the base init containers (init-volume, init-config) added by default.go.
-		initContainer := buildSeccompSetupInitContainer(hostProfilerImage)
+		initContainer := buildSeccompSetupInitContainer(hostProfilerImage, o.loggingSeccomp)
 		managers.PodTemplateSpec().Spec.InitContainers = append(managers.PodTemplateSpec().Spec.InitContainers, initContainer)
 	} else {
 		sc.SeccompProfile = &corev1.SeccompProfile{

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -68,6 +68,9 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, _ *v2alpha1.DatadogAg
 	}
 
 	o.loggingSeccomp = featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnableHostProfilerLoggingSeccompAnnotation)
+	if o.loggingSeccomp && !o.seccompEnabled {
+		o.logger.Info("host profiler: logging-seccomp annotation has no effect when seccomp is disabled")
+	}
 
 	return feature.RequiredComponents{
 		Agent: feature.RequiredComponent{

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -1,6 +1,7 @@
 package hostprofiler
 
 import (
+	"strings"
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -230,6 +231,56 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				}
 			},
 		)
+}
+
+func TestHostProfilerLoggingSeccompAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotation   string
+		wantContains string
+	}{
+		{name: "default seccomp profile", wantContains: "cp " + seccompSourcePath},
+		{name: "logging seccomp profile", annotation: "true", wantContains: "cp " + loggingSeccompSourcePath},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{"agent.datadoghq.com/host-profiler-enabled": "true"}
+			if tt.annotation != "" {
+				annotations["agent.datadoghq.com/host-profiler-logging-seccomp-enabled"] = tt.annotation
+			}
+			dda := testutils.NewDatadogAgentBuilder().WithAnnotations(annotations).Build()
+
+			manager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: string(apicommon.CoreAgentContainerName), Image: images.GetLatestAgentImage()},
+						{
+							Name:            string(apicommon.HostProfiler),
+							Image:           "gcr.io/datadoghq/agent:7.99.0",
+							SecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(true)},
+						},
+					},
+				},
+			})
+
+			feat := buildHostProfilerFeature(nil).(*hostProfilerFeature)
+			feat.Configure(dda, &dda.Spec, nil)
+			assert.NoError(t, feat.ManageNodeAgent(manager))
+
+			var setup *corev1.Container
+			for i := range manager.PodTemplateSpec().Spec.InitContainers {
+				if manager.PodTemplateSpec().Spec.InitContainers[i].Name == string(apicommon.HostProfilerSeccompSetupContainerName) {
+					setup = &manager.PodTemplateSpec().Spec.InitContainers[i]
+					break
+				}
+			}
+			assert.NotNil(t, setup)
+			if setup != nil {
+				assert.Contains(t, strings.Join(setup.Command, " "), tt.wantContains)
+			}
+		})
+	}
 }
 
 func TestResolveHostProfilerImage(t *testing.T) {

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -186,7 +186,7 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 					assert.False(t, *sc.AllowPrivilegeEscalation, "AllowPrivilegeEscalation must be false")
 					assert.NotNil(t, sc.SeccompProfile)
 					assert.Equal(t, corev1.SeccompProfileTypeLocalhost, sc.SeccompProfile.Type)
-					assert.Equal(t, seccompProfileName(hostProfilerImage), *sc.SeccompProfile.LocalhostProfile)
+					assert.Equal(t, seccompProfileName(hostProfilerImage, false), *sc.SeccompProfile.LocalhostProfile)
 					assert.NotNil(t, sc.Capabilities)
 					assert.Contains(t, sc.Capabilities.Drop, corev1.Capability("ALL"))
 					assert.True(t, apiutils.IsEqualStruct(sc.Capabilities.Add, defaultCapabilities()), "capabilities.Add \ndiff = %s", cmp.Diff(sc.Capabilities.Add, defaultCapabilities()))
@@ -220,7 +220,7 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				if setupContainer != nil {
 					assert.Equal(t, hostProfilerImage, setupContainer.Image)
 					assert.Contains(t, setupContainer.Command, seccompSourcePath, "cp source should be the in-image seccomp path")
-					expectedDst := common.SeccompRootVolumePath + "/" + seccompProfileName(hostProfilerImage)
+					expectedDst := common.SeccompRootVolumePath + "/" + seccompProfileName(hostProfilerImage, false)
 					assert.Contains(t, setupContainer.Command, expectedDst, "cp command should target the kubelet seccomp path")
 					// Init container should only mount seccomp-root, not the ConfigMap volume
 					mountNames := map[string]bool{}
@@ -277,7 +277,11 @@ func TestHostProfilerLoggingSeccompAnnotation(t *testing.T) {
 			}
 			assert.NotNil(t, setup)
 			if setup != nil {
-				assert.Contains(t, strings.Join(setup.Command, " "), tt.wantContains)
+				cmd := strings.Join(setup.Command, " ")
+				assert.Contains(t, cmd, tt.wantContains)
+				if tt.annotation == "true" {
+					assert.Contains(t, cmd, "WARNING: logging-seccomp.json not found in image, falling back to default seccomp profile")
+				}
 			}
 		})
 	}
@@ -427,7 +431,7 @@ func TestHostProfilerSeccompImageStaysAlignedThroughOverrides(t *testing.T) {
 			if hostProfilerContainer != nil {
 				assert.Equal(t, tt.wantImage, hostProfilerContainer.Image)
 				assert.Equal(t, ifNotPresent, hostProfilerContainer.ImagePullPolicy)
-				assert.Equal(t, seccompProfileName(tt.wantImage), *hostProfilerContainer.SecurityContext.SeccompProfile.LocalhostProfile)
+				assert.Equal(t, seccompProfileName(tt.wantImage, false), *hostProfilerContainer.SecurityContext.SeccompProfile.LocalhostProfile)
 			}
 
 			var setupContainer *corev1.Container
@@ -441,7 +445,7 @@ func TestHostProfilerSeccompImageStaysAlignedThroughOverrides(t *testing.T) {
 			if setupContainer != nil {
 				assert.Equal(t, tt.wantImage, setupContainer.Image)
 				assert.Equal(t, ifNotPresent, setupContainer.ImagePullPolicy)
-				assert.Contains(t, setupContainer.Command, common.SeccompRootVolumePath+"/"+seccompProfileName(tt.wantImage))
+				assert.Contains(t, setupContainer.Command, common.SeccompRootVolumePath+"/"+seccompProfileName(tt.wantImage, false))
 			}
 		})
 	}

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -16,8 +16,10 @@ import (
 )
 
 const (
-	// seccompSourcePath is the path to the seccomp profile baked into the collector image.
+	// seccompSourcePath is the path to the default seccomp profile baked into the collector image.
 	seccompSourcePath = "/etc/dd-host-profiler/seccomp.json"
+	// loggingSeccompSourcePath is the path to the seccomp profile that also permits logging syscalls.
+	loggingSeccompSourcePath = "/etc/dd-host-profiler/logging-seccomp.json"
 )
 
 // seccompProfileName returns a profile name unique to the image, avoiding
@@ -40,15 +42,23 @@ func defaultCapabilities() []corev1.Capability {
 	}
 }
 
-func buildSeccompSetupInitContainer(image string) corev1.Container {
+func buildSeccompSetupInitContainer(image string, loggingSeccomp bool) corev1.Container {
+	dst := fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName(image))
+	var command []string
+	if loggingSeccomp {
+		// Prefer the logging profile, but fall back to the default if the image predates it
+		// so an older image degrades gracefully instead of crash-looping on a missing file.
+		command = []string{"sh", "-c", fmt.Sprintf(
+			"if [ -f %[1]s ]; then cp %[1]s %[3]s; else cp %[2]s %[3]s; fi",
+			loggingSeccompSourcePath, seccompSourcePath, dst,
+		)}
+	} else {
+		command = []string{"cp", seccompSourcePath, dst}
+	}
 	return corev1.Container{
-		Name:  string(apicommon.HostProfilerSeccompSetupContainerName),
-		Image: image,
-		Command: []string{
-			"cp",
-			seccompSourcePath,
-			fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName(image)),
-		},
+		Name:    string(apicommon.HostProfilerSeccompSetupContainerName),
+		Image:   image,
+		Command: command,
 		VolumeMounts: []corev1.VolumeMount{
 			common.GetVolumeMountForSeccomp(),
 		},

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -22,11 +22,15 @@ const (
 	loggingSeccompSourcePath = "/etc/dd-host-profiler/logging-seccomp.json"
 )
 
-// seccompProfileName returns a profile name unique to the image, avoiding
+// seccompProfileName returns a name unique to the image and variant, avoiding
 // races when multiple host-profiler versions coexist on the same node.
-func seccompProfileName(imageRef string) string {
+func seccompProfileName(imageRef string, logging bool) string {
 	h := sha256.Sum256([]byte(imageRef))
-	return fmt.Sprintf("host-profiler-%x", h[:4])
+	name := fmt.Sprintf("host-profiler-%x", h[:4])
+	if logging {
+		name += "-logging"
+	}
+	return name
 }
 
 func defaultCapabilities() []corev1.Capability {
@@ -43,13 +47,13 @@ func defaultCapabilities() []corev1.Capability {
 }
 
 func buildSeccompSetupInitContainer(image string, loggingSeccomp bool) corev1.Container {
-	dst := fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName(image))
+	dst := fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName(image, loggingSeccomp))
 	var command []string
 	if loggingSeccomp {
 		// Prefer the logging profile, but fall back to the default if the image predates it
 		// so an older image degrades gracefully instead of crash-looping on a missing file.
 		command = []string{"sh", "-c", fmt.Sprintf(
-			"if [ -f %[1]s ]; then cp %[1]s %[3]s; else echo 'WARNING: logging-seccomp.json not found in image, falling back to default seccomp profile' >&2; cp %[2]s %[3]s; fi",
+			"if [ -f %[1]s ]; then cp %[1]s %[3]s; else echo 'WARNING: logging-seccomp.json not found in image, falling back to default seccomp profile'; cp %[2]s %[3]s; fi",
 			loggingSeccompSourcePath, seccompSourcePath, dst,
 		)}
 	} else {

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -49,7 +49,7 @@ func buildSeccompSetupInitContainer(image string, loggingSeccomp bool) corev1.Co
 		// Prefer the logging profile, but fall back to the default if the image predates it
 		// so an older image degrades gracefully instead of crash-looping on a missing file.
 		command = []string{"sh", "-c", fmt.Sprintf(
-			"if [ -f %[1]s ]; then cp %[1]s %[3]s; else cp %[2]s %[3]s; fi",
+			"if [ -f %[1]s ]; then cp %[1]s %[3]s; else echo 'WARNING: logging-seccomp.json not found in image, falling back to default seccomp profile' >&2; cp %[2]s %[3]s; fi",
 			loggingSeccompSourcePath, seccompSourcePath, dst,
 		)}
 	} else {

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -28,8 +28,9 @@ const (
 	// EnableHostProfilerSeccompAnnotation controls whether the host-profiler applies its localhost
 	// seccomp profile (and the init container that installs it on the node). Defaults to enabled;
 	// set to "false" to disable both the seccomp profile and its setup init container.
-	EnableHostProfilerSeccompAnnotation = "agent.datadoghq.com/host-profiler-seccomp-enabled"
-	EnableKSMApiServerCacheAnnotation   = "agent.datadoghq.com/ksm-use-apiserver-cache"
+	EnableHostProfilerSeccompAnnotation        = "agent.datadoghq.com/host-profiler-seccomp-enabled"
+	EnableHostProfilerLoggingSeccompAnnotation = "agent.datadoghq.com/host-profiler-logging-seccomp-enabled"
+	EnableKSMApiServerCacheAnnotation          = "agent.datadoghq.com/ksm-use-apiserver-cache"
 
 	EnableInstrumentationCRDAnnotation = "agent.datadoghq.com/instrumentation-crd-enabled"
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new annotation to let Host Profiler deployments use a logging seccomp profile.

### Motivation

This allows seccomp denials monitoring.

### Additional Notes

Leverages https://github.com/DataDog/datadog-agent/pull/53189

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits