### PR TITLE
give operator priv to create kubeactions clusterrole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -133,6 +133,12 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - deployments/status
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
   - replicasets
   verbs:
   - get

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -152,6 +152,12 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=create;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
+// Configure Kubernetes Actions remediation (grants the Cluster Agent these permissions,
+// so the operator must hold them itself to create the ClusterRole)
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;patch;update
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
+
 // OpenShift
 // +kubebuilder:rbac:groups=quota.openshift.io,resources=clusterresourcequotas,verbs=get;list
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=restricted,verbs=use


### PR DESCRIPTION
### What does this PR do?

Give operator priv so it can create kubeactions clusterrole.

### Motivation

https://datadoghq.atlassian.net/browse/CONTINT-5433 - bug found in qa

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits