### PR TITLE
Rollout Agent for any Referenced ConfigMap Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ errors
 # Exclude claude-data folder except readme.txt
 .devcontainer/claude-data/*
 !.devcontainer/claude-data/readme.txt
+
+# git worktrees
+/.worktrees

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -154,6 +154,7 @@ type options struct {
 	datadogCSIDriverEnabled                bool
 	untaintControllerEnabled               bool
 	untaintControllerWaitForCSIDriver      bool
+	rolloutOnConfigMapChangeEnabled        bool
 
 	// Secret Backend options
 	secretBackendCommand  string
@@ -198,6 +199,8 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.untaintControllerEnabled, "untaintControllerEnabled", false, "Enable the Untaint controller")
 	flag.BoolVar(&opts.untaintControllerWaitForCSIDriver, "untaintControllerWaitForCSIDriver", false,
 		"When true (requires --untaintControllerEnabled), the Untaint controller removes the startup taint only after both the node Agent and Datadog CSI node-server pods are Ready. Requires Pod watch coverage of CSI namespaces (DD_CSIDRIVER_WATCH_NAMESPACE).")
+	flag.BoolVar(&opts.rolloutOnConfigMapChangeEnabled, "rolloutOnConfigMapChangeEnabled", false,
+		"Automatically roll out Agent/Cluster Agent/Cluster Check Runner/OTel Agent Gateway workloads when a ConfigMap referenced by their pod template changes content out-of-band")
 
 	// DatadogAgentInternal
 	flag.BoolVar(&opts.createControllerRevisions, "createControllerRevisions", false, "Enable creation of ControllerRevision snapshots on each DDA spec change")
@@ -242,6 +245,7 @@ func (opts *options) Parse() {
 		boolEnv(&opts.untaintControllerEnabled, "DD_UNTAINT_CONTROLLER_ENABLED"),
 		boolEnv(&opts.untaintControllerWaitForCSIDriver, "DD_UNTAINT_CONTROLLER_WAIT_FOR_CSI_DRIVER"),
 		boolEnv(&opts.createControllerRevisions, "DD_CREATE_CONTROLLER_REVISIONS"),
+		boolEnv(&opts.rolloutOnConfigMapChangeEnabled, "DD_ROLLOUT_ON_CONFIGMAP_CHANGE_ENABLED"),
 	})
 
 	// Parsing flags
@@ -482,6 +486,7 @@ func run(opts *options) error {
 		DatadogCSIDriverEnabled:           opts.datadogCSIDriverEnabled,
 		UntaintControllerEnabled:          opts.untaintControllerEnabled,
 		UntaintControllerWaitForCSIDriver: opts.untaintControllerWaitForCSIDriver,
+		RolloutOnConfigMapChangeEnabled:   opts.rolloutOnConfigMapChangeEnabled,
 		ClusterProviderDetector:           providerDetector,
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -199,7 +199,7 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.untaintControllerEnabled, "untaintControllerEnabled", false, "Enable the Untaint controller")
 	flag.BoolVar(&opts.untaintControllerWaitForCSIDriver, "untaintControllerWaitForCSIDriver", false,
 		"When true (requires --untaintControllerEnabled), the Untaint controller removes the startup taint only after both the node Agent and Datadog CSI node-server pods are Ready. Requires Pod watch coverage of CSI namespaces (DD_CSIDRIVER_WATCH_NAMESPACE).")
-	flag.BoolVar(&opts.rolloutOnConfigMapChangeEnabled, "rolloutOnConfigMapChangeEnabled", false,
+	flag.BoolVar(&opts.rolloutOnConfigMapChangeEnabled, "rolloutOnConfigMapChangeEnabled", true,
 		"Automatically roll out Agent/Cluster Agent/Cluster Check Runner/OTel Agent Gateway workloads when a ConfigMap referenced by their pod template changes content out-of-band")
 
 	// DatadogAgentInternal

--- a/internal/controller/datadogagentinternal/component_reconciler.go
+++ b/internal/controller/datadogagentinternal/component_reconciler.go
@@ -231,7 +231,7 @@ func (r *ComponentRegistry) reconcileComponent(ctx context.Context, params *Reco
 	}
 
 	if r.reconciler.options.RolloutOnConfigMapChangeEnabled {
-		if err := r.reconciler.annotateWithReferencedConfigMapsChecksum(ctx, deployment.Namespace, &deployment.Spec.Template); err != nil {
+		if err := r.reconciler.annotateConfigMapsChecksum(ctx, deployment.Namespace, &deployment.Spec.Template); err != nil {
 			component.UpdateStatus(deployment, params.Status, now, metav1.ConditionFalse, fmt.Sprintf("%s configmap checksum error", component.Name()), err.Error())
 			return result, err
 		}

--- a/internal/controller/datadogagentinternal/component_reconciler.go
+++ b/internal/controller/datadogagentinternal/component_reconciler.go
@@ -230,6 +230,13 @@ func (r *ComponentRegistry) reconcileComponent(ctx context.Context, params *Reco
 		return result, err
 	}
 
+	if r.reconciler.options.RolloutOnConfigMapChangeEnabled {
+		if err := r.reconciler.annotateWithReferencedConfigMapsChecksum(ctx, deployment.Namespace, &deployment.Spec.Template); err != nil {
+			component.UpdateStatus(deployment, params.Status, now, metav1.ConditionFalse, fmt.Sprintf("%s configmap checksum error", component.Name()), err.Error())
+			return result, err
+		}
+	}
+
 	res, err := r.reconciler.createOrUpdateDeployment(ctx, params.DDAI, deployment, params.Status, component.UpdateStatus)
 
 	if err == nil {

--- a/internal/controller/datadogagentinternal/configmap_checksum.go
+++ b/internal/controller/datadogagentinternal/configmap_checksum.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagentinternal
+
+import (
+	"context"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+)
+
+// configMapContent is the subset of a ConfigMap that participates in the
+// referenced-configmaps checksum. Only content fields are hashed so that
+// metadata-only changes (resourceVersion, labels, annotations) on the
+// ConfigMap don't cause spurious rollouts.
+type configMapContent struct {
+	Data       map[string]string `json:"data,omitempty"`
+	BinaryData map[string][]byte `json:"binaryData,omitempty"`
+}
+
+// annotateWithReferencedConfigMapsChecksum walks podTmpl's volumes for
+// ConfigMap references (operator-owned or user-supplied alike), hashes their
+// current content, and stamps the result onto podTmpl's annotations. Because
+// this annotation becomes part of the pod template that is later hashed as a
+// whole by createOrUpdateDaemonset/createOrUpdateDeployment, a ConfigMap
+// content change automatically participates in the existing rollout decision
+// with no further wiring.
+//
+// Missing ConfigMaps are skipped rather than treated as a reconcile error,
+// since a dangling reference is already surfaced elsewhere as a pod mount
+// failure.
+func (r *Reconciler) annotateWithReferencedConfigMapsChecksum(ctx context.Context, namespace string, podTmpl *corev1.PodTemplateSpec) error {
+	names := referencedConfigMapNames(podTmpl)
+	if len(names) == 0 {
+		return nil
+	}
+
+	contents := make(map[string]configMapContent, len(names))
+	for _, name := range names {
+		cm := &corev1.ConfigMap{}
+		err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)
+		if apierrors.IsNotFound(err) {
+			ctrl.LoggerFrom(ctx).Info("referenced ConfigMap not found, skipping checksum contribution", "configmap", name, "namespace", namespace)
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		contents[name] = configMapContent{Data: cm.Data, BinaryData: cm.BinaryData}
+	}
+
+	if len(contents) == 0 {
+		return nil
+	}
+
+	orderedNames := make([]string, 0, len(contents))
+	for name := range contents {
+		orderedNames = append(orderedNames, name)
+	}
+	sort.Strings(orderedNames)
+
+	ordered := make([]configMapContent, 0, len(orderedNames))
+	for _, name := range orderedNames {
+		ordered = append(ordered, contents[name])
+	}
+
+	hash, err := comparison.GenerateMD5ForSpec(ordered)
+	if err != nil {
+		return err
+	}
+
+	if podTmpl.Annotations == nil {
+		podTmpl.Annotations = map[string]string{}
+	}
+	podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey] = hash
+
+	return nil
+}
+
+// referencedConfigMapNames returns the distinct ConfigMap names referenced
+// by podTmpl's volumes.
+func referencedConfigMapNames(podTmpl *corev1.PodTemplateSpec) []string {
+	seen := map[string]struct{}{}
+	var names []string
+	for _, vol := range podTmpl.Spec.Volumes {
+		if vol.ConfigMap == nil {
+			continue
+		}
+		if _, ok := seen[vol.ConfigMap.Name]; ok {
+			continue
+		}
+		seen[vol.ConfigMap.Name] = struct{}{}
+		names = append(names, vol.ConfigMap.Name)
+	}
+	return names
+}

--- a/internal/controller/datadogagentinternal/configmap_checksum.go
+++ b/internal/controller/datadogagentinternal/configmap_checksum.go
@@ -7,6 +7,9 @@ package datadogagentinternal
 
 import (
 	"context"
+	"fmt"
+	"hash"
+	"hash/fnv"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,14 +18,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 )
 
 // configMapContent excludes metadata (resourceVersion, labels, annotations) so
 // those changes don't affect the checksum.
 type configMapContent struct {
-	Data       map[string]string `json:"data,omitempty"`
-	BinaryData map[string][]byte `json:"binaryData,omitempty"`
+	Data       map[string]string
+	BinaryData map[string][]byte
 }
 
 // annotateConfigMapsChecksum hashes the content of ConfigMaps
@@ -55,28 +57,45 @@ func (r *Reconciler) annotateConfigMapsChecksum(ctx context.Context, namespace s
 		return nil
 	}
 
-	orderedNames := make([]string, 0, len(contents))
-	for name := range contents {
-		orderedNames = append(orderedNames, name)
-	}
-	sort.Strings(orderedNames)
-
-	ordered := make([]configMapContent, 0, len(orderedNames))
-	for _, name := range orderedNames {
-		ordered = append(ordered, contents[name])
-	}
-
-	hash, err := comparison.GenerateMD5ForSpec(ordered)
-	if err != nil {
-		return err
-	}
-
 	if podTmpl.Annotations == nil {
 		podTmpl.Annotations = map[string]string{}
 	}
-	podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey] = hash
+	podTmpl.Annotations[constants.ConfigMapsChecksumAnnotationKey] = hashConfigMapContents(contents)
 
 	return nil
+}
+
+// hashConfigMapContents hashes contents in sorted-name order, so the result
+// doesn't depend on map iteration order.
+func hashConfigMapContents(contents map[string]configMapContent) string {
+	names := make([]string, 0, len(contents))
+	for name := range contents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	h := fnv.New64a()
+	for _, name := range names {
+		h.Write([]byte(name))
+		c := contents[name]
+		writeSortedMap(h, c.Data)
+		writeSortedMap(h, c.BinaryData)
+	}
+
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+func writeSortedMap[V ~string | ~[]byte](h hash.Hash, m map[string]V) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte(m[k]))
+	}
 }
 
 func referencedConfigMapNames(podTmpl *corev1.PodTemplateSpec) []string {

--- a/internal/controller/datadogagentinternal/configmap_checksum.go
+++ b/internal/controller/datadogagentinternal/configmap_checksum.go
@@ -18,26 +18,19 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 )
 
-// configMapContent is the subset of a ConfigMap that participates in the
-// referenced-configmaps checksum. Only content fields are hashed so that
-// metadata-only changes (resourceVersion, labels, annotations) on the
-// ConfigMap don't cause spurious rollouts.
+// configMapContent excludes metadata (resourceVersion, labels, annotations) so
+// those changes don't affect the checksum.
 type configMapContent struct {
 	Data       map[string]string `json:"data,omitempty"`
 	BinaryData map[string][]byte `json:"binaryData,omitempty"`
 }
 
-// annotateWithReferencedConfigMapsChecksum walks podTmpl's volumes for
-// ConfigMap references (operator-owned or user-supplied alike), hashes their
-// current content, and stamps the result onto podTmpl's annotations. Because
-// this annotation becomes part of the pod template that is later hashed as a
-// whole by createOrUpdateDaemonset/createOrUpdateDeployment, a ConfigMap
-// content change automatically participates in the existing rollout decision
-// with no further wiring.
+// annotateWithReferencedConfigMapsChecksum hashes the content of ConfigMaps
+// referenced by podTmpl's volumes and stores it as an annotation on podTmpl,
+// so the change is picked up by the existing pod-template-hash rollout.
 //
-// Missing ConfigMaps are skipped rather than treated as a reconcile error,
-// since a dangling reference is already surfaced elsewhere as a pod mount
-// failure.
+// Missing ConfigMaps are skipped rather than erroring, since a dangling
+// reference already surfaces elsewhere as a pod mount failure.
 func (r *Reconciler) annotateWithReferencedConfigMapsChecksum(ctx context.Context, namespace string, podTmpl *corev1.PodTemplateSpec) error {
 	names := referencedConfigMapNames(podTmpl)
 	if len(names) == 0 {
@@ -86,8 +79,6 @@ func (r *Reconciler) annotateWithReferencedConfigMapsChecksum(ctx context.Contex
 	return nil
 }
 
-// referencedConfigMapNames returns the distinct ConfigMap names referenced
-// by podTmpl's volumes.
 func referencedConfigMapNames(podTmpl *corev1.PodTemplateSpec) []string {
 	seen := map[string]struct{}{}
 	var names []string

--- a/internal/controller/datadogagentinternal/configmap_checksum.go
+++ b/internal/controller/datadogagentinternal/configmap_checksum.go
@@ -25,13 +25,13 @@ type configMapContent struct {
 	BinaryData map[string][]byte `json:"binaryData,omitempty"`
 }
 
-// annotateWithReferencedConfigMapsChecksum hashes the content of ConfigMaps
+// annotateConfigMapsChecksum hashes the content of ConfigMaps
 // referenced by podTmpl's volumes and stores it as an annotation on podTmpl,
 // so the change is picked up by the existing pod-template-hash rollout.
 //
 // Missing ConfigMaps are skipped rather than erroring, since a dangling
 // reference already surfaces elsewhere as a pod mount failure.
-func (r *Reconciler) annotateWithReferencedConfigMapsChecksum(ctx context.Context, namespace string, podTmpl *corev1.PodTemplateSpec) error {
+func (r *Reconciler) annotateConfigMapsChecksum(ctx context.Context, namespace string, podTmpl *corev1.PodTemplateSpec) error {
 	names := referencedConfigMapNames(podTmpl)
 	if len(names) == 0 {
 		return nil
@@ -74,7 +74,7 @@ func (r *Reconciler) annotateWithReferencedConfigMapsChecksum(ctx context.Contex
 	if podTmpl.Annotations == nil {
 		podTmpl.Annotations = map[string]string{}
 	}
-	podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey] = hash
+	podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey] = hash
 
 	return nil
 }

--- a/internal/controller/datadogagentinternal/configmap_checksum_test.go
+++ b/internal/controller/datadogagentinternal/configmap_checksum_test.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagentinternal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
+)
+
+func newChecksumTestReconciler(objs ...client.Object) *Reconciler {
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	return &Reconciler{client: fake.NewClientBuilder().WithScheme(sch).WithObjects(objs...).Build()}
+}
+
+func configMapVolume(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: name},
+			},
+		},
+	}
+}
+
+func Test_annotateWithReferencedConfigMapsChecksum_SetsAnnotation(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-config", Namespace: "ns-1"},
+		Data:       map[string]string{"foo": "bar"},
+	}
+	r := newChecksumTestReconciler(cm)
+	podTmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("my-config")}},
+	}
+
+	err := r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
+	require.NoError(t, err)
+
+	wantHash, err := comparison.GenerateMD5ForSpec([]configMapContent{{Data: map[string]string{"foo": "bar"}}})
+	require.NoError(t, err)
+	assert.Equal(t, wantHash, podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey])
+}
+
+func Test_annotateWithReferencedConfigMapsChecksum_NoConfigMapVolumes(t *testing.T) {
+	r := newChecksumTestReconciler()
+	podTmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{{Name: "scratch", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}}},
+	}
+
+	err := r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
+	require.NoError(t, err)
+
+	_, ok := podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey]
+	assert.False(t, ok)
+}
+
+func Test_annotateWithReferencedConfigMapsChecksum_MissingConfigMap(t *testing.T) {
+	r := newChecksumTestReconciler()
+	podTmpl := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("does-not-exist")}},
+	}
+
+	err := r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
+	require.NoError(t, err)
+
+	_, ok := podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey]
+	assert.False(t, ok)
+}
+
+func Test_annotateWithReferencedConfigMapsChecksum_DeterministicOrdering(t *testing.T) {
+	cmA := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-a", Namespace: "ns-1"}, Data: map[string]string{"a": "1"}}
+	cmB := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-b", Namespace: "ns-1"}, Data: map[string]string{"b": "2"}}
+	r := newChecksumTestReconciler(cmA, cmB)
+
+	podTmplAB := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("cm-a"), configMapVolume("cm-b")}},
+	}
+	podTmplBA := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("cm-b"), configMapVolume("cm-a")}},
+	}
+
+	require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmplAB))
+	require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmplBA))
+
+	assert.Equal(t,
+		podTmplAB.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
+		podTmplBA.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
+	)
+}
+
+func Test_annotateWithReferencedConfigMapsChecksum_ContentChangeChangesHash(t *testing.T) {
+	makeReconcilerAndPodTmpl := func(data map[string]string) (*Reconciler, *corev1.PodTemplateSpec) {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-config", Namespace: "ns-1"}, Data: data}
+		r := newChecksumTestReconciler(cm)
+		podTmpl := &corev1.PodTemplateSpec{Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("my-config")}}}
+		return r, podTmpl
+	}
+
+	r1, podTmpl1 := makeReconcilerAndPodTmpl(map[string]string{"foo": "bar"})
+	r2, podTmpl2 := makeReconcilerAndPodTmpl(map[string]string{"foo": "baz"})
+
+	require.NoError(t, r1.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl1))
+	require.NoError(t, r2.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl2))
+
+	assert.NotEqual(t,
+		podTmpl1.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
+		podTmpl2.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
+	)
+}

--- a/internal/controller/datadogagentinternal/configmap_checksum_test.go
+++ b/internal/controller/datadogagentinternal/configmap_checksum_test.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 )
 
 func newChecksumTestReconciler(objs ...client.Object) *Reconciler {
@@ -52,9 +51,10 @@ func Test_annotateConfigMapsChecksum_SetsAnnotation(t *testing.T) {
 	err := r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
 	require.NoError(t, err)
 
-	wantHash, err := comparison.GenerateMD5ForSpec([]configMapContent{{Data: map[string]string{"foo": "bar"}}})
-	require.NoError(t, err)
-	assert.Equal(t, wantHash, podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey])
+	wantHash := hashConfigMapContents(map[string]configMapContent{
+		"my-config": {Data: map[string]string{"foo": "bar"}},
+	})
+	assert.Equal(t, wantHash, podTmpl.Annotations[constants.ConfigMapsChecksumAnnotationKey])
 }
 
 func Test_annotateConfigMapsChecksum_NoConfigMapVolumes(t *testing.T) {
@@ -66,7 +66,7 @@ func Test_annotateConfigMapsChecksum_NoConfigMapVolumes(t *testing.T) {
 	err := r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
 	require.NoError(t, err)
 
-	_, ok := podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey]
+	_, ok := podTmpl.Annotations[constants.ConfigMapsChecksumAnnotationKey]
 	assert.False(t, ok)
 }
 
@@ -79,7 +79,7 @@ func Test_annotateConfigMapsChecksum_MissingConfigMap(t *testing.T) {
 	err := r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
 	require.NoError(t, err)
 
-	_, ok := podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey]
+	_, ok := podTmpl.Annotations[constants.ConfigMapsChecksumAnnotationKey]
 	assert.False(t, ok)
 }
 
@@ -99,9 +99,28 @@ func Test_annotateConfigMapsChecksum_DeterministicOrdering(t *testing.T) {
 	require.NoError(t, r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmplBA))
 
 	assert.Equal(t,
-		podTmplAB.Annotations[constants.MD5ConfigMapsAnnotationKey],
-		podTmplBA.Annotations[constants.MD5ConfigMapsAnnotationKey],
+		podTmplAB.Annotations[constants.ConfigMapsChecksumAnnotationKey],
+		podTmplBA.Annotations[constants.ConfigMapsChecksumAnnotationKey],
 	)
+}
+
+func Test_hashConfigMapContents_Consistent(t *testing.T) {
+	contents := map[string]configMapContent{
+		"cm-a": {Data: map[string]string{"a": "1", "z": "26"}, BinaryData: map[string][]byte{"bin": {0, 1, 2}}},
+		"cm-b": {Data: map[string]string{"foo": "bar"}},
+		"cm-c": {BinaryData: map[string][]byte{"x": []byte("hello"), "y": []byte("world")}},
+	}
+
+	want := hashConfigMapContents(contents)
+	assert.Equal(t, want, hashConfigMapContents(contents))
+
+	// Rebuilding the same logical contents via different map insertion order must not change the hash.
+	rebuilt := map[string]configMapContent{}
+	rebuilt["cm-c"] = configMapContent{BinaryData: map[string][]byte{"y": []byte("world"), "x": []byte("hello")}}
+	rebuilt["cm-b"] = configMapContent{Data: map[string]string{"foo": "bar"}}
+	rebuilt["cm-a"] = configMapContent{Data: map[string]string{"z": "26", "a": "1"}, BinaryData: map[string][]byte{"bin": {0, 1, 2}}}
+
+	assert.Equal(t, want, hashConfigMapContents(rebuilt))
 }
 
 func Test_annotateConfigMapsChecksum_ContentChangeChangesHash(t *testing.T) {
@@ -119,7 +138,7 @@ func Test_annotateConfigMapsChecksum_ContentChangeChangesHash(t *testing.T) {
 	require.NoError(t, r2.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl2))
 
 	assert.NotEqual(t,
-		podTmpl1.Annotations[constants.MD5ConfigMapsAnnotationKey],
-		podTmpl2.Annotations[constants.MD5ConfigMapsAnnotationKey],
+		podTmpl1.Annotations[constants.ConfigMapsChecksumAnnotationKey],
+		podTmpl2.Annotations[constants.ConfigMapsChecksumAnnotationKey],
 	)
 }

--- a/internal/controller/datadogagentinternal/configmap_checksum_test.go
+++ b/internal/controller/datadogagentinternal/configmap_checksum_test.go
@@ -39,7 +39,7 @@ func configMapVolume(name string) corev1.Volume {
 	}
 }
 
-func Test_annotateWithReferencedConfigMapsChecksum_SetsAnnotation(t *testing.T) {
+func Test_annotateConfigMapsChecksum_SetsAnnotation(t *testing.T) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-config", Namespace: "ns-1"},
 		Data:       map[string]string{"foo": "bar"},
@@ -49,41 +49,41 @@ func Test_annotateWithReferencedConfigMapsChecksum_SetsAnnotation(t *testing.T) 
 		Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("my-config")}},
 	}
 
-	err := r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
+	err := r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
 	require.NoError(t, err)
 
 	wantHash, err := comparison.GenerateMD5ForSpec([]configMapContent{{Data: map[string]string{"foo": "bar"}}})
 	require.NoError(t, err)
-	assert.Equal(t, wantHash, podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey])
+	assert.Equal(t, wantHash, podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey])
 }
 
-func Test_annotateWithReferencedConfigMapsChecksum_NoConfigMapVolumes(t *testing.T) {
+func Test_annotateConfigMapsChecksum_NoConfigMapVolumes(t *testing.T) {
 	r := newChecksumTestReconciler()
 	podTmpl := &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{Volumes: []corev1.Volume{{Name: "scratch", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}}},
 	}
 
-	err := r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
+	err := r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
 	require.NoError(t, err)
 
-	_, ok := podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey]
+	_, ok := podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey]
 	assert.False(t, ok)
 }
 
-func Test_annotateWithReferencedConfigMapsChecksum_MissingConfigMap(t *testing.T) {
+func Test_annotateConfigMapsChecksum_MissingConfigMap(t *testing.T) {
 	r := newChecksumTestReconciler()
 	podTmpl := &corev1.PodTemplateSpec{
 		Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("does-not-exist")}},
 	}
 
-	err := r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
+	err := r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl)
 	require.NoError(t, err)
 
-	_, ok := podTmpl.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey]
+	_, ok := podTmpl.Annotations[constants.MD5ConfigMapsAnnotationKey]
 	assert.False(t, ok)
 }
 
-func Test_annotateWithReferencedConfigMapsChecksum_DeterministicOrdering(t *testing.T) {
+func Test_annotateConfigMapsChecksum_DeterministicOrdering(t *testing.T) {
 	cmA := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-a", Namespace: "ns-1"}, Data: map[string]string{"a": "1"}}
 	cmB := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm-b", Namespace: "ns-1"}, Data: map[string]string{"b": "2"}}
 	r := newChecksumTestReconciler(cmA, cmB)
@@ -95,16 +95,16 @@ func Test_annotateWithReferencedConfigMapsChecksum_DeterministicOrdering(t *test
 		Spec: corev1.PodSpec{Volumes: []corev1.Volume{configMapVolume("cm-b"), configMapVolume("cm-a")}},
 	}
 
-	require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmplAB))
-	require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmplBA))
+	require.NoError(t, r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmplAB))
+	require.NoError(t, r.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmplBA))
 
 	assert.Equal(t,
-		podTmplAB.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
-		podTmplBA.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
+		podTmplAB.Annotations[constants.MD5ConfigMapsAnnotationKey],
+		podTmplBA.Annotations[constants.MD5ConfigMapsAnnotationKey],
 	)
 }
 
-func Test_annotateWithReferencedConfigMapsChecksum_ContentChangeChangesHash(t *testing.T) {
+func Test_annotateConfigMapsChecksum_ContentChangeChangesHash(t *testing.T) {
 	makeReconcilerAndPodTmpl := func(data map[string]string) (*Reconciler, *corev1.PodTemplateSpec) {
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-config", Namespace: "ns-1"}, Data: data}
 		r := newChecksumTestReconciler(cm)
@@ -115,11 +115,11 @@ func Test_annotateWithReferencedConfigMapsChecksum_ContentChangeChangesHash(t *t
 	r1, podTmpl1 := makeReconcilerAndPodTmpl(map[string]string{"foo": "bar"})
 	r2, podTmpl2 := makeReconcilerAndPodTmpl(map[string]string{"foo": "baz"})
 
-	require.NoError(t, r1.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl1))
-	require.NoError(t, r2.annotateWithReferencedConfigMapsChecksum(context.Background(), "ns-1", podTmpl2))
+	require.NoError(t, r1.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl1))
+	require.NoError(t, r2.annotateConfigMapsChecksum(context.Background(), "ns-1", podTmpl2))
 
 	assert.NotEqual(t,
-		podTmpl1.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
-		podTmpl2.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey],
+		podTmpl1.Annotations[constants.MD5ConfigMapsAnnotationKey],
+		podTmpl2.Annotations[constants.MD5ConfigMapsAnnotationKey],
 	)
 }

--- a/internal/controller/datadogagentinternal/controller.go
+++ b/internal/controller/datadogagentinternal/controller.go
@@ -66,12 +66,13 @@ const (
 
 // ReconcilerOptions provides options read from command line
 type ReconcilerOptions struct {
-	ExtendedDaemonsetOptions componentagent.ExtendedDaemonsetOptions
-	SupportCilium            bool
-	OperatorMetricsEnabled   bool
-	UntaintControllerEnabled bool
-	DatadogCSIDriverEnabled  bool
-	APIReader                client.Reader
+	ExtendedDaemonsetOptions        componentagent.ExtendedDaemonsetOptions
+	SupportCilium                   bool
+	OperatorMetricsEnabled          bool
+	UntaintControllerEnabled        bool
+	DatadogCSIDriverEnabled         bool
+	RolloutOnConfigMapChangeEnabled bool
+	APIReader                       client.Reader
 }
 
 // Reconciler is the internal reconciler for Datadog Agent

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -135,7 +135,7 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 		}
 
 		if r.options.RolloutOnConfigMapChangeEnabled {
-			if err := r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &eds.Spec.Template); err != nil {
+			if err := r.annotateConfigMapsChecksum(ctx, ddai.Namespace, &eds.Spec.Template); err != nil {
 				return result, err
 			}
 		}
@@ -304,7 +304,7 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 	}
 
 	if r.options.RolloutOnConfigMapChangeEnabled {
-		if err := r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &daemonset.Spec.Template); err != nil {
+		if err := r.annotateConfigMapsChecksum(ctx, ddai.Namespace, &daemonset.Spec.Template); err != nil {
 			return result, err
 		}
 	}

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -133,6 +133,13 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 		if handled, migrationResult, err := r.migrateDaemonSetToExtendedDaemonSet(ctx, ddai, eds, newStatus); handled || err != nil {
 			return migrationResult, err
 		}
+
+		if r.options.RolloutOnConfigMapChangeEnabled {
+			if err := r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &eds.Spec.Template); err != nil {
+				return result, err
+			}
+		}
+
 		return r.createOrUpdateExtendedDaemonset(ctx, ddai, eds, newStatus, updateEDSStatusV2WithAgent)
 	}
 
@@ -295,6 +302,13 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 	if handled, migrationResult, err := r.migrateExtendedDaemonSetToDaemonSet(ctx, ddai, daemonset, newStatus); handled || err != nil {
 		return migrationResult, err
 	}
+
+	if r.options.RolloutOnConfigMapChangeEnabled {
+		if err := r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &daemonset.Spec.Template); err != nil {
+			return result, err
+		}
+	}
+
 	return r.createOrUpdateDaemonset(ctx, ddai, daemonset, newStatus, updateDSStatusV2WithAgent)
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
@@ -1,0 +1,221 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagentinternal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/constants"
+)
+
+// newRolloutTestReconciler builds a Reconciler with a fake client seeded with objs,
+// suitable for driving createOrUpdateDaemonset/annotateWithReferencedConfigMapsChecksum directly.
+func newRolloutTestReconciler(flagEnabled bool, objs ...client.Object) *Reconciler {
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	_ = v1alpha1.AddToScheme(sch)
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "Test_configmapRollout"})
+	return &Reconciler{
+		client:   fake.NewClientBuilder().WithScheme(sch).WithObjects(objs...).Build(),
+		scheme:   sch,
+		recorder: recorder,
+		options:  ReconcilerOptions{RolloutOnConfigMapChangeEnabled: flagEnabled},
+	}
+}
+
+func newRolloutTestDDAI() *v1alpha1.DatadogAgentInternal {
+	return &v1alpha1.DatadogAgentInternal{
+		ObjectMeta: metav1.ObjectMeta{Name: "dda-foo", Namespace: "ns-1"},
+	}
+}
+
+func newRolloutTestDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "dda-foo-agent", Namespace: "ns-1"},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "agent"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "agent"}},
+				Spec: corev1.PodSpec{
+					Volumes:    []corev1.Volume{configMapVolume("agent-custom-config")},
+					Containers: []corev1.Container{{Name: "agent", Image: "agent:latest"}},
+				},
+			},
+		},
+	}
+}
+
+// reconcileOnce drives one createOrUpdate pass: applies the checksum annotation (if enabled)
+// then calls createOrUpdateDaemonset, mirroring the real call site in reconcileV2Agent.
+func reconcileOnce(t *testing.T, r *Reconciler, ddai *v1alpha1.DatadogAgentInternal, ds *appsv1.DaemonSet) {
+	t.Helper()
+	ctx := context.Background()
+	if r.options.RolloutOnConfigMapChangeEnabled {
+		require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &ds.Spec.Template))
+	}
+	_, err := r.createOrUpdateDaemonset(ctx, ddai, ds, &v1alpha1.DatadogAgentInternalStatus{}, updateDSStatusV2WithAgent)
+	require.NoError(t, err)
+}
+
+func getDaemonSet(t *testing.T, r *Reconciler, ds *appsv1.DaemonSet) *appsv1.DaemonSet {
+	t.Helper()
+	got := &appsv1.DaemonSet{}
+	require.NoError(t, r.client.Get(context.Background(), types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}, got))
+	return got
+}
+
+func Test_ConfigMapRollout_FlagDisabled(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}
+	r := newRolloutTestReconciler(false, cm)
+	ddai := newRolloutTestDDAI()
+	ds := newRolloutTestDaemonSet()
+
+	reconcileOnce(t, r, ddai, ds)
+
+	got := getDaemonSet(t, r, ds)
+	_, ok := got.Spec.Template.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey]
+	assert.False(t, ok, "checksum annotation should never be added when the flag is disabled")
+}
+
+func Test_ConfigMapRollout_ContentChange_TriggersUpdate(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}
+	r := newRolloutTestReconciler(true, cm)
+	ddai := newRolloutTestDDAI()
+
+	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
+	firstVersion := getDaemonSet(t, r, newRolloutTestDaemonSet()).ResourceVersion
+
+	// Simulate an out-of-band edit to the referenced ConfigMap.
+	liveCM := &corev1.ConfigMap{}
+	require.NoError(t, r.client.Get(context.Background(), types.NamespacedName{Name: "agent-custom-config", Namespace: "ns-1"}, liveCM))
+	liveCM.Data = map[string]string{"foo": "baz"}
+	require.NoError(t, r.client.Update(context.Background(), liveCM))
+
+	// Reconcile again with no direct DDAI/DaemonSet spec change.
+	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
+
+	got := getDaemonSet(t, r, newRolloutTestDaemonSet())
+	assert.NotEqual(t, firstVersion, got.ResourceVersion, "DaemonSet should be updated when a referenced ConfigMap's content changes")
+}
+
+func Test_ConfigMapRollout_NoChange_NoUpdate(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}
+	r := newRolloutTestReconciler(true, cm)
+	ddai := newRolloutTestDDAI()
+
+	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
+	firstVersion := getDaemonSet(t, r, newRolloutTestDaemonSet()).ResourceVersion
+
+	// Reconcile again with nothing changed anywhere.
+	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
+
+	got := getDaemonSet(t, r, newRolloutTestDaemonSet())
+	assert.Equal(t, firstVersion, got.ResourceVersion, "DaemonSet should not be updated when nothing changed")
+}
+
+func Test_ConfigMapRollout_MissingConfigMap_NoCrash(t *testing.T) {
+	r := newRolloutTestReconciler(true) // no ConfigMap seeded
+	ddai := newRolloutTestDDAI()
+
+	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
+
+	got := getDaemonSet(t, r, newRolloutTestDaemonSet())
+	assert.NotEmpty(t, got.ResourceVersion, "DaemonSet should still be created normally despite the dangling ConfigMap reference")
+}
+
+func Test_ConfigMapRollout_ConfigMapChangeAndSpecChange_SingleUpdate(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}
+	r := newRolloutTestReconciler(true, cm)
+	ddai := newRolloutTestDDAI()
+
+	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
+	firstVersion := getDaemonSet(t, r, newRolloutTestDaemonSet()).ResourceVersion
+
+	// Mutate the referenced ConfigMap...
+	liveCM := &corev1.ConfigMap{}
+	require.NoError(t, r.client.Get(context.Background(), types.NamespacedName{Name: "agent-custom-config", Namespace: "ns-1"}, liveCM))
+	liveCM.Data = map[string]string{"foo": "baz"}
+	require.NoError(t, r.client.Update(context.Background(), liveCM))
+
+	// ...AND make a direct spec change in the same reconcile pass.
+	dsWithSpecChange := newRolloutTestDaemonSet()
+	dsWithSpecChange.Spec.Template.Spec.Containers[0].Image = "agent:new-tag"
+
+	reconcileOnce(t, r, ddai, dsWithSpecChange)
+
+	got := getDaemonSet(t, r, newRolloutTestDaemonSet())
+	assert.NotEqual(t, firstVersion, got.ResourceVersion, "DaemonSet should be updated")
+
+	// A second reconcile with no further changes should be a no-op, proving the
+	// combined change above resulted in exactly one update, not two.
+	stableVersion := got.ResourceVersion
+	reconcileOnce(t, r, ddai, dsWithSpecChange)
+	got = getDaemonSet(t, r, newRolloutTestDaemonSet())
+	assert.Equal(t, stableVersion, got.ResourceVersion, "no further update should occur once both changes have been applied once")
+}
+
+func newRolloutTestClusterAgentDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dda-foo-cluster-agent", Namespace: "ns-1"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "cluster-agent"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "cluster-agent"}},
+				Spec: corev1.PodSpec{
+					Volumes:    []corev1.Volume{configMapVolume("cluster-agent-custom-config")},
+					Containers: []corev1.Container{{Name: "cluster-agent", Image: "cluster-agent:latest"}},
+				},
+			},
+		},
+	}
+}
+
+func noopUpdateDepStatus(*appsv1.Deployment, *v1alpha1.DatadogAgentInternalStatus, metav1.Time, metav1.ConditionStatus, string, string) {}
+
+func Test_ConfigMapRollout_ClusterAgent_ContentChange_TriggersUpdate(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}
+	r := newRolloutTestReconciler(true, cm)
+	ddai := newRolloutTestDDAI()
+	ctx := context.Background()
+
+	reconcileOnDeployment := func(dep *appsv1.Deployment) {
+		require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &dep.Spec.Template))
+		_, err := r.createOrUpdateDeployment(ctx, ddai, dep, &v1alpha1.DatadogAgentInternalStatus{}, noopUpdateDepStatus)
+		require.NoError(t, err)
+	}
+	getDeployment := func() *appsv1.Deployment {
+		got := &appsv1.Deployment{}
+		require.NoError(t, r.client.Get(ctx, types.NamespacedName{Name: "dda-foo-cluster-agent", Namespace: "ns-1"}, got))
+		return got
+	}
+
+	reconcileOnDeployment(newRolloutTestClusterAgentDeployment())
+	firstVersion := getDeployment().ResourceVersion
+
+	liveCM := &corev1.ConfigMap{}
+	require.NoError(t, r.client.Get(ctx, types.NamespacedName{Name: "cluster-agent-custom-config", Namespace: "ns-1"}, liveCM))
+	liveCM.Data = map[string]string{"foo": "baz"}
+	require.NoError(t, r.client.Update(ctx, liveCM))
+
+	reconcileOnDeployment(newRolloutTestClusterAgentDeployment())
+
+	assert.NotEqual(t, firstVersion, getDeployment().ResourceVersion, "Cluster Agent Deployment should be updated when a referenced ConfigMap's content changes")
+}

--- a/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/constants"
 )
 
-// newRolloutTestReconciler builds a Reconciler with a fake client seeded with objs,
-// suitable for driving createOrUpdateDaemonset/annotateWithReferencedConfigMapsChecksum directly.
 func newRolloutTestReconciler(flagEnabled bool, objs ...client.Object) *Reconciler {
 	sch := runtime.NewScheme()
 	_ = scheme.AddToScheme(sch)
@@ -124,7 +122,6 @@ func Test_ConfigMapRollout_NoChange_NoUpdate(t *testing.T) {
 	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
 	firstVersion := getDaemonSet(t, r, newRolloutTestDaemonSet()).ResourceVersion
 
-	// Reconcile again with nothing changed anywhere.
 	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
 
 	got := getDaemonSet(t, r, newRolloutTestDaemonSet())
@@ -149,13 +146,11 @@ func Test_ConfigMapRollout_ConfigMapChangeAndSpecChange_SingleUpdate(t *testing.
 	reconcileOnce(t, r, ddai, newRolloutTestDaemonSet())
 	firstVersion := getDaemonSet(t, r, newRolloutTestDaemonSet()).ResourceVersion
 
-	// Mutate the referenced ConfigMap...
 	liveCM := &corev1.ConfigMap{}
 	require.NoError(t, r.client.Get(context.Background(), types.NamespacedName{Name: "agent-custom-config", Namespace: "ns-1"}, liveCM))
 	liveCM.Data = map[string]string{"foo": "baz"}
 	require.NoError(t, r.client.Update(context.Background(), liveCM))
 
-	// ...AND make a direct spec change in the same reconcile pass.
 	dsWithSpecChange := newRolloutTestDaemonSet()
 	dsWithSpecChange.Spec.Template.Spec.Containers[0].Image = "agent:new-tag"
 
@@ -188,7 +183,8 @@ func newRolloutTestClusterAgentDeployment() *appsv1.Deployment {
 	}
 }
 
-func noopUpdateDepStatus(*appsv1.Deployment, *v1alpha1.DatadogAgentInternalStatus, metav1.Time, metav1.ConditionStatus, string, string) {}
+func noopUpdateDepStatus(*appsv1.Deployment, *v1alpha1.DatadogAgentInternalStatus, metav1.Time, metav1.ConditionStatus, string, string) {
+}
 
 func Test_ConfigMapRollout_ClusterAgent_ContentChange_TriggersUpdate(t *testing.T) {
 	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}

--- a/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
@@ -67,7 +67,7 @@ func reconcileOnce(t *testing.T, r *Reconciler, ddai *v1alpha1.DatadogAgentInter
 	t.Helper()
 	ctx := context.Background()
 	if r.options.RolloutOnConfigMapChangeEnabled {
-		require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &ds.Spec.Template))
+		require.NoError(t, r.annotateConfigMapsChecksum(ctx, ddai.Namespace, &ds.Spec.Template))
 	}
 	_, err := r.createOrUpdateDaemonset(ctx, ddai, ds, &v1alpha1.DatadogAgentInternalStatus{}, updateDSStatusV2WithAgent)
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func Test_ConfigMapRollout_FlagDisabled(t *testing.T) {
 	reconcileOnce(t, r, ddai, ds)
 
 	got := getDaemonSet(t, r, ds)
-	_, ok := got.Spec.Template.Annotations[constants.MD5ReferencedConfigMapsAnnotationKey]
+	_, ok := got.Spec.Template.Annotations[constants.MD5ConfigMapsAnnotationKey]
 	assert.False(t, ok, "checksum annotation should never be added when the flag is disabled")
 }
 
@@ -183,8 +183,7 @@ func newRolloutTestClusterAgentDeployment() *appsv1.Deployment {
 	}
 }
 
-func noopUpdateDepStatus(*appsv1.Deployment, *v1alpha1.DatadogAgentInternalStatus, metav1.Time, metav1.ConditionStatus, string, string) {
-}
+func noopUpdateDepStatus(*appsv1.Deployment, *v1alpha1.DatadogAgentInternalStatus, metav1.Time, metav1.ConditionStatus, string, string) {}
 
 func Test_ConfigMapRollout_ClusterAgent_ContentChange_TriggersUpdate(t *testing.T) {
 	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}
@@ -193,7 +192,7 @@ func Test_ConfigMapRollout_ClusterAgent_ContentChange_TriggersUpdate(t *testing.
 	ctx := context.Background()
 
 	reconcileOnDeployment := func(dep *appsv1.Deployment) {
-		require.NoError(t, r.annotateWithReferencedConfigMapsChecksum(ctx, ddai.Namespace, &dep.Spec.Template))
+		require.NoError(t, r.annotateConfigMapsChecksum(ctx, ddai.Namespace, &dep.Spec.Template))
 		_, err := r.createOrUpdateDeployment(ctx, ddai, dep, &v1alpha1.DatadogAgentInternalStatus{}, noopUpdateDepStatus)
 		require.NoError(t, err)
 	}

--- a/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
@@ -89,7 +89,7 @@ func Test_ConfigMapRollout_FlagDisabled(t *testing.T) {
 	reconcileOnce(t, r, ddai, ds)
 
 	got := getDaemonSet(t, r, ds)
-	_, ok := got.Spec.Template.Annotations[constants.MD5ConfigMapsAnnotationKey]
+	_, ok := got.Spec.Template.Annotations[constants.ConfigMapsChecksumAnnotationKey]
 	assert.False(t, ok, "checksum annotation should never be added when the flag is disabled")
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_configmap_rollout_test.go
@@ -183,7 +183,8 @@ func newRolloutTestClusterAgentDeployment() *appsv1.Deployment {
 	}
 }
 
-func noopUpdateDepStatus(*appsv1.Deployment, *v1alpha1.DatadogAgentInternalStatus, metav1.Time, metav1.ConditionStatus, string, string) {}
+func noopUpdateDepStatus(*appsv1.Deployment, *v1alpha1.DatadogAgentInternalStatus, metav1.Time, metav1.ConditionStatus, string, string) {
+}
 
 func Test_ConfigMapRollout_ClusterAgent_ContentChange_TriggersUpdate(t *testing.T) {
 	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cluster-agent-custom-config", Namespace: "ns-1"}, Data: map[string]string{"foo": "bar"}}

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -56,6 +56,7 @@ type SetupOptions struct {
 	DatadogCSIDriverEnabled           bool
 	UntaintControllerEnabled          bool
 	UntaintControllerWaitForCSIDriver bool
+	RolloutOnConfigMapChangeEnabled   bool
 	ClusterProviderDetector           datadogagent.ProviderReader
 }
 
@@ -172,11 +173,12 @@ func startDatadogAgentInternal(logger logr.Logger, mgr manager.Manager, pInfo ku
 				CanaryAutoFailEnabled:               options.SupportExtendedDaemonset.CanaryAutoFailEnabled,
 				CanaryAutoFailMaxRestarts:           int32(options.SupportExtendedDaemonset.CanaryAutoFailMaxRestarts),
 			},
-			SupportCilium:            options.SupportCilium,
-			OperatorMetricsEnabled:   options.OperatorMetricsEnabled,
-			UntaintControllerEnabled: options.UntaintControllerEnabled,
-			DatadogCSIDriverEnabled:  options.DatadogCSIDriverEnabled,
-			APIReader:                mgr.GetAPIReader(),
+			SupportCilium:                   options.SupportCilium,
+			OperatorMetricsEnabled:          options.OperatorMetricsEnabled,
+			UntaintControllerEnabled:        options.UntaintControllerEnabled,
+			DatadogCSIDriverEnabled:         options.DatadogCSIDriverEnabled,
+			RolloutOnConfigMapChangeEnabled: options.RolloutOnConfigMapChangeEnabled,
+			APIReader:                       mgr.GetAPIReader(),
 		},
 	}).SetupWithManager(mgr, metricForwardersMgr)
 }

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -75,6 +75,9 @@ const (
 	MD5DDAIDeploymentAnnotationKey = "agent.datadoghq.com/ddaispechash"
 	// MD5ChecksumAnnotationKey annotation key is used to identify customConfig configurations
 	MD5ChecksumAnnotationKey = "checksum/%s-custom-config"
+	// MD5ReferencedConfigMapsAnnotationKey annotation key is used to detect content changes in ConfigMaps
+	// referenced by a pod template's volumes, whether operator-owned or user-supplied.
+	MD5ReferencedConfigMapsAnnotationKey = "checksum.agent.datadoghq.com/referenced-configmaps"
 )
 
 // Profiles

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -73,10 +73,10 @@ const (
 	MD5AgentDeploymentAnnotationKey = "agent.datadoghq.com/agentspechash"
 	// MD5DDAIDeploymentAnnotationKey annotation key is used on a DatadogAgentInternal resource to identify if changes have been made to the spec.
 	MD5DDAIDeploymentAnnotationKey = "agent.datadoghq.com/ddaispechash"
-	// MD5ConfigMapsAnnotationKey annotation key is used to detect content changes in ConfigMaps referenced by a pod template's volumes
-	MD5ConfigMapsAnnotationKey = "agent.datadoghq.com/configmapshash"
 	// MD5ChecksumAnnotationKey annotation key is used to identify customConfig configurations
 	MD5ChecksumAnnotationKey = "checksum/%s-custom-config"
+	// ConfigMapsChecksumAnnotationKey annotation key is used to detect content changes in ConfigMaps referenced by a pod template's volumes
+	ConfigMapsChecksumAnnotationKey = "agent.datadoghq.com/configmapshash"
 )
 
 // Profiles

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -75,8 +75,7 @@ const (
 	MD5DDAIDeploymentAnnotationKey = "agent.datadoghq.com/ddaispechash"
 	// MD5ChecksumAnnotationKey annotation key is used to identify customConfig configurations
 	MD5ChecksumAnnotationKey = "checksum/%s-custom-config"
-	// MD5ReferencedConfigMapsAnnotationKey annotation key is used to detect content changes in ConfigMaps
-	// referenced by a pod template's volumes, whether operator-owned or user-supplied.
+	// MD5ReferencedConfigMapsAnnotationKey annotation key is used to detect content changes in ConfigMaps referenced by a pod template's volumes
 	MD5ReferencedConfigMapsAnnotationKey = "checksum.agent.datadoghq.com/referenced-configmaps"
 )
 

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -73,10 +73,10 @@ const (
 	MD5AgentDeploymentAnnotationKey = "agent.datadoghq.com/agentspechash"
 	// MD5DDAIDeploymentAnnotationKey annotation key is used on a DatadogAgentInternal resource to identify if changes have been made to the spec.
 	MD5DDAIDeploymentAnnotationKey = "agent.datadoghq.com/ddaispechash"
+	// MD5ConfigMapsAnnotationKey annotation key is used to detect content changes in ConfigMaps referenced by a pod template's volumes
+	MD5ConfigMapsAnnotationKey = "agent.datadoghq.com/configmapshash"
 	// MD5ChecksumAnnotationKey annotation key is used to identify customConfig configurations
 	MD5ChecksumAnnotationKey = "checksum/%s-custom-config"
-	// MD5ReferencedConfigMapsAnnotationKey annotation key is used to detect content changes in ConfigMaps referenced by a pod template's volumes
-	MD5ReferencedConfigMapsAnnotationKey = "checksum.agent.datadoghq.com/referenced-configmaps"
 )
 
 // Profiles


### PR DESCRIPTION
### What does this PR do?

Re-deploy Agent whenever configmaps (external and internal) are updated by maintaining a hash of all configmaps used into a checksum that is updated on the daemonset/deployment every reconcile loop.

### Motivation

ConfigMaps mounted into Agent/DCA/CCR/OTel/etc sometimes don't trigger a rollout of the Agent. This is particularly true for configmaps not created by the Operator (eg. CustomConfig.ConfigMap.Name). These can be edited outside of the scope of the Operator and no re-deployment occurs. This PR tracks external configmaps to trigger a redeployment.

### Additional Notes

Defaults to `true`; Users can disable this feature by setting `DD_ROLLOUT_ON_CONFIGMAP_CHANGE_ENABLED` to `false` on the Operator.

### Describe your test plan

Install the Operator with the config flag to active configmap monitoring:
```shell
helm repo update datadog
helm install datadog-operator datadog/datadog-operator --devel
```

Create an external config map:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: http-check-extra-confd
  namespace: datadog
data:
  conf.yaml: |
    init_config:
    instances:
      - name: Example Website
        url: https://example.com
```

And attach it to the DatadogAgent CR:
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: datadog
spec:
  override:
    nodeAgent:
      extraConfd:
        configMap:
          name: http-check-extra-confd
          items:
            - key: conf.yaml
              path: http_check.yaml
```

Observe the resourceVersion and `checksum.agent.datadoghq.com/referenced-configmaps` annotation on the DS:
```shell
kubectl -n datadog get daemonset datadog-agent -o jsonpath='{.metadata.resourceVersion}{"\n"}'
kubectl -n datadog get daemonset datadog-agent -o jsonpath='{.spec.template.metadata.annotations}' | python3 -m json.tool
```

Then edit the configmap to trigger a redeployment via `kubectl edit http-check-extra-confd -n datadog`.

After at least 15 seconds (1 reconciliation loop) check to see if the daemonset has been updated and redeployed the Agent nodes with the previous 2 commands.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits