### PR TITLE
Update default Agent/ClusterAgent/DdotCollector image version to 7.81.1

### DIFF
--- a/internal/controller/datadogagent/feature/test/factory_test.go
+++ b/internal/controller/datadogagent/feature/test/factory_test.go
@@ -105,7 +105,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM enabled, 4 agents",
+			name: "APM, NPM enabled, 3 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithAPMEnabled(true).
 				WithNPMEnabled(true).
@@ -113,7 +113,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           false,
@@ -124,7 +124,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM enabled with single container strategy, 4 agents",
+			name: "APM, NPM enabled with single container strategy, 3 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithSingleContainerStrategy(true).
 				WithAPMEnabled(true).
@@ -133,7 +133,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           false,
@@ -144,7 +144,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM, CSPM enabled, 5 agents",
+			name: "APM, NPM, CSPM enabled, 4 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithAPMEnabled(true).
 				WithNPMEnabled(true).
@@ -153,7 +153,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           true,
@@ -164,7 +164,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM, CSPM enabled with single container strategy, 5 agents",
+			name: "APM, NPM, CSPM enabled with single container strategy, 4 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithSingleContainerStrategy(true).
 				WithAPMEnabled(true).
@@ -174,7 +174,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           true,

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -2160,7 +2160,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 60baa72c89bba480e44da7d5c0a1fb6d
+    agent.datadoghq.com/agentspechash: 796858400c16bcf92c5b81a3a03388e0
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -2279,7 +2279,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.1
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2334,7 +2334,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.1
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -2248,7 +2248,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: gcr.io/datadoghq/agent:7.80.4
+        image: gcr.io/datadoghq/agent:7.81.1
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2303,7 +2303,7 @@ spec:
         command:
         - bash
         - -c
-        image: gcr.io/datadoghq/agent:7.80.4
+        image: gcr.io/datadoghq/agent:7.81.1
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -2125,7 +2125,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 396747e4e69c910aa70f8f5d5cc909e9
+    agent.datadoghq.com/agentspechash: 787a0c5a069bf277220d16eb69031348
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -2276,7 +2276,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.1
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2331,7 +2331,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.1
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -2157,7 +2157,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 60baa72c89bba480e44da7d5c0a1fb6d
+    agent.datadoghq.com/agentspechash: 796858400c16bcf92c5b81a3a03388e0
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -2179,7 +2179,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 60baa72c89bba480e44da7d5c0a1fb6d
+    agent.datadoghq.com/agentspechash: 796858400c16bcf92c5b81a3a03388e0
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -2298,7 +2298,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.1
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2353,7 +2353,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.1
         name: init-config
         resources: {}
         volumeMounts:

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.80.4"
+	AgentLatestVersion = "7.81.1"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.80.4"
+	ClusterAgentLatestVersion = "7.81.1"
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
-	DdotCollectorLatestVersion = "7.80.4"
+	DdotCollectorLatestVersion = "7.81.1"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.28"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.


### PR DESCRIPTION
## What does this PR do?

Bumps the default Agent, ClusterAgent, and DdotCollector image versions from `7.80.4` to `7.81.1` for the upcoming `v1.29.0-rc.2` build. `7.81.1` is the latest stable release and is confirmed published on Docker Hub for both `agent` and `cluster-agent`.

## Motivation

Pre-release step for `v1.29.0-rc.2`. `1.29.0-rc.1` shipped with `7.80.4` as a conservative default; `7.81.1` is now well-established (published 2026-07-15), so we bump to it for rc.2.

## Changes
- `pkg/images/images.go` — `AgentLatestVersion`, `ClusterAgentLatestVersion`, `DdotCollectorLatestVersion` → `7.81.1`
- Golden render fixtures (`testdata/golden/comprehensive-*.golden.yaml`) updated to match the new default