### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/go:dev-1.25",
+    "image": "mcr.microsoft.com/devcontainers/go:dev-1.26",
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
             "moby": false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 env:
-  GO_VERSION: 1.25.12
+  GO_VERSION: 1.26.5
 on:
   push:
 # Permission forced by repo-level setting; only elevate on job-level

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.25.12
+  GO_VERSION: 1.26.5
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   # packages: read
 env:
-  GO_VERSION: 1.25.12
+  GO_VERSION: 1.26.5
 jobs:
   build-linux-binary:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/yaml-mapper.yml
+++ b/.github/workflows/yaml-mapper.yml
@@ -12,7 +12,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.25.12
+  GO_VERSION: 1.26.5
 jobs:
   yaml-mapper-test:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/images/mirror/library/golang:1.25.12
+image: registry.ddbuild.io/images/mirror/library/golang:1.26.5
 variables:
   NIGHTLY_BUILD_CONDUCTOR_NAME: "operator-nightly-build"
   PROJECTNAME: "datadog-operator"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG FIPS_ENABLED=false
 
 # Build the manager binary
-FROM golang:1.25.12 AS builder
+FROM golang:1.26.5 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,8 @@
 module github.com/DataDog/datadog-operator/api
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.12
+toolchain go1.26.5
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.56.0

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.12 AS builder
+FROM golang:1.26.5 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/ec2nodeclass.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/ec2nodeclass.go
@@ -51,7 +51,7 @@ func CreateOrUpdateEC2NodeClass(ctx context.Context, client client.Client, clust
 		},
 		Spec: karpawsv1.EC2NodeClassSpec{
 			Role:             "KarpenterNodeRole-" + clusterName,
-			AMIFamily:        lo.ToPtr(nc.GetAMIFamily()),
+			AMIFamily:        new(nc.GetAMIFamily()),
 			AMISelectorTerms: amiSelectorTerms,
 			SubnetSelectorTerms: lo.Map(nc.GetSubnetIDs(), func(subnetID string, _ int) karpawsv1.SubnetSelectorTerm {
 				return karpawsv1.SubnetSelectorTerm{

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/fromnodegroups.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/fromnodegroups.go
@@ -230,14 +230,14 @@ func extractMetadataOptionsFromLaunchTemplate(opts *ec2types.LaunchTemplateInsta
 
 	var hopLimit *int64
 	if opts.HttpPutResponseHopLimit != nil {
-		hopLimit = lo.ToPtr(int64(*opts.HttpPutResponseHopLimit))
+		hopLimit = new(int64(*opts.HttpPutResponseHopLimit))
 	}
 
 	return &MetadataOptions{
-		HTTPEndpoint:            lo.Ternary(opts.HttpEndpoint != "", lo.ToPtr(string(opts.HttpEndpoint)), nil),
-		HTTPTokens:              lo.Ternary(opts.HttpTokens != "", lo.ToPtr(string(opts.HttpTokens)), nil),
+		HTTPEndpoint:            lo.Ternary(opts.HttpEndpoint != "", new(string(opts.HttpEndpoint)), nil),
+		HTTPTokens:              lo.Ternary(opts.HttpTokens != "", new(string(opts.HttpTokens)), nil),
 		HTTPPutResponseHopLimit: hopLimit,
-		HTTPProtocolIPv6:        lo.Ternary(opts.HttpProtocolIpv6 != "", lo.ToPtr(string(opts.HttpProtocolIpv6)), nil),
+		HTTPProtocolIPv6:        lo.Ternary(opts.HttpProtocolIpv6 != "", new(string(opts.HttpProtocolIpv6)), nil),
 	}
 }
 
@@ -256,10 +256,10 @@ func extractBlockDeviceMappingsFromLaunchTemplate(mappings []ec2types.LaunchTemp
 			DeviceName:          mapping.DeviceName,
 			RootVolume:          isRootDevice(mapping.DeviceName),
 			DeleteOnTermination: mapping.Ebs.DeleteOnTermination,
-			VolumeSize:          lo.Ternary(mapping.Ebs.VolumeSize != nil, lo.ToPtr(fmt.Sprintf("%dGi", lo.FromPtr(mapping.Ebs.VolumeSize))), nil),
-			VolumeType:          lo.Ternary(mapping.Ebs.VolumeType != "", lo.ToPtr(string(mapping.Ebs.VolumeType)), nil),
-			IOPS:                lo.Ternary(mapping.Ebs.Iops != nil, lo.ToPtr(int64(lo.FromPtr(mapping.Ebs.Iops))), nil),
-			Throughput:          lo.Ternary(mapping.Ebs.Throughput != nil, lo.ToPtr(int64(lo.FromPtr(mapping.Ebs.Throughput))), nil),
+			VolumeSize:          lo.Ternary(mapping.Ebs.VolumeSize != nil, new(fmt.Sprintf("%dGi", lo.FromPtr(mapping.Ebs.VolumeSize))), nil),
+			VolumeType:          lo.Ternary(mapping.Ebs.VolumeType != "", new(string(mapping.Ebs.VolumeType)), nil),
+			IOPS:                lo.Ternary(mapping.Ebs.Iops != nil, new(int64(lo.FromPtr(mapping.Ebs.Iops))), nil),
+			Throughput:          lo.Ternary(mapping.Ebs.Throughput != nil, new(int64(lo.FromPtr(mapping.Ebs.Throughput))), nil),
 			Encrypted:           mapping.Ebs.Encrypted,
 			KMSKeyID:            mapping.Ebs.KmsKeyId,
 			SnapshotID:          mapping.Ebs.SnapshotId,

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/fromnodes.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/fromnodes.go
@@ -171,14 +171,14 @@ func extractMetadataOptions(opts *ec2types.InstanceMetadataOptionsResponse) *Met
 
 	var hopLimit *int64
 	if opts.HttpPutResponseHopLimit != nil {
-		hopLimit = lo.ToPtr(int64(*opts.HttpPutResponseHopLimit))
+		hopLimit = new(int64(*opts.HttpPutResponseHopLimit))
 	}
 
 	return &MetadataOptions{
-		HTTPEndpoint:            lo.Ternary(opts.HttpEndpoint != "", lo.ToPtr(string(opts.HttpEndpoint)), nil),
-		HTTPTokens:              lo.Ternary(opts.HttpTokens != "", lo.ToPtr(string(opts.HttpTokens)), nil),
+		HTTPEndpoint:            lo.Ternary(opts.HttpEndpoint != "", new(string(opts.HttpEndpoint)), nil),
+		HTTPTokens:              lo.Ternary(opts.HttpTokens != "", new(string(opts.HttpTokens)), nil),
 		HTTPPutResponseHopLimit: hopLimit,
-		HTTPProtocolIPv6:        lo.Ternary(opts.HttpProtocolIpv6 != "", lo.ToPtr(string(opts.HttpProtocolIpv6)), nil),
+		HTTPProtocolIPv6:        lo.Ternary(opts.HttpProtocolIpv6 != "", new(string(opts.HttpProtocolIpv6)), nil),
 	}
 }
 
@@ -256,10 +256,10 @@ func extractBlockDeviceMappingsWithVolumeDetails(ctx context.Context, ec2Client 
 				DeviceName:          mapping.DeviceName,
 				RootVolume:          isRootDevice(mapping.DeviceName),
 				DeleteOnTermination: mapping.Ebs.DeleteOnTermination,
-				VolumeSize:          lo.Ternary(vol.Size != nil, lo.ToPtr(fmt.Sprintf("%dGi", lo.FromPtr(vol.Size))), nil),
-				VolumeType:          lo.Ternary(vol.VolumeType != "", lo.ToPtr(string(vol.VolumeType)), nil),
-				IOPS:                lo.Ternary(vol.Iops != nil, lo.ToPtr(int64(lo.FromPtr(vol.Iops))), nil),
-				Throughput:          lo.Ternary(vol.Throughput != nil, lo.ToPtr(int64(lo.FromPtr(vol.Throughput))), nil),
+				VolumeSize:          lo.Ternary(vol.Size != nil, new(fmt.Sprintf("%dGi", lo.FromPtr(vol.Size))), nil),
+				VolumeType:          lo.Ternary(vol.VolumeType != "", new(string(vol.VolumeType)), nil),
+				IOPS:                lo.Ternary(vol.Iops != nil, new(int64(lo.FromPtr(vol.Iops))), nil),
+				Throughput:          lo.Ternary(vol.Throughput != nil, new(int64(lo.FromPtr(vol.Throughput))), nil),
 				Encrypted:           vol.Encrypted,
 				KMSKeyID:            vol.KmsKeyId,
 				SnapshotID:          vol.SnapshotId,

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/nodepoolsset.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/karpenter/nodepoolsset.go
@@ -261,7 +261,7 @@ func (nps *NodePoolsSet) Add(p NodePoolsSetAddParams) {
 		securityGroupIDs: lo.Keyify(p.SecurityGroupIDs),
 		metadataOptions:  p.MetadataOptions,
 		blockDeviceMappings: lo.Associate(p.BlockDeviceMappings, func(bdm BlockDeviceMapping) (string, *BlockDeviceMapping) {
-			return lo.FromPtr(bdm.DeviceName), lo.ToPtr(bdm)
+			return lo.FromPtr(bdm.DeviceName), new(bdm)
 		}),
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
@@ -399,7 +398,7 @@ func run(opts *options) error {
 		// the sync.Once in SetProvider, routing standard workqueue metrics to the
 		// k8s legacy registry instead of controller-runtime's registry.
 		Controller: ctrlconfig.Controller{
-			UsePriorityQueue: ptr.To(true),
+			UsePriorityQueue: new(true),
 		},
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-operator
 
-go 1.25.12
+go 1.26.5
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.63.0-rc.1 // indirect

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.12
+go 1.26.5
 
-toolchain go1.25.12
+toolchain go1.26.5
 
 use (
 	.

--- a/internal/controller/datadogagent/common/apparmor.go
+++ b/internal/controller/datadogagent/common/apparmor.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -66,7 +65,7 @@ func appArmorProfileFromAnnotation(value string) *corev1.AppArmorProfile {
 	default:
 		return &corev1.AppArmorProfile{
 			Type:             corev1.AppArmorProfileTypeLocalhost,
-			LocalhostProfile: ptr.To(strings.TrimPrefix(value, "localhost/")),
+			LocalhostProfile: new(strings.TrimPrefix(value, "localhost/")),
 		}
 	}
 }

--- a/internal/controller/datadogagent/component/agent/default.go
+++ b/internal/controller/datadogagent/component/agent/default.go
@@ -396,7 +396,7 @@ func agentSingleContainer(dda metav1.Object) []corev1.Container {
 		ReadinessProbe: constants.GetDefaultReadinessProbe(),
 		StartupProbe:   constants.GetDefaultStartupProbe(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 
@@ -448,7 +448,7 @@ func coreAgentContainer(dda metav1.Object) corev1.Container {
 		ReadinessProbe: constants.GetDefaultReadinessProbe(),
 		StartupProbe:   constants.GetDefaultStartupProbe(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -472,7 +472,7 @@ func traceAgentContainer(dda metav1.Object) corev1.Container {
 		VolumeMounts:  volumeMountsForTraceAgent(),
 		LivenessProbe: constants.GetDefaultTraceAgentProbe(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -488,7 +488,7 @@ func processAgentContainer(dda metav1.Object) corev1.Container {
 		Env:          commonEnvVars(dda),
 		VolumeMounts: volumeMountsForProcessAgent(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -522,7 +522,7 @@ func otelAgentContainer(dda metav1.Object) corev1.Container {
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -541,7 +541,7 @@ func hostProfilerContainer(dda metav1.Object) corev1.Container {
 		// the hostprofiler feature adds tracingfs on top via ManageNodeAgent.
 		VolumeMounts: volumeMountsForOtelAgent(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -557,7 +557,7 @@ func securityAgentContainer(dda metav1.Object) corev1.Container {
 		Env:          envVarsForSecurityAgent(dda),
 		VolumeMounts: volumeMountsForSecurityAgent(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -573,7 +573,7 @@ func systemProbeContainer(dda metav1.Object) corev1.Container {
 		Env:          commonEnvVars(dda),
 		VolumeMounts: volumeMountsForSystemProbe(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 			SeccompProfile: &corev1.SeccompProfile{
 				Type:             corev1.SeccompProfileTypeLocalhost,
 				LocalhostProfile: ptr.To(common.SystemProbeSeccompProfileName),
@@ -595,7 +595,7 @@ func privateActionRunnerContainer(dda metav1.Object) corev1.Container {
 		Env:          commonEnvVars(dda),
 		VolumeMounts: volumeMountsForPrivateActionRunner(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -615,7 +615,7 @@ func agentDataPlaneContainer(dda metav1.Object) corev1.Container {
 		LivenessProbe:  constants.GetDefaultAgentDataPlaneLivenessProbe(),
 		ReadinessProbe: constants.GetDefaultAgentDataPlaneReadinessProbe(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }
@@ -630,7 +630,7 @@ func flightRecorderContainer(dda metav1.Object) corev1.Container {
 		Env:          commonEnvVars(dda),
 		VolumeMounts: volumeMountsForFlightRecorder(),
 		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 	}
 }

--- a/internal/controller/datadogagent/component/agent/new.go
+++ b/internal/controller/datadogagent/component/agent/new.go
@@ -107,18 +107,18 @@ func defaultEDSSpec(options *ExtendedDaemonsetOptions) edsv1alpha1.ExtendedDaemo
 		spec.Strategy.Canary.Replicas = apiutils.NewIntOrStringPointer(options.CanaryReplicas)
 	}
 
-	spec.Strategy.Canary.AutoFail.Enabled = edsv1alpha1.NewBool(options.CanaryAutoFailEnabled)
+	spec.Strategy.Canary.AutoFail.Enabled = new(options.CanaryAutoFailEnabled)
 	if options.CanaryAutoFailMaxRestarts > 0 {
-		spec.Strategy.Canary.AutoFail.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoFailMaxRestarts)
+		spec.Strategy.Canary.AutoFail.MaxRestarts = new(options.CanaryAutoFailMaxRestarts)
 	}
 
 	if options.CanaryAutoPauseMaxSlowStartDuration != 0 {
 		spec.Strategy.Canary.AutoPause.MaxSlowStartDuration = &metav1.Duration{Duration: options.CanaryAutoPauseMaxSlowStartDuration}
 	}
 
-	spec.Strategy.Canary.AutoPause.Enabled = edsv1alpha1.NewBool(options.CanaryAutoPauseEnabled)
+	spec.Strategy.Canary.AutoPause.Enabled = new(options.CanaryAutoPauseEnabled)
 	if options.CanaryAutoPauseMaxRestarts > 0 {
-		spec.Strategy.Canary.AutoPause.MaxRestarts = edsv1alpha1.NewInt32(options.CanaryAutoPauseMaxRestarts)
+		spec.Strategy.Canary.AutoPause.MaxRestarts = new(options.CanaryAutoPauseMaxRestarts)
 	}
 	return spec
 }

--- a/internal/controller/datadogagent/component/clusteragent/default.go
+++ b/internal/controller/datadogagent/component/clusteragent/default.go
@@ -14,7 +14,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -66,7 +65,7 @@ func NewDefaultClusterAgentDeployment(ddaMeta metav1.Object, ddaSpec *v2alpha1.D
 
 	maps.Copy(podTemplate.Annotations, deployment.GetAnnotations())
 	deployment.Spec.Template = *podTemplate
-	deployment.Spec.Replicas = ptr.To(defaultClusterAgentReplicas)
+	deployment.Spec.Replicas = new(defaultClusterAgentReplicas)
 
 	return deployment
 }
@@ -132,8 +131,8 @@ func defaultPodSpec(ddaMeta metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, v
 				Command:        nil,
 				Args:           nil,
 				SecurityContext: &corev1.SecurityContext{
-					ReadOnlyRootFilesystem:   ptr.To(true),
-					AllowPrivilegeEscalation: ptr.To(false),
+					ReadOnlyRootFilesystem:   new(true),
+					AllowPrivilegeEscalation: new(false),
 				},
 			},
 		},

--- a/internal/controller/datadogagent/component/clusterchecksrunner/default.go
+++ b/internal/controller/datadogagent/component/clusterchecksrunner/default.go
@@ -16,7 +16,6 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -177,8 +176,8 @@ func defaultPodSpec(dda metav1.Object, volumes []corev1.Volume, volumeMounts []c
 				ReadinessProbe: constants.GetDefaultReadinessProbe(),
 				StartupProbe:   constants.GetDefaultStartupProbe(),
 				SecurityContext: &corev1.SecurityContext{
-					ReadOnlyRootFilesystem:   ptr.To(true),
-					AllowPrivilegeEscalation: ptr.To(false),
+					ReadOnlyRootFilesystem:   new(true),
+					AllowPrivilegeEscalation: new(false),
 				},
 			},
 		},

--- a/internal/controller/datadogagent/component/otelagentgateway/default.go
+++ b/internal/controller/datadogagent/component/otelagentgateway/default.go
@@ -12,7 +12,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -40,7 +39,7 @@ func NewDefaultOtelAgentGatewayDeployment(dda metav1.Object, ddaSpec *v2alpha1.D
 	maps.Copy(podTemplate.Annotations, deployment.GetAnnotations())
 
 	deployment.Spec.Template = *podTemplate
-	deployment.Spec.Replicas = ptr.To(defaultOtelAgentGatewayReplicas)
+	deployment.Spec.Replicas = new(defaultOtelAgentGatewayReplicas)
 
 	return deployment
 }

--- a/internal/controller/datadogagent/defaults/datadogagent_default.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default.go
@@ -156,7 +156,7 @@ func defaultGlobalConfig(ddaSpec *v2alpha1.DatadogAgentSpec) {
 	}
 
 	if ddaSpec.Global.Site == nil {
-		ddaSpec.Global.Site = ptr.To(defaultSite)
+		ddaSpec.Global.Site = new(defaultSite)
 	}
 
 	if ddaSpec.Global.Registry == nil {
@@ -171,7 +171,7 @@ func defaultGlobalConfig(ddaSpec *v2alpha1.DatadogAgentSpec) {
 	}
 
 	if ddaSpec.Global.LogLevel == nil {
-		ddaSpec.Global.LogLevel = ptr.To(defaultLogLevel)
+		ddaSpec.Global.LogLevel = new(defaultLogLevel)
 	}
 
 	if ddaSpec.Global.ContainerStrategy == nil {
@@ -424,7 +424,7 @@ func defaultFeaturesConfig(ddaSpec *v2alpha1.DatadogAgentSpec) {
 
 	if ddaSpec.Features.Dogstatsd.HostPortConfig == nil {
 		ddaSpec.Features.Dogstatsd.HostPortConfig = &v2alpha1.HostPortConfig{
-			Enabled: ptr.To(defaultDogstatsdHostPortEnabled),
+			Enabled: new(defaultDogstatsdHostPortEnabled),
 		}
 	}
 

--- a/internal/controller/datadogagent/feature/admissioncontroller/feature.go
+++ b/internal/controller/datadogagent/feature/admissioncontroller/feature.go
@@ -13,7 +13,6 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -154,7 +153,7 @@ func (f *admissionControllerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 		f.localServiceName = constants.GetLocalAgentServiceName(dda.GetName(), ddaSpec)
 		reqComp = feature.RequiredComponents{
 			ClusterAgent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 			},
 		}

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -16,7 +16,6 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -182,7 +181,7 @@ func (f *apmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 		f.udsHostFilepath = *apm.UnixDomainSocketConfig.Path
 
 		reqComp.Agent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.CoreAgentContainerName,
 				apicommon.TraceAgentContainerName,
@@ -214,7 +213,7 @@ func (f *apmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 			}
 		}
 		reqComp.ClusterAgent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.ClusterAgentContainerName,
 			},

--- a/internal/controller/datadogagent/feature/apm/profile_overlay.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay.go
@@ -41,7 +41,7 @@ func applyAPMProfileSharedConfigOverlay(dst, base *v2alpha1.DatadogAgentSpec, pr
 	if err := mergeSSI(dstSSI, profileSSI); err != nil {
 		return err
 	}
-	dstSSI.Enabled = ptr.To(true)
+	dstSSI.Enabled = new(true)
 	defaultLanguageDetection(dstSSI)
 
 	return nil
@@ -74,8 +74,8 @@ func applyProfileLocalAgentServicePort(dst, base, profileSpec *v2alpha1.DatadogA
 		dst.Features.APM = &v2alpha1.APMFeatureConfig{}
 	}
 	dst.Features.APM.HostPortConfig = &v2alpha1.HostPortConfig{
-		Enabled: ptr.To(true),
-		Port:    ptr.To(profilePort),
+		Enabled: new(true),
+		Port:    new(profilePort),
 	}
 	return nil
 }
@@ -230,7 +230,7 @@ func defaultLanguageDetection(dst *v2alpha1.SingleStepInstrumentation) {
 		dst.LanguageDetection = &v2alpha1.LanguageDetectionConfig{}
 	}
 	if dst.LanguageDetection.Enabled == nil {
-		dst.LanguageDetection.Enabled = ptr.To(true)
+		dst.LanguageDetection.Enabled = new(true)
 	}
 }
 
@@ -255,7 +255,7 @@ func mergeBoolPtr(dst **bool, src *bool, field string) error {
 	if *dst != nil && ptr.Deref(*dst, false) != srcValue {
 		return fmt.Errorf("%s has conflicting values", field)
 	}
-	*dst = ptr.To(srcValue)
+	*dst = new(srcValue)
 	return nil
 }
 

--- a/internal/controller/datadogagent/feature/appsec/feature.go
+++ b/internal/controller/datadogagent/feature/appsec/feature.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -104,7 +103,7 @@ func (f *appsecFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAg
 	// The cluster agent is required for the AppSec feature.
 	return feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.ClusterAgentContainerName,
 			},

--- a/internal/controller/datadogagent/feature/asm/feature.go
+++ b/internal/controller/datadogagent/feature/asm/feature.go
@@ -8,7 +8,6 @@ package asm
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -64,7 +63,7 @@ func (f *asmFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSp
 	// The cluster agent and the admission controller are required for the ASM feature.
 	return feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.ClusterAgentContainerName,
 			},

--- a/internal/controller/datadogagent/feature/autoscaling/feature.go
+++ b/internal/controller/datadogagent/feature/autoscaling/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -92,7 +91,7 @@ func (f *autoscalingFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Data
 
 	return feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 		},
 	}

--- a/internal/controller/datadogagent/feature/clusterchecks/feature.go
+++ b/internal/controller/datadogagent/feature/clusterchecks/feature.go
@@ -11,7 +11,6 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -74,11 +73,11 @@ func (f *clusterChecksFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Da
 		f.useClusterCheckRunners = apiutils.BoolValue(ddaSpec.Features.ClusterChecks.UseClusterChecksRunners)
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
 			},
 			ClusterAgent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 			},
 			ClusterChecksRunner: feature.RequiredComponent{

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/feature.go
@@ -69,7 +69,7 @@ func (f *controlPlaneMonitoringFeature) Configure(dda metav1.Object, ddaSpec *v2
 
 	if controlPlaneMonitoring != nil && apiutils.BoolValue(controlPlaneMonitoring.Enabled) {
 		f.enabled = true
-		reqComp.ClusterAgent.IsRequired = ptr.To(true)
+		reqComp.ClusterAgent.IsRequired = new(true)
 		reqComp.ClusterAgent.Containers = []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName}
 	}
 	return reqComp

--- a/internal/controller/datadogagent/feature/cspm/feature.go
+++ b/internal/controller/datadogagent/feature/cspm/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -110,11 +109,11 @@ func (f *cspmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgen
 
 		reqComp = feature.RequiredComponents{
 			ClusterAgent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 			},
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{
 					nodeContainer,
 				},

--- a/internal/controller/datadogagent/feature/cws/feature.go
+++ b/internal/controller/datadogagent/feature/cws/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -123,7 +122,7 @@ func (f *cwsFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: reqContainers,
 			},
 		}

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -119,7 +118,7 @@ func (f *dogstatsdFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 
 	reqComp = feature.RequiredComponents{
 		Agent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.CoreAgentContainerName,
 			},

--- a/internal/controller/datadogagent/feature/dyninst/feature.go
+++ b/internal/controller/datadogagent/feature/dyninst/feature.go
@@ -8,7 +8,6 @@ package dyninst
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -46,7 +45,7 @@ func (f *dynInstFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAge
 	if apiutils.BoolValue(ddaSpec.Features.DynamicInstrumentation.Enabled) {
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{
 					apicommon.CoreAgentContainerName,
 					apicommon.SystemProbeContainerName,

--- a/internal/controller/datadogagent/feature/ebpfcheck/feature.go
+++ b/internal/controller/datadogagent/feature/ebpfcheck/feature.go
@@ -8,7 +8,6 @@ package ebpfcheck
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -43,7 +42,7 @@ func (f *ebpfCheckFeature) ID() feature.IDType {
 func (f *ebpfCheckFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
 	if ddaSpec.Features != nil && ddaSpec.Features.EBPFCheck != nil && apiutils.BoolValue(ddaSpec.Features.EBPFCheck.Enabled) {
 		reqComp.Agent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName},
 		}
 	}

--- a/internal/controller/datadogagent/feature/eventcollection/feature.go
+++ b/internal/controller/datadogagent/feature/eventcollection/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -86,7 +85,7 @@ func (f *eventCollectionFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.
 
 		reqComp = feature.RequiredComponents{
 			ClusterAgent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 			},
 		}

--- a/internal/controller/datadogagent/feature/externalmetrics/feature.go
+++ b/internal/controller/datadogagent/feature/externalmetrics/feature.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -137,7 +136,7 @@ func (f *externalMetricsFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.
 
 		reqComp = feature.RequiredComponents{
 			ClusterAgent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 			},
 		}

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -84,7 +84,7 @@ func (f *gpuFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSp
 	}
 
 	reqComp.Agent = feature.RequiredComponent{
-		IsRequired: ptr.To(true),
+		IsRequired: new(true),
 		Containers: requiredContainers,
 	}
 

--- a/internal/controller/datadogagent/feature/helmcheck/feature.go
+++ b/internal/controller/datadogagent/feature/helmcheck/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -71,9 +70,9 @@ func (f *helmCheckFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 	helmCheck := ddaSpec.Features.HelmCheck
 
 	if helmCheck != nil && apiutils.BoolValue(helmCheck.Enabled) {
-		reqComp.ClusterAgent.IsRequired = ptr.To(true)
+		reqComp.ClusterAgent.IsRequired = new(true)
 		reqComp.ClusterAgent.Containers = []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName}
-		reqComp.Agent.IsRequired = ptr.To(true)
+		reqComp.Agent.IsRequired = new(true)
 		reqComp.Agent.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 
 		f.configMapName = fmt.Sprintf("%s-%s", f.owner.GetName(), defaultHelmCheckConf)
@@ -85,7 +84,7 @@ func (f *helmCheckFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
 			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.GetName(), ddaSpec)
-			reqComp.ClusterChecksRunner.IsRequired = ptr.To(true)
+			reqComp.ClusterChecksRunner.IsRequired = new(true)
 			reqComp.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 		}
 

--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -69,7 +68,7 @@ func (o *hostProfilerFeature) Configure(dda metav1.Object, _ *v2alpha1.DatadogAg
 
 	return feature.RequiredComponents{
 		Agent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.CoreAgentContainerName,
 				apicommon.HostProfiler,
@@ -122,7 +121,7 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 	hostProfilerImage := resolveHostProfilerImage(o.owner, hostProfilerContainer.Image)
 
 	sc := hostProfilerContainer.SecurityContext
-	sc.AllowPrivilegeEscalation = ptr.To(false)
+	sc.AllowPrivilegeEscalation = new(false)
 	sc.Capabilities = &corev1.Capabilities{
 		Drop: []corev1.Capability{"ALL"},
 		Add:  defaultCapabilities(),
@@ -134,7 +133,7 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 	if o.seccompEnabled {
 		sc.SeccompProfile = &corev1.SeccompProfile{
 			Type:             corev1.SeccompProfileTypeLocalhost,
-			LocalhostProfile: ptr.To(seccompProfileName(hostProfilerImage)),
+			LocalhostProfile: new(seccompProfileName(hostProfilerImage)),
 		}
 
 		// seccomp-root EmptyDir volume (shared with system-probe when both are enabled; VolumeManager deduplicates)

--- a/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
+++ b/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -85,11 +84,11 @@ func (f *instrumentationCRDFeature) Configure(dda metav1.Object, ddaSpec *v2alph
 
 	return feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 		},
 		Agent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName},
 		},
 	}

--- a/internal/controller/datadogagent/feature/kubernetesactions/feature.go
+++ b/internal/controller/datadogagent/feature/kubernetesactions/feature.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -77,7 +76,7 @@ func (f *kubernetesActionsFeature) Configure(dda metav1.Object, ddaSpec *v2alpha
 
 	reqComp = feature.RequiredComponents{
 		ClusterAgent: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName},
 		},
 	}

--- a/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -87,9 +86,9 @@ func (f *ksmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 	var output feature.RequiredComponents
 
 	if ddaSpec.Features != nil && ddaSpec.Features.KubeStateMetricsCore != nil && apiutils.BoolValue(ddaSpec.Features.KubeStateMetricsCore.Enabled) {
-		output.ClusterAgent.IsRequired = ptr.To(true)
+		output.ClusterAgent.IsRequired = new(true)
 		output.ClusterAgent.Containers = []apicommon.AgentContainerName{apicommon.ClusterAgentContainerName}
-		output.Agent.IsRequired = ptr.To(true)
+		output.Agent.IsRequired = new(true)
 		output.Agent.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 
 		f.collectAPIServiceMetrics = true
@@ -107,7 +106,7 @@ func (f *ksmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 			f.runInClusterChecksRunner = true
 			f.rbacSuffix = common.ChecksRunnerSuffix
 			f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.GetName(), ddaSpec)
-			output.ClusterChecksRunner.IsRequired = ptr.To(true)
+			output.ClusterChecksRunner.IsRequired = new(true)
 			output.ClusterChecksRunner.Containers = []apicommon.AgentContainerName{apicommon.CoreAgentContainerName}
 
 			if ccrOverride, ok := ddaSpec.Override[v2alpha1.ClusterChecksRunnerComponentName]; ok {

--- a/internal/controller/datadogagent/feature/livecontainer/feature.go
+++ b/internal/controller/datadogagent/feature/livecontainer/feature.go
@@ -8,7 +8,6 @@ package livecontainer
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -56,7 +55,7 @@ func (f *liveContainerFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.Data
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: reqContainers,
 			},
 		}

--- a/internal/controller/datadogagent/feature/liveprocess/feature.go
+++ b/internal/controller/datadogagent/feature/liveprocess/feature.go
@@ -8,7 +8,6 @@ package liveprocess
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -46,10 +45,10 @@ func (f *liveProcessFeature) ID() feature.IDType {
 func (f *liveProcessFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
 	if ddaSpec.Features.LiveProcessCollection != nil && apiutils.BoolValue(ddaSpec.Features.LiveProcessCollection.Enabled) {
 		if ddaSpec.Features.LiveProcessCollection.ScrubProcessArguments != nil {
-			f.scrubArgs = ptr.To(*ddaSpec.Features.LiveProcessCollection.ScrubProcessArguments)
+			f.scrubArgs = new(*ddaSpec.Features.LiveProcessCollection.ScrubProcessArguments)
 		}
 		if ddaSpec.Features.LiveProcessCollection.StripProcessArguments != nil {
-			f.stripArgs = ptr.To(*ddaSpec.Features.LiveProcessCollection.StripProcessArguments)
+			f.stripArgs = new(*ddaSpec.Features.LiveProcessCollection.StripProcessArguments)
 		}
 
 		reqContainers := []apicommon.AgentContainerName{
@@ -64,7 +63,7 @@ func (f *liveProcessFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.Datado
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: reqContainers,
 			},
 		}

--- a/internal/controller/datadogagent/feature/logcollection/feature.go
+++ b/internal/controller/datadogagent/feature/logcollection/feature.go
@@ -10,7 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -77,7 +76,7 @@ func (f *logCollectionFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.Data
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{
 					apicommon.CoreAgentContainerName,
 				},

--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -8,7 +8,6 @@ package npm
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -73,7 +72,7 @@ func (f *npmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: containers,
 			},
 		}

--- a/internal/controller/datadogagent/feature/oomkill/feature.go
+++ b/internal/controller/datadogagent/feature/oomkill/feature.go
@@ -8,7 +8,6 @@ package oomkill
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -56,7 +55,7 @@ func (f *oomKillFeature) ID() feature.IDType {
 func (f *oomKillFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
 	if ddaSpec.Features != nil && ddaSpec.Features.OOMKill != nil && apiutils.BoolValue(ddaSpec.Features.OOMKill.Enabled) {
 		reqComp.Agent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName},
 		}
 	}

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -91,8 +90,8 @@ func (f *orchestratorExplorerFeature) Configure(dda metav1.Object, ddaSpec *v2al
 
 	if orchestratorExplorer != nil && apiutils.BoolValue(orchestratorExplorer.Enabled) {
 		f.enabled = true
-		reqComp.ClusterAgent.IsRequired = ptr.To(true)
-		reqComp.Agent.IsRequired = ptr.To(true)
+		reqComp.ClusterAgent.IsRequired = new(true)
+		reqComp.Agent.IsRequired = new(true)
 
 		if orchestratorExplorer.Conf != nil || len(orchestratorExplorer.CustomResources) > 0 {
 			f.customConfig = orchestratorExplorer.Conf
@@ -144,7 +143,7 @@ func (f *orchestratorExplorerFeature) Configure(dda metav1.Object, ddaSpec *v2al
 				f.runInClusterChecksRunner = true
 				f.rbacSuffix = common.ChecksRunnerSuffix
 				f.serviceAccountName = constants.GetClusterChecksRunnerServiceAccount(dda.GetName(), ddaSpec)
-				reqComp.ClusterChecksRunner.IsRequired = ptr.To(true)
+				reqComp.ClusterChecksRunner.IsRequired = new(true)
 			}
 		}
 	}

--- a/internal/controller/datadogagent/feature/otelagentgateway/feature.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature.go
@@ -70,7 +70,7 @@ func (f *otelAgentGatewayFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1
 
 	reqComp = feature.RequiredComponents{
 		OtelAgentGateway: feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.OtelAgent},
 		},
 	}

--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -143,7 +143,7 @@ func (o *otelCollectorFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Da
 	if apiutils.BoolValue(ddaSpec.Features.OtelCollector.Enabled) {
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{
 					apicommon.CoreAgentContainerName,
 					apicommon.OtelAgent,
@@ -295,7 +295,7 @@ func otelCollectorSupportsAgentImage(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 }
 
 func otelCollectorRequiresNewerAgent(agentImageName, agentVersion string) bool {
-	return !utils.IsAboveMinVersion(agentVersion, otelAgentMinVersion, ptr.To(true)) && agentImageName == ""
+	return !utils.IsAboveMinVersion(agentVersion, otelAgentMinVersion, new(true)) && agentImageName == ""
 }
 
 func otelCollectorRejectsFullTag(agentImageName, agentVersion string) bool {

--- a/internal/controller/datadogagent/feature/otlp/feature.go
+++ b/internal/controller/datadogagent/feature/otlp/feature.go
@@ -114,7 +114,7 @@ func (f *otlpFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgen
 	if f.grpcEnabled || f.httpEnabled {
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{
 					apicommon.CoreAgentContainerName,
 				},

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -74,7 +73,7 @@ func (f *privateActionRunnerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 		}
 
 		reqComp.Agent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.CoreAgentContainerName,
 				apicommon.PrivateActionRunnerContainerName,
@@ -111,7 +110,7 @@ func (f *privateActionRunnerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 		f.clusterServiceAccountName = constants.GetClusterAgentServiceAccount(dda.GetName(), ddaSpec)
 
 		reqComp.ClusterAgent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{
 				apicommon.ClusterAgentContainerName,
 			},

--- a/internal/controller/datadogagent/feature/processdiscovery/feature.go
+++ b/internal/controller/datadogagent/feature/processdiscovery/feature.go
@@ -8,7 +8,6 @@ package processdiscovery
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -53,7 +52,7 @@ func (p *processDiscoveryFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.D
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: reqContainers,
 			},
 		}

--- a/internal/controller/datadogagent/feature/prometheusscrape/feature.go
+++ b/internal/controller/datadogagent/feature/prometheusscrape/feature.go
@@ -10,7 +10,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -60,13 +59,13 @@ func (f *prometheusScrapeFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.D
 		}
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{
 					apicommon.CoreAgentContainerName,
 				},
 			},
 			ClusterAgent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: []apicommon.AgentContainerName{
 					apicommon.ClusterAgentContainerName,
 				},

--- a/internal/controller/datadogagent/feature/sbom/feature.go
+++ b/internal/controller/datadogagent/feature/sbom/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -87,7 +86,7 @@ func (f *sbomFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.DatadogAgentS
 		}
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: containers,
 			},
 		}

--- a/internal/controller/datadogagent/feature/servicediscovery/feature.go
+++ b/internal/controller/datadogagent/feature/servicediscovery/feature.go
@@ -8,7 +8,6 @@ package servicediscovery
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -48,7 +47,7 @@ func (f *serviceDiscoveryFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.D
 	if resolveEnabled(ddaSpec) {
 		f.useSystemProbeLite = shouldEnableServiceDiscoveryByDefault(ddaSpec)
 		reqComp.Agent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName},
 		}
 	}
@@ -68,7 +67,7 @@ func resolveEnabled(ddaSpec *v2alpha1.DatadogAgentSpec) bool {
 	}
 
 	if ddaSpec.Features.ServiceDiscovery.Enabled == nil {
-		ddaSpec.Features.ServiceDiscovery.Enabled = ptr.To(shouldEnableServiceDiscoveryByDefault(ddaSpec))
+		ddaSpec.Features.ServiceDiscovery.Enabled = new(shouldEnableServiceDiscoveryByDefault(ddaSpec))
 	}
 
 	return apiutils.BoolValue(ddaSpec.Features.ServiceDiscovery.Enabled)
@@ -78,7 +77,7 @@ func shouldEnableServiceDiscoveryByDefault(ddaSpec *v2alpha1.DatadogAgentSpec) b
 	// Agent version must be >= 7.78.0 to enable service discovery by default.
 	if nodeAgent, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok {
 		if nodeAgent != nil && nodeAgent.Image != nil {
-			return pkgutils.IsAboveMinVersion(common.GetAgentVersionFromImage(*nodeAgent.Image), serviceDiscoveryAutoEnableMinVersion, ptr.To(true))
+			return pkgutils.IsAboveMinVersion(common.GetAgentVersionFromImage(*nodeAgent.Image), serviceDiscoveryAutoEnableMinVersion, new(true))
 		}
 	}
 	return pkgutils.IsAboveMinVersion(images.AgentLatestVersion, serviceDiscoveryAutoEnableMinVersion, nil)

--- a/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
+++ b/internal/controller/datadogagent/feature/tcpqueuelength/feature.go
@@ -8,7 +8,6 @@ package tcpqueuelength
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -59,7 +58,7 @@ func (f *tcpQueueLengthFeature) Configure(_ metav1.Object, ddaSpec *v2alpha1.Dat
 	}
 	if ddaSpec.Features.TCPQueueLength != nil && apiutils.BoolValue(ddaSpec.Features.TCPQueueLength.Enabled) {
 		reqComp.Agent = feature.RequiredComponent{
-			IsRequired: ptr.To(true),
+			IsRequired: new(true),
 			Containers: []apicommon.AgentContainerName{apicommon.CoreAgentContainerName, apicommon.SystemProbeContainerName},
 		}
 	}

--- a/internal/controller/datadogagent/feature/types.go
+++ b/internal/controller/datadogagent/feature/types.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -108,9 +107,9 @@ func merge(a, b *bool) *bool {
 		return a
 	}
 	if !apiutils.BoolValue(a) || !apiutils.BoolValue(b) {
-		return ptr.To(false)
+		return new(false)
 	}
-	return ptr.To(true)
+	return new(true)
 }
 
 func mergeSlices(a, b []common.AgentContainerName) []common.AgentContainerName {

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -8,7 +8,6 @@ package usm
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -72,7 +71,7 @@ func (f *usmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 
 		reqComp = feature.RequiredComponents{
 			Agent: feature.RequiredComponent{
-				IsRequired: ptr.To(true),
+				IsRequired: new(true),
 				Containers: containers,
 			},
 		}

--- a/internal/controller/datadogagent/override/container.go
+++ b/internal/controller/datadogagent/override/container.go
@@ -11,7 +11,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -284,7 +283,7 @@ func overrideStartupProbe(startupProbeOverride *corev1.Probe) *corev1.Probe {
 func overrideSecurityContext(securityContext *corev1.SecurityContext) *corev1.SecurityContext {
 	if securityContext.ReadOnlyRootFilesystem == nil {
 		// Default to readOnlyRootFilesystem to true if not explicitly configured.
-		securityContext.ReadOnlyRootFilesystem = ptr.To(true)
+		securityContext.ReadOnlyRootFilesystem = new(true)
 	}
 	return securityContext
 }

--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -313,7 +312,7 @@ func ensureOverrideExists(ddai *v1alpha1.DatadogAgentInternal, componentName v2a
 
 func disableComponent(ddai *v1alpha1.DatadogAgentInternal, componentName v2alpha1.ComponentName) {
 	ensureOverrideExists(ddai, componentName)
-	ddai.Spec.Override[componentName].Disabled = ptr.To(true)
+	ddai.Spec.Override[componentName].Disabled = new(true)
 }
 
 func setProfileDDAIAffinity(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.DatadogAgentProfile) *corev1.Affinity {

--- a/internal/controller/datadogagent/utils.go
+++ b/internal/controller/datadogagent/utils.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
@@ -163,14 +162,14 @@ func getReplicas(currentReplicas, newReplicas *int32) *int32 {
 		if currentReplicas != nil {
 			// Do not overwrite the current value
 			// It's most likely managed by an autoscaler
-			return ptr.To(*currentReplicas)
+			return new(*currentReplicas)
 		}
 
 		// Both new and current are nil
 		return nil
 	}
 
-	return ptr.To(*newReplicas)
+	return new(*newReplicas)
 }
 
 // getDDAICRDFromConfig is only used in tests

--- a/internal/controller/datadogagentinternal/utils.go
+++ b/internal/controller/datadogagentinternal/utils.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -158,14 +157,14 @@ func getReplicas(currentReplicas, newReplicas *int32) *int32 {
 		if currentReplicas != nil {
 			// Do not overwrite the current value
 			// It's most likely managed by an autoscaler
-			return ptr.To(*currentReplicas)
+			return new(*currentReplicas)
 		}
 
 		// Both new and current are nil
 		return nil
 	}
 
-	return ptr.To(*newReplicas)
+	return new(*newReplicas)
 }
 
 // delete ALL workloads for a given DDA/DDAI and orphan pods

--- a/internal/controller/testutils/agent.go
+++ b/internal/controller/testutils/agent.go
@@ -41,8 +41,8 @@ func NewDatadogAgentWithAdmissionController(namespace string, name string) v2alp
 		name,
 		&v2alpha1.DatadogFeatures{
 			AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{
-				Enabled:          ptr.To(true),
-				MutateUnlabelled: ptr.To(true),
+				Enabled:          new(true),
+				MutateUnlabelled: new(true),
 			},
 		},
 	)
@@ -55,10 +55,10 @@ func NewDatadogAgentWithCWSInstrumentation(namespace string, name string) v2alph
 		name,
 		&v2alpha1.DatadogFeatures{
 			AdmissionController: &v2alpha1.AdmissionControllerFeatureConfig{
-				Enabled:          ptr.To(true),
-				MutateUnlabelled: ptr.To(true),
+				Enabled:          new(true),
+				MutateUnlabelled: new(true),
 				CWSInstrumentation: &v2alpha1.CWSInstrumentationConfig{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 				},
 			},
 		},
@@ -72,9 +72,9 @@ func NewDatadogAgentWithAPM(namespace string, name string) v2alpha1.DatadogAgent
 		name,
 		&v2alpha1.DatadogFeatures{
 			APM: &v2alpha1.APMFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 				HostPortConfig: &v2alpha1.HostPortConfig{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 				},
 			},
 		},
@@ -88,8 +88,8 @@ func NewDatadogAgentWithClusterChecks(namespace string, name string) v2alpha1.Da
 		name,
 		&v2alpha1.DatadogFeatures{
 			ClusterChecks: &v2alpha1.ClusterChecksFeatureConfig{
-				Enabled:                 ptr.To(true),
-				UseClusterChecksRunners: ptr.To(true),
+				Enabled:                 new(true),
+				UseClusterChecksRunners: new(true),
 			},
 		},
 	)
@@ -102,7 +102,7 @@ func NewDatadogAgentWithCSPM(namespace string, name string) v2alpha1.DatadogAgen
 		name,
 		&v2alpha1.DatadogFeatures{
 			CSPM: &v2alpha1.CSPMFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 				CheckInterval: &metav1.Duration{
 					Duration: 1 * time.Second,
 				},
@@ -118,10 +118,10 @@ func NewDatadogAgentWithCWS(namespace string, name string) v2alpha1.DatadogAgent
 		name,
 		&v2alpha1.DatadogFeatures{
 			CWS: &v2alpha1.CWSFeatureConfig{
-				Enabled:               ptr.To(true),
-				SyscallMonitorEnabled: ptr.To(true),
+				Enabled:               new(true),
+				SyscallMonitorEnabled: new(true),
 				SecurityProfiles: &v2alpha1.CWSSecurityProfilesConfig{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 				},
 			},
 		},
@@ -136,7 +136,7 @@ func NewDatadogAgentWithDogstatsd(namespace string, name string) v2alpha1.Datado
 		&v2alpha1.DatadogFeatures{
 			Dogstatsd: &v2alpha1.DogstatsdFeatureConfig{
 				HostPortConfig: &v2alpha1.HostPortConfig{
-					Enabled: ptr.To(true),
+					Enabled: new(true),
 					Port:    ptr.To[int32](1234),
 				},
 			},
@@ -151,7 +151,7 @@ func NewDatadogAgentWithEBPFCheck(namespace string, name string) v2alpha1.Datado
 		name,
 		&v2alpha1.DatadogFeatures{
 			EBPFCheck: &v2alpha1.EBPFCheckFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -164,7 +164,7 @@ func NewDatadogAgentWithServiceDiscovery(namespace, name string) v2alpha1.Datado
 		name,
 		&v2alpha1.DatadogFeatures{
 			ServiceDiscovery: &v2alpha1.ServiceDiscoveryFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -177,7 +177,7 @@ func NewDatadogAgentWithEventCollection(namespace string, name string) v2alpha1.
 		name,
 		&v2alpha1.DatadogFeatures{
 			EventCollection: &v2alpha1.EventCollectionFeatureConfig{
-				CollectKubernetesEvents: ptr.To(true),
+				CollectKubernetesEvents: new(true),
 			},
 		},
 	)
@@ -190,9 +190,9 @@ func NewDatadogAgentWithExternalMetrics(namespace string, name string) v2alpha1.
 		name,
 		&v2alpha1.DatadogFeatures{
 			ExternalMetricsServer: &v2alpha1.ExternalMetricsServerFeatureConfig{
-				Enabled:           ptr.To(true),
-				WPAController:     ptr.To(true),
-				UseDatadogMetrics: ptr.To(true),
+				Enabled:           new(true),
+				WPAController:     new(true),
+				UseDatadogMetrics: new(true),
 			},
 		},
 	)
@@ -205,7 +205,7 @@ func NewDatadogAgentWithKSM(namespace string, name string) v2alpha1.DatadogAgent
 		name,
 		&v2alpha1.DatadogFeatures{
 			KubeStateMetricsCore: &v2alpha1.KubeStateMetricsCoreFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -218,7 +218,7 @@ func NewDatadogAgentWithLiveContainerCollection(namespace string, name string) v
 		name,
 		&v2alpha1.DatadogFeatures{
 			LiveContainerCollection: &v2alpha1.LiveContainerCollectionFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -231,7 +231,7 @@ func NewDatadogAgentWithLiveProcessCollection(namespace string, name string) v2a
 		name,
 		&v2alpha1.DatadogFeatures{
 			LiveProcessCollection: &v2alpha1.LiveProcessCollectionFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -244,8 +244,8 @@ func NewDatadogAgentWithLogCollection(namespace string, name string) v2alpha1.Da
 		name,
 		&v2alpha1.DatadogFeatures{
 			LogCollection: &v2alpha1.LogCollectionFeatureConfig{
-				Enabled:             ptr.To(true),
-				ContainerCollectAll: ptr.To(true),
+				Enabled:             new(true),
+				ContainerCollectAll: new(true),
 			},
 		},
 	)
@@ -258,7 +258,7 @@ func NewDatadogAgentWithNPM(namespace string, name string) v2alpha1.DatadogAgent
 		name,
 		&v2alpha1.DatadogFeatures{
 			NPM: &v2alpha1.NPMFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -271,7 +271,7 @@ func NewDatadogAgentWithOOMKill(namespace string, name string) v2alpha1.DatadogA
 		name,
 		&v2alpha1.DatadogFeatures{
 			OOMKill: &v2alpha1.OOMKillFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -285,7 +285,7 @@ func NewDatadogAgentWithOrchestratorExplorer(namespace string, name string) v2al
 		name,
 		&v2alpha1.DatadogFeatures{
 			OrchestratorExplorer: &v2alpha1.OrchestratorExplorerFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -301,10 +301,10 @@ func NewDatadogAgentWithOTLP(namespace string, name string) v2alpha1.DatadogAgen
 				Receiver: v2alpha1.OTLPReceiverConfig{
 					Protocols: v2alpha1.OTLPProtocolsConfig{
 						GRPC: &v2alpha1.OTLPGRPCConfig{
-							Enabled: ptr.To(true),
+							Enabled: new(true),
 						},
 						HTTP: &v2alpha1.OTLPHTTPConfig{
-							Enabled: ptr.To(true),
+							Enabled: new(true),
 						},
 					},
 				},
@@ -320,7 +320,7 @@ func NewDatadogAgentWithPrometheusScrape(namespace string, name string) v2alpha1
 		name,
 		&v2alpha1.DatadogFeatures{
 			PrometheusScrape: &v2alpha1.PrometheusScrapeFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -333,7 +333,7 @@ func NewDatadogAgentWithTCPQueueLength(namespace string, name string) v2alpha1.D
 		name,
 		&v2alpha1.DatadogFeatures{
 			TCPQueueLength: &v2alpha1.TCPQueueLengthFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -346,7 +346,7 @@ func NewDatadogAgentWithUSM(namespace string, name string) v2alpha1.DatadogAgent
 		name,
 		&v2alpha1.DatadogFeatures{
 			USM: &v2alpha1.USMFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -359,7 +359,7 @@ func NewDatadogAgentWithGPUMonitoring(namespace string, name string) v2alpha1.Da
 		name,
 		&v2alpha1.DatadogFeatures{
 			GPU: &v2alpha1.GPUFeatureConfig{
-				Enabled: ptr.To(true),
+				Enabled: new(true),
 			},
 		},
 	)
@@ -374,22 +374,22 @@ func NewDatadogAgentWithGlobalConfigSettings(namespace string, name string) v2al
 	// to verify that the operator does not crash when parsing it and using it
 	// to configure some agent dependencies.
 	agent.Spec.Global = &v2alpha1.GlobalConfig{
-		ClusterAgentToken: ptr.To("my-cluster-agent-token"),
-		ClusterName:       ptr.To("my-cluster"),
-		Site:              ptr.To("some-dd-site"),
+		ClusterAgentToken: new("my-cluster-agent-token"),
+		ClusterName:       new("my-cluster"),
+		Site:              new("some-dd-site"),
 		Credentials: &v2alpha1.DatadogCredentials{
-			APIKey: ptr.To("my-api-key"),
-			AppKey: ptr.To("my-app-key"),
+			APIKey: new("my-api-key"),
+			AppKey: new("my-app-key"),
 		},
 		Endpoint: &v2alpha1.Endpoint{
-			URL: ptr.To("some-url"),
+			URL: new("some-url"),
 			Credentials: &v2alpha1.DatadogCredentials{
-				APIKey: ptr.To("my-api-key"),
-				AppKey: ptr.To("my-app-key"),
+				APIKey: new("my-api-key"),
+				AppKey: new("my-app-key"),
 			},
 		},
-		Registry: ptr.To("my-custom-registry"),
-		LogLevel: ptr.To("INFO"),
+		Registry: new("my-custom-registry"),
+		LogLevel: new("INFO"),
 		Tags:     []string{"tagA:valA", "tagB:valB"},
 		Env: []v1.EnvVar{
 			{
@@ -413,12 +413,12 @@ func NewDatadogAgentWithGlobalConfigSettings(namespace string, name string) v2al
 			"some-group.some-resource": {"some-annotation": "some-tag"},
 		},
 		NetworkPolicy: &v2alpha1.NetworkPolicyConfig{
-			Create: ptr.To(true),
+			Create: new(true),
 			Flavor: v2alpha1.NetworkPolicyFlavorKubernetes,
 		},
 		LocalService: &v2alpha1.LocalService{
-			NameOverride:            ptr.To("my-local-service"),
-			ForceEnableLocalService: ptr.To(true),
+			NameOverride:            new("my-local-service"),
+			ForceEnableLocalService: new(true),
 		},
 		Kubelet: &v2alpha1.KubeletConfig{
 			Host: &v1.EnvVarSource{
@@ -426,11 +426,11 @@ func NewDatadogAgentWithGlobalConfigSettings(namespace string, name string) v2al
 					FieldPath: common.FieldPathSpecNodeName,
 				},
 			},
-			TLSVerify:  ptr.To(true),
+			TLSVerify:  new(true),
 			HostCAPath: "some/path",
 		},
-		DockerSocketPath: ptr.To("/some/path"),
-		CriSocketPath:    ptr.To("/another/path"),
+		DockerSocketPath: new("/some/path"),
+		CriSocketPath:    new("/another/path"),
 	}
 
 	return agent
@@ -448,8 +448,8 @@ func NewDatadogAgentWithOverrides(namespace string, name string) v2alpha1.Datado
 	agent.Spec.Override[v2alpha1.NodeAgentComponentName] = &v2alpha1.DatadogAgentComponentOverride{
 		Name:               nil, // Don't override because these tests assume that it's always the default
 		Replicas:           nil, // Does not apply for the node agent
-		CreateRbac:         ptr.To(true),
-		ServiceAccountName: ptr.To("an-overridden-sa"),
+		CreateRbac:         new(true),
+		ServiceAccountName: new("an-overridden-sa"),
 		Image: &v2alpha1.AgentImageConfig{
 			Name:       "an-overridden-image-name",
 			Tag:        "7",
@@ -466,8 +466,8 @@ func NewDatadogAgentWithOverrides(namespace string, name string) v2alpha1.Datado
 		ExtraChecksd:         nil, // Also requires creating a configmap
 		Containers: map[apicommon.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{
 			apicommon.CoreAgentContainerName: {
-				Name:     ptr.To("my-container-name"),
-				LogLevel: ptr.To("debug"),
+				Name:     new("my-container-name"),
+				LogLevel: new("debug"),
 				Env: []v1.EnvVar{
 					{
 						Name:  "DD_LOG_LEVEL",
@@ -535,14 +535,14 @@ func NewDatadogAgentWithOverrides(namespace string, name string) v2alpha1.Datado
 					RunAsUser: ptr.To[int64](12345),
 				},
 				SeccompConfig: &v2alpha1.SeccompConfig{
-					CustomRootPath: ptr.To("/some/path"),
+					CustomRootPath: new("/some/path"),
 					CustomProfile: &v2alpha1.CustomConfig{
 						ConfigMap: &v2alpha1.ConfigMapConfig{
 							Name: "custom-seccomp-cm",
 						},
 					},
 				},
-				AppArmorProfileName: ptr.To("runtime/default"),
+				AppArmorProfileName: new("runtime/default"),
 			},
 		},
 		Volumes: []v1.Volume{
@@ -556,7 +556,7 @@ func NewDatadogAgentWithOverrides(namespace string, name string) v2alpha1.Datado
 		SecurityContext: &v1.PodSecurityContext{
 			RunAsUser: ptr.To[int64](1234),
 		},
-		PriorityClassName: ptr.To("a-priority-class"),
+		PriorityClassName: new("a-priority-class"),
 		Affinity: &v1.Affinity{
 			PodAntiAffinity: &v1.PodAntiAffinity{
 				PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
@@ -590,9 +590,9 @@ func NewDatadogAgentWithOverrides(namespace string, name string) v2alpha1.Datado
 		Labels: map[string]string{
 			"some-label": "456",
 		},
-		HostNetwork: ptr.To(false),
-		HostPID:     ptr.To(true),
-		Disabled:    ptr.To(false),
+		HostNetwork: new(false),
+		HostPID:     new(true),
+		Disabled:    new(false),
 	}
 
 	return agent

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -834,11 +834,11 @@ func (mf *metricsForwarder) forwardEvent(event Event) error {
 // delegatedSendEvent is separated from forwardEvent to facilitate mocking the Datadog API
 func (mf *metricsForwarder) delegatedSendEvent(eventTitle string, eventType EventType) error {
 	eventRequest := datadogV1.EventCreateRequest{
-		DateHappened:   datadogapi.PtrInt64(time.Now().Unix()),
+		DateHappened:   new(time.Now().Unix()),
 		Title:          eventTitle,
 		Text:           "",
 		Tags:           append(mf.globalTags, mf.tags...),
-		SourceTypeName: datadogapi.PtrString(datadogOperatorSourceType),
+		SourceTypeName: new(datadogOperatorSourceType),
 	}
 
 	ctx := mf.generateDatadogContext()
@@ -934,8 +934,8 @@ func (mf *metricsForwarder) sendMetric(ctx context.Context, metricName string, m
 				Metric: metricName,
 				Points: []datadogV2.MetricPoint{
 					{
-						Timestamp: datadogapi.PtrInt64(time.Now().Unix()),
-						Value:     datadogapi.PtrFloat64(value),
+						Timestamp: new(time.Now().Unix()),
+						Value:     new(value),
 					},
 				},
 				Type: metricType.Ptr(),

--- a/pkg/kubernetes/platforminfo.go
+++ b/pkg/kubernetes/platforminfo.go
@@ -5,7 +5,6 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/DataDog/datadog-operator/pkg/utils"
@@ -123,5 +122,5 @@ func (platformInfo *PlatformInfo) SupportsAppArmorProfile() bool {
 		return false
 	}
 
-	return utils.IsAboveMinVersion(platformInfo.versionInfo.GitVersion, appArmorProfileMinimumVersion, ptr.To(false))
+	return utils.IsAboveMinVersion(platformInfo.versionInfo.GitVersion, appArmorProfileMinimumVersion, new(false))
 }

--- a/pkg/testutils/builder.go
+++ b/pkg/testutils/builder.go
@@ -10,7 +10,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/defaults"
@@ -97,50 +96,50 @@ func (builder *DatadogAgentBuilder) initDogstatsd() {
 
 func (builder *DatadogAgentBuilder) WithDogstatsdHostPortEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.HostPortConfig.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.Dogstatsd.HostPortConfig.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithDogstatsdHostPortConfig(port int32) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.HostPortConfig.Port = ptr.To(port)
+	builder.datadogAgent.Spec.Features.Dogstatsd.HostPortConfig.Port = new(port)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithDogstatsdOriginDetectionEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.OriginDetectionEnabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.Dogstatsd.OriginDetectionEnabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithDogstatsdTagCardinality(cardinality string) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.OriginDetectionEnabled = ptr.To(true)
-	builder.datadogAgent.Spec.Features.Dogstatsd.TagCardinality = ptr.To(cardinality)
+	builder.datadogAgent.Spec.Features.Dogstatsd.OriginDetectionEnabled = new(true)
+	builder.datadogAgent.Spec.Features.Dogstatsd.TagCardinality = new(cardinality)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithDogstatsdUnixDomainSocketConfigEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithDogstatsdUnixDomainSocketConfigPath(customPath string) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Path = ptr.To(customPath)
+	builder.datadogAgent.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Path = new(customPath)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithDogstatsdMapperProfiles(customMapperProfilesConf string) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.MapperProfiles = &v2alpha1.CustomConfig{ConfigData: ptr.To(customMapperProfilesConf)}
+	builder.datadogAgent.Spec.Features.Dogstatsd.MapperProfiles = &v2alpha1.CustomConfig{ConfigData: new(customMapperProfilesConf)}
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithDogstatsdNonLocalTraffic(enabled bool) *DatadogAgentBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgent.Spec.Features.Dogstatsd.NonLocalTraffic = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.Dogstatsd.NonLocalTraffic = new(enabled)
 	return builder
 }
 
@@ -153,7 +152,7 @@ func (builder *DatadogAgentBuilder) initLiveContainer() {
 
 func (builder *DatadogAgentBuilder) WithLiveContainerCollectionEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initLiveContainer()
-	builder.datadogAgent.Spec.Features.LiveContainerCollection.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.LiveContainerCollection.Enabled = new(enabled)
 	return builder
 }
 
@@ -166,21 +165,21 @@ func (builder *DatadogAgentBuilder) initLiveProcesses() {
 
 func (builder *DatadogAgentBuilder) WithLiveProcessEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initLiveProcesses()
-	builder.datadogAgent.Spec.Features.LiveProcessCollection.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.LiveProcessCollection.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithLiveProcessScrubStrip(scrubEnabled, stripEnabled bool) *DatadogAgentBuilder {
 	builder.initLiveProcesses()
-	builder.datadogAgent.Spec.Features.LiveProcessCollection.ScrubProcessArguments = ptr.To(scrubEnabled)
-	builder.datadogAgent.Spec.Features.LiveProcessCollection.StripProcessArguments = ptr.To(stripEnabled)
+	builder.datadogAgent.Spec.Features.LiveProcessCollection.ScrubProcessArguments = new(scrubEnabled)
+	builder.datadogAgent.Spec.Features.LiveProcessCollection.StripProcessArguments = new(stripEnabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithWorkloadAutoscalerEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Features.Autoscaling = &v2alpha1.AutoscalingFeatureConfig{
 		Workload: &v2alpha1.WorkloadAutoscalingFeatureConfig{
-			Enabled: ptr.To(enabled),
+			Enabled: new(enabled),
 		},
 	}
 
@@ -217,61 +216,61 @@ func (builder *DatadogAgentBuilder) initSidecarInjection() {
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerValidationEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.Validation.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.Validation.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerMutationEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.Mutation.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.Mutation.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerMutateUnlabelled(enabled bool) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.MutateUnlabelled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.MutateUnlabelled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerServiceName(name string) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.ServiceName = ptr.To(name)
+	builder.datadogAgent.Spec.Features.AdmissionController.ServiceName = new(name)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerAgentCommunicationMode(comMode string) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.AgentCommunicationMode = ptr.To(comMode)
+	builder.datadogAgent.Spec.Features.AdmissionController.AgentCommunicationMode = new(comMode)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerFailurePolicy(policy string) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.FailurePolicy = ptr.To(policy)
+	builder.datadogAgent.Spec.Features.AdmissionController.FailurePolicy = new(policy)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerWebhookName(name string) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.WebhookName = ptr.To(name)
+	builder.datadogAgent.Spec.Features.AdmissionController.WebhookName = new(name)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerRegistry(name string) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.Registry = ptr.To(name)
+	builder.datadogAgent.Spec.Features.AdmissionController.Registry = new(name)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithAdmissionControllerProbeEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgent.Spec.Features.AdmissionController.Probe.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.Probe.Enabled = new(enabled)
 	return builder
 }
 
@@ -291,10 +290,10 @@ func (builder *DatadogAgentBuilder) WithAdmissionControllerProbeGracePeriod(grac
 func (builder *DatadogAgentBuilder) WithSidecarInjectionEnabled(enabled bool) *DatadogAgentBuilder {
 	// builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Enabled = new(enabled)
 	if enabled {
-		builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = ptr.To(enabled)
-		builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = ptr.To("fargate")
+		builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = new(enabled)
+		builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = new("fargate")
 		builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Image.Name = "agent"
 		builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Image.Tag = images.AgentLatestVersion
 	}
@@ -304,21 +303,21 @@ func (builder *DatadogAgentBuilder) WithSidecarInjectionEnabled(enabled bool) *D
 func (builder *DatadogAgentBuilder) WithSidecarInjectionClusterAgentCommunicationEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithSidecarInjectionProvider(provider string) *DatadogAgentBuilder {
 	builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = ptr.To(provider)
+	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = new(provider)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithSidecarInjectionRegistry(registry string) *DatadogAgentBuilder {
 	builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Registry = ptr.To(registry)
+	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.Registry = new(registry)
 	return builder
 }
 
@@ -399,8 +398,8 @@ func (builder *DatadogAgentBuilder) WithSidecarInjectionTLSVerification(enabled,
 	if builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentTLSVerification == nil {
 		builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentTLSVerification = &v2alpha1.AdmissionControllerClusterAgentTLSVerificationConfig{}
 	}
-	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentTLSVerification.Enabled = ptr.To(enabled)
-	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentTLSVerification.CopyCaConfigMap = ptr.To(copyCaConfigMap)
+	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentTLSVerification.Enabled = new(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentTLSVerification.CopyCaConfigMap = new(copyCaConfigMap)
 	return builder
 }
 
@@ -413,7 +412,7 @@ func (builder *DatadogAgentBuilder) initProcessDiscovery() {
 
 func (builder *DatadogAgentBuilder) WithProcessDiscoveryEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initProcessDiscovery()
-	builder.datadogAgent.Spec.Features.ProcessDiscovery.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.ProcessDiscovery.Enabled = new(enabled)
 	return builder
 }
 
@@ -426,13 +425,13 @@ func (builder *DatadogAgentBuilder) initOtelCollector() {
 
 func (builder *DatadogAgentBuilder) WithOTelCollectorEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initOtelCollector()
-	builder.datadogAgent.Spec.Features.OtelCollector.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.OtelCollector.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithOTelCollectorConfig() *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Features.OtelCollector.Conf = &v2alpha1.CustomConfig{}
-	builder.datadogAgent.Spec.Features.OtelCollector.Conf.ConfigData = ptr.To(otelcollectordefaultconfig.DefaultOtelCollectorConfig)
+	builder.datadogAgent.Spec.Features.OtelCollector.Conf.ConfigData = new(otelcollectordefaultconfig.DefaultOtelCollectorConfig)
 	return builder
 }
 
@@ -440,7 +439,7 @@ func (builder *DatadogAgentBuilder) WithOTelCollectorCoreConfigEnabled(enabled b
 	if builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig == nil {
 		builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig = &v2alpha1.CoreConfig{}
 	}
-	builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig.Enabled = new(enabled)
 	return builder
 }
 
@@ -448,7 +447,7 @@ func (builder *DatadogAgentBuilder) WithOTelCollectorCoreConfigExtensionTimeout(
 	if builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig == nil {
 		builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig = &v2alpha1.CoreConfig{}
 	}
-	builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig.ExtensionTimeout = ptr.To(timeout)
+	builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig.ExtensionTimeout = new(timeout)
 	return builder
 }
 
@@ -456,7 +455,7 @@ func (builder *DatadogAgentBuilder) WithOTelCollectorCoreConfigExtensionURL(url 
 	if builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig == nil {
 		builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig = &v2alpha1.CoreConfig{}
 	}
-	builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig.ExtensionURL = ptr.To(url)
+	builder.datadogAgent.Spec.Features.OtelCollector.CoreConfig.ExtensionURL = new(url)
 	return builder
 }
 
@@ -511,13 +510,13 @@ func (builder *DatadogAgentBuilder) initOtelAgentGateway() {
 
 func (builder *DatadogAgentBuilder) WithOTelAgentGatewayEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initOtelAgentGateway()
-	builder.datadogAgent.Spec.Features.OtelAgentGateway.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.OtelAgentGateway.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithOTelAgentGatewayConfig() *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Features.OtelAgentGateway.Conf = &v2alpha1.CustomConfig{}
-	builder.datadogAgent.Spec.Features.OtelAgentGateway.Conf.ConfigData = ptr.To(otelagentgatewaydefaultconfig.DefaultOtelAgentGatewayConfig)
+	builder.datadogAgent.Spec.Features.OtelAgentGateway.Conf.ConfigData = new(otelagentgatewaydefaultconfig.DefaultOtelAgentGatewayConfig)
 	return builder
 }
 
@@ -578,40 +577,40 @@ func (builder *DatadogAgentBuilder) initLogCollection() {
 
 func (builder *DatadogAgentBuilder) WithLogCollectionEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initLogCollection()
-	builder.datadogAgent.Spec.Features.LogCollection.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.LogCollection.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithLogCollectionCollectAll(enabled bool) *DatadogAgentBuilder {
 	builder.initLogCollection()
-	builder.datadogAgent.Spec.Features.LogCollection.ContainerCollectAll = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.LogCollection.ContainerCollectAll = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithLogCollectionLogCollectionUsingFiles(enabled bool) *DatadogAgentBuilder {
 	builder.initLogCollection()
-	builder.datadogAgent.Spec.Features.LogCollection.ContainerCollectUsingFiles = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.LogCollection.ContainerCollectUsingFiles = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithLogCollectionOpenFilesLimit(limit int32) *DatadogAgentBuilder {
 	builder.initLogCollection()
-	builder.datadogAgent.Spec.Features.LogCollection.OpenFilesLimit = ptr.To(limit)
+	builder.datadogAgent.Spec.Features.LogCollection.OpenFilesLimit = new(limit)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithLogCollectionAutoMultiLineDetection(enabled bool) *DatadogAgentBuilder {
 	builder.initLogCollection()
-	builder.datadogAgent.Spec.Features.LogCollection.AutoMultiLineDetection = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.LogCollection.AutoMultiLineDetection = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithLogCollectionPaths(podLogs, containerLogs, containerSymlinks, tempStorate string) *DatadogAgentBuilder {
 	builder.initLogCollection()
-	builder.datadogAgent.Spec.Features.LogCollection.PodLogsPath = ptr.To(podLogs)
-	builder.datadogAgent.Spec.Features.LogCollection.ContainerLogsPath = ptr.To(containerLogs)
-	builder.datadogAgent.Spec.Features.LogCollection.ContainerSymlinksPath = ptr.To(containerSymlinks)
-	builder.datadogAgent.Spec.Features.LogCollection.TempStoragePath = ptr.To(tempStorate)
+	builder.datadogAgent.Spec.Features.LogCollection.PodLogsPath = new(podLogs)
+	builder.datadogAgent.Spec.Features.LogCollection.ContainerLogsPath = new(containerLogs)
+	builder.datadogAgent.Spec.Features.LogCollection.ContainerSymlinksPath = new(containerSymlinks)
+	builder.datadogAgent.Spec.Features.LogCollection.TempStoragePath = new(tempStorate)
 	return builder
 }
 
@@ -624,14 +623,14 @@ func (builder *DatadogAgentBuilder) initEventCollection() {
 
 func (builder *DatadogAgentBuilder) WithEventCollectionKubernetesEvents(enabled bool) *DatadogAgentBuilder {
 	builder.initEventCollection()
-	builder.datadogAgent.Spec.Features.EventCollection.CollectKubernetesEvents = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.EventCollection.CollectKubernetesEvents = new(enabled)
 
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithEventCollectionUnbundleEvents(enabled bool, eventTypes []v2alpha1.EventTypes) *DatadogAgentBuilder {
 	builder.initEventCollection()
-	builder.datadogAgent.Spec.Features.EventCollection.UnbundleEvents = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.EventCollection.UnbundleEvents = new(enabled)
 	builder.datadogAgent.Spec.Features.EventCollection.CollectedEventTypes = eventTypes
 
 	return builder
@@ -646,7 +645,7 @@ func (builder *DatadogAgentBuilder) initRemoteConfig() {
 
 func (builder *DatadogAgentBuilder) WithRemoteConfigEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initRemoteConfig()
-	builder.datadogAgent.Spec.Features.RemoteConfiguration.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.RemoteConfiguration.Enabled = new(enabled)
 	return builder
 }
 
@@ -660,14 +659,14 @@ func (builder *DatadogAgentBuilder) initKSM() {
 
 func (builder *DatadogAgentBuilder) WithKSMEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initKSM()
-	builder.datadogAgent.Spec.Features.KubeStateMetricsCore.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.KubeStateMetricsCore.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithKSMCustomConf(customData string) *DatadogAgentBuilder {
 	builder.initKSM()
 	builder.datadogAgent.Spec.Features.KubeStateMetricsCore.Conf = &v2alpha1.CustomConfig{
-		ConfigData: ptr.To(customData),
+		ConfigData: new(customData),
 	}
 	return builder
 }
@@ -682,13 +681,13 @@ func (builder *DatadogAgentBuilder) initOE() {
 
 func (builder *DatadogAgentBuilder) WithOrchestratorExplorerEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initOE()
-	builder.datadogAgent.Spec.Features.OrchestratorExplorer.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.OrchestratorExplorer.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithOrchestratorExplorerScrubContainers(enabled bool) *DatadogAgentBuilder {
 	builder.initOE()
-	builder.datadogAgent.Spec.Features.OrchestratorExplorer.ScrubContainers = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.OrchestratorExplorer.ScrubContainers = new(enabled)
 	return builder
 }
 
@@ -700,7 +699,7 @@ func (builder *DatadogAgentBuilder) WithOrchestratorExplorerExtraTags(tags []str
 
 func (builder *DatadogAgentBuilder) WithOrchestratorExplorerDDUrl(ddUrl string) *DatadogAgentBuilder {
 	builder.initOE()
-	builder.datadogAgent.Spec.Features.OrchestratorExplorer.DDUrl = ptr.To(ddUrl)
+	builder.datadogAgent.Spec.Features.OrchestratorExplorer.DDUrl = new(ddUrl)
 	return builder
 }
 
@@ -728,20 +727,20 @@ func (builder *DatadogAgentBuilder) initCC() {
 
 func (builder *DatadogAgentBuilder) WithClusterChecksEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initCC()
-	builder.datadogAgent.Spec.Features.ClusterChecks.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.ClusterChecks.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithClusterChecksUseCLCEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initCC()
-	builder.datadogAgent.Spec.Features.ClusterChecks.UseClusterChecksRunners = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.ClusterChecks.UseClusterChecksRunners = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithClusterChecks(enabled bool, useRunners bool) *DatadogAgentBuilder {
 	builder.initCC()
-	builder.datadogAgent.Spec.Features.ClusterChecks.Enabled = ptr.To(enabled)
-	builder.datadogAgent.Spec.Features.ClusterChecks.UseClusterChecksRunners = ptr.To(useRunners)
+	builder.datadogAgent.Spec.Features.ClusterChecks.Enabled = new(enabled)
+	builder.datadogAgent.Spec.Features.ClusterChecks.UseClusterChecksRunners = new(useRunners)
 	return builder
 }
 
@@ -755,25 +754,25 @@ func (builder *DatadogAgentBuilder) initPrometheusScrape() {
 
 func (builder *DatadogAgentBuilder) WithPrometheusScrapeEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgent.Spec.Features.PrometheusScrape.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.PrometheusScrape.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithPrometheusScrapeServiceEndpoints(enabled bool) *DatadogAgentBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgent.Spec.Features.PrometheusScrape.EnableServiceEndpoints = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.PrometheusScrape.EnableServiceEndpoints = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithPrometheusScrapeAdditionalConfigs(additionalConfig string) *DatadogAgentBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgent.Spec.Features.PrometheusScrape.AdditionalConfigs = ptr.To(additionalConfig)
+	builder.datadogAgent.Spec.Features.PrometheusScrape.AdditionalConfigs = new(additionalConfig)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithPrometheusScrapeVersion(version int) *DatadogAgentBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgent.Spec.Features.PrometheusScrape.Version = ptr.To(version)
+	builder.datadogAgent.Spec.Features.PrometheusScrape.Version = new(version)
 	return builder
 }
 
@@ -787,14 +786,14 @@ func (builder *DatadogAgentBuilder) initAPM() {
 
 func (builder *DatadogAgentBuilder) WithAPMEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initAPM()
-	builder.datadogAgent.Spec.Features.APM.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.APM.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithErrorTrackingStandalone(enabled bool) *DatadogAgentBuilder {
 	builder.initAPM()
 	builder.datadogAgent.Spec.Features.APM.ErrorTrackingStandalone = &v2alpha1.ErrorTrackingStandalone{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 	}
 	return builder
 }
@@ -802,7 +801,7 @@ func (builder *DatadogAgentBuilder) WithErrorTrackingStandalone(enabled bool) *D
 func (builder *DatadogAgentBuilder) WithAPMHostPortEnabled(enabled bool, port *int32) *DatadogAgentBuilder {
 	builder.initAPM()
 	builder.datadogAgent.Spec.Features.APM.HostPortConfig = &v2alpha1.HostPortConfig{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 	}
 	if port != nil {
 		builder.datadogAgent.Spec.Features.APM.HostPortConfig.Port = port
@@ -813,8 +812,8 @@ func (builder *DatadogAgentBuilder) WithAPMHostPortEnabled(enabled bool, port *i
 func (builder *DatadogAgentBuilder) WithAPMUDSEnabled(enabled bool, apmSocketHostPath string) *DatadogAgentBuilder {
 	builder.initAPM()
 	builder.datadogAgent.Spec.Features.APM.UnixDomainSocketConfig = &v2alpha1.UnixDomainSocketConfig{
-		Enabled: ptr.To(enabled),
-		Path:    ptr.To(apmSocketHostPath),
+		Enabled: new(enabled),
+		Path:    new(apmSocketHostPath),
 	}
 	return builder
 }
@@ -839,11 +838,11 @@ func (builder *DatadogAgentBuilder) WithNodeAgentTag(tag string) *DatadogAgentBu
 func (builder *DatadogAgentBuilder) WithAPMSingleStepInstrumentationEnabled(enabled bool, enabledNamespaces []string, disabledNamespaces []string, libVersion map[string]string, languageDetectionEnabled bool, injectorImageTag string, targets []v2alpha1.SSITarget, injectionMode v2alpha1.InjectionModeType) *DatadogAgentBuilder {
 	builder.initAPM()
 	builder.datadogAgent.Spec.Features.APM.SingleStepInstrumentation = &v2alpha1.SingleStepInstrumentation{
-		Enabled:            ptr.To(enabled),
+		Enabled:            new(enabled),
 		EnabledNamespaces:  enabledNamespaces,
 		DisabledNamespaces: disabledNamespaces,
 		LibVersions:        libVersion,
-		LanguageDetection:  &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(languageDetectionEnabled)},
+		LanguageDetection:  &v2alpha1.LanguageDetectionConfig{Enabled: new(languageDetectionEnabled)},
 		Injector: &v2alpha1.InjectorConfig{
 			ImageTag: injectorImageTag,
 		},
@@ -856,13 +855,13 @@ func (builder *DatadogAgentBuilder) WithAPMSingleStepInstrumentationEnabled(enab
 func (builder *DatadogAgentBuilder) WithASMEnabled(threats, sca, iast bool) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Features.ASM = &v2alpha1.ASMFeatureConfig{
 		Threats: &v2alpha1.ASMThreatsConfig{
-			Enabled: ptr.To(threats),
+			Enabled: new(threats),
 		},
 		SCA: &v2alpha1.ASMSCAConfig{
-			Enabled: ptr.To(sca),
+			Enabled: new(sca),
 		},
 		IAST: &v2alpha1.ASMIASTConfig{
-			Enabled: ptr.To(iast),
+			Enabled: new(iast),
 		},
 	}
 	return builder
@@ -882,12 +881,12 @@ func (builder *DatadogAgentBuilder) initOTLP() {
 func (builder *DatadogAgentBuilder) WithOTLPGRPCSettings(enabled bool, hostPortEnabled bool, customHostPort int32, endpoint string) *DatadogAgentBuilder {
 	builder.initOTLP()
 	builder.datadogAgent.Spec.Features.OTLP.Receiver.Protocols.GRPC = &v2alpha1.OTLPGRPCConfig{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 		HostPortConfig: &v2alpha1.HostPortConfig{
-			Enabled: ptr.To(hostPortEnabled),
-			Port:    ptr.To(customHostPort),
+			Enabled: new(hostPortEnabled),
+			Port:    new(customHostPort),
 		},
-		Endpoint: ptr.To(endpoint),
+		Endpoint: new(endpoint),
 	}
 	return builder
 }
@@ -895,12 +894,12 @@ func (builder *DatadogAgentBuilder) WithOTLPGRPCSettings(enabled bool, hostPortE
 func (builder *DatadogAgentBuilder) WithOTLPHTTPSettings(enabled bool, hostPortEnabled bool, customHostPort int32, endpoint string) *DatadogAgentBuilder {
 	builder.initOTLP()
 	builder.datadogAgent.Spec.Features.OTLP.Receiver.Protocols.HTTP = &v2alpha1.OTLPHTTPConfig{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 		HostPortConfig: &v2alpha1.HostPortConfig{
-			Enabled: ptr.To(hostPortEnabled),
-			Port:    ptr.To(customHostPort),
+			Enabled: new(hostPortEnabled),
+			Port:    new(customHostPort),
 		},
-		Endpoint: ptr.To(endpoint),
+		Endpoint: new(endpoint),
 	}
 	return builder
 }
@@ -915,7 +914,7 @@ func (builder *DatadogAgentBuilder) initNPM() {
 
 func (builder *DatadogAgentBuilder) WithNPMEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initNPM()
-	builder.datadogAgent.Spec.Features.NPM.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.NPM.Enabled = new(enabled)
 	return builder
 }
 
@@ -929,7 +928,7 @@ func (builder *DatadogAgentBuilder) initCSPM() {
 
 func (builder *DatadogAgentBuilder) WithCSPMEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initCSPM()
-	builder.datadogAgent.Spec.Features.CSPM.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.CSPM.Enabled = new(enabled)
 	return builder
 }
 
@@ -943,7 +942,7 @@ func (builder *DatadogAgentBuilder) initCWS() {
 
 func (builder *DatadogAgentBuilder) WithCWSEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initCWS()
-	builder.datadogAgent.Spec.Features.CWS.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.CWS.Enabled = new(enabled)
 	return builder
 }
 
@@ -957,13 +956,13 @@ func (builder *DatadogAgentBuilder) initCWSInstrumentation() {
 
 func (builder *DatadogAgentBuilder) WithCWSInstrumentationEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initCWSInstrumentation()
-	builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithCWSInstrumentationMode(mode string) *DatadogAgentBuilder {
 	builder.initCWSInstrumentation()
-	builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation.Mode = ptr.To(mode)
+	builder.datadogAgent.Spec.Features.AdmissionController.CWSInstrumentation.Mode = new(mode)
 	return builder
 }
 
@@ -977,7 +976,7 @@ func (builder *DatadogAgentBuilder) initOOMKill() {
 
 func (builder *DatadogAgentBuilder) WithOOMKillEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initOOMKill()
-	builder.datadogAgent.Spec.Features.OOMKill.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.OOMKill.Enabled = new(enabled)
 	return builder
 }
 
@@ -991,13 +990,13 @@ func (builder *DatadogAgentBuilder) initHelmCheck() {
 
 func (builder *DatadogAgentBuilder) WithHelmCheckEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initHelmCheck()
-	builder.datadogAgent.Spec.Features.HelmCheck.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.HelmCheck.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithHelmCheckCollectEvents(enabled bool) *DatadogAgentBuilder {
 	builder.initHelmCheck()
-	builder.datadogAgent.Spec.Features.HelmCheck.CollectEvents = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.HelmCheck.CollectEvents = new(enabled)
 	return builder
 }
 
@@ -1015,7 +1014,7 @@ func (builder *DatadogAgentBuilder) initKubernetesActions() {
 
 func (builder *DatadogAgentBuilder) WithKubernetesActionsEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initKubernetesActions()
-	builder.datadogAgent.Spec.Features.KubernetesActions.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.KubernetesActions.Enabled = new(enabled)
 	return builder
 }
 
@@ -1023,7 +1022,7 @@ func (builder *DatadogAgentBuilder) WithKubernetesActionsEnabled(enabled bool) *
 
 func (builder *DatadogAgentBuilder) WithGlobalKubeletConfig(hostCAPath, agentCAPath string, tlsVerify bool, podResourcesSocketDir string) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Global.Kubelet = &v2alpha1.KubeletConfig{
-		TLSVerify:              ptr.To(tlsVerify),
+		TLSVerify:              new(tlsVerify),
 		HostCAPath:             hostCAPath,
 		AgentCAPath:            agentCAPath,
 		PodResourcesSocketPath: podResourcesSocketDir,
@@ -1032,12 +1031,12 @@ func (builder *DatadogAgentBuilder) WithGlobalKubeletConfig(hostCAPath, agentCAP
 }
 
 func (builder *DatadogAgentBuilder) WithGlobalDockerSocketPath(dockerSocketPath string) *DatadogAgentBuilder {
-	builder.datadogAgent.Spec.Global.DockerSocketPath = ptr.To(dockerSocketPath)
+	builder.datadogAgent.Spec.Global.DockerSocketPath = new(dockerSocketPath)
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithGlobalCriSocketPath(criSocketPath string) *DatadogAgentBuilder {
-	builder.datadogAgent.Spec.Global.DockerSocketPath = ptr.To(criSocketPath)
+	builder.datadogAgent.Spec.Global.DockerSocketPath = new(criSocketPath)
 	return builder
 }
 
@@ -1058,8 +1057,8 @@ func (builder *DatadogAgentBuilder) WithSingleContainerStrategy(enabled bool) *D
 
 func (builder *DatadogAgentBuilder) WithCredentials(apiKey, appKey string) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Global.Credentials = &v2alpha1.DatadogCredentials{
-		APIKey: ptr.To(apiKey),
-		AppKey: ptr.To(appKey),
+		APIKey: new(apiKey),
+		AppKey: new(appKey),
 	}
 	return builder
 }
@@ -1083,7 +1082,7 @@ func (builder *DatadogAgentBuilder) WithCredentialsFromSecret(apiSecretName, api
 
 // Global DCA Token
 func (builder *DatadogAgentBuilder) WithDCAToken(token string) *DatadogAgentBuilder {
-	builder.datadogAgent.Spec.Global.ClusterAgentToken = ptr.To(token)
+	builder.datadogAgent.Spec.Global.ClusterAgentToken = new(token)
 	return builder
 }
 
@@ -1099,7 +1098,7 @@ func (builder *DatadogAgentBuilder) WithDCATokenFromSecret(secretName, secretKey
 
 func (builder *DatadogAgentBuilder) WithOriginDetectionUnified(enabled bool) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Global.OriginDetectionUnified = &v2alpha1.OriginDetectionUnified{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 	}
 	return builder
 }
@@ -1107,7 +1106,7 @@ func (builder *DatadogAgentBuilder) WithOriginDetectionUnified(enabled bool) *Da
 // Global Registry
 
 func (builder *DatadogAgentBuilder) WithRegistry(registry string) *DatadogAgentBuilder {
-	builder.datadogAgent.Spec.Global.Registry = ptr.To(registry)
+	builder.datadogAgent.Spec.Global.Registry = new(registry)
 
 	return builder
 }
@@ -1115,14 +1114,14 @@ func (builder *DatadogAgentBuilder) WithRegistry(registry string) *DatadogAgentB
 // Global ChecksTagCardinality
 
 func (builder *DatadogAgentBuilder) WithChecksTagCardinality(cardinality string) *DatadogAgentBuilder {
-	builder.datadogAgent.Spec.Global.ChecksTagCardinality = ptr.To(cardinality)
+	builder.datadogAgent.Spec.Global.ChecksTagCardinality = new(cardinality)
 	return builder
 }
 
 // CSI Activation Config
 
 func (builder *DatadogAgentBuilder) WithCSIActivation(enabled bool) *DatadogAgentBuilder {
-	builder.datadogAgent.Spec.Global.CSI = &v2alpha1.CSIConfig{Enabled: ptr.To(enabled)}
+	builder.datadogAgent.Spec.Global.CSI = &v2alpha1.CSIConfig{Enabled: new(enabled)}
 	return builder
 }
 
@@ -1130,11 +1129,11 @@ func (builder *DatadogAgentBuilder) WithCSIActivation(enabled bool) *DatadogAgen
 
 func (builder *DatadogAgentBuilder) WithGlobalSecretBackendGlobalPerms(command string, args string, timeout int32, refreshInterval int32) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{
-		Command:                 ptr.To(command),
-		Args:                    ptr.To(args),
-		Timeout:                 ptr.To(timeout),
-		RefreshInterval:         ptr.To(refreshInterval),
-		EnableGlobalPermissions: ptr.To(true),
+		Command:                 new(command),
+		Args:                    new(args),
+		Timeout:                 new(timeout),
+		RefreshInterval:         new(refreshInterval),
+		EnableGlobalPermissions: new(true),
 	}
 	return builder
 }
@@ -1143,21 +1142,21 @@ func (builder *DatadogAgentBuilder) WithGlobalSecretBackendType(backendType stri
 	if builder.datadogAgent.Spec.Global.SecretBackend == nil {
 		builder.datadogAgent.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{}
 	}
-	builder.datadogAgent.Spec.Global.SecretBackend.Type = ptr.To(backendType)
+	builder.datadogAgent.Spec.Global.SecretBackend.Type = new(backendType)
 	builder.datadogAgent.Spec.Global.SecretBackend.Config = config
 	return builder
 }
 
 func (builder *DatadogAgentBuilder) WithGlobalSecretBackendSpecificRoles(command string, args string, timeout int32, refreshInterval int32, secretNs string, secretNames []string) *DatadogAgentBuilder {
 	builder.datadogAgent.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{
-		Command:                 ptr.To(command),
-		Args:                    ptr.To(args),
-		Timeout:                 ptr.To(timeout),
-		RefreshInterval:         ptr.To(refreshInterval),
-		EnableGlobalPermissions: ptr.To(false),
+		Command:                 new(command),
+		Args:                    new(args),
+		Timeout:                 new(timeout),
+		RefreshInterval:         new(refreshInterval),
+		EnableGlobalPermissions: new(false),
 		Roles: []*v2alpha1.SecretBackendRolesConfig{
 			{
-				Namespace: ptr.To(secretNs),
+				Namespace: new(secretNs),
 				Secrets:   secretNames,
 			},
 		},
@@ -1193,7 +1192,7 @@ func (builder *DatadogAgentBuilder) WithClusterAgentImage(image string) *Datadog
 
 func (builder *DatadogAgentBuilder) WithClusterAgentDisabled(disabled bool) *DatadogAgentBuilder {
 	builder.WithComponentOverride(v2alpha1.ClusterAgentComponentName, v2alpha1.DatadogAgentComponentOverride{
-		Disabled: ptr.To(disabled),
+		Disabled: new(disabled),
 	})
 	return builder
 }
@@ -1235,7 +1234,7 @@ func (builder *DatadogAgentBuilder) WithUseFIPSAgent() *DatadogAgentBuilder {
 		builder.datadogAgent.Spec.Global = &v2alpha1.GlobalConfig{}
 	}
 
-	builder.datadogAgent.Spec.Global.UseFIPSAgent = ptr.To(true)
+	builder.datadogAgent.Spec.Global.UseFIPSAgent = new(true)
 	return builder
 }
 
@@ -1258,8 +1257,8 @@ func (builder *DatadogAgentBuilder) initGPUMonitoring() {
 
 func (builder *DatadogAgentBuilder) WithGPUMonitoringEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initGPUMonitoring()
-	builder.datadogAgent.Spec.Features.GPU.Enabled = ptr.To(enabled)
-	builder.datadogAgent.Spec.Features.GPU.PrivilegedMode = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.GPU.Enabled = new(enabled)
+	builder.datadogAgent.Spec.Features.GPU.PrivilegedMode = new(enabled)
 	return builder
 }
 
@@ -1271,7 +1270,7 @@ func (builder *DatadogAgentBuilder) initControlPlaneMonitoring() {
 
 func (builder *DatadogAgentBuilder) WithControlPlaneMonitoring(enabled bool) *DatadogAgentBuilder {
 	builder.initControlPlaneMonitoring()
-	builder.datadogAgent.Spec.Features.ControlPlaneMonitoring.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.ControlPlaneMonitoring.Enabled = new(enabled)
 	return builder
 }
 
@@ -1286,7 +1285,7 @@ func (builder *DatadogAgentBuilder) initDataPlane() {
 
 func (builder *DatadogAgentBuilder) WithDataPlaneEnabled(enabled bool) *DatadogAgentBuilder {
 	builder.initDataPlane()
-	builder.datadogAgent.Spec.Features.DataPlane.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.DataPlane.Enabled = new(enabled)
 	return builder
 }
 
@@ -1295,7 +1294,7 @@ func (builder *DatadogAgentBuilder) WithDataPlaneDogstatsdEnabled(enabled bool) 
 	if builder.datadogAgent.Spec.Features.DataPlane.Dogstatsd == nil {
 		builder.datadogAgent.Spec.Features.DataPlane.Dogstatsd = &v2alpha1.DataPlaneDogstatsdConfig{}
 	}
-	builder.datadogAgent.Spec.Features.DataPlane.Dogstatsd.Enabled = ptr.To(enabled)
+	builder.datadogAgent.Spec.Features.DataPlane.Dogstatsd.Enabled = new(enabled)
 	return builder
 }
 

--- a/pkg/testutils/ddai_builder.go
+++ b/pkg/testutils/ddai_builder.go
@@ -10,7 +10,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -97,44 +96,44 @@ func (builder *DatadogAgentInternalBuilder) initDogstatsd() {
 
 func (builder *DatadogAgentInternalBuilder) WithDogstatsdHostPortEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.HostPortConfig.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.HostPortConfig.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithDogstatsdHostPortConfig(port int32) *DatadogAgentInternalBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.HostPortConfig.Port = ptr.To(port)
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.HostPortConfig.Port = new(port)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithDogstatsdOriginDetectionEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.OriginDetectionEnabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.OriginDetectionEnabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithDogstatsdTagCardinality(cardinality string) *DatadogAgentInternalBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.OriginDetectionEnabled = ptr.To(true)
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.TagCardinality = ptr.To(cardinality)
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.OriginDetectionEnabled = new(true)
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.TagCardinality = new(cardinality)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithDogstatsdUnixDomainSocketConfigEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithDogstatsdUnixDomainSocketConfigPath(customPath string) *DatadogAgentInternalBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Path = ptr.To(customPath)
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.UnixDomainSocketConfig.Path = new(customPath)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithDogstatsdMapperProfiles(customMapperProfilesConf string) *DatadogAgentInternalBuilder {
 	builder.initDogstatsd()
-	builder.datadogAgentInternal.Spec.Features.Dogstatsd.MapperProfiles = &v2alpha1.CustomConfig{ConfigData: ptr.To(customMapperProfilesConf)}
+	builder.datadogAgentInternal.Spec.Features.Dogstatsd.MapperProfiles = &v2alpha1.CustomConfig{ConfigData: new(customMapperProfilesConf)}
 	return builder
 }
 
@@ -148,7 +147,7 @@ func (builder *DatadogAgentInternalBuilder) initLiveContainer() {
 
 func (builder *DatadogAgentInternalBuilder) WithLiveContainerCollectionEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initLiveContainer()
-	builder.datadogAgentInternal.Spec.Features.LiveContainerCollection.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.LiveContainerCollection.Enabled = new(enabled)
 	return builder
 }
 
@@ -161,21 +160,21 @@ func (builder *DatadogAgentInternalBuilder) initLiveProcesses() {
 
 func (builder *DatadogAgentInternalBuilder) WithLiveProcessEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initLiveProcesses()
-	builder.datadogAgentInternal.Spec.Features.LiveProcessCollection.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.LiveProcessCollection.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithLiveProcessScrubStrip(scrubEnabled, stripEnabled bool) *DatadogAgentInternalBuilder {
 	builder.initLiveProcesses()
-	builder.datadogAgentInternal.Spec.Features.LiveProcessCollection.ScrubProcessArguments = ptr.To(scrubEnabled)
-	builder.datadogAgentInternal.Spec.Features.LiveProcessCollection.StripProcessArguments = ptr.To(stripEnabled)
+	builder.datadogAgentInternal.Spec.Features.LiveProcessCollection.ScrubProcessArguments = new(scrubEnabled)
+	builder.datadogAgentInternal.Spec.Features.LiveProcessCollection.StripProcessArguments = new(stripEnabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithWorkloadAutoscalerEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Features.Autoscaling = &v2alpha1.AutoscalingFeatureConfig{
 		Workload: &v2alpha1.WorkloadAutoscalingFeatureConfig{
-			Enabled: ptr.To(enabled),
+			Enabled: new(enabled),
 		},
 	}
 
@@ -212,61 +211,61 @@ func (builder *DatadogAgentInternalBuilder) initSidecarInjection() {
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerValidationEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.Validation.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.Validation.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerMutationEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.Mutation.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.Mutation.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerMutateUnlabelled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.MutateUnlabelled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.MutateUnlabelled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerServiceName(name string) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.ServiceName = ptr.To(name)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.ServiceName = new(name)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerAgentCommunicationMode(comMode string) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentCommunicationMode = ptr.To(comMode)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentCommunicationMode = new(comMode)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerFailurePolicy(policy string) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.FailurePolicy = ptr.To(policy)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.FailurePolicy = new(policy)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerWebhookName(name string) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.WebhookName = ptr.To(name)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.WebhookName = new(name)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerRegistry(name string) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.Registry = ptr.To(name)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.Registry = new(name)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerProbeEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.Probe.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.Probe.Enabled = new(enabled)
 	return builder
 }
 
@@ -286,10 +285,10 @@ func (builder *DatadogAgentInternalBuilder) WithAdmissionControllerProbeGracePer
 func (builder *DatadogAgentInternalBuilder) WithSidecarInjectionEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	// builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Enabled = new(enabled)
 	if enabled {
-		builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = ptr.To(enabled)
-		builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = ptr.To("fargate")
+		builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = new(enabled)
+		builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = new("fargate")
 		builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Image.Name = "agent"
 		builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Image.Tag = images.AgentLatestVersion
 	}
@@ -299,21 +298,21 @@ func (builder *DatadogAgentInternalBuilder) WithSidecarInjectionEnabled(enabled 
 func (builder *DatadogAgentInternalBuilder) WithSidecarInjectionClusterAgentCommunicationEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.ClusterAgentCommunicationEnabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithSidecarInjectionProvider(provider string) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = ptr.To(provider)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Provider = new(provider)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithSidecarInjectionRegistry(registry string) *DatadogAgentInternalBuilder {
 	builder.initAdmissionController()
 	builder.initSidecarInjection()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Registry = ptr.To(registry)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.AgentSidecarInjection.Registry = new(registry)
 	return builder
 }
 
@@ -397,7 +396,7 @@ func (builder *DatadogAgentInternalBuilder) initProcessDiscovery() {
 
 func (builder *DatadogAgentInternalBuilder) WithProcessDiscoveryEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initProcessDiscovery()
-	builder.datadogAgentInternal.Spec.Features.ProcessDiscovery.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.ProcessDiscovery.Enabled = new(enabled)
 	return builder
 }
 
@@ -410,14 +409,14 @@ func (builder *DatadogAgentInternalBuilder) initOtelCollector() {
 
 func (builder *DatadogAgentInternalBuilder) WithOTelCollectorEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initOtelCollector()
-	builder.datadogAgentInternal.Spec.Features.OtelCollector.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.OtelCollector.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithOTelCollectorConfig() *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Features.OtelCollector.Conf = &v2alpha1.CustomConfig{}
 	builder.datadogAgentInternal.Spec.Features.OtelCollector.Conf.ConfigData =
-		ptr.To(defaultconfig.DefaultOtelCollectorConfig)
+		new(defaultconfig.DefaultOtelCollectorConfig)
 	return builder
 }
 
@@ -425,7 +424,7 @@ func (builder *DatadogAgentInternalBuilder) WithOTelCollectorCoreConfigEnabled(e
 	if builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig == nil {
 		builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig = &v2alpha1.CoreConfig{}
 	}
-	builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig.Enabled = new(enabled)
 	return builder
 }
 
@@ -433,7 +432,7 @@ func (builder *DatadogAgentInternalBuilder) WithOTelCollectorCoreConfigExtension
 	if builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig == nil {
 		builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig = &v2alpha1.CoreConfig{}
 	}
-	builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig.ExtensionTimeout = ptr.To(timeout)
+	builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig.ExtensionTimeout = new(timeout)
 	return builder
 }
 
@@ -441,7 +440,7 @@ func (builder *DatadogAgentInternalBuilder) WithOTelCollectorCoreConfigExtension
 	if builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig == nil {
 		builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig = &v2alpha1.CoreConfig{}
 	}
-	builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig.ExtensionURL = ptr.To(url)
+	builder.datadogAgentInternal.Spec.Features.OtelCollector.CoreConfig.ExtensionURL = new(url)
 	return builder
 }
 
@@ -478,40 +477,40 @@ func (builder *DatadogAgentInternalBuilder) initLogCollection() {
 
 func (builder *DatadogAgentInternalBuilder) WithLogCollectionEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initLogCollection()
-	builder.datadogAgentInternal.Spec.Features.LogCollection.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithLogCollectionCollectAll(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initLogCollection()
-	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerCollectAll = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerCollectAll = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithLogCollectionLogCollectionUsingFiles(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initLogCollection()
-	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerCollectUsingFiles = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerCollectUsingFiles = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithLogCollectionOpenFilesLimit(limit int32) *DatadogAgentInternalBuilder {
 	builder.initLogCollection()
-	builder.datadogAgentInternal.Spec.Features.LogCollection.OpenFilesLimit = ptr.To(limit)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.OpenFilesLimit = new(limit)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithLogCollectionAutoMultiLineDetection(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initLogCollection()
-	builder.datadogAgentInternal.Spec.Features.LogCollection.AutoMultiLineDetection = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.AutoMultiLineDetection = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithLogCollectionPaths(podLogs, containerLogs, containerSymlinks, tempStorate string) *DatadogAgentInternalBuilder {
 	builder.initLogCollection()
-	builder.datadogAgentInternal.Spec.Features.LogCollection.PodLogsPath = ptr.To(podLogs)
-	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerLogsPath = ptr.To(containerLogs)
-	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerSymlinksPath = ptr.To(containerSymlinks)
-	builder.datadogAgentInternal.Spec.Features.LogCollection.TempStoragePath = ptr.To(tempStorate)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.PodLogsPath = new(podLogs)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerLogsPath = new(containerLogs)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.ContainerSymlinksPath = new(containerSymlinks)
+	builder.datadogAgentInternal.Spec.Features.LogCollection.TempStoragePath = new(tempStorate)
 	return builder
 }
 
@@ -524,14 +523,14 @@ func (builder *DatadogAgentInternalBuilder) initEventCollection() {
 
 func (builder *DatadogAgentInternalBuilder) WithEventCollectionKubernetesEvents(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initEventCollection()
-	builder.datadogAgentInternal.Spec.Features.EventCollection.CollectKubernetesEvents = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.EventCollection.CollectKubernetesEvents = new(enabled)
 
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithEventCollectionUnbundleEvents(enabled bool, eventTypes []v2alpha1.EventTypes) *DatadogAgentInternalBuilder {
 	builder.initEventCollection()
-	builder.datadogAgentInternal.Spec.Features.EventCollection.UnbundleEvents = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.EventCollection.UnbundleEvents = new(enabled)
 	builder.datadogAgentInternal.Spec.Features.EventCollection.CollectedEventTypes = eventTypes
 
 	return builder
@@ -546,7 +545,7 @@ func (builder *DatadogAgentInternalBuilder) initRemoteConfig() {
 
 func (builder *DatadogAgentInternalBuilder) WithRemoteConfigEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initRemoteConfig()
-	builder.datadogAgentInternal.Spec.Features.RemoteConfiguration.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.RemoteConfiguration.Enabled = new(enabled)
 	return builder
 }
 
@@ -560,14 +559,14 @@ func (builder *DatadogAgentInternalBuilder) initKSM() {
 
 func (builder *DatadogAgentInternalBuilder) WithKSMEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initKSM()
-	builder.datadogAgentInternal.Spec.Features.KubeStateMetricsCore.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.KubeStateMetricsCore.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithKSMCustomConf(customData string) *DatadogAgentInternalBuilder {
 	builder.initKSM()
 	builder.datadogAgentInternal.Spec.Features.KubeStateMetricsCore.Conf = &v2alpha1.CustomConfig{
-		ConfigData: ptr.To(customData),
+		ConfigData: new(customData),
 	}
 	return builder
 }
@@ -582,13 +581,13 @@ func (builder *DatadogAgentInternalBuilder) initOE() {
 
 func (builder *DatadogAgentInternalBuilder) WithOrchestratorExplorerEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initOE()
-	builder.datadogAgentInternal.Spec.Features.OrchestratorExplorer.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.OrchestratorExplorer.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithOrchestratorExplorerScrubContainers(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initOE()
-	builder.datadogAgentInternal.Spec.Features.OrchestratorExplorer.ScrubContainers = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.OrchestratorExplorer.ScrubContainers = new(enabled)
 	return builder
 }
 
@@ -600,7 +599,7 @@ func (builder *DatadogAgentInternalBuilder) WithOrchestratorExplorerExtraTags(ta
 
 func (builder *DatadogAgentInternalBuilder) WithOrchestratorExplorerDDUrl(ddUrl string) *DatadogAgentInternalBuilder {
 	builder.initOE()
-	builder.datadogAgentInternal.Spec.Features.OrchestratorExplorer.DDUrl = ptr.To(ddUrl)
+	builder.datadogAgentInternal.Spec.Features.OrchestratorExplorer.DDUrl = new(ddUrl)
 	return builder
 }
 
@@ -628,13 +627,13 @@ func (builder *DatadogAgentInternalBuilder) initCC() {
 
 func (builder *DatadogAgentInternalBuilder) WithClusterChecksEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initCC()
-	builder.datadogAgentInternal.Spec.Features.ClusterChecks.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.ClusterChecks.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithClusterChecksUseCLCEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initCC()
-	builder.datadogAgentInternal.Spec.Features.ClusterChecks.UseClusterChecksRunners = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.ClusterChecks.UseClusterChecksRunners = new(enabled)
 	return builder
 }
 
@@ -648,25 +647,25 @@ func (builder *DatadogAgentInternalBuilder) initPrometheusScrape() {
 
 func (builder *DatadogAgentInternalBuilder) WithPrometheusScrapeEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithPrometheusScrapeServiceEndpoints(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.EnableServiceEndpoints = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.EnableServiceEndpoints = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithPrometheusScrapeAdditionalConfigs(additionalConfig string) *DatadogAgentInternalBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.AdditionalConfigs = ptr.To(additionalConfig)
+	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.AdditionalConfigs = new(additionalConfig)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithPrometheusScrapeVersion(version int) *DatadogAgentInternalBuilder {
 	builder.initPrometheusScrape()
-	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.Version = ptr.To(version)
+	builder.datadogAgentInternal.Spec.Features.PrometheusScrape.Version = new(version)
 	return builder
 }
 
@@ -680,14 +679,14 @@ func (builder *DatadogAgentInternalBuilder) initAPM() {
 
 func (builder *DatadogAgentInternalBuilder) WithAPMEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAPM()
-	builder.datadogAgentInternal.Spec.Features.APM.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.APM.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithErrorTrackingStandalone(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initAPM()
 	builder.datadogAgentInternal.Spec.Features.APM.ErrorTrackingStandalone = &v2alpha1.ErrorTrackingStandalone{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 	}
 	return builder
 }
@@ -695,7 +694,7 @@ func (builder *DatadogAgentInternalBuilder) WithErrorTrackingStandalone(enabled 
 func (builder *DatadogAgentInternalBuilder) WithAPMHostPortEnabled(enabled bool, port *int32) *DatadogAgentInternalBuilder {
 	builder.initAPM()
 	builder.datadogAgentInternal.Spec.Features.APM.HostPortConfig = &v2alpha1.HostPortConfig{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 	}
 	if port != nil {
 		builder.datadogAgentInternal.Spec.Features.APM.HostPortConfig.Port = port
@@ -706,8 +705,8 @@ func (builder *DatadogAgentInternalBuilder) WithAPMHostPortEnabled(enabled bool,
 func (builder *DatadogAgentInternalBuilder) WithAPMUDSEnabled(enabled bool, apmSocketHostPath string) *DatadogAgentInternalBuilder {
 	builder.initAPM()
 	builder.datadogAgentInternal.Spec.Features.APM.UnixDomainSocketConfig = &v2alpha1.UnixDomainSocketConfig{
-		Enabled: ptr.To(enabled),
-		Path:    ptr.To(apmSocketHostPath),
+		Enabled: new(enabled),
+		Path:    new(apmSocketHostPath),
 	}
 	return builder
 }
@@ -722,11 +721,11 @@ func (builder *DatadogAgentInternalBuilder) WithClusterAgentTag(tag string) *Dat
 func (builder *DatadogAgentInternalBuilder) WithAPMSingleStepInstrumentationEnabled(enabled bool, enabledNamespaces []string, disabledNamespaces []string, libVersion map[string]string, languageDetectionEnabled bool, injectorImageTag string, targets []v2alpha1.SSITarget, injectionMode v2alpha1.InjectionModeType) *DatadogAgentInternalBuilder {
 	builder.initAPM()
 	builder.datadogAgentInternal.Spec.Features.APM.SingleStepInstrumentation = &v2alpha1.SingleStepInstrumentation{
-		Enabled:            ptr.To(enabled),
+		Enabled:            new(enabled),
 		EnabledNamespaces:  enabledNamespaces,
 		DisabledNamespaces: disabledNamespaces,
 		LibVersions:        libVersion,
-		LanguageDetection:  &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(languageDetectionEnabled)},
+		LanguageDetection:  &v2alpha1.LanguageDetectionConfig{Enabled: new(languageDetectionEnabled)},
 		Injector: &v2alpha1.InjectorConfig{
 			ImageTag: injectorImageTag,
 		},
@@ -739,13 +738,13 @@ func (builder *DatadogAgentInternalBuilder) WithAPMSingleStepInstrumentationEnab
 func (builder *DatadogAgentInternalBuilder) WithASMEnabled(threats, sca, iast bool) *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Features.ASM = &v2alpha1.ASMFeatureConfig{
 		Threats: &v2alpha1.ASMThreatsConfig{
-			Enabled: ptr.To(threats),
+			Enabled: new(threats),
 		},
 		SCA: &v2alpha1.ASMSCAConfig{
-			Enabled: ptr.To(sca),
+			Enabled: new(sca),
 		},
 		IAST: &v2alpha1.ASMIASTConfig{
-			Enabled: ptr.To(iast),
+			Enabled: new(iast),
 		},
 	}
 	return builder
@@ -765,12 +764,12 @@ func (builder *DatadogAgentInternalBuilder) initOTLP() {
 func (builder *DatadogAgentInternalBuilder) WithOTLPGRPCSettings(enabled bool, hostPortEnabled bool, customHostPort int32, endpoint string) *DatadogAgentInternalBuilder {
 	builder.initOTLP()
 	builder.datadogAgentInternal.Spec.Features.OTLP.Receiver.Protocols.GRPC = &v2alpha1.OTLPGRPCConfig{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 		HostPortConfig: &v2alpha1.HostPortConfig{
-			Enabled: ptr.To(hostPortEnabled),
-			Port:    ptr.To(customHostPort),
+			Enabled: new(hostPortEnabled),
+			Port:    new(customHostPort),
 		},
-		Endpoint: ptr.To(endpoint),
+		Endpoint: new(endpoint),
 	}
 	return builder
 }
@@ -778,12 +777,12 @@ func (builder *DatadogAgentInternalBuilder) WithOTLPGRPCSettings(enabled bool, h
 func (builder *DatadogAgentInternalBuilder) WithOTLPHTTPSettings(enabled bool, hostPortEnabled bool, customHostPort int32, endpoint string) *DatadogAgentInternalBuilder {
 	builder.initOTLP()
 	builder.datadogAgentInternal.Spec.Features.OTLP.Receiver.Protocols.HTTP = &v2alpha1.OTLPHTTPConfig{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 		HostPortConfig: &v2alpha1.HostPortConfig{
-			Enabled: ptr.To(hostPortEnabled),
-			Port:    ptr.To(customHostPort),
+			Enabled: new(hostPortEnabled),
+			Port:    new(customHostPort),
 		},
-		Endpoint: ptr.To(endpoint),
+		Endpoint: new(endpoint),
 	}
 	return builder
 }
@@ -798,7 +797,7 @@ func (builder *DatadogAgentInternalBuilder) initNPM() {
 
 func (builder *DatadogAgentInternalBuilder) WithNPMEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initNPM()
-	builder.datadogAgentInternal.Spec.Features.NPM.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.NPM.Enabled = new(enabled)
 	return builder
 }
 
@@ -812,7 +811,7 @@ func (builder *DatadogAgentInternalBuilder) initCSPM() {
 
 func (builder *DatadogAgentInternalBuilder) WithCSPMEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initCSPM()
-	builder.datadogAgentInternal.Spec.Features.CSPM.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.CSPM.Enabled = new(enabled)
 	return builder
 }
 
@@ -826,7 +825,7 @@ func (builder *DatadogAgentInternalBuilder) initCWS() {
 
 func (builder *DatadogAgentInternalBuilder) WithCWSEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initCWS()
-	builder.datadogAgentInternal.Spec.Features.CWS.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.CWS.Enabled = new(enabled)
 	return builder
 }
 
@@ -840,13 +839,13 @@ func (builder *DatadogAgentInternalBuilder) initCWSInstrumentation() {
 
 func (builder *DatadogAgentInternalBuilder) WithCWSInstrumentationEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initCWSInstrumentation()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.CWSInstrumentation.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.CWSInstrumentation.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithCWSInstrumentationMode(mode string) *DatadogAgentInternalBuilder {
 	builder.initCWSInstrumentation()
-	builder.datadogAgentInternal.Spec.Features.AdmissionController.CWSInstrumentation.Mode = ptr.To(mode)
+	builder.datadogAgentInternal.Spec.Features.AdmissionController.CWSInstrumentation.Mode = new(mode)
 	return builder
 }
 
@@ -860,7 +859,7 @@ func (builder *DatadogAgentInternalBuilder) initOOMKill() {
 
 func (builder *DatadogAgentInternalBuilder) WithOOMKillEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initOOMKill()
-	builder.datadogAgentInternal.Spec.Features.OOMKill.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.OOMKill.Enabled = new(enabled)
 	return builder
 }
 
@@ -874,13 +873,13 @@ func (builder *DatadogAgentInternalBuilder) initHelmCheck() {
 
 func (builder *DatadogAgentInternalBuilder) WithHelmCheckEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initHelmCheck()
-	builder.datadogAgentInternal.Spec.Features.HelmCheck.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.HelmCheck.Enabled = new(enabled)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithHelmCheckCollectEvents(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initHelmCheck()
-	builder.datadogAgentInternal.Spec.Features.HelmCheck.CollectEvents = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.HelmCheck.CollectEvents = new(enabled)
 	return builder
 }
 
@@ -894,7 +893,7 @@ func (builder *DatadogAgentInternalBuilder) WithHelmCheckValuesAsTags(valuesAsTa
 
 func (builder *DatadogAgentInternalBuilder) WithGlobalKubeletConfig(hostCAPath, agentCAPath string, tlsVerify bool, podResourcesSocketDir string) *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Global.Kubelet = &v2alpha1.KubeletConfig{
-		TLSVerify:              ptr.To(tlsVerify),
+		TLSVerify:              new(tlsVerify),
 		HostCAPath:             hostCAPath,
 		AgentCAPath:            agentCAPath,
 		PodResourcesSocketPath: podResourcesSocketDir,
@@ -903,12 +902,12 @@ func (builder *DatadogAgentInternalBuilder) WithGlobalKubeletConfig(hostCAPath, 
 }
 
 func (builder *DatadogAgentInternalBuilder) WithGlobalDockerSocketPath(dockerSocketPath string) *DatadogAgentInternalBuilder {
-	builder.datadogAgentInternal.Spec.Global.DockerSocketPath = ptr.To(dockerSocketPath)
+	builder.datadogAgentInternal.Spec.Global.DockerSocketPath = new(dockerSocketPath)
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithGlobalCriSocketPath(criSocketPath string) *DatadogAgentInternalBuilder {
-	builder.datadogAgentInternal.Spec.Global.DockerSocketPath = ptr.To(criSocketPath)
+	builder.datadogAgentInternal.Spec.Global.DockerSocketPath = new(criSocketPath)
 	return builder
 }
 
@@ -929,8 +928,8 @@ func (builder *DatadogAgentInternalBuilder) WithSingleContainerStrategy(enabled 
 
 func (builder *DatadogAgentInternalBuilder) WithCredentials(apiKey, appKey string) *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Global.Credentials = &v2alpha1.DatadogCredentials{
-		APIKey: ptr.To(apiKey),
-		AppKey: ptr.To(appKey),
+		APIKey: new(apiKey),
+		AppKey: new(appKey),
 	}
 	return builder
 }
@@ -954,7 +953,7 @@ func (builder *DatadogAgentInternalBuilder) WithCredentialsFromSecret(apiSecretN
 
 // Global DCA Token
 func (builder *DatadogAgentInternalBuilder) WithDCAToken(token string) *DatadogAgentInternalBuilder {
-	builder.datadogAgentInternal.Spec.Global.ClusterAgentToken = ptr.To(token)
+	builder.datadogAgentInternal.Spec.Global.ClusterAgentToken = new(token)
 	return builder
 }
 
@@ -970,7 +969,7 @@ func (builder *DatadogAgentInternalBuilder) WithDCATokenFromSecret(secretName, s
 
 func (builder *DatadogAgentInternalBuilder) WithOriginDetectionUnified(enabled bool) *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Global.OriginDetectionUnified = &v2alpha1.OriginDetectionUnified{
-		Enabled: ptr.To(enabled),
+		Enabled: new(enabled),
 	}
 	return builder
 }
@@ -978,7 +977,7 @@ func (builder *DatadogAgentInternalBuilder) WithOriginDetectionUnified(enabled b
 // Global Registry
 
 func (builder *DatadogAgentInternalBuilder) WithRegistry(registry string) *DatadogAgentInternalBuilder {
-	builder.datadogAgentInternal.Spec.Global.Registry = ptr.To(registry)
+	builder.datadogAgentInternal.Spec.Global.Registry = new(registry)
 
 	return builder
 }
@@ -986,7 +985,7 @@ func (builder *DatadogAgentInternalBuilder) WithRegistry(registry string) *Datad
 // Global ChecksTagCardinality
 
 func (builder *DatadogAgentInternalBuilder) WithChecksTagCardinality(cardinality string) *DatadogAgentInternalBuilder {
-	builder.datadogAgentInternal.Spec.Global.ChecksTagCardinality = ptr.To(cardinality)
+	builder.datadogAgentInternal.Spec.Global.ChecksTagCardinality = new(cardinality)
 	return builder
 }
 
@@ -994,10 +993,10 @@ func (builder *DatadogAgentInternalBuilder) WithChecksTagCardinality(cardinality
 
 func (builder *DatadogAgentInternalBuilder) WithGlobalSecretBackendGlobalPerms(command string, args string, timeout int32) *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{
-		Command:                 ptr.To(command),
-		Args:                    ptr.To(args),
-		Timeout:                 ptr.To(timeout),
-		EnableGlobalPermissions: ptr.To(true),
+		Command:                 new(command),
+		Args:                    new(args),
+		Timeout:                 new(timeout),
+		EnableGlobalPermissions: new(true),
 	}
 	return builder
 }
@@ -1006,20 +1005,20 @@ func (builder *DatadogAgentInternalBuilder) WithGlobalSecretBackendType(backendT
 	if builder.datadogAgentInternal.Spec.Global.SecretBackend == nil {
 		builder.datadogAgentInternal.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{}
 	}
-	builder.datadogAgentInternal.Spec.Global.SecretBackend.Type = ptr.To(backendType)
+	builder.datadogAgentInternal.Spec.Global.SecretBackend.Type = new(backendType)
 	builder.datadogAgentInternal.Spec.Global.SecretBackend.Config = config
 	return builder
 }
 
 func (builder *DatadogAgentInternalBuilder) WithGlobalSecretBackendSpecificRoles(command string, args string, timeout int32, secretNs string, secretNames []string) *DatadogAgentInternalBuilder {
 	builder.datadogAgentInternal.Spec.Global.SecretBackend = &v2alpha1.SecretBackendConfig{
-		Command:                 ptr.To(command),
-		Args:                    ptr.To(args),
-		Timeout:                 ptr.To(timeout),
-		EnableGlobalPermissions: ptr.To(false),
+		Command:                 new(command),
+		Args:                    new(args),
+		Timeout:                 new(timeout),
+		EnableGlobalPermissions: new(false),
 		Roles: []*v2alpha1.SecretBackendRolesConfig{
 			{
-				Namespace: ptr.To(secretNs),
+				Namespace: new(secretNs),
 				Secrets:   secretNames,
 			},
 		},
@@ -1045,7 +1044,7 @@ func (builder *DatadogAgentInternalBuilder) WithUseFIPSAgent() *DatadogAgentInte
 		builder.datadogAgentInternal.Spec.Global = &v2alpha1.GlobalConfig{}
 	}
 
-	builder.datadogAgentInternal.Spec.Global.UseFIPSAgent = ptr.To(true)
+	builder.datadogAgentInternal.Spec.Global.UseFIPSAgent = new(true)
 	return builder
 }
 
@@ -1068,6 +1067,6 @@ func (builder *DatadogAgentInternalBuilder) initGPUMonitoring() {
 
 func (builder *DatadogAgentInternalBuilder) WithGPUMonitoringEnabled(enabled bool) *DatadogAgentInternalBuilder {
 	builder.initGPUMonitoring()
-	builder.datadogAgentInternal.Spec.Features.GPU.Enabled = ptr.To(enabled)
+	builder.datadogAgentInternal.Spec.Features.GPU.Enabled = new(enabled)
 	return builder
 }

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-operator/test/e2e
 
-go 1.25.12
+go 1.26.5
 
 require (
 	github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260604205353-3e3ae70e791b


### PR DESCRIPTION
### What does this PR do?

Updates Go from 1.25.12 to 1.26.5 across the workspace, modules, CI workflows, dev container, and builder images. It also modernizes pointer helper calls to Go 1.26's `new(expr)` syntax.

### Motivation

Go 1.26 is required by newer fake-intake releases used in the next PR in this stack.

### Additional Notes

This is the second PR in the stack and depends on #3284.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

- Ran `make update-golang`.
- Ran `make build`.
- Ran `make ci-test`.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits