### PR TITLE
Show DDAI errors in respective DDA or DAP

### DIFF
--- a/internal/controller/datadogagent/common/const.go
+++ b/internal/controller/datadogagent/common/const.go
@@ -55,6 +55,8 @@ const (
 	OverrideReconcileConflictConditionType = "OverrideReconcileConflict"
 	// DatadogAgentReconcileErrorConditionType ReconcileConditionType for DatadogAgent reconcile error
 	DatadogAgentReconcileErrorConditionType = "DatadogAgentReconcileError"
+	// DatadogAgentInternalReconcileErrorConditionType ReconcileConditionType surfacing a DatadogAgentInternal reconcile error on its owning DatadogAgent or DatadogAgentProfile
+	DatadogAgentInternalReconcileErrorConditionType = "DatadogAgentInternalReconcileError"
 	// ClusterProviderDetectedConditionType reports the detected (or user-specified) cluster provider
 	ClusterProviderDetectedConditionType = "ClusterProviderDetected"
 	// FeatureNotSupportedOnProviderConditionType reports that an enabled feature is not supported on the detected provider

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -165,7 +165,7 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 		}
 
 		// Add DDAI status to DDA status
-		if e := r.addDDAIStatusToDDAStatus(newDDAStatus, ddai.ObjectMeta); e != nil {
+		if e := r.addDDAIStatusToDDAStatus(newDDAStatus, ddai.ObjectMeta, now); e != nil {
 			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
 		}
 

--- a/internal/controller/datadogagent/controller_reconcile_v2_common.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common.go
@@ -187,7 +187,7 @@ func (r *Reconciler) createOrUpdateDDAI(ddai *v1alpha1.DatadogAgentInternal) err
 	return nil
 }
 
-func (r *Reconciler) addDDAIStatusToDDAStatus(status *v2alpha1.DatadogAgentStatus, ddai metav1.ObjectMeta) error {
+func (r *Reconciler) addDDAIStatusToDDAStatus(status *v2alpha1.DatadogAgentStatus, ddai metav1.ObjectMeta, now metav1.Time) error {
 	currentDDAI := &v1alpha1.DatadogAgentInternal{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: ddai.Name, Namespace: ddai.Namespace}, currentDDAI); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -202,7 +202,15 @@ func (r *Reconciler) addDDAIStatusToDDAStatus(status *v2alpha1.DatadogAgentStatu
 	status.ClusterAgent = condition.CombineDeploymentStatus(status.ClusterAgent, currentDDAI.Status.ClusterAgent)
 	status.ClusterChecksRunner = condition.CombineDeploymentStatus(status.ClusterChecksRunner, currentDDAI.Status.ClusterChecksRunner)
 
-	// TODO: Add and/or merge conditions once DDAI reconcile PR is merged
+	// Only the default DDAI runs dependency management (e.g. RBAC-gated
+	// resources), so it's the only DDAI whose reconcile error is surfaced on
+	// the DDA. Profile DDAI reconcile errors are surfaced on their own
+	// DatadogAgentProfile status instead (see addDDAIStatusToProfileStatus).
+	if currentDDAI.Labels[constants.ProfileLabelKey] == "" {
+		if ddaiErrCond := condition.GetDDAICondition(&currentDDAI.Status, controllercommon.DatadogAgentReconcileErrorConditionType); ddaiErrCond != nil && ddaiErrCond.Status == metav1.ConditionTrue {
+			condition.UpdateDatadogAgentStatusConditions(status, now, controllercommon.DatadogAgentInternalReconcileErrorConditionType, metav1.ConditionTrue, "DatadogAgentInternal_reconcile_error", fmt.Sprintf("%s: %s", currentDDAI.Name, ddaiErrCond.Message), false)
+		}
+	}
 
 	return nil
 }

--- a/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2_common_test.go
@@ -2,11 +2,14 @@ package datadogagent
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/utils/ptr"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 
 	assert "github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +25,8 @@ func Test_addDDAIStatusToDDAStatus(t *testing.T) {
 	_ = scheme.AddToScheme(sch)
 	_ = v1alpha1.AddToScheme(sch)
 	_ = v2alpha1.AddToScheme(sch)
+
+	now := metav1.NewTime(time.Now())
 
 	tests := []struct {
 		name           string
@@ -91,6 +96,61 @@ func Test_addDDAIStatusToDDAStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "Default DDAI reconcile error is surfaced on the DDA",
+			status: v2alpha1.DatadogAgentStatus{},
+			existingDDAI: v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ddai",
+					Namespace: "test-namespace",
+				},
+				Status: v1alpha1.DatadogAgentInternalStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    common.DatadogAgentReconcileErrorConditionType,
+							Status:  metav1.ConditionTrue,
+							Reason:  "DatadogAgent_reconcile_error",
+							Message: "rbac error: clusterroles.rbac.authorization.k8s.io is forbidden",
+						},
+					},
+				},
+			},
+			expectedStatus: v2alpha1.DatadogAgentStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               common.DatadogAgentInternalReconcileErrorConditionType,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: now,
+						Reason:             "DatadogAgentInternal_reconcile_error",
+						Message:            "test-ddai: rbac error: clusterroles.rbac.authorization.k8s.io is forbidden",
+					},
+				},
+			},
+		},
+		{
+			name:   "Profile DDAI reconcile error is NOT surfaced on the DDA",
+			status: v2alpha1.DatadogAgentStatus{},
+			existingDDAI: v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-profile-ddai",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						constants.ProfileLabelKey: "test-profile",
+					},
+				},
+				Status: v1alpha1.DatadogAgentInternalStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    common.DatadogAgentReconcileErrorConditionType,
+							Status:  metav1.ConditionTrue,
+							Reason:  "DatadogAgent_reconcile_error",
+							Message: "some daemonset error",
+						},
+					},
+				},
+			},
+			expectedStatus: v2alpha1.DatadogAgentStatus{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -102,7 +162,7 @@ func Test_addDDAIStatusToDDAStatus(t *testing.T) {
 				log:    logf.Log.WithName(tt.name),
 			}
 
-			err := r.addDDAIStatusToDDAStatus(&tt.status, tt.existingDDAI.ObjectMeta)
+			err := r.addDDAIStatusToDDAStatus(&tt.status, tt.existingDDAI.ObjectMeta, now)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedStatus, tt.status)
 		})

--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/metrics"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
+	"github.com/DataDog/datadog-operator/pkg/condition"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
@@ -87,6 +88,8 @@ func (r *Reconciler) reconcileProfiles(ctx context.Context, dsNSName types.Names
 	for _, profile := range sortedProfiles {
 		originalStatus := profile.Status.DeepCopy()
 		logger.Info("reconciling profile", "datadogagentprofile", profile.Name, "datadogagentprofile_namespace", profile.Namespace)
+
+		r.addDDAIStatusToProfileStatus(ctx, &profile, defaultDDAI.Name, defaultDDAI.Namespace, now)
 
 		requirements, err := agentprofile.ValidateProfileAndReturnRequirements(&profile)
 		if err != nil {
@@ -358,6 +361,31 @@ func setProfileDDAIMeta(ddai *v1alpha1.DatadogAgentInternal, profile *v1alpha1.D
 		ddai.Annotations[kubernetes.ProviderAnnotationKey] = v
 	}
 	return nil
+}
+
+// addDDAIStatusToProfileStatus surfaces the profile's DatadogAgentInternal
+// reconcile-error condition on the DatadogAgentProfile itself. Unlike the DDA's
+// conditions (rebuilt from scratch every reconcile), DatadogAgentProfile
+// conditions persist across reconciles, so the condition must be explicitly
+// set to False on recovery or a stale error would linger forever.
+func (r *Reconciler) addDDAIStatusToProfileStatus(ctx context.Context, profile *v1alpha1.DatadogAgentProfile, ddaiName, ddaiNamespace string, now metav1.Time) {
+	ddaiName = getProfileDDAIName(ddaiName, profile.Name, profile.Namespace)
+	ddai := &v1alpha1.DatadogAgentInternal{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: ddaiName, Namespace: ddaiNamespace}, ddai); err != nil {
+		if !apierrors.IsNotFound(err) {
+			r.log.Error(err, "unexpected error during DDAI get", "datadogagentprofile", profile.Name, "datadogagentprofile_namespace", profile.Namespace)
+		}
+		// DDAI not yet created
+		return
+	}
+
+	var newCondition metav1.Condition
+	if ddaiErrCond := condition.GetDDAICondition(&ddai.Status, common.DatadogAgentReconcileErrorConditionType); ddaiErrCond != nil && ddaiErrCond.Status == metav1.ConditionTrue {
+		newCondition = agentprofile.NewDatadogAgentProfileCondition(agentprofile.DDAIReconcileErrorConditionType, metav1.ConditionTrue, now, agentprofile.DDAIReconcileErrorConditionReason, fmt.Sprintf("%s: %s", ddai.Name, ddaiErrCond.Message))
+	} else {
+		newCondition = agentprofile.NewDatadogAgentProfileCondition(agentprofile.DDAIReconcileErrorConditionType, metav1.ConditionFalse, now, agentprofile.DDAIReconcileOKConditionReason, "")
+	}
+	profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, newCondition)
 }
 
 // getProfileDDAIName returns the name of the DDAI when profiles are used.

--- a/internal/controller/datadogagent/profile.go
+++ b/internal/controller/datadogagent/profile.go
@@ -14,6 +14,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -374,8 +375,14 @@ func (r *Reconciler) addDDAIStatusToProfileStatus(ctx context.Context, profile *
 	if err := r.client.Get(ctx, types.NamespacedName{Name: ddaiName, Namespace: ddaiNamespace}, ddai); err != nil {
 		if !apierrors.IsNotFound(err) {
 			r.log.Error(err, "unexpected error during DDAI get", "datadogagentprofile", profile.Name, "datadogagentprofile_namespace", profile.Namespace)
+			return
 		}
-		// DDAI not yet created
+		// Leave a new profile untouched until its DDAI is created, but clear
+		// an error left behind after a previously existing DDAI is removed.
+		if apimeta.FindStatusCondition(profile.Status.Conditions, agentprofile.DDAIReconcileErrorConditionType) != nil {
+			newCondition := agentprofile.NewDatadogAgentProfileCondition(agentprofile.DDAIReconcileErrorConditionType, metav1.ConditionFalse, now, agentprofile.DDAIReconcileOKConditionReason, "")
+			profile.Status.Conditions = agentprofile.SetDatadogAgentProfileCondition(profile.Status.Conditions, newCondition)
+		}
 		return
 	}
 

--- a/internal/controller/datadogagent/profile_test.go
+++ b/internal/controller/datadogagent/profile_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
 	"github.com/DataDog/datadog-operator/pkg/agentprofile"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -1819,4 +1820,124 @@ func testAPMMatrixConditionMessage(conditions []metav1.Condition, conditionType 
 		}
 	}
 	return ""
+}
+
+func Test_addDDAIStatusToProfileStatus(t *testing.T) {
+	sch := agenttestutils.TestScheme()
+	ctx := context.Background()
+	now := metav1.NewTime(time.Now())
+
+	newProfile := func() *v1alpha1.DatadogAgentProfile {
+		return &v1alpha1.DatadogAgentProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-profile",
+				Namespace: "default",
+			},
+		}
+	}
+
+	tests := []struct {
+		name              string
+		profile           *v1alpha1.DatadogAgentProfile
+		existingDDAI      *v1alpha1.DatadogAgentInternal
+		expectNoCondition bool
+		expectStatus      metav1.ConditionStatus
+		expectReason      string
+		expectMessage     string
+	}{
+		{
+			name:              "DDAI not yet created leaves conditions untouched",
+			profile:           newProfile(),
+			existingDDAI:      nil,
+			expectNoCondition: true,
+		},
+		{
+			name:    "DDAI reconcile error is surfaced on the profile",
+			profile: newProfile(),
+			existingDDAI: &v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-profile",
+					Namespace: "default",
+				},
+				Status: v1alpha1.DatadogAgentInternalStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    common.DatadogAgentReconcileErrorConditionType,
+							Status:  metav1.ConditionTrue,
+							Reason:  "DatadogAgent_reconcile_error",
+							Message: "some daemonset error",
+						},
+					},
+				},
+			},
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  agentprofile.DDAIReconcileErrorConditionReason,
+			expectMessage: "test-profile: some daemonset error",
+		},
+		{
+			name: "recovered DDAI clears a stale profile error condition",
+			profile: func() *v1alpha1.DatadogAgentProfile {
+				p := newProfile()
+				p.Status.Conditions = []metav1.Condition{
+					{
+						Type:    agentprofile.DDAIReconcileErrorConditionType,
+						Status:  metav1.ConditionTrue,
+						Reason:  agentprofile.DDAIReconcileErrorConditionReason,
+						Message: "test-profile: some daemonset error",
+					},
+				}
+				return p
+			}(),
+			existingDDAI: &v1alpha1.DatadogAgentInternal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-profile",
+					Namespace: "default",
+				},
+				Status: v1alpha1.DatadogAgentInternalStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   common.DatadogAgentReconcileErrorConditionType,
+							Status: metav1.ConditionFalse,
+							Reason: "DatadogAgent_reconcile_ok",
+						},
+					},
+				},
+			},
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  agentprofile.DDAIReconcileOKConditionReason,
+			expectMessage: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := []k8sruntime.Object{}
+			if tt.existingDDAI != nil {
+				objects = append(objects, tt.existingDDAI)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithRuntimeObjects(objects...).Build()
+			r := &Reconciler{
+				client: fakeClient,
+				log:    logf.Log.WithName(tt.name),
+			}
+
+			r.addDDAIStatusToProfileStatus(ctx, tt.profile, "test-profile", "default", now)
+
+			var found *metav1.Condition
+			for i := range tt.profile.Status.Conditions {
+				if tt.profile.Status.Conditions[i].Type == agentprofile.DDAIReconcileErrorConditionType {
+					found = &tt.profile.Status.Conditions[i]
+				}
+			}
+
+			if tt.expectNoCondition {
+				assert.Nil(t, found)
+				return
+			}
+			require.NotNil(t, found)
+			assert.Equal(t, tt.expectStatus, found.Status)
+			assert.Equal(t, tt.expectReason, found.Reason)
+			assert.Equal(t, tt.expectMessage, found.Message)
+		})
+	}
 }

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -183,7 +183,7 @@ func (r *Reconciler) updateStatusIfNeededV2(ctx context.Context, agentdeployment
 	if currentError == nil {
 		condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionFalse, "DatadogAgent_reconcile_ok", "DatadogAgent reconcile ok", false)
 	} else {
-		condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionTrue, "DatadogAgent_reconcile_error", "DatadogAgent reconcile error", false)
+		condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionTrue, "DatadogAgent_reconcile_error", currentError.Error(), false)
 	}
 
 	r.setMetricsForwarderStatusV2(ctx, agentdeployment, newStatus)

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common_test.go
@@ -2,10 +2,20 @@ package datadogagentinternal
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/pkg/condition"
 )
 
 func Test_ensureSelectorInPodTemplateLabels(t *testing.T) {
@@ -97,6 +107,85 @@ func Test_ensureSelectorInPodTemplateLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			labels := ensureSelectorInPodTemplateLabels(context.Background(), tt.selector, tt.podTemplateLabels)
 			assert.Equal(t, tt.expectedLabels, labels)
+		})
+	}
+}
+
+func Test_updateStatusIfNeededV2_ReconcileErrorCondition(t *testing.T) {
+	sch := runtime.NewScheme()
+	_ = scheme.AddToScheme(sch)
+	_ = v1alpha1.AddToScheme(sch)
+
+	now := metav1.NewTime(metav1.Now().Time)
+
+	ddai := &v1alpha1.DatadogAgentInternal{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ddai",
+			Namespace: "test-namespace",
+		},
+	}
+
+	tests := []struct {
+		name              string
+		existingCondition *metav1.Condition
+		currentError      error
+		expectNoCondition bool
+		expectStatus      metav1.ConditionStatus
+		expectReason      string
+		expectMessage     string
+	}{
+		{
+			name:              "no error and no prior condition adds nothing",
+			currentError:      nil,
+			expectNoCondition: true,
+		},
+		{
+			name: "no error clears a prior error condition",
+			existingCondition: &metav1.Condition{
+				Type:    common.DatadogAgentReconcileErrorConditionType,
+				Status:  metav1.ConditionTrue,
+				Reason:  "DatadogAgent_reconcile_error",
+				Message: "some prior error",
+			},
+			currentError:  nil,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "DatadogAgent_reconcile_ok",
+			expectMessage: "DatadogAgent reconcile ok",
+		},
+		{
+			name:          "error surfaces its real message",
+			currentError:  fmt.Errorf("rbac error: clusterroles.rbac.authorization.k8s.io is forbidden"),
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "DatadogAgent_reconcile_error",
+			expectMessage: "rbac error: clusterroles.rbac.authorization.k8s.io is forbidden",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(sch).WithStatusSubresource(&v1alpha1.DatadogAgentInternal{}).WithObjects([]client.Object{ddai.DeepCopy()}...).Build()
+			r := &Reconciler{client: fakeClient}
+
+			currentDDAI := &v1alpha1.DatadogAgentInternal{}
+			assert.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(ddai), currentDDAI))
+
+			newStatus := &v1alpha1.DatadogAgentInternalStatus{}
+			if tt.existingCondition != nil {
+				newStatus.Conditions = append(newStatus.Conditions, *tt.existingCondition)
+			}
+
+			_, err := r.updateStatusIfNeededV2(context.Background(), currentDDAI, newStatus, reconcile.Result{}, tt.currentError, now)
+			assert.Equal(t, tt.currentError, err)
+
+			cond := condition.GetDDAICondition(newStatus, common.DatadogAgentReconcileErrorConditionType)
+			if tt.expectNoCondition {
+				assert.Nil(t, cond)
+				return
+			}
+			assert.NotNil(t, cond)
+			assert.Equal(t, tt.expectStatus, cond.Status)
+			assert.Equal(t, tt.expectReason, cond.Reason)
+			assert.Equal(t, tt.expectMessage, cond.Message)
 		})
 	}
 }

--- a/pkg/agentprofile/status.go
+++ b/pkg/agentprofile/status.go
@@ -32,6 +32,13 @@ const (
 	AppliedConditionReason = "Applied"
 	// ConflictConditionReason is for DatadogAgentProfiles that conflict with an existing DatadogAgentProfile
 	ConflictConditionReason = "Conflict"
+
+	// DDAIReconcileErrorConditionType surfaces a reconcile error from the profile's DatadogAgentInternal
+	DDAIReconcileErrorConditionType = "DatadogAgentInternalReconcileError"
+	// DDAIReconcileErrorConditionReason is used when the profile's DatadogAgentInternal failed to reconcile
+	DDAIReconcileErrorConditionReason = "DatadogAgentInternal_reconcile_error"
+	// DDAIReconcileOKConditionReason is used when the profile's DatadogAgentInternal is reconciling successfully
+	DDAIReconcileOKConditionReason = "DatadogAgentInternal_reconcile_ok"
 )
 
 func UpdateProfileStatus(logger logr.Logger, profile *v1alpha1.DatadogAgentProfile, newStatus v1alpha1.DatadogAgentProfileStatus, now metav1.Time) {


### PR DESCRIPTION
### What does this PR do?

Show DDAI errors in respective DDA or DAP. Right now they stay in the DDAI so it's difficult to tell if there's a reconcile error for DDAIs

### Motivation

https://datadoghq.atlassian.net/browse/CONTP-1712

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

* Deploy the operator with DAPs enabled (`--set datadogAgentProfile.enabled=true --set datadogCRDs.crds.datadogAgentProfiles=true`) and create a DDA and DAP
* Force a reconciliation error. Example:
```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicy
metadata:
  name: block-agent-daemonsets
spec:
  failurePolicy: Fail
  matchConstraints:
    resourceRules:
    - apiGroups: ["apps"]
      apiVersions: ["v1"]
      operations: ["UPDATE"]
      resources: ["daemonsets"]
  validations:
  - expression: "false"
    message: "blocked for CONTP-1712"
---
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingAdmissionPolicyBinding
metadata:
  name: block-agent-daemonsets-binding
spec:
  policyName: block-agent-daemonsets
  validationActions: ["Deny"]
```
* Force DDA and DAP to reconcile:
```shell
$ kubectl patch datadogagent <dda-name> --type=json \
    -p='[{"op":"add","path":"/spec/override/nodeAgent/containers/agent/env/-","value":{"name":"COMBINED_TEST","value":"true"}}]'

$ kubectl patch datadogagentprofile <dap-name> --type=json \
    -p='[{"op":"add","path":"/spec/config/override/nodeAgent/containers/agent/env/-","value":{"name":"COMBINED_TEST","value":"true"}}]'
```
* Check DDA and DAP to see that their respective DDAI errors are present in the status: `kubectl describe dd <dda-name>` and `kubectl describe dap <dap-name>`

### Checklist

- [ x PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits