### PR TITLE
Harden Operator lifecycle readiness signals

### DIFF
--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -186,10 +186,21 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 }
 
 func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus, result reconcile.Result, currentError error, now metav1.Time) (reconcile.Result, error) {
+	reconcileCondition := metav1.Condition{
+		Type:               common.DatadogAgentReconcileErrorConditionType,
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: agentdeployment.Generation,
+		LastTransitionTime: now,
+		Reason:             "DatadogAgent_reconcile_ok",
+		Message:            "DatadogAgent reconcile ok",
+	}
 	if currentError == nil {
-		condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionFalse, "DatadogAgent_reconcile_ok", "DatadogAgent reconcile ok", false)
+		meta.SetStatusCondition(&newStatus.Conditions, reconcileCondition)
 	} else {
-		condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionTrue, "DatadogAgent_reconcile_error", "DatadogAgent reconcile error", false)
+		reconcileCondition.Status = metav1.ConditionTrue
+		reconcileCondition.Reason = "DatadogAgent_reconcile_error"
+		reconcileCondition.Message = "DatadogAgent reconcile error"
+		meta.SetStatusCondition(&newStatus.Conditions, reconcileCondition)
 	}
 
 	r.setMetricsForwarderStatusV2(logger, agentdeployment, newStatus)

--- a/internal/controller/datadogagent/controller_reconcile_v2_status_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_status_test.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+)
+
+func TestUpdateStatusRecordsSuccessfulObservedGeneration(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, datadoghqv2alpha1.AddToScheme(scheme))
+	dda := &datadoghqv2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "datadog-agent",
+			Namespace:  "datadog",
+			Generation: 7,
+		},
+		Status: datadoghqv2alpha1.DatadogAgentStatus{
+			Conditions: []metav1.Condition{{
+				Type:               common.DatadogAgentReconcileErrorConditionType,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: 6,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "DatadogAgent_reconcile_ok",
+				Message:            "DatadogAgent reconcile ok",
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&datadoghqv2alpha1.DatadogAgent{}).
+		WithObjects(dda).
+		Build()
+	current := &datadoghqv2alpha1.DatadogAgent{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(dda), current))
+	r := &Reconciler{client: c}
+
+	newStatus := current.Status.DeepCopy()
+	_, err := r.updateStatusIfNeededV2(logr.Discard(), current, newStatus, reconcile.Result{}, nil, metav1.Now())
+	require.NoError(t, err)
+
+	updated := &datadoghqv2alpha1.DatadogAgent{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(dda), updated))
+	condition := meta.FindStatusCondition(updated.Status.Conditions, common.DatadogAgentReconcileErrorConditionType)
+	require.NotNil(t, condition)
+	require.Equal(t, metav1.ConditionFalse, condition.Status)
+	require.Equal(t, int64(7), condition.ObservedGeneration)
+}

--- a/internal/controller/datadogagent/object/labels.go
+++ b/internal/controller/datadogagent/object/labels.go
@@ -18,6 +18,12 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
+const (
+	eksInstallationIDLabel = "eks.datadoghq.com/installation-id"
+	eksARNLabelIDLabel     = "eks.datadoghq.com/arn-id"
+	eksARNHashAnnotation   = "eks.datadoghq.com/arn-sha256"
+)
+
 // GetDefaultLabels return default labels attached to a DatadogAgent resource.
 func GetDefaultLabels(dda metav1.Object, instanceName, version string) map[string]string {
 	labels := make(map[string]string)
@@ -29,7 +35,7 @@ func GetDefaultLabels(dda metav1.Object, instanceName, version string) map[strin
 
 	// Copy Datadog labels from DDA Labels
 	for k, v := range dda.GetLabels() {
-		if strings.HasPrefix(k, DatadogTagPrefix) {
+		if strings.HasPrefix(k, DatadogTagPrefix) || k == eksInstallationIDLabel || k == eksARNLabelIDLabel {
 			labels[k] = v
 		}
 	}
@@ -39,8 +45,11 @@ func GetDefaultLabels(dda metav1.Object, instanceName, version string) map[strin
 
 // GetDefaultAnnotations return default annotations attached to a DatadogAgent resource.
 func GetDefaultAnnotations(dda metav1.Object) map[string]string {
-	// Currently we don't have any annotation to set by default
-	return map[string]string{}
+	annotations := map[string]string{}
+	if value := dda.GetAnnotations()[eksARNHashAnnotation]; value != "" {
+		annotations[eksARNHashAnnotation] = value
+	}
+	return annotations
 }
 
 // MergeAnnotationsLabels used to merge Annotations and Labels

--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -169,12 +169,14 @@ func ApplyProfile(logger logr.Logger, profile *v1alpha1.DatadogAgentProfile, nod
 		UpdateProfileStatus(logger, profile, profileStatus, now)
 		return profileAppliedByNode, err
 	}
+	metrics.DAPValid.With(prometheus.Labels{"datadogagentprofile": profile.Name}).Set(metrics.TrueValue)
+	profileStatus.Valid = metav1.ConditionTrue
+	profileStatus.Conditions = SetDatadogAgentProfileCondition(profileStatus.Conditions, NewDatadogAgentProfileCondition(ValidConditionType, metav1.ConditionTrue, now, ValidConditionReason, "Valid manifest"))
+	profileStatus.Applied = metav1.ConditionTrue
+	profileStatus.Conditions = SetDatadogAgentProfileCondition(profileStatus.Conditions, NewDatadogAgentProfileCondition(AppliedConditionType, metav1.ConditionTrue, now, AppliedConditionReason, "Profile applied"))
 
 	for _, node := range nodes {
 		matchesNode := profileMatchesNodeWithRequirements(profileRequirements, node.Labels)
-		metrics.DAPValid.With(prometheus.Labels{"datadogagentprofile": profile.Name}).Set(metrics.TrueValue)
-		profileStatus.Valid = metav1.ConditionTrue
-		profileStatus.Conditions = SetDatadogAgentProfileCondition(profileStatus.Conditions, NewDatadogAgentProfileCondition(ValidConditionType, metav1.ConditionTrue, now, ValidConditionReason, "Valid manifest"))
 
 		if matchesNode {
 			if existingProfile, found := profileAppliedByNode[node.Name]; found {
@@ -192,8 +194,6 @@ func ApplyProfile(logger logr.Logger, profile *v1alpha1.DatadogAgentProfile, nod
 					matchingNodes[node.Name] = false
 					toLabelNodeCount++
 				}
-				profileStatus.Conditions = SetDatadogAgentProfileCondition(profileStatus.Conditions, NewDatadogAgentProfileCondition(AppliedConditionType, metav1.ConditionTrue, now, AppliedConditionReason, "Profile applied"))
-				profileStatus.Applied = metav1.ConditionTrue
 			}
 		}
 	}

--- a/pkg/agentprofile/agent_profile_test.go
+++ b/pkg/agentprofile/agent_profile_test.go
@@ -265,6 +265,25 @@ func TestApplyProfile(t *testing.T) {
 	}
 }
 
+func TestApplyProfileCompletesWithNoMatchingNodes(t *testing.T) {
+	t.Setenv(apicommon.CreateStrategyEnabled, "true")
+	profile := exampleProfileForWindows()
+	now := metav1.NewTime(time.Now())
+
+	_, err := ApplyProfile(logr.Discard(), &profile, nil, map[string]types.NamespacedName{}, now, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, metav1.ConditionTrue, profile.Status.Valid)
+	assert.Equal(t, metav1.ConditionTrue, profile.Status.Applied)
+	assert.NotNil(t, profile.Status.CreateStrategy)
+	assert.Equal(t, v1alpha1.WaitingStatus, profile.Status.CreateStrategy.Status)
+
+	_, err = ApplyProfile(logr.Discard(), &profile, nil, map[string]types.NamespacedName{}, now, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, v1alpha1.CompletedStatus, profile.Status.CreateStrategy.Status)
+	assert.Zero(t, profile.Status.CreateStrategy.NodesLabeled)
+	assert.Zero(t, profile.Status.CreateStrategy.PodsReady)
+}
+
 func TestOverrideFromProfile(t *testing.T) {
 	overrideNameForLinuxProfile := "datadog-agent-with-profile-default-linux"
 	overrideNameForExampleProfile := "datadog-agent-with-profile-default-example"

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -514,6 +514,7 @@ func IsEqualConditions(current []metav1.Condition, newCond []metav1.Condition) b
 func IsEqualCondition(current *metav1.Condition, newCond *metav1.Condition) bool {
 	if current.Type != newCond.Type ||
 		current.Status != newCond.Status ||
+		current.ObservedGeneration != newCond.ObservedGeneration ||
 		current.Reason != newCond.Reason ||
 		current.Message != newCond.Message {
 		return false

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -119,3 +119,21 @@ func TestUpdateWhenDSNil(t *testing.T) {
 	dsStatus = UpdateDaemonSetStatus("ds", ds, dsStatus, &metav1.Time{Time: time.Now()})
 	assert.Equal(t, 1, len(dsStatus))
 }
+
+func TestIsEqualConditionIncludesObservedGeneration(t *testing.T) {
+	current := metav1.Condition{
+		Type:               "ReconcileError",
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: 4,
+		LastTransitionTime: metav1.NewTime(time.Unix(1, 0)),
+		Reason:             "ReconcileOK",
+		Message:            "reconcile succeeded",
+	}
+	same := current
+	same.LastTransitionTime = metav1.NewTime(time.Unix(2, 0))
+	assert.True(t, IsEqualCondition(&current, &same))
+
+	newGeneration := current
+	newGeneration.ObservedGeneration++
+	assert.False(t, IsEqualCondition(&current, &newGeneration))
+}


### PR DESCRIPTION
### What does this PR do?

Improves the Operator status and ownership signals used to decide when an Agent installation is ready.

### Motivation

The EKS add-on lifecycle flow needs stable readiness signals before it can safely report that an install or uninstall has finished.

### Additional Notes

This is the prerequisite for the Operator lifecycle handling PR.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Ran the focused controller, object, Agent profile, and condition unit tests.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
