### PR TITLE
Fix GKE COS system-probe NVML mount

### DIFF
--- a/internal/controller/datadogagent/feature/gpu/const.go
+++ b/internal/controller/datadogagent/feature/gpu/const.go
@@ -14,9 +14,11 @@ const (
 	// /home/kubernetes/bin/nvidia/lib64 on the host. They are mounted into the
 	// path where the nvidia-container-runtime expects the driver libraries so
 	// that the agent and system-probe can load them.
-	gkeCOSNVIDIADriverLib64VolumeName = "gke-nvidia-driver-lib64"
-	gkeCOSNVIDIADriverLib64HostPath   = "/home/kubernetes/bin/nvidia/lib64"
-	gkeCOSNVIDIADriverLib64MountPath  = "/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
+	gkeCOSNVIDIADriverLib64VolumeName         = "gke-nvidia-driver-lib64"
+	gkeCOSNVIDIADriverLib64HostRootVolumeName = "gke-nvidia-driver-lib64-hostroot"
+	gkeCOSNVIDIADriverLib64HostPath           = "/home/kubernetes/bin/nvidia/lib64"
+	gkeCOSNVIDIADriverLib64MountPath          = "/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
+	gkeCOSNVIDIADriverLib64HostRootMountPath  = "/host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
 
 	// defaultGPURuntimeClass default runtime class for GPU pods
 	defaultGPURuntimeClass = "nvidia"

--- a/internal/controller/datadogagent/feature/gpu/const.go
+++ b/internal/controller/datadogagent/feature/gpu/const.go
@@ -14,11 +14,10 @@ const (
 	// /home/kubernetes/bin/nvidia/lib64 on the host. They are mounted into the
 	// path where the nvidia-container-runtime expects the driver libraries so
 	// that the agent and system-probe can load them.
-	gkeCOSNVIDIADriverLib64VolumeName         = "gke-nvidia-driver-lib64"
-	gkeCOSNVIDIADriverLib64HostRootVolumeName = "gke-nvidia-driver-lib64-hostroot"
-	gkeCOSNVIDIADriverLib64HostPath           = "/home/kubernetes/bin/nvidia/lib64"
-	gkeCOSNVIDIADriverLib64MountPath          = "/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
-	gkeCOSNVIDIADriverLib64HostRootMountPath  = "/host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
+	gkeCOSNVIDIADriverLib64VolumeName        = "gke-nvidia-driver-lib64"
+	gkeCOSNVIDIADriverLib64HostPath          = "/home/kubernetes/bin/nvidia/lib64"
+	gkeCOSNVIDIADriverLib64MountPath         = "/host/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
+	gkeCOSNVIDIADriverLib64HostRootMountPath = "/host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu"
 
 	// defaultGPURuntimeClass default runtime class for GPU pods
 	defaultGPURuntimeClass = "nvidia"

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -56,15 +56,29 @@ func (f *gpuFeature) NodeAgentProviderCapabilities() providercaps.ProviderCapabi
 	vol, volMount := volume.GetVolumes(gkeCOSNVIDIADriverLib64VolumeName, gkeCOSNVIDIADriverLib64HostPath, gkeCOSNVIDIADriverLib64MountPath, true)
 	vol.VolumeSource.HostPath.Type = ptr.To(corev1.HostPathDirectoryOrCreate)
 
+	volumeMounts := []providercaps.VolumeAndMount{
+		{
+			Volume:     vol,
+			Mount:      volMount,
+			Containers: containers,
+		},
+	}
+	if f.isPrivilegedModeEnabled {
+		systemProbeHostRootVol := vol
+		systemProbeHostRootVol.Name = gkeCOSNVIDIADriverLib64HostRootVolumeName
+		systemProbeHostRootMount := volMount
+		systemProbeHostRootMount.Name = gkeCOSNVIDIADriverLib64HostRootVolumeName
+		systemProbeHostRootMount.MountPath = gkeCOSNVIDIADriverLib64HostRootMountPath
+		volumeMounts = append(volumeMounts, providercaps.VolumeAndMount{
+			Volume:     systemProbeHostRootVol,
+			Mount:      systemProbeHostRootMount,
+			Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
+		})
+	}
+
 	return providercaps.ProviderCapabilityMap{
 		kubernetes.GKECosProvider: {
-			Volumes: []providercaps.VolumeAndMount{
-				{
-					Volume:     vol,
-					Mount:      volMount,
-					Containers: containers,
-				},
-			},
+			Volumes: volumeMounts,
 		},
 	}
 }

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -158,6 +158,10 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 
 	managers.VolumeMount().AddVolumeMountToContainer(nvidiaDevicesMount, apicommon.SystemProbeContainerName)
 
+	hostRootVol, hostRootMount := volume.GetVolumes(common.HostRootVolumeName, common.HostRootHostPath, common.HostRootMountPath, true)
+	managers.VolumeMount().AddVolumeMountToContainer(&hostRootMount, apicommon.SystemProbeContainerName)
+	managers.Volume().AddVolume(&hostRootVol)
+
 	// socket volume mount (needs write perms for the system probe container but not the others)
 	procdirVol, procdirMount := volume.GetVolumes(common.ProcdirVolumeName, common.ProcdirHostPath, common.ProcdirMountPath, true)
 	managers.VolumeMount().AddVolumeMountToContainer(&procdirMount, apicommon.SystemProbeContainerName)
@@ -185,6 +189,12 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 
 	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, socketEnvVar)
 	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, socketEnvVar)
+
+	hostRootEnvVar := &corev1.EnvVar{
+		Name:  common.DDHostRootEnvVar,
+		Value: common.HostRootMountPath,
+	}
+	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, hostRootEnvVar)
 
 	// Now we need to add the NVIDIA_VISIBLE_DEVICES env var to both agents again so
 	// that the nvidia runtime can expose the GPU devices in the container

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -48,11 +48,6 @@ func (f *gpuFeature) ID() feature.IDType {
 // On GKE COS, the NVIDIA driver libraries are not available at the standard path used
 // by the nvidia-container-runtime; mount them from the host location.
 func (f *gpuFeature) NodeAgentProviderCapabilities() providercaps.ProviderCapabilityMap {
-	containers := []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
-	if f.isPrivilegedModeEnabled {
-		containers = append(containers, apicommon.SystemProbeContainerName)
-	}
-
 	vol, volMount := volume.GetVolumes(gkeCOSNVIDIADriverLib64VolumeName, gkeCOSNVIDIADriverLib64HostPath, gkeCOSNVIDIADriverLib64MountPath, true)
 	vol.VolumeSource.HostPath.Type = ptr.To(corev1.HostPathDirectoryOrCreate)
 
@@ -60,17 +55,14 @@ func (f *gpuFeature) NodeAgentProviderCapabilities() providercaps.ProviderCapabi
 		{
 			Volume:     vol,
 			Mount:      volMount,
-			Containers: containers,
+			Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
 		},
 	}
 	if f.isPrivilegedModeEnabled {
-		systemProbeHostRootVol := vol
-		systemProbeHostRootVol.Name = gkeCOSNVIDIADriverLib64HostRootVolumeName
 		systemProbeHostRootMount := volMount
-		systemProbeHostRootMount.Name = gkeCOSNVIDIADriverLib64HostRootVolumeName
 		systemProbeHostRootMount.MountPath = gkeCOSNVIDIADriverLib64HostRootMountPath
 		volumeMounts = append(volumeMounts, providercaps.VolumeAndMount{
-			Volume:     systemProbeHostRootVol,
+			Volume:     vol,
 			Mount:      systemProbeHostRootMount,
 			Containers: []apicommon.AgentContainerName{apicommon.SystemProbeContainerName},
 		})

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -124,6 +124,11 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				MountPath: nvidiaDevicesMountPath,
 				ReadOnly:  true,
 			},
+			{
+				Name:      common.HostRootVolumeName,
+				MountPath: common.HostRootMountPath,
+				ReadOnly:  true,
+			},
 		}
 
 		coreAgentVolumeMounts := mgr.VolumeMountMgr.VolumeMountsByC[apicommon.CoreAgentContainerName]
@@ -173,6 +178,14 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				},
 			},
 			{
+				Name: common.HostRootVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: common.HostRootHostPath,
+					},
+				},
+			},
+			{
 				Name: common.KubeletPodResourcesVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{Path: podResourcesSocketPath},
@@ -196,6 +209,10 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 			{
 				Name:  NVIDIAVisibleDevicesEnvVar,
 				Value: "all",
+			},
+			{
+				Name:  common.DDHostRootEnvVar,
+				Value: common.HostRootMountPath,
 			},
 		}
 

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -432,9 +432,16 @@ func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
 			},
 		},
 	}
+	wantSystemProbeHostRootVolume := wantVolume
+	wantSystemProbeHostRootVolume.Name = gkeCOSNVIDIADriverLib64HostRootVolumeName
 	wantMount := corev1.VolumeMount{
 		Name:      gkeCOSNVIDIADriverLib64VolumeName,
 		MountPath: gkeCOSNVIDIADriverLib64MountPath,
+		ReadOnly:  true,
+	}
+	wantSystemProbeHostRootMount := corev1.VolumeMount{
+		Name:      gkeCOSNVIDIADriverLib64HostRootVolumeName,
+		MountPath: gkeCOSNVIDIADriverLib64HostRootMountPath,
 		ReadOnly:  true,
 	}
 
@@ -467,8 +474,10 @@ func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
 		providercaps.ApplyProviderCapabilities(mgr, kubernetes.GKECosProvider, f.NodeAgentProviderCapabilities())
 
 		assert.Contains(t, tmpl.Spec.Volumes, wantVolume)
+		assert.Contains(t, tmpl.Spec.Volumes, wantSystemProbeHostRootVolume)
 		assert.Contains(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts, wantMount)
 		assert.Contains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantMount)
+		assert.Contains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantSystemProbeHostRootMount)
 	})
 
 	t.Run("gke-cos non-privileged mounts into core agent only", func(t *testing.T) {
@@ -479,8 +488,10 @@ func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
 		providercaps.ApplyProviderCapabilities(mgr, kubernetes.GKECosProvider, f.NodeAgentProviderCapabilities())
 
 		assert.Contains(t, tmpl.Spec.Volumes, wantVolume)
+		assert.NotContains(t, tmpl.Spec.Volumes, wantSystemProbeHostRootVolume)
 		assert.Contains(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts, wantMount)
 		assert.NotContains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantMount)
+		assert.NotContains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantSystemProbeHostRootMount)
 	})
 
 	t.Run("non-gke-cos provider adds nothing", func(t *testing.T) {

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -432,15 +432,13 @@ func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
 			},
 		},
 	}
-	wantSystemProbeHostRootVolume := wantVolume
-	wantSystemProbeHostRootVolume.Name = gkeCOSNVIDIADriverLib64HostRootVolumeName
 	wantMount := corev1.VolumeMount{
 		Name:      gkeCOSNVIDIADriverLib64VolumeName,
 		MountPath: gkeCOSNVIDIADriverLib64MountPath,
 		ReadOnly:  true,
 	}
 	wantSystemProbeHostRootMount := corev1.VolumeMount{
-		Name:      gkeCOSNVIDIADriverLib64HostRootVolumeName,
+		Name:      gkeCOSNVIDIADriverLib64VolumeName,
 		MountPath: gkeCOSNVIDIADriverLib64HostRootMountPath,
 		ReadOnly:  true,
 	}
@@ -474,9 +472,8 @@ func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
 		providercaps.ApplyProviderCapabilities(mgr, kubernetes.GKECosProvider, f.NodeAgentProviderCapabilities())
 
 		assert.Contains(t, tmpl.Spec.Volumes, wantVolume)
-		assert.Contains(t, tmpl.Spec.Volumes, wantSystemProbeHostRootVolume)
 		assert.Contains(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts, wantMount)
-		assert.Contains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantMount)
+		assert.NotContains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantMount)
 		assert.Contains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantSystemProbeHostRootMount)
 	})
 
@@ -488,7 +485,6 @@ func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
 		providercaps.ApplyProviderCapabilities(mgr, kubernetes.GKECosProvider, f.NodeAgentProviderCapabilities())
 
 		assert.Contains(t, tmpl.Spec.Volumes, wantVolume)
-		assert.NotContains(t, tmpl.Spec.Volumes, wantSystemProbeHostRootVolume)
 		assert.Contains(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts, wantMount)
 		assert.NotContains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantMount)
 		assert.NotContains(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts, wantSystemProbeHostRootMount)


### PR DESCRIPTION
### What does this PR do?

Mounts the GKE COS NVIDIA driver libraries at system-probe's `HOST_ROOT` path when GPU privileged mode is enabled, and sets `HOST_ROOT=/host/root` for the GPU system-probe container.

### Motivation

This keeps operator-managed GPU deployments aligned with the Helm chart behavior and lets system-probe find NVML on GKE COS nodes.

### Additional Notes

The core Agent keeps the `/host/run/...` mount path, while system-probe uses `/host/root/run/...` to match its `HOST_ROOT` value.

### Minimum Agent Versions

* Agent: No change
* Cluster Agent: No change

### Describe your test plan

Validated with focused GPU feature tests, the COS provider reconcile test, and a live GKE COS DatadogAgent reconciliation using the local PR operator. The operator-rendered system-probe found NVML at `/host/root/run/nvidia/driver/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1` and started the GPU module.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commits/signing-commits