### PR TITLE
[CONTP-1887] Retry on conflict to write resource ID in status

### DIFF
--- a/internal/controller/datadoggenericresource/controller.go
+++ b/internal/controller/datadoggenericresource/controller.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -289,8 +290,37 @@ func applyResourceState(state string, status *v1alpha1.DatadogGenericResourceSta
 
 func (r *Reconciler) updateStatusIfNeeded(ctx context.Context, instance *v1alpha1.DatadogGenericResource, status *v1alpha1.DatadogGenericResourceStatus, result ctrl.Result) (ctrl.Result, error) {
 	if !apiequality.Semantic.DeepEqual(&instance.Status, status) {
-		instance.Status = *status
-		if err := r.client.Status().Update(ctx, instance); err != nil {
+		desiredStatus := status.DeepCopy()
+		instance.Status = *desiredStatus.DeepCopy()
+		err := r.client.Status().Update(ctx, instance)
+		if apierrors.IsConflict(err) {
+			// The Datadog API operation may already have succeeded, so preserve
+			// the resulting status (most importantly the remote resource ID) and
+			// retry only the Kubernetes status write against the latest object.
+			key := client.ObjectKeyFromObject(instance)
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latest := &v1alpha1.DatadogGenericResource{}
+				if getErr := r.client.Get(ctx, key, latest); getErr != nil {
+					return getErr
+				}
+
+				if apiequality.Semantic.DeepEqual(&latest.Status, desiredStatus) {
+					instance.ResourceVersion = latest.ResourceVersion
+					instance.Status = latest.Status
+					return nil
+				}
+
+				latest.Status = *desiredStatus.DeepCopy()
+				if updateErr := r.client.Status().Update(ctx, latest); updateErr != nil {
+					return updateErr
+				}
+
+				instance.ResourceVersion = latest.ResourceVersion
+				instance.Status = latest.Status
+				return nil
+			})
+		}
+		if err != nil {
 			logger := ctrl.LoggerFrom(ctx)
 			if apierrors.IsConflict(err) {
 				logger.Error(err, "unable to update DatadogGenericResource status due to update conflict")

--- a/internal/controller/datadoggenericresource/controller_test.go
+++ b/internal/controller/datadoggenericresource/controller_test.go
@@ -35,6 +35,92 @@ const (
 	resourcesNamespace = "bar"
 )
 
+type conflictOnceClient struct {
+	client.Client
+	remainingConflicts int
+}
+
+func (c *conflictOnceClient) Status() client.SubResourceWriter {
+	return &conflictOnceStatusWriter{
+		SubResourceWriter: c.Client.Status(),
+		client:            c,
+	}
+}
+
+type conflictOnceStatusWriter struct {
+	client.SubResourceWriter
+	client *conflictOnceClient
+}
+
+func (w *conflictOnceStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if w.client.remainingConflicts > 0 {
+		w.client.remainingConflicts--
+
+		latest := &datadoghqv1alpha1.DatadogGenericResource{}
+		if err := w.client.Client.Get(ctx, client.ObjectKeyFromObject(obj), latest); err != nil {
+			return err
+		}
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		latest.Annotations["issue-3272-conflict"] = "true"
+		if err := w.client.Client.Update(ctx, latest); err != nil {
+			return err
+		}
+
+		return apierrors.NewConflict(
+			datadoghqv1alpha1.GroupVersion.WithResource("datadoggenericresources").GroupResource(),
+			obj.GetName(),
+			fmt.Errorf("injected status update conflict"),
+		)
+	}
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+func TestReconcileGenericResource_RetriesCreatedStatusAfterConflict(t *testing.T) {
+	resetMockHandlerState()
+	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	s := scheme.Scheme
+	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogGenericResource{})
+
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(s, corev1.EventSource{Component: "TestReconcileGenericResource_RetriesCreatedStatusAfterConflict"})
+
+	baseClient := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build()
+	conflictingClient := &conflictOnceClient{Client: baseClient}
+	r := NewReconciler(
+		conflictingClient,
+		config.NewCredentialManager(fake.NewClientBuilder().Build()),
+		s,
+		logf.Log.WithName("created-status-conflict"),
+		recorder,
+	)
+	r.handlers = map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
+		mockSubresource: &MockHandler{},
+	}
+
+	instance := mockGenericResource()
+	instance.Finalizers = []string{datadogGenericResourceFinalizer}
+	assert.NoError(t, r.client.Create(context.TODO(), instance))
+
+	conflictingClient.remainingConflicts = 1
+	result, err := reconcileRequest(r, context.TODO(), newRequest(resourcesNamespace, resourcesName))
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: defaultRequeuePeriod}, result)
+	assert.Equal(t, 0, conflictingClient.remainingConflicts, "the injected status conflict should be consumed")
+
+	assert.NoError(t, r.client.Get(context.TODO(), client.ObjectKeyFromObject(instance), instance))
+	assert.Equal(t, mockResourceID, instance.Status.Id, "the ID returned by the successful create must be persisted")
+	assert.Equal(t, "true", instance.Annotations["issue-3272-conflict"], "the concurrent metadata update must be preserved")
+
+	_, err = reconcileRequest(r, context.TODO(), newRequest(resourcesNamespace, resourcesName))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, mockCreateCalls, "a status conflict must not cause a second Datadog create")
+}
+
 func TestReconcileGenericResource_Reconcile(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileGenericResource_Reconcile"})

--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -333,8 +334,37 @@ func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, datadogMonitor *da
 	condition.SetErrorActiveConditions(status, now, currentErr)
 
 	if !apiequality.Semantic.DeepEqual(&datadogMonitor.Status, status) {
-		datadogMonitor.Status = *status
-		if err := r.client.Status().Update(context.TODO(), datadogMonitor); err != nil {
+		desiredStatus := status.DeepCopy()
+		datadogMonitor.Status = *desiredStatus.DeepCopy()
+		err := r.client.Status().Update(context.TODO(), datadogMonitor)
+		if apierrors.IsConflict(err) {
+			// The Datadog API operation may already have succeeded, so preserve
+			// the resulting status (most importantly the remote resource ID) and
+			// retry only the Kubernetes status write against the latest object.
+			key := client.ObjectKeyFromObject(datadogMonitor)
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latest := &datadoghqv1alpha1.DatadogMonitor{}
+				if getErr := r.client.Get(context.TODO(), key, latest); getErr != nil {
+					return getErr
+				}
+
+				if apiequality.Semantic.DeepEqual(&latest.Status, desiredStatus) {
+					datadogMonitor.ResourceVersion = latest.ResourceVersion
+					datadogMonitor.Status = latest.Status
+					return nil
+				}
+
+				latest.Status = *desiredStatus.DeepCopy()
+				if updateErr := r.client.Status().Update(context.TODO(), latest); updateErr != nil {
+					return updateErr
+				}
+
+				datadogMonitor.ResourceVersion = latest.ResourceVersion
+				datadogMonitor.Status = latest.Status
+				return nil
+			})
+		}
+		if err != nil {
 			if apierrors.IsConflict(err) {
 				logger.Error(err, "unable to update DatadogMonitor status due to update conflict")
 				return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, nil

--- a/internal/controller/datadogmonitor/controller_test.go
+++ b/internal/controller/datadogmonitor/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -41,6 +42,116 @@ const (
 	resourcesName      = "foo"
 	resourcesNamespace = "bar"
 )
+
+type conflictOnceClient struct {
+	client.Client
+	remainingConflicts atomic.Int32
+}
+
+func (c *conflictOnceClient) Status() client.SubResourceWriter {
+	return &conflictOnceStatusWriter{
+		SubResourceWriter: c.Client.Status(),
+		client:            c,
+	}
+}
+
+type conflictOnceStatusWriter struct {
+	client.SubResourceWriter
+	client *conflictOnceClient
+}
+
+func (w *conflictOnceStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if w.client.remainingConflicts.CompareAndSwap(1, 0) {
+		latest := &datadoghqv1alpha1.DatadogMonitor{}
+		if err := w.client.Client.Get(ctx, client.ObjectKeyFromObject(obj), latest); err != nil {
+			return err
+		}
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		latest.Annotations["issue-3272-conflict"] = "true"
+		if err := w.client.Client.Update(ctx, latest); err != nil {
+			return err
+		}
+
+		return apierrors.NewConflict(
+			datadoghqv1alpha1.GroupVersion.WithResource("datadogmonitors").GroupResource(),
+			obj.GetName(),
+			fmt.Errorf("injected status update conflict"),
+		)
+	}
+	return w.SubResourceWriter.Update(ctx, obj, opts...)
+}
+
+func TestReconcileDatadogMonitor_RetriesCreatedStatusAfterConflict(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileDatadogMonitor_RetriesCreatedStatusAfterConflict"})
+
+	s := scheme.Scheme
+	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogMonitor{})
+
+	var createCount atomic.Int32
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/validate"):
+			fmt.Fprint(w, `{}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/monitor":
+			createCount.Add(1)
+			fmt.Fprint(w, `{"id":12345,"name":"test monitor","query":"q","type":"metric alert","created":"2026-07-21T08:00:00Z","creator":{"email":"test@example.com"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/monitor/12345":
+			fmt.Fprint(w, `{"id":12345,"name":"test monitor","query":"q","type":"metric alert"}`)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/monitor/12345":
+			fmt.Fprint(w, `{"id":12345,"name":"test monitor","query":"q","type":"metric alert"}`)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer httpServer.Close()
+
+	t.Setenv("DD_URL", httpServer.URL)
+	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+
+	testConfig := datadogapi.NewConfiguration()
+	testConfig.HTTPClient = httpServer.Client()
+	apiClient := datadogapi.NewAPIClient(testConfig)
+	ddClient := datadogV1.NewMonitorsApi(apiClient)
+
+	baseClient := fake.NewClientBuilder().WithStatusSubresource(&datadoghqv1alpha1.DatadogMonitor{}).Build()
+	conflictingClient := &conflictOnceClient{Client: baseClient}
+	r := &Reconciler{
+		client:        conflictingClient,
+		datadogClient: ddClient,
+		credsManager:  config.NewCredentialManager(fake.NewClientBuilder().Build()),
+		scheme:        s,
+		recorder:      recorder,
+		log:           logf.Log.WithName("created-status-conflict"),
+	}
+
+	dm := genericDatadogMonitor(r.client)
+	dm.Finalizers = []string{datadogMonitorFinalizer}
+	dm.Spec.Tags = []string{requiredTag}
+	assert.NoError(t, r.client.Update(context.TODO(), dm))
+	assert.NoError(t, r.client.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm))
+
+	conflictingClient.remainingConflicts.Store(1)
+	result, err := r.Reconcile(context.TODO(), dm)
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: defaultRequeuePeriod}, result)
+	assert.Equal(t, int32(0), conflictingClient.remainingConflicts.Load(), "the injected status conflict should be consumed")
+
+	assert.NoError(t, r.client.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm))
+	assert.Equal(t, 12345, dm.Status.ID, "the ID returned by the successful create must be persisted")
+	assert.True(t, dm.Status.Primary)
+	assert.Equal(t, "true", dm.Annotations["issue-3272-conflict"], "the concurrent metadata update must be preserved")
+
+	_, err = r.Reconcile(context.TODO(), dm)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(1), createCount.Load(), "a status conflict must not cause a second Datadog create")
+}
 
 func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 	eventBroadcaster := record.NewBroadcaster()


### PR DESCRIPTION
### What does this PR do?

Retries conflicting Kubernetes status writes for `DatadogMonitor` and `DatadogGenericResource` while preserving the ID returned by a successful Datadog API create. This prevents duplicate creates and orphaned remote resources.

### Motivation

Fixes #3272. A concurrent Kubernetes update could make the post-create status write fail with a conflict, discard the remote ID, and cause every subsequent reconciliation to retry the create.

### Additional Notes

The shared `DatadogGenericResource` fix covers all supported resource types. No CRD or Agent changes are required.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Automated tests:

```bash
go test ./internal/controller/datadogmonitor/ ./internal/controller/datadoggenericresource/ -count=1
go vet ./internal/controller/datadogmonitor/ ./internal/controller/datadoggenericresource/
```

Manual conflict reproduction:

1. Build and deploy the PR image with the relevant controller enabled.
2. Prepare a valid, uniquely named resource in a watched namespace, based on `examples/datadogmonitor/metric-monitor-test.yaml` or `examples/datadoggenericresource/monitor-sample.yaml`. Do not add finalizers or controller-managed tags to the manifest.
3. Start the watcher below before applying the manifest. It waits for the controller to add its finalizer (and the required `DatadogMonitor` tag), then changes annotations while the Datadog create request is running:

```bash
KIND=datadogmonitor # repeat with datadoggenericresource
NAME=<resource-name> # for instance, datadog-monitor-test if using the example manifest below
MANIFEST=<manifest-path> # /Users/<>/go/src/github.com/DataDog/datadog-operator/examples/datadogmonitor/metric-monitor-test.yaml
FINALIZER=finalizer.monitor.datadoghq.com # use finalizer.datadoghq.com/genericresource for DDGR

(
  until kubectl get "$KIND" "$NAME" -o json 2>/dev/null |
    jq -e --arg finalizer "$FINALIZER" '(.metadata.finalizers // []) | index($finalizer)' >/dev/null; do
    sleep 0.05
  done

  if [ "$KIND" = datadogmonitor ]; then
    until kubectl get "$KIND" "$NAME" -o json |
      jq -e '(.spec.tags // []) | index("generated:kubernetes")' >/dev/null; do
      sleep 0.05
    done
  fi

  for i in $(seq 1 30); do
    kubectl annotate "$KIND" "$NAME" issue-3272-race="$i" --overwrite
    sleep 0.1
  done
) &

race_pid=$!
kubectl apply -f "$MANIFEST"
wait "$race_pid"
sleep 8
```

4. Verify the remote ID is persisted, no spam of 400 error logs in operator logs

```json
{"level":"ERROR","ts":"2026-07-21T08:26:28.976Z","logger":"controllers.DatadogMonitor","msg":"unable to update DatadogMonitor status due to update conflict","datadogmonitor":{"name":"datadog-monitor-test","namespace":"default"},"error":"Operation cannot be fulfilled on datadogmonitors.datadoghq.com \"datadog-monitor-test\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"github.com/DataDog/datadog-operator/internal/controller/datadogmonitor.(*Reconciler).updateStatusIfNeeded\n\t/workspace/internal/controller/datadogmonitor/controller.go:321\ngithub.com/DataDog/datadog-operator/internal/controller/datadogmonitor.(*Reconciler).internalReconcile\n\t/workspace/internal/controller/datadogmonitor/controller.go:237\ngithub.com/DataDog/datadog-operator/internal/controller/datadogmonitor.(*Reconciler).Reconcile\n\t/workspace/internal/controller/datadogmonitor/controller.go:95\ngithub.com/DataDog/datadog-operator/internal/controller.(*DatadogMonitorReconciler).Reconcile\n\t/workspace/internal/controller/datadogmonitor_controller.go:44\nsigs.k8s.io/controller-runtime/pkg/reconcile.(*objectReconcilerAdapter[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/reconcile/reconcile.go:164\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:296"}
```


Expected: annotation `30`, a non-empty `status.id`, exactly one create log, and no duplicate error. Delete the CR and confirm its finalizer removes the remote resource.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
