### PR TITLE
[PROF-15441][Host Profiler] OOB SELinux to `spc_t`

### DIFF
--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -19,11 +19,15 @@ import (
 
 var errHostPIDDisabledManually = errors.New("Host PID is required for host profiler")
 
+// SELinux type applied to the host-profiler container unless overridden via the annotation.
+const defaultSELinuxType = "spc_t"
+
 type hostProfilerFeature struct {
 	owner                   metav1.Object
 	hostPIDDisabledManually bool
 	seccompEnabled          bool
 	loggingSeccomp          bool
+	selinuxType             string
 
 	logger logr.Logger
 }
@@ -70,6 +74,12 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, _ *v2alpha1.DatadogAg
 	o.loggingSeccomp = featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnableHostProfilerLoggingSeccompAnnotation)
 	if o.loggingSeccomp && !o.seccompEnabled {
 		o.logger.V(1).Info("host profiler: logging-seccomp annotation has no effect when seccomp is disabled")
+	}
+
+	// SELinux type defaults to spc_t; override via the selinux-type annotation.
+	o.selinuxType = defaultSELinuxType
+	if str, ok := dda.GetAnnotations()[featureutils.HostProfilerSELinuxTypeAnnotation]; ok && str != "" {
+		o.selinuxType = str
 	}
 
 	return feature.RequiredComponents{
@@ -159,6 +169,13 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 	// AppArmor: unconfined so the default containerd profile doesn't block ptrace cross-profile,
 	// which host-profiler requires to read /proc/<pid>/map_files for process profiling.
 	managers.Annotation().AddAnnotation(common.AppArmorAnnotationKey+"/"+string(apicommon.HostProfiler), "unconfined")
+
+	// SELinux: run as the super-privileged container type (spc_t by default) so SELinux-enforcing
+	// nodes don't block the cross-process /proc access the host-profiler needs. Overridable via the
+	// host-profiler-selinux-type annotation.
+	sc.SELinuxOptions = &corev1.SELinuxOptions{
+		Type: o.selinuxType,
+	}
 
 	// Tracingfs volume
 	volumeTracingfs := corev1.Volume{

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -122,6 +123,10 @@ func Test_hostProfilerFeature_SeccompDisabled(t *testing.T) {
 	// AppArmor annotation is independent of seccomp and must remain.
 	assert.Equal(t, "unconfined", manager.AnnotationMgr.Annotations[common.AppArmorAnnotationKey+"/"+string(apicommon.HostProfiler)])
 
+	// SELinux options are independent of seccomp and must remain.
+	assert.NotNil(t, hpContainer.SecurityContext.SELinuxOptions, "SELinuxOptions must be set when seccomp is disabled")
+	assert.Equal(t, "spc_t", hpContainer.SecurityContext.SELinuxOptions.Type)
+
 	// seccomp-root volume must be absent.
 	for _, v := range manager.VolumeMgr.Volumes {
 		assert.NotEqual(t, common.SeccompRootVolumeName, v.Name, "seccomp-root volume must be absent when seccomp is disabled")
@@ -131,6 +136,46 @@ func Test_hostProfilerFeature_SeccompDisabled(t *testing.T) {
 	for _, c := range manager.Tpl.Spec.InitContainers {
 		assert.NotEqual(t, string(apicommon.HostProfilerSeccompSetupContainerName), c.Name, "seccomp setup init container must be absent when seccomp is disabled")
 	}
+}
+
+func Test_hostProfilerFeature_SELinuxTypeAnnotation(t *testing.T) {
+	hostProfilerImage := "gcr.io/datadoghq/agent:7.99.0-fips"
+	dda := testutils.NewDatadogAgentBuilder().
+		WithName("datadog-agent").
+		WithAnnotations(map[string]string{
+			"agent.datadoghq.com/host-profiler-enabled":      "true",
+			"agent.datadoghq.com/host-profiler-selinux-type": "custom_t",
+		}).
+		Build()
+
+	manager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: string(apicommon.CoreAgentContainerName), Image: images.GetLatestAgentImage()},
+				{
+					Name:            string(apicommon.HostProfiler),
+					Image:           hostProfilerImage,
+					SecurityContext: &corev1.SecurityContext{ReadOnlyRootFilesystem: ptr.To(true)},
+				},
+			},
+		},
+	})
+
+	hostProfilerFeat := buildHostProfilerFeature(nil).(*hostProfilerFeature)
+	hostProfilerFeat.Configure(dda, &dda.Spec, nil)
+	assert.NoError(t, hostProfilerFeat.ManageNodeAgent(manager))
+
+	var hpContainer *corev1.Container
+	for i := range manager.Tpl.Spec.Containers {
+		if manager.Tpl.Spec.Containers[i].Name == string(apicommon.HostProfiler) {
+			hpContainer = &manager.Tpl.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, hpContainer)
+	// The selinux-type annotation overrides the spc_t default.
+	require.NotNil(t, hpContainer.SecurityContext.SELinuxOptions)
+	assert.Equal(t, "custom_t", hpContainer.SecurityContext.SELinuxOptions.Type)
 }
 
 func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expectedVolumeMount []corev1.VolumeMount) *test.ComponentTest {

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -30,7 +30,9 @@ const (
 	// set to "false" to disable both the seccomp profile and its setup init container.
 	EnableHostProfilerSeccompAnnotation        = "agent.datadoghq.com/host-profiler-seccomp-enabled"
 	EnableHostProfilerLoggingSeccompAnnotation = "agent.datadoghq.com/host-profiler-logging-seccomp-enabled"
-	EnableKSMApiServerCacheAnnotation          = "agent.datadoghq.com/ksm-use-apiserver-cache"
+	// HostProfilerSELinuxTypeAnnotation overrides the SELinux type applied to the host-profiler container.
+	HostProfilerSELinuxTypeAnnotation = "agent.datadoghq.com/host-profiler-selinux-type"
+	EnableKSMApiServerCacheAnnotation = "agent.datadoghq.com/ksm-use-apiserver-cache"
 
 	EnableInstrumentationCRDAnnotation = "agent.datadoghq.com/instrumentation-crd-enabled"
 


### PR DESCRIPTION
### What does this PR do?

Defaults `securityContext.SELinuxOptions` to `type: spc_t` so the host profiler can work out of the box on nodes enforcing SELinux profiles.
Adds an annotation to change the value.

### Motivation

Without this, the default SELinux profile denies ptrace and the profiler only shows kernel frames.

### Additional Notes

Based on https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/6986172492/Accepted+Handling+of+LSMs+across+OSes.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Setting `seLinuxOptions.type: spc_t` alongside apparmor was tested on:
- eks ubuntu / bottlerocket nodes
- on rel-env
- on stingchameleon and charcadet (experimental clusters)

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits