### PR TITLE
Fix GKE Autopilot registry coercion for agent profiles

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -54,7 +54,7 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadogh
 	instanceCopy := instance.DeepCopy()
 	defaults.DefaultDatadogAgentSpec(&instanceCopy.Spec)
 	if experimental.IsAutopilotEnabled(instanceCopy) {
-		ensureGCRAutopilotRegistry(instanceCopy)
+		ensureGCRAutopilotRegistry(&instanceCopy.Spec)
 	}
 
 	// 4. Delegate to the main reconcile function.
@@ -63,22 +63,22 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadogh
 
 // Force GCR registry if not set to avoid defaulting to Datadog registry
 // Required by GKE Autopilot workloadallowlist
-func ensureGCRAutopilotRegistry(instance *datadoghqv2alpha1.DatadogAgent) {
+func ensureGCRAutopilotRegistry(spec *datadoghqv2alpha1.DatadogAgentSpec) {
 	// Should never happen as credentials are configured under `spec.global`
-	if instance.Spec.Global == nil {
-		instance.Spec.Global = &datadoghqv2alpha1.GlobalConfig{}
+	if spec.Global == nil {
+		spec.Global = &datadoghqv2alpha1.GlobalConfig{}
 	}
 	// No registry set
-	if instance.Spec.Global.Registry == nil {
-		instance.Spec.Global.Registry = ptr.To(images.GCRContainerRegistry)
+	if spec.Global.Registry == nil {
+		spec.Global.Registry = ptr.To(images.GCRContainerRegistry)
 		return
 	}
 	// Registry set to a GCR variation, allowed in workloadallowlist
-	if images.IsGCRRegistry(*instance.Spec.Global.Registry) {
+	if images.IsGCRRegistry(*spec.Global.Registry) {
 		return
 	}
 	// Registry set outside GCR, not allowed in workloadallowlist, force back GCR
-	instance.Spec.Global.Registry = ptr.To(images.GCRContainerRegistry)
+	spec.Global.Registry = ptr.To(images.GCRContainerRegistry)
 }
 
 func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent) (reconcile.Result, error) {

--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -22,6 +22,7 @@ import (
 	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
@@ -241,6 +242,12 @@ func (r *Reconciler) computeProfileMerge(ddai *v1alpha1.DatadogAgentInternal, pr
 	typedObj, ok := obj.(*v1alpha1.DatadogAgentInternal)
 	if !ok {
 		return nil, fmt.Errorf("unexpected type: %T", obj)
+	}
+	// Profile merging replaces the DDAI spec and can reintroduce a registry that
+	// is rejected by the GKE Autopilot workload allowlist. Enforce the registry
+	// constraint on the final merged object before computing its spec hash.
+	if experimental.IsAutopilotEnabled(typedObj) {
+		ensureGCRAutopilotRegistry(&typedObj.Spec)
 	}
 
 	// Set spec hash

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -26,6 +26,8 @@ import (
 	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/images"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
 func Test_computeProfileMerge(t *testing.T) {
@@ -300,6 +302,79 @@ func Test_computeProfileMerge(t *testing.T) {
 			assert.Equal(t, tt.want.Name, ddai.Name)
 			assert.Equal(t, tt.want.Annotations[constants.MD5DDAIDeploymentAnnotationKey], ddai.Annotations[constants.MD5DDAIDeploymentAnnotationKey])
 			assert.Equal(t, tt.want.Spec, ddai.Spec)
+		})
+	}
+}
+
+func Test_computeProfileMergeEnforcesAutopilotRegistry(t *testing.T) {
+	sch := k8sruntime.NewScheme()
+	require.NoError(t, scheme.AddToScheme(sch))
+	require.NoError(t, v1alpha1.AddToScheme(sch))
+	require.NoError(t, v2alpha1.AddToScheme(sch))
+	require.NoError(t, corev1.AddToScheme(sch))
+	require.NoError(t, apiextensionsv1.AddToScheme(sch))
+
+	tests := []struct {
+		name     string
+		registry string
+	}{
+		{
+			name:     "Datadog registry",
+			registry: images.DatadogContainerRegistry,
+		},
+		{
+			name:     "public ECR registry",
+			registry: images.PublicECSContainerRegistry,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ddai := &v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+					Annotations: map[string]string{
+						kubernetes.ProviderAnnotationKey: kubernetes.GKEAutopilotProvider,
+					},
+				},
+				Spec: v2alpha1.DatadogAgentSpec{
+					Global: &v2alpha1.GlobalConfig{
+						Registry: ptr.To(images.GCRContainerRegistry),
+					},
+				},
+			}
+			profile := &v1alpha1.DatadogAgentProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-profile",
+					Namespace: "bar",
+				},
+				Spec: v1alpha1.DatadogAgentProfileSpec{
+					Config: &v2alpha1.DatadogAgentSpec{
+						Global: &v2alpha1.GlobalConfig{
+							Registry: ptr.To(tt.registry),
+						},
+					},
+				},
+			}
+
+			crd, err := getDDAICRDFromConfig(sch)
+			require.NoError(t, err)
+			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(ddai, crd).Build()
+			fieldManager, err := newFieldManager(fakeClient, sch, v1alpha1.GroupVersion.WithKind("DatadogAgentInternal"))
+			require.NoError(t, err)
+			r := &Reconciler{
+				client:       fakeClient,
+				scheme:       sch,
+				fieldManager: fieldManager,
+			}
+
+			mergedDDAI, err := r.computeProfileMerge(ddai, profile)
+			require.NoError(t, err)
+			require.NotNil(t, mergedDDAI.Spec.Global)
+			require.NotNil(t, mergedDDAI.Spec.Global.Registry)
+			assert.Equal(t, images.GCRContainerRegistry, *mergedDDAI.Spec.Global.Registry)
+			assert.NotEmpty(t, mergedDDAI.Annotations[constants.MD5DDAIDeploymentAnnotationKey])
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Enforces the GCR registry constraint on the final `DatadogAgentInternal` produced after a `DatadogAgentProfile` merge when GKE Autopilot is enabled.

It also adds unit coverage for profiles that configure either `registry.datadoghq.com` or the Datadog public ECR registry.

### Motivation

GKE Autopilot registry coercion previously ran only on the base `DatadogAgent` copy. Profile reconciliation happens later and can replace `spec.global.registry`, producing an Autopilot-annotated `DatadogAgentInternal` with images that are rejected by the GKE workload allowlist.

Applying the constraint to the final merged object ensures every Autopilot profile uses an allowed GCR registry and that the generation hash reflects the corrected spec.

### Additional Notes

This addresses the profile merge edge case identified in the review of #3254.

### Minimum Agent Versions

No minimum Agent or Cluster Agent version is required.

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Unit tests + on a kind/local cluster with 2 nodes+:
* Deploy operator with profiles enabled
* Apply a `DatadogAgent` manifest with registry set to `registry.datadoghq.com` and with the Autopilot annotation `experimental.agent.datadoghq.com/autopilot: "true"`
    * Note you will get error logs in the operator about not being able to apply the allowlistsynchronizer (CRD from GKE) that can be ignored
* Apply a valid profile so you have 2 DDAIs (default + profile one)
* Ensure each DDAI has `gcr.io/datadoghq` registry instead
```console
╭─ ~/tmp/profiles                                                                                                                         󱃾 kind-local-k8s/system 13:50:27
╰─❯ k get dd datadog-agent -oyaml | yq .spec.global.registry
registry.datadoghq.com
╭─ ~/tmp/profiles                                                                                                                         󱃾 kind-local-k8s/system 13:52:39
╰─❯ k get ddai datadog-agent -oyaml | yq .spec.global.registry
gcr.io/datadoghq
╭─ ~/tmp/profiles                                                                                                                         󱃾 kind-local-k8s/system 13:52:47
╰─❯ k get ddai foo -oyaml | yq .spec.global.registry
gcr.io/datadoghq
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits