### PR TITLE
[cleanup] remove release-dashboard-api policy from us1.prod.dog

### DIFF
--- a/.github/chainguard/release-dashboard-api.sts.yaml
+++ b/.github/chainguard/release-dashboard-api.sts.yaml
@@ -1,9 +1,0 @@
-# Issued to: rapid-agent-delivery/release-dashboard-api on us1 prod
-issuer: https://vault.us1.prod.dog/v1/identity/oidc
-
-# ddtool auth whois --datacenter us1.prod.dog rapid-agent-delivery-release-dashboard-api --format json | jq -r .id
-subject: ccd54910-9533-855e-e357-49e2d692b508
-
-permissions:
-  contents: read
-  pull_requests: read


### PR DESCRIPTION
### Motivation
- This api is no longer being used in us1.prod.dog we are conducting a cleanup to remove everything referencing the api in us1.prod.dog