### PR TITLE
Replace deprecated --config flag with --cfgpath on process-agent

### DIFF
--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -482,7 +482,7 @@ func processAgentContainer(dda metav1.Object) corev1.Container {
 		Name:  string(apicommon.ProcessAgentContainerName),
 		Image: agentImage(),
 		Command: []string{
-			"process-agent", fmt.Sprintf("--config=%s", agentCustomConfigVolumePath),
+			"process-agent", fmt.Sprintf("--cfgpath=%s", agentCustomConfigVolumePath),
 			fmt.Sprintf("--sysprobe-config=%s", systemProbeConfigVolumePath),
 		},
 		Env:          commonEnvVars(dda),


### PR DESCRIPTION
## Summary
- The process-agent's `--config` flag was deprecated in favor of `--cfgpath` in [DataDog/datadog-agent#11328](https://github.com/DataDog/datadog-agent/pull/11328), and usage of the deprecated flag emits a warning. For customers, this can be unexpected when they have actually set up the operator correctly.
- This PR updates the default process-agent container command (`default.go`). The `-config` flag is also used for the GKE Autopilot override ([`provider_apply.go`](https://github.com/DataDog/datadog-operator/blob/2ba0ea304d2f61e2c26fc3a5e3b9aa53353d2b4d/internal/controller/datadogagent/global/provider_apply.go#L82)), but `--cfgpath` is not in the [allowlist](https://github.com/DataDog/datadog-gke-workload-allowlist/blob/876391f742cef10c2a9078ce9d14ddb16fd40058/datadog/datadog-datadog-daemonset-exemption-v1.0.5.yaml#L112-L114), so it is unchanged here.

Jira: [CXP-3069](https://datadoghq.atlassian.net/browse/CXP-3069)

## Test plan
- [ ] Deploy an agent with process collection enabled and confirm the process-agent container starts successfully with `--cfgpath` and no deprecation warning is logged

[CXP-3069]: https://datadoghq.atlassian.net/browse/CXP-3069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ