### PR TITLE
Native SGC support for the operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,18 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" 
 
 FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
 
-FROM registry.access.redhat.com/ubi10/ubi-micro:latest
+# secret-generic-connector (SGC) source image, pinned by digest
+ARG SGC_IMAGE=datadog/secret-generic-connector:7.81.0-rc.1@sha256:9bf1ecb5018deea4e7b6dd1522455a0cebfeea50a9aae481b91fbca00251bfb8
+FROM ${SGC_IMAGE} AS sgc
+
+# Non-FIPS runtime: embed SGC so the operator can resolve its own secrets via the connector.
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest AS runtime-false
+COPY --from=sgc --chmod=550 /secret-generic-connector /opt/datadog-agent/bin/secret-generic-connector
+
+# FIPS runtime: omit SGC until a FIPS SGC image is published (no -fips tag exists yet).
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest AS runtime-true
+
+FROM runtime-${FIPS_ENABLED}
 
 LABEL name="datadog/operator"
 LABEL vendor="Datadog Inc."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 #
 ARG FIPS_ENABLED=false
 
+# Pin SGC by digest so released operator images cannot change without review.
+# hadolint ignore=DL3026
+FROM docker.io/datadog/secret-generic-connector:7.84.0-rc.2@sha256:00a3a7f53ddeaeac7864c41009c8d36c25fe5babeab2498e02c111e83ab27860 AS sgc-false
+# hadolint ignore=DL3026
+FROM docker.io/datadog/secret-generic-connector:7.84.0-rc.2-fips@sha256:f79d4d94e7c43bfc1152f4b19c9d64a9d6caea9ae64da2bbb8d7dd2483673e6e AS sgc-true
+FROM sgc-${FIPS_ENABLED} AS sgc
+
 # Build the manager binary
 FROM golang:1.26.7 AS builder
 
@@ -57,6 +64,7 @@ COPY --from=certs /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=sgc --chmod=755 /secret-generic-connector /usr/local/bin/secret-generic-connector
 
 COPY --from=builder --chmod=550 /workspace/helpers .
 COPY --chmod=550 scripts/readsecret.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,18 +42,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -ldflags "${LDFLAGS}" 
 
 FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
 
-# secret-generic-connector (SGC) source image, pinned by digest
-ARG SGC_IMAGE=datadog/secret-generic-connector:7.81.0-rc.1@sha256:9bf1ecb5018deea4e7b6dd1522455a0cebfeea50a9aae481b91fbca00251bfb8
-FROM ${SGC_IMAGE} AS sgc
-
-# Non-FIPS runtime: embed SGC so the operator can resolve its own secrets via the connector.
-FROM registry.access.redhat.com/ubi10/ubi-micro:latest AS runtime-false
-COPY --from=sgc --chmod=550 /secret-generic-connector /opt/datadog-agent/bin/secret-generic-connector
-
-# FIPS runtime: omit SGC until a FIPS SGC image is published (no -fips tag exists yet).
-FROM registry.access.redhat.com/ubi10/ubi-micro:latest AS runtime-true
-
-FROM runtime-${FIPS_ENABLED}
+FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 
 LABEL name="datadog/operator"
 LABEL vendor="Datadog Inc."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 #
 ARG FIPS_ENABLED=false
+ARG SGC_VERSION=7.84.0-rc.2
+ARG SGC_TAG_SUFFIX
 
-# Pin SGC by digest so released operator images cannot change without review.
-# hadolint ignore=DL3026
-FROM docker.io/datadog/secret-generic-connector:7.84.0-rc.2@sha256:00a3a7f53ddeaeac7864c41009c8d36c25fe5babeab2498e02c111e83ab27860 AS sgc-false
-# hadolint ignore=DL3026
-FROM docker.io/datadog/secret-generic-connector:7.84.0-rc.2-fips@sha256:f79d4d94e7c43bfc1152f4b19c9d64a9d6caea9ae64da2bbb8d7dd2483673e6e AS sgc-true
-FROM sgc-${FIPS_ENABLED} AS sgc
+FROM datadog/secret-generic-connector:${SGC_VERSION}${SGC_TAG_SUFFIX} AS sgc
 
 # Build the manager binary
 FROM golang:1.26.7 AS builder

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ PLATFORM=$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m)
 ROOT=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 KUSTOMIZE_CONFIG?=config/default
 FIPS_ENABLED?=false
+SGC_TAG_SUFFIX?=$(if $(filter true,$(FIPS_ENABLED)),-fips,)
 
 # Default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
@@ -173,7 +174,7 @@ docker-build: generate docker-build-ci docker-build-check-ci
 # For local use
 .PHONY: docker-build-ci
 docker-build-ci:
-	docker build . -t ${IMG} --build-arg FIPS_ENABLED="${FIPS_ENABLED}" --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}"
+	docker build . -t ${IMG} --build-arg FIPS_ENABLED="${FIPS_ENABLED}" --build-arg SGC_TAG_SUFFIX="${SGC_TAG_SUFFIX}" --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}"
 
 # For local use
 .PHONY: docker-build-check-ci
@@ -184,7 +185,7 @@ docker-build-check-ci:
 # For Gitlab use
 .PHONY: docker-build-push-ci
 docker-build-push-ci:
-	docker buildx build . -t ${IMG} --build-arg FIPS_ENABLED="${FIPS_ENABLED}" --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}" --platform=linux/${GOARCH} --output=type=image,oci-mediatypes=true --push
+	docker buildx build . -t ${IMG} --build-arg FIPS_ENABLED="${FIPS_ENABLED}" --build-arg SGC_TAG_SUFFIX="${SGC_TAG_SUFFIX}" --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}" --platform=linux/${GOARCH} --output=type=image,oci-mediatypes=true --push
 
 # For Gitlab use
 .PHONY: docker-build-push-check-ci

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/http"
@@ -159,6 +160,8 @@ type options struct {
 	// Secret Backend options
 	secretBackendCommand  string
 	secretBackendArgs     stringSlice
+	secretBackendType     string
+	secretBackendConfig   string
 	secretRefreshInterval time.Duration
 }
 
@@ -180,6 +183,8 @@ func (opts *options) Parse() {
 	// Custom flags
 	flag.StringVar(&opts.secretBackendCommand, "secretBackendCommand", "", "Secret backend command")
 	flag.Var(&opts.secretBackendArgs, "secretBackendArgs", "Space separated arguments of the secret backend command")
+	flag.StringVar(&opts.secretBackendType, "secretBackendType", "", "Secret backend type for the embedded secret-generic-connector")
+	flag.StringVar(&opts.secretBackendConfig, "secretBackendConfig", "", "JSON object of secret backend config for the secret-generic-connector")
 	flag.DurationVar(&opts.secretRefreshInterval, "secretRefreshInterval", 0, "Interval for refreshing secrets from secret backend")
 	flag.BoolVar(&opts.supportCilium, "supportCilium", false, "Support usage of Cilium network policies.")
 	flag.BoolVar(&opts.datadogAgentEnabled, "datadogAgentEnabled", true, "Enable the DatadogAgent controller")
@@ -352,6 +357,15 @@ func run(opts *options) error {
 	// Dispatch CLI flags to each package
 	secrets.SetSecretBackendCommand(opts.secretBackendCommand)
 	secrets.SetSecretBackendArgs(opts.secretBackendArgs)
+	secrets.SetSecretBackendType(opts.secretBackendType)
+	if opts.secretBackendConfig != "" {
+		var backendConfig map[string]any
+		if err := json.Unmarshal([]byte(opts.secretBackendConfig), &backendConfig); err != nil {
+			setupLog.Error(err, "Invalid -secretBackendConfig JSON, ignoring")
+		} else {
+			secrets.SetSecretBackendConfig(backendConfig)
+		}
+	}
 
 	renewDeadline := opts.leaderElectionLeaseDuration / 2
 	retryPeriod := opts.leaderElectionLeaseDuration / 4
@@ -416,9 +430,10 @@ func run(opts *options) error {
 		setupLog.Error(err, "Unable to get credentials")
 	}
 
-	if opts.secretRefreshInterval > 0 && opts.secretBackendCommand == "" {
-		setupLog.Error(nil, "secretRefreshInterval is set but secretBackendCommand is not configured")
-	} else if opts.secretBackendCommand != "" && opts.secretRefreshInterval > 0 {
+	secretBackendConfigured := opts.secretBackendCommand != "" || opts.secretBackendType != ""
+	if opts.secretRefreshInterval > 0 && !secretBackendConfigured {
+		setupLog.Error(nil, "secretRefreshInterval is set but no secret backend is configured")
+	} else if secretBackendConfigured && opts.secretRefreshInterval > 0 {
 		go credsManager.StartCredentialRefreshRoutine(opts.secretRefreshInterval, setupLog)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -342,8 +342,8 @@ func run(opts *options) error {
 	secrets.SetSecretBackendArgs(opts.secretBackendArgs)
 	secrets.SetSecretBackendType(opts.secretBackendType)
 	if opts.secretBackendConfig != "" {
-		var backendConfig map[string]any
-		if err := json.Unmarshal([]byte(opts.secretBackendConfig), &backendConfig); err != nil {
+		backendConfig, err := parseSecretBackendConfig(opts.secretBackendConfig)
+		if err != nil {
 			setupLog.Error(err, "Invalid -secretBackendConfig JSON, ignoring")
 		} else {
 			secrets.SetSecretBackendConfig(backendConfig)
@@ -566,6 +566,12 @@ func run(opts *options) error {
 	}
 
 	return nil
+}
+
+func parseSecretBackendConfig(raw string) (map[string]any, error) {
+	var config map[string]any
+	err := json.Unmarshal([]byte(raw), &config)
+	return config, err
 }
 
 func getVersionAndPlatformInfo(configCopy *rest.Config) (*apimversion.Info, kubernetes.PlatformInfo, error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -338,16 +338,8 @@ func run(opts *options) error {
 	}
 
 	// Dispatch CLI flags to each package
-	secrets.SetSecretBackendCommand(opts.secretBackendCommand)
-	secrets.SetSecretBackendArgs(opts.secretBackendArgs)
-	secrets.SetSecretBackendType(opts.secretBackendType)
-	if opts.secretBackendConfig != "" {
-		backendConfig, err := parseSecretBackendConfig(opts.secretBackendConfig)
-		if err != nil {
-			setupLog.Error(err, "Invalid -secretBackendConfig JSON, ignoring")
-		} else {
-			secrets.SetSecretBackendConfig(backendConfig)
-		}
+	if err := configureSecretBackend(opts); err != nil {
+		setupLog.Error(err, "Invalid -secretBackendConfig JSON, ignoring")
 	}
 
 	renewDeadline := opts.leaderElectionLeaseDuration / 2
@@ -572,6 +564,22 @@ func parseSecretBackendConfig(raw string) (map[string]any, error) {
 	var config map[string]any
 	err := json.Unmarshal([]byte(raw), &config)
 	return config, err
+}
+
+func configureSecretBackend(opts *options) error {
+	secrets.SetSecretBackendCommand(opts.secretBackendCommand)
+	secrets.SetSecretBackendArgs(opts.secretBackendArgs)
+	secrets.SetSecretBackendType(opts.secretBackendType)
+	if opts.secretBackendConfig == "" {
+		return nil
+	}
+
+	backendConfig, err := parseSecretBackendConfig(opts.secretBackendConfig)
+	if err != nil {
+		return err
+	}
+	secrets.SetSecretBackendConfig(backendConfig)
+	return nil
 }
 
 func getVersionAndPlatformInfo(configCopy *rest.Config) (*apimversion.Info, kubernetes.PlatformInfo, error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/http"
@@ -144,6 +145,8 @@ type options struct {
 	// Secret Backend options
 	secretBackendCommand  string
 	secretBackendArgs     stringSlice
+	secretBackendType     string
+	secretBackendConfig   string
 	secretRefreshInterval time.Duration
 }
 
@@ -165,6 +168,8 @@ func (opts *options) Parse() {
 	// Custom flags
 	flag.StringVar(&opts.secretBackendCommand, "secretBackendCommand", "", "Secret backend command")
 	flag.Var(&opts.secretBackendArgs, "secretBackendArgs", "Space separated arguments of the secret backend command")
+	flag.StringVar(&opts.secretBackendType, "secretBackendType", "", "Secret backend type for the embedded secret-generic-connector")
+	flag.StringVar(&opts.secretBackendConfig, "secretBackendConfig", "", "JSON object of secret backend config for the secret-generic-connector")
 	flag.DurationVar(&opts.secretRefreshInterval, "secretRefreshInterval", 0, "Interval for refreshing secrets from secret backend")
 	flag.BoolVar(&opts.supportCilium, "supportCilium", false, "Support usage of Cilium network policies.")
 	flag.BoolVar(&opts.datadogAgentEnabled, "datadogAgentEnabled", true, "Enable the DatadogAgent controller")
@@ -335,6 +340,15 @@ func run(opts *options) error {
 	// Dispatch CLI flags to each package
 	secrets.SetSecretBackendCommand(opts.secretBackendCommand)
 	secrets.SetSecretBackendArgs(opts.secretBackendArgs)
+	secrets.SetSecretBackendType(opts.secretBackendType)
+	if opts.secretBackendConfig != "" {
+		var backendConfig map[string]any
+		if err := json.Unmarshal([]byte(opts.secretBackendConfig), &backendConfig); err != nil {
+			setupLog.Error(err, "Invalid -secretBackendConfig JSON, ignoring")
+		} else {
+			secrets.SetSecretBackendConfig(backendConfig)
+		}
+	}
 
 	renewDeadline := opts.leaderElectionLeaseDuration / 2
 	retryPeriod := opts.leaderElectionLeaseDuration / 4
@@ -429,9 +443,10 @@ func run(opts *options) error {
 		setupLog.Error(err, "Unable to get credentials")
 	}
 
-	if opts.secretRefreshInterval > 0 && opts.secretBackendCommand == "" {
-		setupLog.Error(nil, "secretRefreshInterval is set but secretBackendCommand is not configured")
-	} else if opts.secretBackendCommand != "" && opts.secretRefreshInterval > 0 {
+	secretBackendConfigured := opts.secretBackendCommand != "" || opts.secretBackendType != ""
+	if opts.secretRefreshInterval > 0 && !secretBackendConfigured {
+		setupLog.Error(nil, "secretRefreshInterval is set but no secret backend is configured")
+	} else if secretBackendConfigured && opts.secretRefreshInterval > 0 {
 		go credsManager.StartCredentialRefreshRoutine(opts.secretRefreshInterval, setupLog)
 	}
 

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -148,6 +148,30 @@ func TestOptionsParse_CLIOverridesEnv(t *testing.T) {
 	require.False(t, opts.defaultDataPlaneLinuxEnabled)
 }
 
+func TestOptionsParse_SecretBackendSGC(t *testing.T) {
+	resetCommandLine(t,
+		"-secretBackendType=hashicorp.vault",
+		`-secretBackendConfig={"vault_session":{"vault_auth_type":"kubernetes"}}`,
+	)
+
+	var opts options
+	opts.Parse()
+
+	require.Equal(t, "hashicorp.vault", opts.secretBackendType)
+	require.JSONEq(t, `{"vault_session":{"vault_auth_type":"kubernetes"}}`, opts.secretBackendConfig)
+}
+
+func TestParseSecretBackendConfig(t *testing.T) {
+	config, err := parseSecretBackendConfig(`{"vault_session":{"vault_auth_type":"kubernetes"}}`)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"vault_session": map[string]any{"vault_auth_type": "kubernetes"},
+	}, config)
+
+	_, err = parseSecretBackendConfig("not-json")
+	require.Error(t, err)
+}
+
 func TestOptionsParse_InvalidEnvLeavesDefault(t *testing.T) {
 	resetCommandLine(t)
 	t.Setenv("DD_MAXIMUM_GOROUTINES", "not-an-int")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-operator/pkg/fleet"
+	"github.com/DataDog/datadog-operator/pkg/secrets"
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -170,6 +171,22 @@ func TestParseSecretBackendConfig(t *testing.T) {
 
 	_, err = parseSecretBackendConfig("not-json")
 	require.Error(t, err)
+}
+
+func TestConfigureSecretBackend(t *testing.T) {
+	t.Cleanup(func() {
+		secrets.SetSecretBackendCommand("")
+		secrets.SetSecretBackendArgs(nil)
+		secrets.SetSecretBackendType("")
+		secrets.SetSecretBackendConfig(map[string]any{})
+	})
+
+	require.NoError(t, configureSecretBackend(&options{}))
+	require.NoError(t, configureSecretBackend(&options{
+		secretBackendType:   "hashicorp.vault",
+		secretBackendConfig: `{"vault_session":{"vault_auth_type":"kubernetes"}}`,
+	}))
+	require.Error(t, configureSecretBackend(&options{secretBackendConfig: "not-json"}))
 }
 
 func TestOptionsParse_InvalidEnvLeavesDefault(t *testing.T) {

--- a/go.work.sum
+++ b/go.work.sum
@@ -333,6 +333,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.2
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0 h1:f2Qw/Ehhimh5uO1fayV0QIW7DShEQqhtUfhYc+cBPlw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0/go.mod h1:2bIszWvQRlJVmJLiuLhukLImRjKPcYdzzsx6darK02A=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/IBM/sarama v1.40.0 h1:QTVmX+gMKye52mT5x+Ve/Bod2D0Gy7ylE2Wslv+RHtc=
 github.com/IBM/sarama v1.40.0/go.mod h1:6pBloAs1WanL/vsq5qFTyTGulJUntZHhMLOUYEIs9mg=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
@@ -447,6 +448,7 @@ github.com/bazelbuild/rules_go v0.49.0/go.mod h1:Dhcz716Kqg1RHNWos+N6MlXNkjNP2Ew
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
+github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
 github.com/bketelsen/crypt v0.0.4 h1:w/jqZtC9YD4DS/Vp9GhWfWcCpuAL58oTnLoI8vE9YHU=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
@@ -511,6 +513,7 @@ github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1Ig
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 h1:Om6kYQYDUk5wWbT0t0q6pvyM49i9XZAv9dDrkDA7gjk=
 github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
+github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
@@ -521,6 +524,7 @@ github.com/confluentinc/confluent-kafka-go v1.9.2/go.mod h1:ptXNqsuDfYbAE/LBW6pn
 github.com/confluentinc/confluent-kafka-go/v2 v2.2.0 h1:qy+SfqDauR/TX2qH2VuZqA1rcEAqApBYtHpI6rcqM0U=
 github.com/confluentinc/confluent-kafka-go/v2 v2.2.0/go.mod h1:mfGzHbxQ6LRc25qqaLotDHkhdYmeZQ3ctcKNlPUjDW4=
 github.com/containerd/aufs v1.0.0 h1:2oeJiwX5HstO7shSrPZjrohJZLzK36wvpdmzDRkL/LY=
+github.com/containerd/aufs v1.0.0/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=
 github.com/containerd/btrfs v1.0.0 h1:osn1exbzdub9L5SouXO5swW4ea/xVdJZ3wokxN5GrnA=
 github.com/containerd/btrfs/v2 v2.0.0 h1:FN4wsx7KQrYoLXN7uLP0vBV4oVWHOIKDRQ1G2Z0oL5M=
 github.com/containerd/btrfs/v2 v2.0.0/go.mod h1:swkD/7j9HApWpzl8OHfrHNxppPd9l44DFZdF94BUj9k=
@@ -543,6 +547,7 @@ github.com/containerd/containerd/api v1.8.0/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87
 github.com/containerd/continuity v0.1.0 h1:UFRRY5JemiAhPZrr/uE0n8fMTLcZsUvySPr1+D7pgr8=
 github.com/containerd/continuity v0.4.4 h1:/fNVfTJ7wIl/YPMHjf+5H32uFhl63JucB34PlCpMKII=
 github.com/containerd/continuity v0.4.4/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
+github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
@@ -550,6 +555,7 @@ github.com/containerd/go-cni v1.0.2 h1:YbJAhpTevL2v6u8JC1NhCYRwf+3Vzxcc5vGnYoJ7V
 github.com/containerd/go-cni v1.1.9 h1:ORi7P1dYzCwVM6XPN4n3CbkuOx/NZ2DOqy+SHRdo9rU=
 github.com/containerd/go-cni v1.1.9/go.mod h1:XYrZJ1d5W6E2VOvjffL3IZq0Dz6bsVlERHbekNK90PM=
 github.com/containerd/go-runc v1.0.0 h1:oU+lLv1ULm5taqgV/CJivypVODI4SUz1znWjv3nNYS0=
+github.com/containerd/go-runc v1.0.0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
 github.com/containerd/imgcrypt v1.1.1 h1:LBwiTfoUsdiEGAR1TpvxE+Gzt7469oVu87iR3mv3Byc=
 github.com/containerd/imgcrypt v1.1.8 h1:ZS7TuywcRNLoHpU0g+v4/PsKynl6TYlw5xDVWWoIyFA=
 github.com/containerd/imgcrypt v1.1.8/go.mod h1:x6QvFIkMyO2qGIY2zXc88ivEzcbgvLdWjoZyGqDap5U=
@@ -565,6 +571,7 @@ github.com/containerd/ttrpc v1.2.5/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQ
 github.com/containerd/ttrpc v1.2.7 h1:qIrroQvuOL9HQ1X6KHe2ohc7p+HP/0VE6XPU7elJRqQ=
 github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
+github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=
 github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/containerd/zfs v1.0.0 h1:cXLJbx+4Jj7rNsTiqVfm6i+RNLx6FFA2fMmDlEf+Wm8=
@@ -594,6 +601,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
+github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
@@ -607,6 +615,7 @@ github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuA
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
 github.com/danieljoos/wincred v1.2.1 h1:dl9cBrupW8+r5250DYkYxocLeZ1Y4vB1kxgtjxw8GQs=
 github.com/danieljoos/wincred v1.2.1/go.mod h1:uGaFL9fDn3OLTvzCGulzE+SzjEe5NGlh5FdCcyfPwps=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/daviddengcn/go-colortext v1.0.0 h1:ANqDyC0ys6qCSvuEK7l3g5RaehL/Xck9EX8ATG8oKsE=
 github.com/daviddengcn/go-colortext v1.0.0/go.mod h1:zDqEI5NVUop5QPpVJUxE9UO10hRnmkD5G4Pmri9+m4c=
 github.com/deckarep/golang-set/v2 v2.5.0 h1:hn6cEZtQ0h3J8kFrHR/NrzyOoTnjgW1+FmNJzQ7y/sA=
@@ -632,6 +641,7 @@ github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaft
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arXfYcAtECDFgAgHklGI8CxgjHnXKJ4=
@@ -666,12 +676,14 @@ github.com/envoyproxy/go-control-plane v0.13.4/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHl
 github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4/go.mod h1:Gzjc5k8JcJswLjAx1Zm+wSYE20UrLtt7JZMWiWQXQEw=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v1.1.0 h1:tntQDh69XqOCOZsDz0lVJQez/2L6Uu2PdjCQwWCJ3bM=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
 github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
+github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
@@ -709,6 +721,7 @@ github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQr
 github.com/go-jose/go-jose/v4 v4.0.4 h1:VsjPI33J0SB9vQM6PLmNjoHqMQNGPiZ0rHL7Ni7Q6/E=
 github.com/go-jose/go-jose/v4 v4.0.4/go.mod h1:NKb5HO1EZccyMpiZNbdUw/14tiXNyUJh188dfnMCAfc=
 github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
@@ -982,6 +995,7 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0 h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
@@ -994,6 +1008,7 @@ github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZY
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
@@ -1065,7 +1080,11 @@ github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWe
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f h1:2+myh5ml7lgEU/51gbeLHfKGNfgEQQIWrlbdaOsidbQ=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
+github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
+github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/moby/api v1.54.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
+github.com/moby/moby/client v0.3.0/go.mod h1:HJgFbJRvogDQjbM8fqc1MCEm4mIAGMLjXbgwoZp6jCQ=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mountinfo v0.4.1 h1:1O+1cHA1aujwEwwVMa2Xm2l+gIpUHyd3+D+d7LZh1kM=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
@@ -1101,6 +1120,7 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
+github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0/go.mod h1:F/7q8/HZz+TXjlsoZQQKVYvXTZaFH4QRa3y+j1p7MS0=
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
@@ -1253,6 +1273,7 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tchap/go-patricia v2.2.6+incompatible h1:JvoDL7JSoIP2HDE8AbDH3zC8QBPxmzYe32HHy5yQ+Ck=
@@ -1391,6 +1412,7 @@ go.etcd.io/raft/v3 v3.6.0/go.mod h1:nLvLevg6+xrVtHUmVaTcTz603gQPHfh7kUAwV6YpfGo=
 go.mongodb.org/mongo-driver v1.12.1 h1:nLkghSU8fQNaK7oUmDhQFsnrtcoNy7Z6LVFKsEecqgE=
 go.mongodb.org/mongo-driver v1.12.1/go.mod h1:/rGBTebI3XYboVmgz+Wv3Bcbl3aD0QF9zl6kDDw18rQ=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
+go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
@@ -1407,6 +1429,7 @@ go.opentelemetry.io/contrib/detectors/gcp v1.31.0/go.mod h1:tzQL6E1l+iV44YFTkcAe
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0 h1:JRxssobiPg23otYU5SbWtQC//snGVIM3Tx6QRzlQBao=
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
 go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
+go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1/go.mod h1:4UoMYEZOC0yN/sPGH76KPkkU7zgiEWYWL9vwmbnTJPE=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0/go.mod h1:Mjt1i1INqiaoZOMGR1RIUJN+i3ChKoFRqzrRQhlkbs0=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0/go.mod h1:BMsdeOxN04K0L5FNUBfjFdvwWGNe/rkmSwH4Aelu/X0=
@@ -1618,6 +1641,7 @@ golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc h1:bH6xUXay0AIFMElXG2r
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
+golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1055,7 +1055,6 @@ github.com/mistifyio/go-zfs/v3 v3.0.1/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkO
 github.com/mitchellh/cli v1.1.5 h1:OxRIeJXpAMztws/XHlN2vu6imG5Dpq+j61AzAX5fLng=
 github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
@@ -1192,6 +1191,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
 github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
@@ -1671,9 +1672,7 @@ golang.org/x/tools v0.37.0/go.mod h1:MBN5QPQtLMHVdvsbtarmTNukZDdgwdwlO5qGacAzF0w
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
-golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
-golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/plot v0.15.2/go.mod h1:DX+x+DWso3LTha+AdkJEv5Txvi+Tql3KAGkehP0/Ubg=
 google.golang.org/api v0.152.0/go.mod h1:3qNJX5eOmhiWYc67jRA/3GsDw97UFb5ivv7Y2PrriAY=

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -31,7 +31,7 @@ var (
 
 const (
 	defaultCmdOutputMaxSize = 1024 * 1024
-	defaultCmdTimeout       = 5 * time.Second
+	defaultCmdTimeout       = 30 * time.Second
 
 	// PayloadVersion represents the version of the SB API
 	PayloadVersion = "1.0"

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -25,6 +25,8 @@ import (
 var (
 	secretBackendCommand = ""
 	secretBackendArgs    = []string{}
+	secretBackendType    = ""
+	secretBackendConfig  = map[string]any{}
 )
 
 const (
@@ -33,6 +35,12 @@ const (
 
 	// PayloadVersion represents the version of the SB API
 	PayloadVersion = "1.0"
+	// sgcPayloadVersion is the API version sent when resolving via the embedded secret-generic-connector,
+	// whose payload additionally carries the backend "type" and "config".
+	sgcPayloadVersion = "1.1"
+
+	// defaultSGCBinaryPath is the embedded secret-generic-connector binary shipped in the operator image.
+	defaultSGCBinaryPath = "/opt/datadog-agent/bin/secret-generic-connector"
 )
 
 // SetSecretBackendCommand set the secretBackendCommand var
@@ -45,11 +53,32 @@ func SetSecretBackendArgs(args []string) {
 	secretBackendArgs = args
 }
 
+// SetSecretBackendType sets the secret backend type used by the embedded
+// secret-generic-connector (e.g. "hashicorp.vault"). When set with an empty
+// secret backend command, secrets are resolved via the embedded SGC binary.
+func SetSecretBackendType(backendType string) {
+	secretBackendType = backendType
+}
+
+// SetSecretBackendConfig sets the secret backend config passed to the
+// secret-generic-connector in the resolution payload.
+func SetSecretBackendConfig(config map[string]any) {
+	secretBackendConfig = config
+}
+
 // NewSecretBackend returns a new SecretBackend instance
 func NewSecretBackend() *SecretBackend {
+	cmd := secretBackendCommand
+	// When a backend type is set without an explicit command, resolve secrets
+	// through the embedded secret-generic-connector binary.
+	if cmd == "" && secretBackendType != "" {
+		cmd = defaultSGCBinaryPath
+	}
 	return &SecretBackend{
-		cmd:              secretBackendCommand,
+		cmd:              cmd,
 		cmdArgs:          secretBackendArgs,
+		backendType:      secretBackendType,
+		backendConfig:    secretBackendConfig,
 		cmdOutputMaxSize: defaultCmdOutputMaxSize,
 		cmdTimeout:       defaultCmdTimeout,
 	}
@@ -64,6 +93,23 @@ func (sb *SecretBackend) Decrypt(encrypted []string) (map[string]string, error) 
 	return sb.fetchSecret(encrypted)
 }
 
+// buildPayload assembles the JSON payload sent to the secret backend binary.
+func (sb *SecretBackend) buildPayload(handles []string) map[string]any {
+	if sb.backendType != "" {
+		return map[string]any{
+			"version":                sgcPayloadVersion,
+			"secrets":                handles,
+			"type":                   sb.backendType,
+			"config":                 sb.backendConfig,
+			"secret_backend_timeout": sb.cmdTimeout.Seconds(),
+		}
+	}
+	return map[string]any{
+		"version": PayloadVersion,
+		"secrets": handles,
+	}
+}
+
 // fetchSecret tries to get secrets by executing the secret backend command
 func (sb *SecretBackend) fetchSecret(encrypted []string) (map[string]string, error) {
 	handles, err := extractHandles(encrypted)
@@ -71,12 +117,7 @@ func (sb *SecretBackend) fetchSecret(encrypted []string) (map[string]string, err
 		return nil, NewDecryptorError(err, false)
 	}
 
-	payload := map[string]any{
-		"version": PayloadVersion,
-		"secrets": handles,
-	}
-
-	jsonPayload, err := json.Marshal(payload)
+	jsonPayload, err := json.Marshal(sb.buildPayload(handles))
 	if err != nil {
 		return nil, NewDecryptorError(err, false)
 	}

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -40,7 +40,7 @@ const (
 	sgcPayloadVersion = "1.1"
 
 	// defaultSGCBinaryPath is the embedded secret-generic-connector binary shipped in the operator image.
-	defaultSGCBinaryPath = "/opt/datadog-agent/bin/secret-generic-connector"
+	defaultSGCBinaryPath = "/usr/local/bin/secret-generic-connector"
 )
 
 // SetSecretBackendCommand set the secretBackendCommand var
@@ -69,16 +69,25 @@ func SetSecretBackendConfig(config map[string]any) {
 // NewSecretBackend returns a new SecretBackend instance
 func NewSecretBackend() *SecretBackend {
 	cmd := secretBackendCommand
-	// When a backend type is set without an explicit command, resolve secrets
-	// through the embedded secret-generic-connector binary.
-	if cmd == "" && secretBackendType != "" {
+	cmdArgs := secretBackendArgs
+	backendType := secretBackendType
+	backendConfig := secretBackendConfig
+
+	if cmd != "" {
+		// An explicit command uses the legacy secret-backend protocol.
+		backendType = ""
+		backendConfig = nil
+	} else if backendType != "" {
+		// A backend type without a command uses the embedded SGC binary.
 		cmd = defaultSGCBinaryPath
+		cmdArgs = nil
 	}
+
 	return &SecretBackend{
 		cmd:              cmd,
-		cmdArgs:          secretBackendArgs,
-		backendType:      secretBackendType,
-		backendConfig:    secretBackendConfig,
+		cmdArgs:          cmdArgs,
+		backendType:      backendType,
+		backendConfig:    backendConfig,
 		cmdOutputMaxSize: defaultCmdOutputMaxSize,
 		cmdTimeout:       defaultCmdTimeout,
 	}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -8,6 +8,7 @@ package secrets
 import (
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestSecretBackend_execCommand(t *testing.T) {
@@ -120,6 +121,62 @@ func TestSecretBackend_Decrypt(t *testing.T) {
 				t.Errorf("SecretBackend.Decrypt() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSecretBackend_buildPayload(t *testing.T) {
+	handles := []string{"api_key", "app_key"}
+
+	// Classic command path: only version + secrets, no SGC fields.
+	legacy := (&SecretBackend{}).buildPayload(handles)
+	if legacy["version"] != PayloadVersion {
+		t.Errorf("legacy version = %v, want %v", legacy["version"], PayloadVersion)
+	}
+	for _, k := range []string{"type", "config", "secret_backend_timeout"} {
+		if _, ok := legacy[k]; ok {
+			t.Errorf("legacy payload must not include %q", k)
+		}
+	}
+
+	// SGC path: version 1.1 plus type, config and timeout.
+	sb := &SecretBackend{
+		backendType:   "hashicorp.vault",
+		backendConfig: map[string]any{"vault_session": map[string]any{"vault_auth_type": "kubernetes"}},
+		cmdTimeout:    30 * time.Second,
+	}
+	sgc := sb.buildPayload(handles)
+	if sgc["version"] != sgcPayloadVersion {
+		t.Errorf("sgc version = %v, want %v", sgc["version"], sgcPayloadVersion)
+	}
+	if sgc["type"] != "hashicorp.vault" {
+		t.Errorf("sgc type = %v, want hashicorp.vault", sgc["type"])
+	}
+	if sgc["secret_backend_timeout"] != float64(30) {
+		t.Errorf("sgc secret_backend_timeout = %v, want 30", sgc["secret_backend_timeout"])
+	}
+	if !reflect.DeepEqual(sgc["config"], sb.backendConfig) {
+		t.Errorf("sgc config = %v, want %v", sgc["config"], sb.backendConfig)
+	}
+}
+
+func TestNewSecretBackend_embeddedSGC(t *testing.T) {
+	defer func() {
+		secretBackendCommand = ""
+		secretBackendType = ""
+		secretBackendConfig = map[string]any{}
+	}()
+
+	// Backend type set without an explicit command -> use the embedded SGC binary.
+	secretBackendCommand = ""
+	secretBackendType = "hashicorp.vault"
+	if sb := NewSecretBackend(); sb.cmd != defaultSGCBinaryPath {
+		t.Errorf("cmd = %q, want embedded SGC path %q", sb.cmd, defaultSGCBinaryPath)
+	}
+
+	// An explicit command always wins over the embedded default.
+	secretBackendCommand = "/custom/secret-backend"
+	if sb := NewSecretBackend(); sb.cmd != "/custom/secret-backend" {
+		t.Errorf("cmd = %q, want /custom/secret-backend", sb.cmd)
 	}
 }
 

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -169,8 +169,14 @@ func TestNewSecretBackend_embeddedSGC(t *testing.T) {
 	// Backend type set without an explicit command -> use the embedded SGC binary.
 	secretBackendCommand = ""
 	secretBackendType = "hashicorp.vault"
-	if sb := NewSecretBackend(); sb.cmd != defaultSGCBinaryPath {
+	sb := NewSecretBackend()
+	if sb.cmd != defaultSGCBinaryPath {
 		t.Errorf("cmd = %q, want embedded SGC path %q", sb.cmd, defaultSGCBinaryPath)
+	}
+	// The timeout is sent to SGC as secret_backend_timeout, so it must not be shorter
+	// than SGC's own 30s default
+	if sb.cmdTimeout < 30*time.Second {
+		t.Errorf("cmdTimeout = %v, want >= 30s for SGC operations", sb.cmdTimeout)
 	}
 
 	// An explicit command always wins over the embedded default.

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -161,17 +161,23 @@ func TestSecretBackend_buildPayload(t *testing.T) {
 
 func TestNewSecretBackend_embeddedSGC(t *testing.T) {
 	defer func() {
-		secretBackendCommand = ""
-		secretBackendType = ""
-		secretBackendConfig = map[string]any{}
+		SetSecretBackendCommand("")
+		SetSecretBackendArgs([]string{})
+		SetSecretBackendType("")
+		SetSecretBackendConfig(map[string]any{})
 	}()
 
 	// Backend type set without an explicit command -> use the embedded SGC binary.
-	secretBackendCommand = ""
-	secretBackendType = "hashicorp.vault"
+	SetSecretBackendCommand("")
+	SetSecretBackendArgs([]string{"--legacy-arg"})
+	SetSecretBackendType("hashicorp.vault")
+	SetSecretBackendConfig(map[string]any{"vault_session": map[string]any{"vault_auth_type": "kubernetes"}})
 	sb := NewSecretBackend()
 	if sb.cmd != defaultSGCBinaryPath {
 		t.Errorf("cmd = %q, want embedded SGC path %q", sb.cmd, defaultSGCBinaryPath)
+	}
+	if len(sb.cmdArgs) != 0 {
+		t.Errorf("embedded SGC args = %v, want none", sb.cmdArgs)
 	}
 	// The timeout is sent to SGC as secret_backend_timeout, so it must not be shorter
 	// than SGC's own 30s default
@@ -180,9 +186,21 @@ func TestNewSecretBackend_embeddedSGC(t *testing.T) {
 	}
 
 	// An explicit command always wins over the embedded default.
-	secretBackendCommand = "/custom/secret-backend"
-	if sb := NewSecretBackend(); sb.cmd != "/custom/secret-backend" {
+	SetSecretBackendCommand("/custom/secret-backend")
+	sb = NewSecretBackend()
+	if sb.cmd != "/custom/secret-backend" {
 		t.Errorf("cmd = %q, want /custom/secret-backend", sb.cmd)
+	}
+	if !reflect.DeepEqual(sb.cmdArgs, secretBackendArgs) {
+		t.Errorf("explicit command args = %v, want %v", sb.cmdArgs, secretBackendArgs)
+	}
+	if sb.backendType != "" || sb.backendConfig != nil {
+		t.Errorf("explicit command must use the legacy payload; got type %q and config %v", sb.backendType, sb.backendConfig)
+	}
+	for _, key := range []string{"type", "config", "secret_backend_timeout"} {
+		if _, found := sb.buildPayload([]string{"api_key"})[key]; found {
+			t.Errorf("explicit command payload must not include %q", key)
+		}
 	}
 }
 

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -63,6 +63,8 @@ type Decryptor interface {
 type SecretBackend struct {
 	cmd              string
 	cmdArgs          []string
+	backendType      string
+	backendConfig    map[string]any
 	cmdOutputMaxSize int
 	cmdTimeout       time.Duration
 }


### PR DESCRIPTION
### What does this PR do?

Adds native SGC support for resolving the Operator's own `ENC[...]` credentials. When `-secretBackendType` is set without `-secretBackendCommand`, the Operator invokes `/usr/local/bin/secret-generic-connector` using the SGC v1.1 payload, including the backend type, nested configuration, and a 30-second timeout.

The public Operator image includes the normal or FIPS SGC binary selected by `FIPS_ENABLED`. Both flavors currently use SGC `7.84.0-rc.2` through the `SGC_VERSION` build argument.

The existing command-based secret backend remains unchanged and takes precedence when configured.

### Motivation

This allows the Operator to use the same out-of-the-box secret management implementation as the Agent, so deployments can replace `datadog-vault-secrets` after rollout validation.

### Additional Notes

Documentation for the operator will have to be updated

The internal GBI wrapper image preserves the bundled SGC binary in https://github.com/DataDog/images/pull/11615. Enabling SGC in deployment values is handled separately.

### Minimum Agent Versions

None. This change resolves the Operator's own credentials and does not depend on an Agent or Cluster Agent version.

### Describe your test plan

```shell
go test -count=1 ./pkg/secrets ./cmd
make managergobuild
make lint
```

<details>
<summary>Local Operator + SGC + Vault end-to-end validation</summary>

#### 1. Build the Operator with SGC

From the `datadog-operator` PR branch:

```shell
export ARCH="$(go env GOARCH)"

docker build \
  --build-arg FIPS_ENABLED=false \
  --build-arg GOARCH="$ARCH" \
  -t local/datadog-operator:sgc-e2e \
  .

docker run --rm \
  --entrypoint /usr/local/bin/secret-generic-connector \
  local/datadog-operator:sgc-e2e \
  --version
```

Expected:

```text
secret-generic-connector 7.84.0-rc.2
```

#### 2. Create a kind cluster and install Vault

```shell
export KUBECONFIG=/tmp/sgc-operator-e2e.kubeconfig

kind create cluster \
  --name sgc-operator-e2e \
  --kubeconfig "$KUBECONFIG"

kind load docker-image \
  --name sgc-operator-e2e \
  local/datadog-operator:sgc-e2e

kubectl create namespace datadog-agent

# Required by the internal Operator chart's node affinity.
kubectl label node sgc-operator-e2e-control-plane \
  node-role.kubernetes.io/nodeless=true \
  --overwrite

helm repo add hashicorp https://helm.releases.hashicorp.com --force-update
helm repo update hashicorp

helm upgrade --install vault hashicorp/vault \
  --namespace vault \
  --create-namespace \
  --set server.dev.enabled=true \
  --set server.dev.devRootToken=root \
  --set injector.enabled=false \
  --wait \
  --timeout 180s

kubectl -n vault wait \
  --for=condition=Ready pod/vault-0 \
  --timeout=120s

kubectl -n vault exec vault-0 -- vault status
```

#### 3. Configure Vault Kubernetes authentication

```shell
kubectl create clusterrolebinding vault-tokenreview-binding \
  --clusterrole=system:auth-delegator \
  --serviceaccount=vault:vault

kubectl -n vault exec vault-0 -- vault auth enable kubernetes

kubectl -n vault exec vault-0 -- sh -ec '
vault write auth/kubernetes/config \
  kubernetes_host=https://kubernetes.default.svc:443 \
  token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
  kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
'

kubectl -n vault exec vault-0 -- \
  vault secrets enable -path=applications kv-v2
```

Create the policy and role:

```shell
kubectl -n vault exec -i vault-0 -- \
  vault policy write datadog-operator /dev/stdin <<'EOF'
path "applications/data/datadog-operator/*" {
  capabilities = ["read"]
}
EOF

kubectl -n vault exec vault-0 -- \
  vault write auth/kubernetes/role/datadog-operator \
  bound_service_account_names=datadog-operator \
  bound_service_account_namespaces=datadog-agent \
  policies=datadog-operator \
  ttl=1h
```

Add dummy credentials and enable audit logging:

```shell
kubectl -n vault exec vault-0 -- \
  vault kv put applications/datadog-operator/api \
  value=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

kubectl -n vault exec vault-0 -- \
  vault kv put applications/datadog-operator/app \
  value=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

kubectl -n vault exec vault-0 -- \
  vault audit enable file file_path=/tmp/audit.log
```

#### 4. Deploy the Operator

Set the path to a `k8s-datadog-agent-ops` checkout:

```shell
export OPS_REPO=/path/to/k8s-datadog-agent-ops
export ARM_ENABLED=false

if [ "$(go env GOARCH)" = "arm64" ]; then
  export ARM_ENABLED=true
fi
```

Create the Helm values:

```shell
cat >/tmp/operator-sgc-values.yaml <<EOF
global:
  docker:
    registry: local
  cni:
    cilium:
      enabled: false
  datacenter:
    arm_enabled: ${ARM_ENABLED}

replicaCount: 1

image:
  name: datadog-operator
  tag: sgc-e2e
  pullPolicy: Never
  useFips: false

apiKey: "ENC[vault://applications/data/datadog-operator/api#/data/value]"
appKey: "ENC[vault://applications/data/datadog-operator/app#/data/value]"

supportExtendedDaemonset: false
enableDatadogMonitor: false
enableDatadogSLO: false
enableIntrospection: false
enableDatadogDashboard: false
enableDatadogAgentProfile: false
enableDatadogAgentInternal: false
dpa:
  enabled: false
EOF
```

Install the chart:

```shell
helm upgrade --install datadog-operator \
  "$OPS_REPO/charts/datadog-operator" \
  --namespace datadog-agent \
  -f /tmp/operator-sgc-values.yaml \
  --no-hooks
```

The chart wiring is handled separately, so patch the Deployment with the new SGC flags:

```shell
cat >/tmp/operator-sgc-patch.yaml <<'EOF'
spec:
  template:
    spec:
      containers:
        - name: datadog-operator
          args:
            - -secretBackendCommand=
            - -secretBackendType=hashicorp.vault
            - '-secretBackendConfig={"vault_session":{"vault_auth_type":"kubernetes"}}'
            - -secretRefreshInterval=5s
            - -datadogMonitorEnabled=false
            - -datadogSLOEnabled=false
            - -introspectionEnabled=false
            - -operatorMetricsEnabled=false
            - -logEncoder=json
            - -metrics-addr=:8383
            - -loglevel=debug
          env:
            - name: VAULT_ADDR
              value: http://vault.vault.svc:8200
            - name: DD_SECRETS_VAULT_AUTH_PATH
              value: auth/kubernetes/login
            - name: DD_SECRETS_VAULT_ROLE
              value: datadog-operator
            - name: DD_SECRETS_SA_TOKEN_PATH
              value: /var/run/secrets/kubernetes.io/serviceaccount/token
EOF

kubectl -n datadog-agent patch deployment datadog-operator \
  --type=strategic \
  --patch-file=/tmp/operator-sgc-patch.yaml

kubectl -n datadog-agent rollout status \
  deployment/datadog-operator \
  --timeout=180s
```

#### 5. Verify secret retrieval

```shell
export POD="$(
  kubectl -n datadog-agent get pod \
    -l app.kubernetes.io/name=datadog-operator \
    --field-selector=status.phase=Running \
    -o jsonpath='{.items[0].metadata.name}'
)"

kubectl -n datadog-agent exec "$POD" -- \
  /usr/local/bin/secret-generic-connector --version

kubectl -n datadog-agent logs "$POD" | \
  grep -E 'Unable to get credentials|Failed to refresh credentials|unsupported backend|failed to provide a vault address' || true
```

No decryption errors should be returned.

Confirm Vault received the authentication and secret-read requests:

```shell
kubectl -n vault exec vault-0 -- \
  cat /tmp/audit.log >/tmp/vault-audit.log

jq -r '
  select(.type == "request") |
  [.request.operation, .request.path] |
  @tsv
' /tmp/vault-audit.log | sort | uniq -c
```

Expected paths:

```text
update auth/kubernetes/login
read applications/data/datadog-operator/api
read applications/data/datadog-operator/app
```

#### 6. Verify secret rotation

```shell
export ROTATION_START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

kubectl -n vault exec vault-0 -- \
  vault kv put applications/datadog-operator/api \
  value=cccccccccccccccccccccccccccccccc

kubectl -n vault exec vault-0 -- \
  vault kv put applications/datadog-operator/app \
  value=dddddddddddddddddddddddddddddddddddddddd

sleep 10

kubectl -n datadog-agent logs "$POD" \
  --since-time="$ROTATION_START" | \
  grep 'Credentials have changed, cache updated'
```

Expected:

```text
Credentials have changed, cache updated
```

This validates that the Operator retrieves and refreshes its own `ENC[vault://...]` credentials through SGC using Vault Kubernetes authentication.

</details>

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
