### PR TITLE
Force metrics v2 in operator E2E tests

### DIFF
--- a/config/new-e2e/agent-metrics-v2-env.yaml
+++ b/config/new-e2e/agent-metrics-v2-env.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-metrics-v2-env
+data:
+  # TODO: Remove once the e2e fakeintake client supports metrics v3.
+  DD_USE_V3_API_SERIES_ENABLED: "false"

--- a/config/new-e2e/kustomization.yaml
+++ b/config/new-e2e/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: e2e-operator
 resources:
 - ../crd
 - ../rbac
+- agent-metrics-v2-env.yaml

--- a/test/e2e/manifests/apm/datadog-agent-apm.yaml
+++ b/test/e2e/manifests/apm/datadog-agent-apm.yaml
@@ -18,3 +18,16 @@ spec:
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/datadog-agent-ccr-enabled.yaml
+++ b/test/e2e/manifests/datadog-agent-ccr-enabled.yaml
@@ -35,3 +35,16 @@ spec:
                 type: gauge
               help: Number of up-to-date agents
               name: uptodateagents
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/datadog-agent-gke-autopilot.yaml
+++ b/test/e2e/manifests/datadog-agent-gke-autopilot.yaml
@@ -14,3 +14,16 @@ spec:
       containerCollectAll: true
     npm:
       enabled: true
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/datadog-agent-logs.yaml
+++ b/test/e2e/manifests/datadog-agent-logs.yaml
@@ -19,3 +19,16 @@ spec:
       containerCollectAll: true
     liveContainerCollection:
       enabled: true
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/datadog-agent-minimum.yaml
+++ b/test/e2e/manifests/datadog-agent-minimum.yaml
@@ -9,3 +9,16 @@ spec:
     registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-adp.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-adp.yaml
@@ -20,3 +20,16 @@ spec:
       enabled: true
       dogstatsd:
         enabled: true
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp.yaml
@@ -16,3 +16,16 @@ spec:
         hostPort: 8125
       unixDomainSocketConfig:
         enabled: false
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds-adp.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds-adp.yaml
@@ -20,3 +20,16 @@ spec:
       enabled: true
       dogstatsd:
         enabled: true
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-uds.yaml
@@ -16,3 +16,16 @@ spec:
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/dsd.socket
+  override:
+    nodeAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterAgent:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env
+    clusterChecksRunner:
+      envFrom:
+        - configMapRef:
+            name: datadog-operator-e2e-agent-metrics-v2-env


### PR DESCRIPTION
### What does this PR do?

Disables metrics v3 in operator E2E DatadogAgent manifests so metrics remain visible to the pinned fake-intake client.

### Motivation

Agent 7.81.1 enables metrics v3 by default, while the current fake-intake dependency only reads metrics from the v2 endpoint.

### Additional Notes

This is temporary. Remove the override after the repository is upgraded to Go 1.26 and the fake-intake dependency can be bumped to a version with metrics v3 support.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- Rendered `config/new-e2e` with Kustomize.
- Verified every E2E DatadogAgent manifest references the shared environment ConfigMap.
- Compiled the Kubernetes E2E suite.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits