### PR TITLE
DDOT: explicitly declare bundled mode

### DIFF
--- a/internal/controller/datadogagent/feature/otelcollector/envvar.go
+++ b/internal/controller/datadogagent/feature/otelcollector/envvar.go
@@ -11,4 +11,5 @@ const (
 	DDOtelCollectorCoreConfigExtensionTimeout = "DD_OTELCOLLECTOR_EXTENSION_TIMEOUT"
 	DDOtelCollectorConverterFeatures          = "DD_OTELCOLLECTOR_CONVERTER_FEATURES"
 	DDOtelCollectorInstallationMethod         = "DD_OTELCOLLECTOR_INSTALLATION_METHOD"
+	DDOtelStandalone                          = "DD_OTEL_STANDALONE"
 )

--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -449,6 +449,11 @@ func (o *otelCollectorFeature) ManageNodeAgent(managers feature.PodTemplateManag
 		Value: "kubernetes",
 	})
 
+	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.OtelAgent}, &corev1.EnvVar{
+		Name:  DDOtelStandalone,
+		Value: "false",
+	})
+
 	return nil
 }
 

--- a/internal/controller/datadogagent/feature/otelcollector/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature_test.go
@@ -681,6 +681,12 @@ func testExpectedAgent(
 				})
 			}
 
+			// DD_OTEL_STANDALONE is always set on the otel-agent container.
+			wantEnvVarsOTel = append(wantEnvVarsOTel, &corev1.EnvVar{
+				Name:  DDOtelStandalone,
+				Value: "false",
+			})
+
 			if len(wantEnvVars) == 0 {
 				wantEnvVars = nil
 			}

--- a/internal/controller/datadogagent/global/otelagentgateway.go
+++ b/internal/controller/datadogagent/global/otelagentgateway.go
@@ -46,7 +46,7 @@ func applyOtelAgentGatewayResources(manager feature.PodTemplateManagers, ddaSpec
 		Value: "true",
 	})
 
-	// Disable standalone mode
+	// Explicitly set bundled mode (DD_OTEL_STANDALONE=false)
 	manager.EnvVar().AddEnvVarToContainer(apicommon.OtelAgent, &corev1.EnvVar{
 		Name:  "DD_OTEL_STANDALONE",
 		Value: "false",

--- a/internal/controller/datadogagent/global/otelagentgateway.go
+++ b/internal/controller/datadogagent/global/otelagentgateway.go
@@ -46,6 +46,12 @@ func applyOtelAgentGatewayResources(manager feature.PodTemplateManagers, ddaSpec
 		Value: "true",
 	})
 
+	// Disable standalone mode
+	manager.EnvVar().AddEnvVarToContainer(apicommon.OtelAgent, &corev1.EnvVar{
+		Name:  "DD_OTEL_STANDALONE",
+		Value: "false",
+	})
+
 	// Set hostname from spec.nodeName
 	manager.EnvVar().AddEnvVarToContainer(apicommon.OtelAgent, &corev1.EnvVar{
 		Name: "DD_HOSTNAME",

--- a/internal/controller/datadogagent/global/otelagentgateway_test.go
+++ b/internal/controller/datadogagent/global/otelagentgateway_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package global
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
+)
+
+func Test_applyOtelAgentGatewayResources(t *testing.T) {
+	mgr := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
+
+	applyOtelAgentGatewayResources(mgr, &v2alpha1.DatadogAgentSpec{})
+
+	wantEnvVars := []*corev1.EnvVar{
+		{
+			Name:  "DD_OTELCOLLECTOR_ENABLED",
+			Value: "true",
+		},
+		{
+			Name:  "DD_OTELCOLLECTOR_INSTALLATION_METHOD",
+			Value: "kubernetes",
+		},
+		{
+			Name:  "DD_OTELCOLLECTOR_GATEWAY_MODE",
+			Value: "true",
+		},
+		{
+			Name:  "DD_OTEL_STANDALONE",
+			Value: "false",
+		},
+		{
+			Name: "DD_HOSTNAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name:  "DD_OTELCOLLECTOR_CONVERTER_FEATURES",
+			Value: "health_check,zpages,pprof,datadog",
+		},
+		{
+			Name:  "DD_ENABLE_METADATA_COLLECTION",
+			Value: "false",
+		},
+		{
+			Name:  "DD_PROCESS_AGENT_ENABLED",
+			Value: "false",
+		},
+		{
+			Name:  "DD_REMOTE_CONFIGURATION_ENABLED",
+			Value: "false",
+		},
+		{
+			Name:  "DD_INVENTORIES_ENABLED",
+			Value: "false",
+		},
+		{
+			Name:  "DD_CMD_PORT",
+			Value: "0",
+		},
+		{
+			Name:  "DD_AGENT_IPC_PORT",
+			Value: "0",
+		},
+		{
+			Name:  "DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL",
+			Value: "0",
+		},
+	}
+
+	otelAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.OtelAgent]
+	assert.ElementsMatch(t, otelAgentEnvVars, wantEnvVars, "otel-agent gateway envvars \ndiff = %s", cmp.Diff(otelAgentEnvVars, wantEnvVars))
+}


### PR DESCRIPTION
### What does this PR do?

Add an env var to DDOT containers to explicitly set it to bundled mode

### Motivation

[OTAGENT-1165](https://datadoghq.atlassian.net/browse/OTAGENT-1165?atlOrigin=eyJpIjoiYjkzMjkyNDIxYWViNGRlMGJkMjk1MjQwYzUwMDhiYWIiLCJwIjoiaiJ9)

### Describe your test plan

Validate DDOT starts without error, including in the gateway deployment.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

[OTAGENT-1165]: https://datadoghq.atlassian.net/browse/OTAGENT-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ