### PR TITLE
Update default Agent/ClusterAgent/DdotCollector image version to 7.80.4

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.80.2"
+	AgentLatestVersion = "7.81.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.80.2"
+	ClusterAgentLatestVersion = "7.81.0"
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
-	DdotCollectorLatestVersion = "7.80.2"
+	DdotCollectorLatestVersion = "7.81.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.28"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.81.0"
+	AgentLatestVersion = "7.80.4"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.81.0"
+	ClusterAgentLatestVersion = "7.80.4"
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
-	DdotCollectorLatestVersion = "7.81.0"
+	DdotCollectorLatestVersion = "7.80.4"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.28"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.


### PR DESCRIPTION
## What does this PR do?

Bumps the default Agent, ClusterAgent, and DdotCollector image versions from `7.80.2` to `7.80.4` (latest confirmed stable) in preparation for the `v1.29.0` RC1 release.

Plan to bump to `7.81.0` in RC2 once it's confirmed stable.

## Checklist
- [x] `pkg/images/images.go` — `AgentLatestVersion`, `ClusterAgentLatestVersion`, `DdotCollectorLatestVersion` updated to `7.80.4`