### PR TITLE
Update reason in status for invalid daps

### DIFF
--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -153,7 +153,7 @@ func (r *Reconciler) reconcileProfile(ctx context.Context, profile *v1alpha1.Dat
 	if err != nil {
 		metrics.DAPValid.With(prometheus.Labels{"datadogagentprofile": profile.Name}).Set(metrics.FalseValue)
 		profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, agentprofile.NewDatadogAgentProfileCondition(agentprofile.ValidConditionType, metav1.ConditionFalse, now, agentprofile.InvalidConditionReason, err.Error()))
-		profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, agentprofile.NewDatadogAgentProfileCondition(agentprofile.AppliedConditionType, metav1.ConditionUnknown, now, "", ""))
+		profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, agentprofile.NewDatadogAgentProfileCondition(agentprofile.AppliedConditionType, metav1.ConditionUnknown, now, agentprofile.InvalidConditionReason, "Profile is invalid"))
 		return err
 	}
 	metrics.DAPValid.With(prometheus.Labels{"datadogagentprofile": profile.Name}).Set(metrics.TrueValue)

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -12,9 +12,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -839,8 +841,8 @@ func Test_reconcileProfile(t *testing.T) {
 						Type:               agentprofile.AppliedConditionType,
 						Status:             metav1.ConditionUnknown,
 						LastTransitionTime: now,
-						Reason:             "",
-						Message:            "",
+						Reason:             agentprofile.InvalidConditionReason,
+						Message:            "Profile is invalid",
 					},
 				},
 			},
@@ -1009,9 +1011,17 @@ func Test_reconcileProfile(t *testing.T) {
 
 			assert.Equal(t, tt.wantErr, err)
 			assert.Equal(t, tt.wantStatus, profileCopy.Status)
+			assertProfileConditionsValid(t, profileCopy.Status.Conditions)
 			assert.Equal(t, tt.wantProfilesByNode, tt.profilesByNode)
 		})
 	}
+}
+
+func assertProfileConditionsValid(t *testing.T, conditions []metav1.Condition) {
+	t.Helper()
+
+	conditionErrs := metav1validation.ValidateConditions(conditions, field.NewPath("status").Child("conditions"))
+	require.Empty(t, conditionErrs)
 }
 
 func Test_reconcileProfile_SharedOverlayConflictDoesNotCommitNodeAssignment(t *testing.T) {
@@ -1268,7 +1278,11 @@ func Test_reconcileProfiles(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			objects := append(tt.existingProfiles, tt.existingNodes...)
-			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(objects...).Build()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(sch).
+				WithRuntimeObjects(objects...).
+				WithStatusSubresource(&v1alpha1.DatadogAgentProfile{}).
+				Build()
 			logger := logf.Log.WithName("Test_reconcileProfiles")
 			eventBroadcaster := record.NewBroadcaster()
 			recorder := eventBroadcaster.NewRecorder(sch, corev1.EventSource{Component: "Test_reconcileProfiles"})
@@ -1291,6 +1305,15 @@ func Test_reconcileProfiles(t *testing.T) {
 
 			assert.Equal(t, tt.wantErr, err)
 			assert.Equal(t, tt.wantAppliedProfiles, len(appliedProfiles))
+			for _, existingProfile := range tt.existingProfiles {
+				profile, ok := existingProfile.(*v1alpha1.DatadogAgentProfile)
+				require.True(t, ok)
+
+				persistedProfile := &v1alpha1.DatadogAgentProfile{}
+				err := fakeClient.Get(ctx, types.NamespacedName{Namespace: profile.Namespace, Name: profile.Name}, persistedProfile)
+				require.NoError(t, err)
+				assertProfileConditionsValid(t, persistedProfile.Status.Conditions)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Add a reason to the status since the status update is invalid without it:
```
{"level":"ERROR","ts":"2026-07-15T13:55:32.274Z","logger":"controllers.DatadogAgent","msg":"unable to update profile status","datadogagentprofile":"datadogagentprofile-sample","datadogagentprofile_namespace":"default","error":"DatadogAgentProfile.datadoghq.com \"datadogagentprofile-sample\" is invalid: status.conditions[1].reason: Invalid value: \"\": conditions[1].reason in body should be at least 1 chars long","stacktrace":"github.com/DataDog/datadog-operator/internal/controller/datadogagent.(*Reconciler).reconcileProfiles\n\t/workspace/internal/controller/datadogagent/profile.go:97\ngithub.com/DataDog/datadog-operator/internal/controller/datadogagent.(*Reconciler).reconcileInstanceV3\n\t/workspace/internal/controller/datadogagent/controller_reconcile_v2.go:118\ngithub.com/DataDog/datadog-operator/internal/controller/datadogagent.(*
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Create an invalid DAP
```yaml
  config:
    override:
      nodeAgent:
        nodeSelector:
          disktype: ssd
```

The operator should reject it: `{"level":"ERROR","ts":"2026-07-15T14:17:10.961Z","logger":"controllers.DatadogAgent","msg":"unable to reconcile profile","datadogagentprofile":"invalid-dap","datadogagentprofile_namespace":"default","error":"profile spec is invalid: component node selector override is not supported","stacktrace":...}`

The dap status should update:
```
$ kubectl get dap
NAME          VALID   APPLIED   AGE
invalid-dap   False   Unknown   24m
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits