### PR TITLE
chore(tooling): Make Latest Publish Jobs Dependent only on Respective Publish Job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -683,8 +683,12 @@ publish_public_latest:
     # Skip latest jobs for vX.Y.Z-rc.W tags
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
       when: never
-    - if: $CI_COMMIT_TAG
+    # Auto-promote to latest only for proper vX.Y.Z stable release tags
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
+    # Any other tag shape: require manual confirmation instead of auto-publishing latest
+    - if: $CI_COMMIT_TAG
+      when: manual
     - when: never
   trigger:
     project: DataDog/public-images
@@ -735,8 +739,15 @@ publish_redhat_public_latest:
   needs:
     - publish_redhat_public_tag
   rules:
-    - if: $CI_COMMIT_TAG
+    # Skip latest jobs for vX.Y.Z-rc.W tags
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
+      when: never
+    # Auto-promote to latest only for proper vX.Y.Z stable release tags
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
+    # Any other tag shape: require manual confirmation instead of auto-publishing latest
+    - if: $CI_COMMIT_TAG
+      when: manual
     - when: never
   trigger:
     project: DataDog/public-images

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -677,12 +677,14 @@ publish_redhat_public_tag:
 
 publish_public_latest:
   stage: release-latest
+  needs:
+    - publish_public_tag
   rules:
     # Skip latest jobs for vX.Y.Z-rc.W tags
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
       when: never
     - if: $CI_COMMIT_TAG
-      when: manual
+      when: on_success
     - when: never
   trigger:
     project: DataDog/public-images
@@ -696,15 +698,19 @@ publish_public_latest:
 
 publish_public_latest_fips:
   extends: publish_public_latest
+  needs:
+    - publish_public_tag_fips
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
     IMG_DESTINATIONS: operator:latest-fips
 
 publish_public_rc_latest:
   stage: release-latest
+  needs:
+    - publish_public_tag
   rules:
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
-      when: manual
+      when: on_success
     - when: never
   trigger:
     project: DataDog/public-images
@@ -718,15 +724,19 @@ publish_public_rc_latest:
 
 publish_public_rc_latest_fips:
   extends: publish_public_rc_latest
+  needs:
+    - publish_public_tag_fips
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips-arm64
     IMG_DESTINATIONS: operator:rc-latest-fips
 
 publish_redhat_public_latest:
   stage: release-latest
+  needs:
+    - publish_redhat_public_tag
   rules:
     - if: $CI_COMMIT_TAG
-      when: manual
+      when: on_success
     - when: never
   trigger:
     project: DataDog/public-images


### PR DESCRIPTION
### What does this PR do?

Updates the dependencies on the `release-latest` jobs to only depend on their respective `release` jobs. In other words, if we don't complete the entire `release` stage including things like the redhat public tag, we can still proceed with running the latest job for other tags.

### Motivation

Simplify the release process 

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits


### Additional Information

needs: creates a direct dependency on the specific named job, not on the whole stage. So publish_public_latest only waits for publish_public_tag to succeed. It won't wait for unrelated release-stage jobs like publish_redhat_public_tag, trigger_internal_operator_image, etc. As soon as publish_public_tag reports success, publish_public_latest unblocks and runs, even if other release-stage jobs are still pending, running, or sitting unclicked in manual state.