### PR TITLE
(docs) Adjust codeowners for documentation team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,16 @@
 *                       @DataDog/container-platform
 
 # Documentation
-README.md               @DataDog/documentation  @DataDog/container-platform
-/docs/                  @DataDog/documentation  @DataDog/container-platform
-/docs/kubectl-plugin.md @DataDog/documentation  @DataDog/container-platform @DataDog/container-autoscaling
+README.md                                       @DataDog/container-platform
+/docs/                                          @DataDog/container-platform
+/docs/kubectl-plugin.md                         @DataDog/documentation  @DataDog/container-platform @DataDog/container-autoscaling
+/docs/docs/configuration_public.md              @DataDog/documentation  @DataDog/container-platform
+/docs/custom_check.md                           @DataDog/documentation  @DataDog/container-platform
+/docs/data_collected.md                         @DataDog/documentation  @DataDog/container-platform
+/docs/installation.md                           @DataDog/documentation  @DataDog/container-platform
+/docs/kubectl-plugin.md                         @DataDog/documentation  @DataDog/container-platform
+/docs/secret_management.md                      @DataDog/documentation  @DataDog/container-platform
+/docs/v2alpha1_migration.md                     @DataDog/documentation  @DataDog/container-platform
 
 
 # Features owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,11 +9,10 @@
 README.md                                       @DataDog/container-platform
 /docs/                                          @DataDog/container-platform
 /docs/kubectl-plugin.md                         @DataDog/documentation  @DataDog/container-platform @DataDog/container-autoscaling
-/docs/docs/configuration_public.md              @DataDog/documentation  @DataDog/container-platform
+/docs/configuration_public.md              @DataDog/documentation  @DataDog/container-platform
 /docs/custom_check.md                           @DataDog/documentation  @DataDog/container-platform
 /docs/data_collected.md                         @DataDog/documentation  @DataDog/container-platform
 /docs/installation.md                           @DataDog/documentation  @DataDog/container-platform
-/docs/kubectl-plugin.md                         @DataDog/documentation  @DataDog/container-platform
 /docs/secret_management.md                      @DataDog/documentation  @DataDog/container-platform
 /docs/v2alpha1_migration.md                     @DataDog/documentation  @DataDog/container-platform
 


### PR DESCRIPTION
### What does this PR do?

Removed the documentation team from any docs we don't pull into the official documentation website.

### Motivation

The docs team reviews a lot of PRs every day. This will reduce our involvement in this repo to only things we need to check before they're published to the docs site.

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits