### PR TITLE
Trigger backport PR job on merge, not just label-added

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -59,6 +59,10 @@ jobs:
             // Parse the backport PR number from the JSON output
             const backportData = JSON.parse(process.env.BACKPORT_PR);
             const prNumber = Object.values(backportData)[0];
+            if (!prNumber) {
+              console.log('No backport PR was created, skipping milestone copy.');
+              return;
+            }
             console.log('Parsed PR number:', prNumber);
             console.log(`Copying milestone ${milestoneNumber} to PR ${prNumber}`);
 

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -1,7 +1,7 @@
 name: Backport PR
 on:
   pull_request:
-    types: [ labeled ]
+    types: [ labeled, closed ]
 
 permissions:
   id-token: write # Required for dd-octo-sts action
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     if: >
         (github.event_name == 'workflow_dispatch' ||
+        (github.event.pull_request.merged &&
+        (github.event.action == 'closed' ||
         (github.event.action == 'labeled'
-        && contains(github.event.label.name, 'backport/')))
+        && contains(github.event.label.name, 'backport/')))))
     steps:
       - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -1,7 +1,7 @@
 name: Backport PR
 on:
   pull_request:
-    types: [ labeled, closed ]
+    types: [labeled, closed]
 
 permissions:
   id-token: write # Required for dd-octo-sts action
@@ -10,12 +10,15 @@ jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
+    # 1.  PR must always be merged, then either:
+    # 2a. backport/* label is added to the closed PR
+    # 2b. PR is closed while already carrying a backport/* label
     if: >
-        (github.event_name == 'workflow_dispatch' ||
-        (github.event.pull_request.merged &&
-        (github.event.action == 'closed' ||
-        (github.event.action == 'labeled'
-        && contains(github.event.label.name, 'backport/')))))
+      github.event.pull_request.merged &&
+      ((github.event.action == 'labeled' &&
+      startsWith(github.event.label.name, 'backport/')) ||
+      (github.event.action == 'closed' &&
+      contains(format(',{0},', join(github.event.pull_request.labels.*.name, ',')), ',backport/')))
     steps:
       - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts


### PR DESCRIPTION
### What does this PR do?

Adjusts `.github/workflows/backport-pr.yml` so a `backport` label applied *before* a PR is merged still results in a backport PR being created.

- Adds `closed` alongside `labeled` to the `pull_request` trigger types.
- Gates the job's `if` on `github.event.pull_request.merged`, accepting either a `closed` event or a `labeled` event carrying a `backport/*` label.

### Motivation

Today the job only runs on the `labeled` event. If a maintainer adds a `backport/*` label before the PR merges, the job fires immediately, but `tibdex/backport` requires the PR to already be merged and fails. Nothing re-triggers it once the merge actually happens, so the backport silently never gets created unless someone re-adds the label after merge.

Aligns the Operator backport process with the Agent backport process to avoid confusion for developers.

### Checklist
- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits