### PR TITLE
[CONTP-1884] Migrate AppArmor annotations to appArmorProfile

### DIFF
--- a/internal/controller/datadogagent/common/apparmor.go
+++ b/internal/controller/datadogagent/common/apparmor.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package common
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+// FinalizeAppArmorProfile applies Kubernetes-version compatibility to AppArmor
+// settings on a completed Pod template. It must run after features and overrides
+// have finished mutating the template, but before the workload is hashed and sent
+// to the API server.
+//
+// On Kubernetes 1.30 and later, it moves deprecated container-scoped AppArmor
+// annotations to securityContext.appArmorProfile. Older Kubernetes versions keep
+// the annotations. An explicitly configured appArmorProfile field takes precedence
+// over an annotation.
+func FinalizeAppArmorProfile(podTemplate *corev1.PodTemplateSpec, platformInfo kubernetes.PlatformInfo) {
+	if podTemplate == nil || !platformInfo.SupportsAppArmorProfile() {
+		return
+	}
+
+	for annotation, value := range podTemplate.Annotations {
+		containerName, found := strings.CutPrefix(annotation, AppArmorAnnotationKey+"/")
+		if !found {
+			continue
+		}
+
+		setAppArmorProfile(podTemplate.Spec.Containers, containerName, value)
+		setAppArmorProfile(podTemplate.Spec.InitContainers, containerName, value)
+		delete(podTemplate.Annotations, annotation)
+	}
+
+	if len(podTemplate.Annotations) == 0 {
+		podTemplate.Annotations = nil
+	}
+}
+
+func setAppArmorProfile(containers []corev1.Container, containerName, value string) {
+	for i := range containers {
+		if containers[i].Name != containerName {
+			continue
+		}
+
+		if containers[i].SecurityContext == nil {
+			containers[i].SecurityContext = &corev1.SecurityContext{}
+		}
+		if containers[i].SecurityContext.AppArmorProfile == nil {
+			containers[i].SecurityContext.AppArmorProfile = appArmorProfileFromAnnotation(value)
+		}
+		return
+	}
+}
+
+func appArmorProfileFromAnnotation(value string) *corev1.AppArmorProfile {
+	switch value {
+	case "runtime/default":
+		return &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeRuntimeDefault}
+	case "unconfined":
+		return &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeUnconfined}
+	default:
+		return &corev1.AppArmorProfile{
+			Type:             corev1.AppArmorProfileTypeLocalhost,
+			LocalhostProfile: ptr.To(strings.TrimPrefix(value, "localhost/")),
+		}
+	}
+}

--- a/internal/controller/datadogagent/common/apparmor.go
+++ b/internal/controller/datadogagent/common/apparmor.go
@@ -38,10 +38,6 @@ func FinalizeAppArmorProfile(podTemplate *corev1.PodTemplateSpec, platformInfo k
 		setAppArmorProfile(podTemplate.Spec.InitContainers, containerName, value)
 		delete(podTemplate.Annotations, annotation)
 	}
-
-	if len(podTemplate.Annotations) == 0 {
-		podTemplate.Annotations = nil
-	}
 }
 
 func setAppArmorProfile(containers []corev1.Container, containerName, value string) {

--- a/internal/controller/datadogagent/common/apparmor.go
+++ b/internal/controller/datadogagent/common/apparmor.go
@@ -62,7 +62,8 @@ func setAppArmorProfile(containers []corev1.Container, containerName, value stri
 
 func appArmorProfileFromAnnotation(value string) *corev1.AppArmorProfile {
 	switch value {
-	case "runtime/default":
+	case "", "runtime/default":
+		// Kubernetes treats an empty legacy AppArmor annotation as runtime/default.
 		return &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeRuntimeDefault}
 	case "unconfined":
 		return &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeUnconfined}

--- a/internal/controller/datadogagent/common/apparmor_test.go
+++ b/internal/controller/datadogagent/common/apparmor_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+func TestFinalizeAppArmorProfile(t *testing.T) {
+	t.Run("keeps annotations before Kubernetes 1.30", func(t *testing.T) {
+		podTemplate := appArmorPodTemplate()
+		platformInfo := kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "v1.29.9"}, nil, nil)
+
+		FinalizeAppArmorProfile(&podTemplate, platformInfo)
+
+		assert.Equal(t, "unconfined", podTemplate.Annotations[AppArmorAnnotationKey+"/system-probe"])
+		assert.Nil(t, podTemplate.Spec.Containers[0].SecurityContext)
+	})
+
+	t.Run("migrates annotations on Kubernetes 1.30 and later", func(t *testing.T) {
+		podTemplate := appArmorPodTemplate()
+		platformInfo := kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "v1.30.0"}, nil, nil)
+
+		FinalizeAppArmorProfile(&podTemplate, platformInfo)
+
+		assert.Equal(t, map[string]string{"other": "annotation"}, podTemplate.Annotations)
+
+		systemProbeProfile := requireAppArmorProfile(t, podTemplate.Spec.Containers[0])
+		assert.Equal(t, corev1.AppArmorProfileTypeUnconfined, systemProbeProfile.Type)
+		assert.Nil(t, systemProbeProfile.LocalhostProfile)
+
+		agentProfile := requireAppArmorProfile(t, podTemplate.Spec.Containers[1])
+		assert.Equal(t, corev1.AppArmorProfileTypeRuntimeDefault, agentProfile.Type)
+		assert.Nil(t, agentProfile.LocalhostProfile)
+
+		processAgentProfile := requireAppArmorProfile(t, podTemplate.Spec.Containers[2])
+		assert.Equal(t, corev1.AppArmorProfileTypeLocalhost, processAgentProfile.Type)
+		require.NotNil(t, processAgentProfile.LocalhostProfile)
+		assert.Equal(t, "custom-profile", *processAgentProfile.LocalhostProfile)
+
+		initProfile := requireAppArmorProfile(t, podTemplate.Spec.InitContainers[0])
+		assert.Equal(t, corev1.AppArmorProfileTypeLocalhost, initProfile.Type)
+		require.NotNil(t, initProfile.LocalhostProfile)
+		assert.Equal(t, "bare-custom-profile", *initProfile.LocalhostProfile)
+	})
+
+	t.Run("preserves an explicit appArmorProfile field", func(t *testing.T) {
+		podTemplate := corev1.PodTemplateSpec{
+			ObjectMeta: appArmorPodTemplate().ObjectMeta,
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{
+				Name: "system-probe",
+				SecurityContext: &corev1.SecurityContext{AppArmorProfile: &corev1.AppArmorProfile{
+					Type: corev1.AppArmorProfileTypeRuntimeDefault,
+				}},
+			}}},
+		}
+		platformInfo := kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "v1.31.0"}, nil, nil)
+
+		FinalizeAppArmorProfile(&podTemplate, platformInfo)
+
+		profile := requireAppArmorProfile(t, podTemplate.Spec.Containers[0])
+		assert.Equal(t, corev1.AppArmorProfileTypeRuntimeDefault, profile.Type)
+		_, found := podTemplate.Annotations[AppArmorAnnotationKey+"/system-probe"]
+		assert.False(t, found)
+	})
+}
+
+func appArmorPodTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			AppArmorAnnotationKey + "/system-probe":  "unconfined",
+			AppArmorAnnotationKey + "/agent":         "runtime/default",
+			AppArmorAnnotationKey + "/process-agent": "localhost/custom-profile",
+			AppArmorAnnotationKey + "/init":          "bare-custom-profile",
+			AppArmorAnnotationKey + "/absent":        "unconfined",
+			"other":                                  "annotation",
+		}},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "system-probe"},
+				{Name: "agent"},
+				{Name: "process-agent"},
+			},
+			InitContainers: []corev1.Container{{Name: "init"}},
+		},
+	}
+}
+
+func requireAppArmorProfile(t *testing.T, container corev1.Container) *corev1.AppArmorProfile {
+	t.Helper()
+	require.NotNil(t, container.SecurityContext)
+	require.NotNil(t, container.SecurityContext.AppArmorProfile)
+	return container.SecurityContext.AppArmorProfile
+}

--- a/internal/controller/datadogagent/common/apparmor_test.go
+++ b/internal/controller/datadogagent/common/apparmor_test.go
@@ -89,7 +89,8 @@ func TestFinalizeAppArmorProfile(t *testing.T) {
 		profile := requireAppArmorProfile(t, podTemplate.Spec.Containers[0])
 		assert.Equal(t, corev1.AppArmorProfileTypeRuntimeDefault, profile.Type)
 		assert.Nil(t, profile.LocalhostProfile)
-		assert.Nil(t, podTemplate.Annotations)
+		assert.NotNil(t, podTemplate.Annotations)
+		assert.Empty(t, podTemplate.Annotations)
 	})
 }
 

--- a/internal/controller/datadogagent/common/apparmor_test.go
+++ b/internal/controller/datadogagent/common/apparmor_test.go
@@ -74,6 +74,23 @@ func TestFinalizeAppArmorProfile(t *testing.T) {
 		_, found := podTemplate.Annotations[AppArmorAnnotationKey+"/system-probe"]
 		assert.False(t, found)
 	})
+
+	t.Run("maps an empty annotation value to runtime default", func(t *testing.T) {
+		podTemplate := corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				AppArmorAnnotationKey + "/agent": "",
+			}},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "agent"}}},
+		}
+		platformInfo := kubernetes.NewPlatformInfoFromVersionMaps(&version.Info{GitVersion: "v1.30.0"}, nil, nil)
+
+		FinalizeAppArmorProfile(&podTemplate, platformInfo)
+
+		profile := requireAppArmorProfile(t, podTemplate.Spec.Containers[0])
+		assert.Equal(t, corev1.AppArmorProfileTypeRuntimeDefault, profile.Type)
+		assert.Nil(t, profile.LocalhostProfile)
+		assert.Nil(t, podTemplate.Annotations)
+	})
 }
 
 func appArmorPodTemplate() corev1.PodTemplateSpec {

--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -26,6 +26,7 @@ import (
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	controllercommon "github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
@@ -52,6 +53,8 @@ func (r *Reconciler) createOrUpdateDeployment(parentLogger logr.Logger, dda *v2a
 	if err = controllerutil.SetControllerReference(dda, deployment, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
+	// Finalize Kubernetes-version-dependent Pod template compatibility after all mutations and before hashing.
+	controllercommon.FinalizeAppArmorProfile(&deployment.Spec.Template, r.platformInfo)
 
 	// From here the PodTemplateSpec should be ready, we can generate the hash that will be used to compare this deployment with the current one (if it exists).
 	var hash string

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common.go
@@ -24,6 +24,7 @@ import (
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	controllercommon "github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
@@ -50,6 +51,8 @@ func (r *Reconciler) createOrUpdateDeployment(ctx context.Context, ddai *v1alpha
 	if err = controllerutil.SetControllerReference(ddai, deployment, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
+	// Finalize Kubernetes-version-dependent Pod template compatibility after all mutations and before hashing.
+	controllercommon.FinalizeAppArmorProfile(&deployment.Spec.Template, r.platformInfo)
 
 	// From here the PodTemplateSpec should be ready, we can generate the hash that will be used to compare this deployment with the current one (if it exists).
 	var hash string
@@ -163,6 +166,8 @@ func (r *Reconciler) createOrUpdateDaemonset(ctx context.Context, ddai *v1alpha1
 	if err = controllerutil.SetControllerReference(ddai, daemonset, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
+	// Finalize Kubernetes-version-dependent Pod template compatibility after all mutations and before hashing.
+	controllercommon.FinalizeAppArmorProfile(&daemonset.Spec.Template, r.platformInfo)
 
 	// Get the current daemonset and compare
 	nsName := types.NamespacedName{
@@ -323,6 +328,8 @@ func (r *Reconciler) createOrUpdateExtendedDaemonset(ctx context.Context, ddai *
 	if err = controllerutil.SetControllerReference(ddai, eds, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
+	// Finalize Kubernetes-version-dependent Pod template compatibility after all mutations and before hashing.
+	controllercommon.FinalizeAppArmorProfile(&eds.Spec.Template, r.platformInfo)
 
 	// From here the PodTemplateSpec should be ready, we can generate the hash that will be used to compare this extendeddaemonset with the current one (if it exists).
 	var hash string

--- a/internal/controller/testutils/renderer/render_e2e_test.go
+++ b/internal/controller/testutils/renderer/render_e2e_test.go
@@ -122,6 +122,43 @@ func TestRender_WithDAP(t *testing.T) {
 	}, kindSequence(string(out)))
 }
 
+func TestRender_AppArmorProfileVersionGate(t *testing.T) {
+	tests := []struct {
+		name              string
+		kubernetesVersion string
+		wantAnnotation    bool
+		wantProfileField  bool
+	}{
+		{
+			name:              "Kubernetes 1.29 uses the annotation",
+			kubernetesVersion: "v1.29.9",
+			wantAnnotation:    true,
+		},
+		{
+			name:              "Kubernetes 1.30 uses the field",
+			kubernetesVersion: "v1.30.0",
+			wantProfileField:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dda, err := LoadDDA("testdata/comprehensive-dda.yaml")
+			require.NoError(t, err)
+
+			objects, scheme, err := Render(Options{DDA: dda, KubernetesVersion: tt.kubernetesVersion})
+			require.NoError(t, err)
+
+			out, err := Serialize(objects, scheme, "yaml", false)
+			require.NoError(t, err)
+			rendered := string(out)
+
+			assert.Equal(t, tt.wantAnnotation, strings.Contains(rendered, "container.apparmor.security.beta.kubernetes.io/system-probe: unconfined"))
+			assert.Equal(t, tt.wantProfileField, strings.Contains(rendered, "appArmorProfile:\n            type: Unconfined"))
+		})
+	}
+}
+
 // kindSequence extracts the ordered list of "kind: X" values from serialized YAML.
 func kindSequence(yaml string) []string {
 	var kinds []string

--- a/pkg/kubernetes/platforminfo.go
+++ b/pkg/kubernetes/platforminfo.go
@@ -5,8 +5,13 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/DataDog/datadog-operator/pkg/utils"
 )
+
+const appArmorProfileMinimumVersion = "1.30.0-0"
 
 type PlatformInfo struct {
 	versionInfo          *version.Info
@@ -108,4 +113,15 @@ func (platformInfo *PlatformInfo) GetApiVersions(name string) (preferred string,
 
 func (platformInfo *PlatformInfo) GetVersionInfo() *version.Info {
 	return platformInfo.versionInfo
+}
+
+// SupportsAppArmorProfile returns whether the Kubernetes API server supports
+// the appArmorProfile security context field. The field is available starting
+// with Kubernetes 1.30.
+func (platformInfo *PlatformInfo) SupportsAppArmorProfile() bool {
+	if platformInfo == nil || platformInfo.versionInfo == nil || platformInfo.versionInfo.GitVersion == "" {
+		return false
+	}
+
+	return utils.IsAboveMinVersion(platformInfo.versionInfo.GitVersion, appArmorProfileMinimumVersion, ptr.To(false))
 }


### PR DESCRIPTION
### What does this PR do?

Migrate deprecated container-scoped AppArmor annotations to `securityContext.appArmorProfile` on Kubernetes 1.30 and later.

The completed Pod template is finalized after features and overrides are applied, but before workload hashing and submission. On Kubernetes versions older than 1.30, the existing annotations are preserved for compatibility. The finalizer supports `unconfined`, `runtime/default`, and localhost profiles, and preserves an explicitly configured `appArmorProfile` field.

### Motivation

Kubernetes 1.30 deprecates `container.apparmor.security.beta.kubernetes.io/<container>` annotations in favor of the structured `appArmorProfile` field. The annotation path will no longer be supported starting with Kubernetes 1.37 (refer to discussion on https://github.com/kubernetes/enhancements/issues/24)

This removes the deprecation warning on supported clusters while retaining compatibility with older Kubernetes versions.

### Additional Notes

I considered directly setting `securityContext.appArmorProfile` in every feature that currently requests an AppArmor profile, instead of using the annotation as an intermediate representation and finalizing it at the workload boundary.

Pros of the direct approach:

- Each feature would express its final security-context intent locally.
- Generated templates would never contain the deprecated annotation internally.
- The relationship between a feature and its AppArmor requirements would be more explicit.

Cons of the direct approach:

- AppArmor is currently emitted by several features as well as container overrides and raw Pod annotation overrides; updating only feature code would be incomplete.
- A correct implementation would need to thread `PlatformInfo` through `PodTemplateManagers` or the security-context manager, including its fake implementations and tests.
- Duplicating Kubernetes-version branching across producers would increase the risk of omissions and future behavioral drift.
- Raw annotation overrides would still require a centralized compatibility path.

The centralized Pod-template finalizer keeps the Kubernetes-version policy in one place, covers current and future annotation producers, and gives an explicitly configured `appArmorProfile` field precedence.

### Minimum Agent Versions

No minimum Datadog Agent or Cluster Agent version is required.

* Agent: none
* Cluster Agent: none

### Describe your test plan

Automated validation:

- `go test ./internal/controller/datadogagent/common ./pkg/kubernetes`
- `go test ./internal/controller/datadogagent ./internal/controller/datadogagentinternal`
- `go test ./internal/controller/testutils/renderer -run 'TestRender_AppArmorProfileVersionGate|TestRender_MinimalDDA'`

QA instructions:

1. Deploy the Operator on a Kubernetes 1.30+ cluster.
2. Deploy a DatadogAgent with a system-probe feature enabled, for example:

   ```yaml
   spec:
     features:
       npm:
         enabled: true
   ```

3. Inspect an Agent Pod created from that DatadogAgent.
4. Verify that the `system-probe` container has `securityContext.appArmorProfile.type: Unconfined`.
5. Verify that the Pod no longer has the `container.apparmor.security.beta.kubernetes.io/system-probe` annotation (can verify the annotation is present once again if deploying previous/stable operator version)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits