### PR TITLE
[CONTP-1803] Migrate CSI registrar image to registry.k8s.io

### DIFF
--- a/internal/controller/datadogcsidriver/const.go
+++ b/internal/controller/datadogcsidriver/const.go
@@ -21,7 +21,7 @@ const (
 	// defaultRegistrarImageName is the default CSI node driver registrar image name
 	defaultRegistrarImageName = "csi-node-driver-registrar"
 	// defaultRegistrarImageRegistry is the default CSI node driver registrar image registry
-	defaultRegistrarImageRegistry = "k8s.gcr.io/sig-storage"
+	defaultRegistrarImageRegistry = "registry.k8s.io/sig-storage"
 	// defaultAPMSocketPath is the default host path to the APM socket
 	defaultAPMSocketPath = "/var/run/datadog/apm.socket"
 	// defaultDSDSocketPath is the default host path to the DogStatsD socket

--- a/internal/controller/datadogcsidriver/controller_test.go
+++ b/internal/controller/datadogcsidriver/controller_test.go
@@ -126,7 +126,7 @@ func TestReconcile_CreatesResources(t *testing.T) {
 
 	registrarContainer := ds.Spec.Template.Spec.Containers[1]
 	assert.Equal(t, v1alpha1.CSINodeDriverRegistrarContainerName, registrarContainer.Name)
-	assert.Equal(t, fmt.Sprintf("%s/%s:%s", defaultRegistrarImageRegistry, defaultRegistrarImageName, images.DefaultRegistrarImageVersion), registrarContainer.Image)
+	assert.Equal(t, "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1", registrarContainer.Image)
 	assert.Contains(t, registrarContainer.Env, corev1.EnvVar{
 		Name:  envDriverRegSock,
 		Value: csiSocketPath,

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer.go
@@ -23,8 +23,13 @@ import (
 const DefaultWorkloadAllowlistVersion = "v1.0.5"
 
 // DefaultCSIWorkloadAllowlistVersion is the default version of the Datadog CSI
-// driver daemonset WorkloadAllowlist.
-const DefaultCSIWorkloadAllowlistVersion = "v1.1.0"
+// driver daemonset WorkloadAllowlist. v1.1.1 allows the registrar image from
+// registry.k8s.io.
+const DefaultCSIWorkloadAllowlistVersion = "v1.1.1"
+
+// previousCSIWorkloadAllowlistVersion remains synchronized while the new
+// default propagates across GKE node versions.
+const previousCSIWorkloadAllowlistVersion = "v1.1.0"
 
 const allowlistSynchronizerFieldOwner = "datadog-operator-allowlist-synchronizer"
 
@@ -98,24 +103,34 @@ func applyAllowlistSynchronizerResource(k8sClient client.Client, version, partOf
 		k8sClient,
 		agentAllowlistSynchronizerName,
 		agentAllowlistAppNameLabel,
-		fmt.Sprintf("Datadog/datadog/datadog-datadog-daemonset-exemption-%s.yaml", version),
+		[]string{fmt.Sprintf("Datadog/datadog/datadog-datadog-daemonset-exemption-%s.yaml", version)},
 		partOfLabel,
 		commonLabels,
 	)
 }
 
 func applyCSIAllowlistSynchronizerResource(k8sClient client.Client, version, partOfLabel string, commonLabels map[string]string) error {
+	allowlistPaths := make([]string, 0, 2)
+	if version == DefaultCSIWorkloadAllowlistVersion && version != previousCSIWorkloadAllowlistVersion {
+		allowlistPaths = append(allowlistPaths, csiWorkloadAllowlistPath(previousCSIWorkloadAllowlistVersion))
+	}
+	allowlistPaths = append(allowlistPaths, csiWorkloadAllowlistPath(version))
+
 	return applyAllowlistSynchronizerResourceForPath(
 		k8sClient,
 		csiAllowlistSynchronizerName,
 		csiAllowlistAppNameLabel,
-		fmt.Sprintf("Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-%s.yaml", version),
+		allowlistPaths,
 		partOfLabel,
 		commonLabels,
 	)
 }
 
-func applyAllowlistSynchronizerResourceForPath(k8sClient client.Client, name, appNameLabel, allowlistPath, partOfLabel string, commonLabels map[string]string) error {
+func csiWorkloadAllowlistPath(version string) string {
+	return fmt.Sprintf("Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-%s.yaml", version)
+}
+
+func applyAllowlistSynchronizerResourceForPath(k8sClient client.Client, name, appNameLabel string, allowlistPaths []string, partOfLabel string, commonLabels map[string]string) error {
 	labels := map[string]string{
 		"app.kubernetes.io/created-by":           "datadog-operator",
 		kubernetes.AppKubernetesManageByLabelKey: "datadog-operator",
@@ -139,9 +154,7 @@ func applyAllowlistSynchronizerResourceForPath(k8sClient client.Client, name, ap
 			Labels: labels,
 		},
 		Spec: AllowlistSynchronizerSpec{
-			AllowlistPaths: []string{
-				allowlistPath,
-			},
+			AllowlistPaths: allowlistPaths,
 		},
 	}
 
@@ -176,7 +189,8 @@ func CreateAllowlistSynchronizer(version, partOfLabel string, commonLabels map[s
 //
 // version selects the Datadog CSI driver WorkloadAllowlist YAML to point at.
 // Pass an empty string to use DefaultCSIWorkloadAllowlistVersion. Malformed
-// versions also fall back to the default.
+// versions also fall back to the default. While the new default propagates
+// across GKE node versions, the previous default is synchronized alongside it.
 //
 // commonLabels are merged into the AllowlistSynchronizer ObjectMeta labels so
 // that required-label admission policies (e.g. Kyverno) do not reject the

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
@@ -62,7 +62,7 @@ func TestDefaultWorkloadAllowlistVersion(t *testing.T) {
 
 func TestDefaultCSIWorkloadAllowlistVersion(t *testing.T) {
 	// Sanity check — locks the default to a known value so a silent bump is caught.
-	assert.Equal(t, "v1.1.0", DefaultCSIWorkloadAllowlistVersion)
+	assert.Equal(t, "v1.1.1", DefaultCSIWorkloadAllowlistVersion)
 }
 
 func TestApplyAllowlistSynchronizerResource_AllowlistPath(t *testing.T) {
@@ -109,19 +109,31 @@ func TestApplyCSIAllowlistSynchronizerResource_AllowlistPath(t *testing.T) {
 	require.NoError(t, SchemeBuilder.AddToScheme(scheme))
 
 	tests := []struct {
-		name       string
-		version    string
-		expectPath string
+		name        string
+		version     string
+		expectPaths []string
 	}{
 		{
-			name:       "default version",
-			version:    DefaultCSIWorkloadAllowlistVersion,
-			expectPath: "Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml",
+			name:    "default version retains previous version",
+			version: DefaultCSIWorkloadAllowlistVersion,
+			expectPaths: []string{
+				"Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml",
+				"Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.1.yaml",
+			},
 		},
 		{
-			name:       "user override",
-			version:    "v1.2.0",
-			expectPath: "Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.2.0.yaml",
+			name:    "previous version override is not duplicated",
+			version: previousCSIWorkloadAllowlistVersion,
+			expectPaths: []string{
+				"Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml",
+			},
+		},
+		{
+			name:    "user override",
+			version: "v1.2.0",
+			expectPaths: []string{
+				"Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.2.0.yaml",
+			},
 		},
 	}
 
@@ -132,8 +144,7 @@ func TestApplyCSIAllowlistSynchronizerResource_AllowlistPath(t *testing.T) {
 
 			got := &AllowlistSynchronizer{}
 			require.NoError(t, c.Get(context.TODO(), client.ObjectKey{Name: "datadog-csi-synchronizer"}, got))
-			require.Len(t, got.Spec.AllowlistPaths, 1)
-			assert.Equal(t, tt.expectPath, got.Spec.AllowlistPaths[0])
+			assert.Equal(t, tt.expectPaths, got.Spec.AllowlistPaths)
 			assert.Empty(t, got.Annotations)
 			assert.Equal(t, "datadog-operator", got.Labels["app.kubernetes.io/created-by"])
 			assert.Equal(t, "datadog-operator", got.Labels[kubernetes.AppKubernetesManageByLabelKey])
@@ -200,12 +211,14 @@ func TestApplyCSIAllowlistSynchronizerResource_UpdatesExistingResource(t *testin
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
 
-	require.NoError(t, applyCSIAllowlistSynchronizerResource(c, "v1.1.0", "default-foo", nil))
+	require.NoError(t, applyCSIAllowlistSynchronizerResource(c, DefaultCSIWorkloadAllowlistVersion, "default-foo", nil))
 
 	got := &AllowlistSynchronizer{}
 	require.NoError(t, c.Get(context.TODO(), client.ObjectKey{Name: "datadog-csi-synchronizer"}, got))
-	require.Len(t, got.Spec.AllowlistPaths, 1)
-	assert.Equal(t, "Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml", got.Spec.AllowlistPaths[0])
+	assert.Equal(t, []string{
+		"Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.0.yaml",
+		"Datadog/datadog-csi-driver/datadog-datadog-csi-driver-daemonset-exemption-v1.1.1.yaml",
+	}, got.Spec.AllowlistPaths)
 	assert.Equal(t, "default-foo", got.Labels[kubernetes.AppKubernetesPartOfLabelKey])
 	assert.Equal(t, "datadog-operator", got.Labels[kubernetes.AppKubernetesManageByLabelKey])
 	assert.Equal(t, "datadog-csi-allowlist-synchronizer", got.Labels[kubernetes.AppKubernetesNameLabelKey])


### PR DESCRIPTION
### What does this PR do?

Migrates the default CSI node driver registrar image from `k8s.gcr.io` to `registry.k8s.io`.

It also updates the default CSI WorkloadAllowlist from `v1.1.0` to `v1.1.1`. The CSI `AllowlistSynchronizer` intentionally keeps `v1.1.0` whenever `v1.1.1` is selected, whether by default or through an explicit `v1.1.1` override, while the new allowlist propagates across GKE node versions. Overrides to versions other than `v1.1.1` synchronize only the requested version.

### Motivation

`k8s.gcr.io` is frozen and Kubernetes images have moved to `registry.k8s.io`. Some environments block the deprecated registry, so the Operator default image and its corresponding GKE Autopilot WorkloadAllowlist need to move together.

### Additional Notes

This mirrors the `datadog-csi-driver` Helm chart migration in DataDog/helm-charts#2781 and uses the WorkloadAllowlist introduced by DataDog/datadog-gke-workload-allowlist#19.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

1. Start the Operator with the `DatadogCSIDriver` controller enabled.
2. Deploy a default, empty `DatadogCSIDriver`:

   ```yaml
   apiVersion: datadoghq.com/v1alpha1
   kind: DatadogCSIDriver
   metadata:
     name: datadog-csi
     namespace: default
   spec: {}
   ```

3. Inspect the generated DaemonSet and verify the `csi-node-driver-registrar` container uses `registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.0.1`:

   ```shell
   kubectl -n default get daemonset datadog-csi-driver-node-server -o yaml
   ```

4. On a GKE Autopilot cluster with CSI allowlist synchronization enabled through an Autopilot-enabled `DatadogAgent` and with `global.csi.enabled: true`, verify the CSI `AllowlistSynchronizer` is present and contains both the `v1.1.0` and `v1.1.1` paths:

   ```shell
   kubectl get allowlistsynchronizer datadog-csi-synchronizer -o yaml
   ```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits