### PR TITLE
Require gsed on MacOS and update go.work version in script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,11 +365,11 @@ verify-licenses: bin/$(PLATFORM)/go-licenses ## Verify licenses
 	hack/verify-licenses.sh
 
 # Update the golang version across the repo.
-# Pass VERSION=x.y.z to also update go.work first.
-# Usage: make update-golang VERSION=1.25.12
+# Pass GOVERSION=x.y.z to also update go.work first.
+# Usage: make update-golang GOVERSION=1.25.12
 .PHONY: update-golang
 update-golang: bin/$(PLATFORM)/jq bin/$(PLATFORM)/yq ensure-gsed
-	hack/update-golang.sh $(VERSION)
+	hack/update-golang.sh $(GOVERSION)
 
 .PHONY: sync
 sync: ## Run go work sync

--- a/Makefile
+++ b/Makefile
@@ -312,8 +312,15 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 ##@ Datadog Custom part
+
+.PHONY: ensure-gsed
+ensure-gsed: ## Install GNU sed on macOS if not present (no-op on Linux)
+	@if [ "$$(uname -s)" = "Darwin" ]; then \
+		command -v gsed >/dev/null 2>&1 || brew install gnu-sed; \
+	fi
+
 .PHONY: install-tools
-install-tools: bin/$(PLATFORM)/golangci-lint bin/$(PLATFORM)/operator-sdk bin/$(PLATFORM)/yq bin/$(PLATFORM)/jq bin/$(PLATFORM)/kubebuilder bin/$(PLATFORM)/controller-tools bin/$(PLATFORM)/go-licenses bin/$(PLATFORM)/openapi-gen
+install-tools: bin/$(PLATFORM)/golangci-lint bin/$(PLATFORM)/operator-sdk bin/$(PLATFORM)/yq bin/$(PLATFORM)/jq bin/$(PLATFORM)/kubebuilder bin/$(PLATFORM)/controller-tools bin/$(PLATFORM)/go-licenses bin/$(PLATFORM)/openapi-gen ensure-gsed
 
 .PHONY: generate-openapi
 generate-openapi: bin/$(PLATFORM)/openapi-gen
@@ -357,10 +364,12 @@ licenses: bin/$(PLATFORM)/go-licenses
 verify-licenses: bin/$(PLATFORM)/go-licenses ## Verify licenses
 	hack/verify-licenses.sh
 
-# Update the golang version in different repository files from the version present in go.mod file
+# Update the golang version across the repo.
+# Pass VERSION=x.y.z to also update go.work first.
+# Usage: make update-golang VERSION=1.25.12
 .PHONY: update-golang
-update-golang:
-	hack/update-golang.sh
+update-golang: bin/$(PLATFORM)/jq bin/$(PLATFORM)/yq ensure-gsed
+	hack/update-golang.sh $(VERSION)
 
 .PHONY: sync
 sync: ## Run go work sync

--- a/hack/update-golang.sh
+++ b/hack/update-golang.sh
@@ -32,6 +32,13 @@ if [[ ! -x "$YQ" ]]; then
     exit 1
 fi
 
+# If a version argument is provided, update go.work first
+# This will trigger the command to actually update the Go version.
+if [[ -n "${1:-}" ]]; then
+    echo "Updating go.work to Go $1..."
+    go work edit -go "$1" -toolchain "go$1"
+fi
+
 # Get Go version from go.work and parse it
 GOVERSION=$(go work edit --json | $JQ -r .Go)
 IFS='.' read -r major minor revision <<< "$GOVERSION"


### PR DESCRIPTION
### What does this PR do?

go update script accepts the target version to avoid needing to remember to properly run `go work edit -go X.Y.Z -toolchain goX.Y.Z`

include `gsed` as a required installed dependency for MacOS Darwin environments.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits