### PR TITLE
feat(dashboard): support tabs in DatadogDashboard

### DIFF
--- a/api/datadoghq/v1alpha1/datadogdashboard_types.go
+++ b/api/datadoghq/v1alpha1/datadogdashboard_types.go
@@ -29,6 +29,11 @@ type DatadogDashboardSpec struct {
 	// widgets should not have layouts.
 	// +optional
 	ReflowType *datadogV1.DashboardReflowType `json:"reflowType,omitempty"`
+	// Tabs is a JSON string representation of a list of Datadog API dashboard Tabs
+	// that organize widgets into named sections. Widget references may use the @N
+	// positional format (1-indexed), matching the Datadog dashboard JSON editor.
+	// +optional
+	Tabs string `json:"tabs,omitempty"`
 	// Tags is a list of team names representing ownership of a dashboard.
 	// +listType=set
 	// +optional

--- a/api/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/api/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -939,6 +939,13 @@ func schema_datadog_operator_api_datadoghq_v1alpha1_DatadogDashboardSpec(ref com
 							Format:      "",
 						},
 					},
+					"tabs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Tabs is a JSON string representation of a list of Datadog API dashboard Tabs that organize widgets into named sections. Widget references may use the @N positional format (1-indexed), matching the Datadog dashboard JSON editor.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tags": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{

--- a/config/crd/bases/v1/datadoghq.com_datadogdashboards.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogdashboards.yaml
@@ -72,6 +72,12 @@ spec:
                     If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
                     widgets should not have layouts.
                   type: string
+                tabs:
+                  description: |-
+                    Tabs is a JSON string representation of a list of Datadog API dashboard Tabs
+                    that organize widgets into named sections. Widget references may use the @N
+                    positional format (1-indexed), matching the Datadog dashboard JSON editor.
+                  type: string
                 tags:
                   description: Tags is a list of team names representing ownership of a dashboard.
                   items:

--- a/internal/controller/datadogdashboard/dashboard.go
+++ b/internal/controller/datadogdashboard/dashboard.go
@@ -54,6 +54,18 @@ func buildDashboard(logger logr.Logger, ddb *v1alpha1.DatadogDashboard) *datadog
 		dashboard.SetTemplateVariables(convertTempVars(ddb.Spec.TemplateVariables))
 	}
 
+	if ddb.Spec.Tabs != "" {
+		tabs := []interface{}{}
+		if err := json.Unmarshal([]byte(ddb.Spec.Tabs), &tabs); err != nil {
+			logger.Error(err, "unable to unmarshal dashboard tabs")
+		} else {
+			if dashboard.AdditionalProperties == nil {
+				dashboard.AdditionalProperties = map[string]interface{}{}
+			}
+			dashboard.AdditionalProperties["tabs"] = tabs
+		}
+	}
+
 	return dashboard
 }
 

--- a/internal/controller/datadogdashboard/dashboard_test.go
+++ b/internal/controller/datadogdashboard/dashboard_test.go
@@ -77,6 +77,41 @@ func TestBuildDashboard(t *testing.T) {
 	assert.Nil(t, dashboard.IsReadOnly, "discrepancy found in parameter: IsReadOnly")
 }
 
+func TestBuildDashboardTabs(t *testing.T) {
+	tabs := `[{"name":"Shared","widget_ids":["@1","@2"]},{"name":"Agents","widget_ids":["@3"]}]`
+	db := &v1alpha1.DatadogDashboard{
+		Spec: v1alpha1.DatadogDashboardSpec{
+			LayoutType: "ordered",
+			Title:      "test dashboard",
+			Widgets:    "",
+			Tabs:       tabs,
+		},
+	}
+
+	dashboard := buildDashboard(testLogger, db)
+	assert.Contains(t, dashboard.AdditionalProperties, "tabs", "tabs should be injected into AdditionalProperties")
+
+	marshaled, err := dashboard.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Contains(t, string(marshaled), `"tabs"`, "marshaled dashboard should contain tabs")
+	assert.Contains(t, string(marshaled), `"@1"`, "positional @N widget references must be preserved")
+	assert.Contains(t, string(marshaled), `"Agents"`, "tab names must be preserved")
+}
+
+func TestBuildDashboardNoTabs(t *testing.T) {
+	db := &v1alpha1.DatadogDashboard{
+		Spec: v1alpha1.DatadogDashboardSpec{
+			LayoutType: "ordered",
+			Title:      "test dashboard",
+			Widgets:    "",
+		},
+	}
+
+	dashboard := buildDashboard(testLogger, db)
+	_, ok := dashboard.AdditionalProperties["tabs"]
+	assert.False(t, ok, "tabs must not be set when Spec.Tabs is empty")
+}
+
 func Test_getDashboard(t *testing.T) {
 	dbID := "test_id"
 	expectedDashboard := genericDashboard(dbID)


### PR DESCRIPTION
### What does this PR do?

Adds a `tabs` field to `DatadogDashboardSpec` so operator-managed dashboards can organize
widgets into named tabs (the Datadog dashboard `tabs` feature).

### Motivation

Dashboards managed via the `DatadogDashboard` CRD could set widgets, template variables,
tags, etc., but not tabs. The Datadog dashboard API supports a top-level `tabs` array, and
`datadog-api-client-go` exposes `Dashboard.Tabs`, but the CRD had no way to express it, so
GitOps-managed dashboards silently lost their tabs.

Tabs reference widgets using the `@N` positional format (1-indexed), which the Datadog
backend accepts as a convenience for declarative tools. The strongly-typed
`DashboardTab.WidgetIds` is `[]int64` and cannot represent `@N`, so — consistent with the
existing `Spec.Widgets` design — `Spec.Tabs` is a **raw JSON string**, unmarshaled and
passed through via the dashboard's additional properties. This preserves `@N` references
and requires no client-library bump.

### Additional Notes

- `buildDashboard()` injects tabs only when `Spec.Tabs` is non-empty; unmarshal errors are
  logged and non-fatal (the rest of the dashboard still syncs).
- CRD and openapi manifests regenerated; unit tests cover the tabs and no-tabs paths.
- `go build` / `go vet` / `go test ./internal/controller/datadogdashboard/...` pass.

### Minimum Agent Versions

Not applicable (no Agent/Cluster Agent behavior change).

### Describe your test plan

- `go test ./internal/controller/datadogdashboard/...` — new `TestBuildDashboardTabs`
  asserts tabs are injected and `@N` references + tab names survive marshaling;
  `TestBuildDashboardNoTabs` asserts nothing is set when `Spec.Tabs` is empty.
- Applied a `DatadogDashboard` with a `tabs` JSON string and confirmed the rendered API
  request carries the `tabs` array with `@N` widget references.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed off (DCO)
