### PR TITLE
[CONTP-1890] Migrate between DaemonSet and ExtendedDaemonSet

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -321,7 +321,6 @@ rules:
   - datadoghq.com
   resources:
   - datadoginstrumentations
-  - extendeddaemonsetreplicasets
   - watermarkpodautoscalers
   verbs:
   - get
@@ -353,6 +352,15 @@ rules:
   - datadogpodautoscalers/status
   verbs:
   - '*'
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - extendeddaemonsetreplicasets
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -204,6 +204,45 @@ default in effect.
 Duration values follow Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration);
 for example, `30s`, `5m`, or `1h`. Integer values use base 10.
 
+### Switch between DaemonSet and ExtendedDaemonSet
+
+Changing `--supportExtendedDaemonset` migrates the node Agent workload in either
+direction. The Operator completes the ownership handoff before it creates the
+target workload, so old and new Agent pods do not remain scheduled together and
+compete for the same node resources.
+
+- **DaemonSet to ExtendedDaemonSet:** The Operator changes the old DaemonSet to
+  the `OnDelete` update strategy, labels its existing pods for the
+  ExtendedDaemonSet controller, and deletes the DaemonSet with orphan
+  propagation. The ExtendedDaemonSet then treats the preserved pods as the
+  previous revision and replaces them using its configured rolling-update
+  policy.
+- **ExtendedDaemonSet to DaemonSet:** The Operator deletes the
+  ExtendedDaemonSet and its ExtendedDaemonSetReplicaSets with orphan
+  propagation. It updates selector labels on the preserved pods when necessary,
+  then creates the DaemonSet. The Kubernetes DaemonSet controller adopts
+  matching pods. Pods that cannot match the new selector are deleted before the
+  DaemonSet is created.
+
+The migration is reconciled from the resources that remain in the cluster, so
+it resumes after an Operator restart. To roll back an in-progress migration,
+restore the previous value of `--supportExtendedDaemonset` and restart the
+Operator; do not manually delete the preserved Agent pods.
+
+Keep the ExtendedDaemonSet CRDs and controller installed until a migration to a
+native DaemonSet has converged. Avoid changing the node Agent name override in
+the same rollout as this flag because the migration identifies the old and new
+workloads by their shared name.
+
+To verify convergence, replace `<namespace>` with the namespace containing the
+`DatadogAgent`:
+
+```shell
+kubectl get daemonset,extendeddaemonset,extendeddaemonsetreplicaset -n <namespace>
+```
+
+Only the workload kind selected by `--supportExtendedDaemonset` should remain.
+
 For example, to enable the DatadogMonitor controller in an OLM deployment:
 
 ```yaml

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -204,45 +204,6 @@ default in effect.
 Duration values follow Go's [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration);
 for example, `30s`, `5m`, or `1h`. Integer values use base 10.
 
-### Switch between DaemonSet and ExtendedDaemonSet
-
-Changing `--supportExtendedDaemonset` migrates the node Agent workload in either
-direction. The Operator completes the ownership handoff before it creates the
-target workload, so old and new Agent pods do not remain scheduled together and
-compete for the same node resources.
-
-- **DaemonSet to ExtendedDaemonSet:** The Operator changes the old DaemonSet to
-  the `OnDelete` update strategy, labels its existing pods for the
-  ExtendedDaemonSet controller, and deletes the DaemonSet with orphan
-  propagation. The ExtendedDaemonSet then treats the preserved pods as the
-  previous revision and replaces them using its configured rolling-update
-  policy.
-- **ExtendedDaemonSet to DaemonSet:** The Operator deletes the
-  ExtendedDaemonSet and its ExtendedDaemonSetReplicaSets with orphan
-  propagation. It updates selector labels on the preserved pods when necessary,
-  then creates the DaemonSet. The Kubernetes DaemonSet controller adopts
-  matching pods. Pods that cannot match the new selector are deleted before the
-  DaemonSet is created.
-
-The migration is reconciled from the resources that remain in the cluster, so
-it resumes after an Operator restart. To roll back an in-progress migration,
-restore the previous value of `--supportExtendedDaemonset` and restart the
-Operator; do not manually delete the preserved Agent pods.
-
-Keep the ExtendedDaemonSet CRDs and controller installed until a migration to a
-native DaemonSet has converged. Avoid changing the node Agent name override in
-the same rollout as this flag because the migration identifies the old and new
-workloads by their shared name.
-
-To verify convergence, replace `<namespace>` with the namespace containing the
-`DatadogAgent`:
-
-```shell
-kubectl get daemonset,extendeddaemonset,extendeddaemonsetreplicaset -n <namespace>
-```
-
-Only the workload kind selected by `--supportExtendedDaemonset` should remain.
-
 For example, to enable the DatadogMonitor controller in an OLM deployment:
 
 ```yaml

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -112,7 +112,7 @@ type DatadogAgentReconciler struct {
 
 // Use ExtendedDaemonSet
 // +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsetreplicasets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=datadoghq.com,resources=extendeddaemonsetreplicasets,verbs=get;list;watch;delete
 
 // Use CiliumNetworkPolicy
 // +kubebuilder:rbac:groups=cilium.io,resources=ciliumnetworkpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent.go
@@ -130,6 +130,9 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 			return reconcile.Result{}, nil
 		}
 
+		if handled, migrationResult, err := r.migrateDaemonSetToExtendedDaemonSet(ctx, ddai, eds, newStatus); handled || err != nil {
+			return migrationResult, err
+		}
 		return r.createOrUpdateExtendedDaemonset(ctx, ddai, eds, newStatus, updateEDSStatusV2WithAgent)
 	}
 
@@ -289,6 +292,9 @@ func (r *Reconciler) reconcileV2Agent(ctx context.Context, requiredComponents fe
 		return reconcile.Result{}, nil
 	}
 
+	if handled, migrationResult, err := r.migrateExtendedDaemonSetToDaemonSet(ctx, ddai, daemonset, newStatus); handled || err != nil {
+		return migrationResult, err
+	}
 	return r.createOrUpdateDaemonset(ctx, ddai, daemonset, newStatus, updateDSStatusV2WithAgent)
 }
 

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent_migration.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent_migration.go
@@ -1,0 +1,381 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagentinternal
+
+import (
+	"context"
+	"maps"
+	"time"
+
+	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+const workloadMigrationRequeuePeriod = time.Second
+
+// migrateDaemonSetToExtendedDaemonSet retires a native DaemonSet before its
+// replacement ExtendedDaemonSet is created. The old pods are labelled so the
+// EDS controller sees them as the previous revision and replaces them according
+// to its rolling-update policy instead of scheduling a second pod on every node.
+//
+// A DaemonSet cannot be paused. Switching it to OnDelete before orphaning it
+// prevents the template-label update below from restarting healthy pods, while
+// also ensuring that pods created for nodes joining during the migration carry
+// the EDS discovery label.
+func (r *Reconciler) migrateDaemonSetToExtendedDaemonSet(
+	ctx context.Context,
+	ddai *datadoghqv1alpha1.DatadogAgentInternal,
+	eds *edsv1alpha1.ExtendedDaemonSet,
+	newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus,
+) (bool, reconcile.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues(
+		"migration", "DaemonSetToExtendedDaemonSet",
+		"object.namespace", eds.Namespace,
+		"object.name", eds.Name,
+	)
+	nsName := types.NamespacedName{Namespace: eds.Namespace, Name: eds.Name}
+	currentDaemonSet := &appsv1.DaemonSet{}
+	if err := r.client.Get(ctx, nsName, currentDaemonSet); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return true, reconcile.Result{}, err
+		}
+
+		// If the target EDS already exists, its ReplicaSets are active owners and
+		// must not be touched. This is the converged state (or the EDS portion of
+		// a migration that has already advanced past the DaemonSet deletion).
+		currentEDS := &edsv1alpha1.ExtendedDaemonSet{}
+		if err := r.client.Get(ctx, nsName, currentEDS); err == nil {
+			if currentEDS.DeletionTimestamp != nil {
+				return true, workloadMigrationResult(), nil
+			}
+			return false, reconcile.Result{}, nil
+		} else if !resourceIsAbsent(err) {
+			return true, reconcile.Result{}, err
+		}
+
+		// A rollback can leave orphaned ERSs after the EDS itself has gone.
+		// Remove that stale ownership layer before recreating the EDS; its pods
+		// remain available and are discovered below by their EDS label.
+		replicaSets := &edsv1alpha1.ExtendedDaemonSetReplicaSetList{}
+		if err := r.client.List(
+			ctx,
+			replicaSets,
+			client.InNamespace(eds.Namespace),
+			client.MatchingLabels{edsv1alpha1.ExtendedDaemonSetNameLabelKey: eds.Name},
+		); err != nil {
+			if !resourceIsAbsent(err) {
+				return true, reconcile.Result{}, err
+			}
+			replicaSets.Items = nil
+		}
+		if len(replicaSets.Items) > 0 {
+			orphan := metav1.DeletePropagationOrphan
+			for i := range replicaSets.Items {
+				replicaSet := &replicaSets.Items[i]
+				if replicaSet.DeletionTimestamp != nil {
+					continue
+				}
+				if err := r.client.Delete(ctx, replicaSet, &client.DeleteOptions{PropagationPolicy: &orphan}); err != nil && !apierrors.IsNotFound(err) {
+					return true, reconcile.Result{}, err
+				}
+				logger.Info("Removed stale ExtendedDaemonSetReplicaSet during rollback", "replicaset.name", replicaSet.Name)
+			}
+			return true, workloadMigrationResult(), nil
+		}
+
+		// Complete interrupted migrations where the DaemonSet was orphaned
+		// after creating a pod from the old template but before labelling it.
+		if err := r.labelOrphanedDaemonSetPodsForEDS(ctx, eds); err != nil {
+			return true, reconcile.Result{}, err
+		}
+		return false, reconcile.Result{}, nil
+	}
+
+	if currentDaemonSet.DeletionTimestamp != nil {
+		return true, workloadMigrationResult(), nil
+	}
+
+	if prepareDaemonSetForEDSMigration(currentDaemonSet, eds.Name) {
+		logger.Info("Preparing DaemonSet for migration to ExtendedDaemonSet")
+		if err := r.client.Update(ctx, currentDaemonSet); err != nil {
+			return true, reconcile.Result{}, err
+		}
+		return true, workloadMigrationResult(), nil
+	}
+
+	if err := r.labelDaemonSetPodsForEDS(ctx, currentDaemonSet, eds.Name); err != nil {
+		return true, reconcile.Result{}, err
+	}
+
+	orphan := metav1.DeletePropagationOrphan
+	if err := r.client.Delete(ctx, currentDaemonSet, &client.DeleteOptions{PropagationPolicy: &orphan}); err != nil && !apierrors.IsNotFound(err) {
+		return true, reconcile.Result{}, err
+	}
+
+	logger.Info("Orphaned DaemonSet pods for migration to ExtendedDaemonSet")
+	event := buildEventInfo(currentDaemonSet.Name, currentDaemonSet.Namespace, kubernetes.DaemonSetKind, datadog.DeletionEvent)
+	r.recordEvent(ddai, event)
+	newStatus.Agent = nil
+
+	return true, workloadMigrationResult(), nil
+}
+
+// migrateExtendedDaemonSetToDaemonSet removes the two-level EDS ownership
+// chain (EDS -> ERS -> Pod) with orphan propagation. Once both owners are gone,
+// the native DaemonSet controller can adopt the matching pods before applying
+// its normal update policy. Pods that cannot match the target selector are
+// deleted before the new DaemonSet is created so they cannot compete for node
+// capacity.
+func (r *Reconciler) migrateExtendedDaemonSetToDaemonSet(
+	ctx context.Context,
+	ddai *datadoghqv1alpha1.DatadogAgentInternal,
+	daemonSet *appsv1.DaemonSet,
+	newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus,
+) (bool, reconcile.Result, error) {
+	logger := ctrl.LoggerFrom(ctx).WithValues(
+		"migration", "ExtendedDaemonSetToDaemonSet",
+		"object.namespace", daemonSet.Namespace,
+		"object.name", daemonSet.Name,
+	)
+	nsName := types.NamespacedName{Namespace: daemonSet.Namespace, Name: daemonSet.Name}
+	currentEDS := &edsv1alpha1.ExtendedDaemonSet{}
+	if err := r.client.Get(ctx, nsName, currentEDS); err == nil {
+		if currentEDS.DeletionTimestamp != nil {
+			return true, workloadMigrationResult(), nil
+		}
+
+		orphan := metav1.DeletePropagationOrphan
+		if deleteErr := r.client.Delete(ctx, currentEDS, &client.DeleteOptions{PropagationPolicy: &orphan}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+			return true, reconcile.Result{}, deleteErr
+		}
+
+		logger.Info("Orphaned ExtendedDaemonSet ReplicaSets for migration to DaemonSet")
+		event := buildEventInfo(currentEDS.Name, currentEDS.Namespace, kubernetes.ExtendedDaemonSetKind, datadog.DeletionEvent)
+		r.recordEvent(ddai, event)
+		newStatus.Agent = nil
+		return true, workloadMigrationResult(), nil
+	} else if !resourceIsAbsent(err) {
+		return true, reconcile.Result{}, err
+	}
+
+	replicaSets := &edsv1alpha1.ExtendedDaemonSetReplicaSetList{}
+	if err := r.client.List(
+		ctx,
+		replicaSets,
+		client.InNamespace(daemonSet.Namespace),
+		client.MatchingLabels{edsv1alpha1.ExtendedDaemonSetNameLabelKey: daemonSet.Name},
+	); err != nil {
+		if !resourceIsAbsent(err) {
+			return true, reconcile.Result{}, err
+		}
+		replicaSets.Items = nil
+	}
+
+	if len(replicaSets.Items) > 0 {
+		orphan := metav1.DeletePropagationOrphan
+		for i := range replicaSets.Items {
+			replicaSet := &replicaSets.Items[i]
+			if replicaSet.DeletionTimestamp != nil {
+				continue
+			}
+			if err := r.client.Delete(ctx, replicaSet, &client.DeleteOptions{PropagationPolicy: &orphan}); err != nil && !apierrors.IsNotFound(err) {
+				return true, reconcile.Result{}, err
+			}
+			logger.Info("Orphaned ExtendedDaemonSetReplicaSet pods", "replicaset.name", replicaSet.Name)
+		}
+		return true, workloadMigrationResult(), nil
+	}
+
+	handled, err := r.prepareOrphanedEDSPodsForDaemonSet(ctx, daemonSet)
+	if err != nil {
+		return true, reconcile.Result{}, err
+	}
+	if handled {
+		return true, workloadMigrationResult(), nil
+	}
+
+	return false, reconcile.Result{}, nil
+}
+
+func prepareDaemonSetForEDSMigration(daemonSet *appsv1.DaemonSet, edsName string) bool {
+	needsUpdate := false
+	if daemonSet.Spec.UpdateStrategy.Type != appsv1.OnDeleteDaemonSetStrategyType || daemonSet.Spec.UpdateStrategy.RollingUpdate != nil {
+		daemonSet.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{
+			Type: appsv1.OnDeleteDaemonSetStrategyType,
+		}
+		needsUpdate = true
+	}
+	if daemonSet.Spec.Template.Labels == nil {
+		daemonSet.Spec.Template.Labels = map[string]string{}
+	}
+	if daemonSet.Spec.Template.Labels[edsv1alpha1.ExtendedDaemonSetNameLabelKey] != edsName {
+		daemonSet.Spec.Template.Labels[edsv1alpha1.ExtendedDaemonSetNameLabelKey] = edsName
+		needsUpdate = true
+	}
+	return needsUpdate
+}
+
+func (r *Reconciler) labelDaemonSetPodsForEDS(ctx context.Context, daemonSet *appsv1.DaemonSet, edsName string) error {
+	selector := labels.Everything()
+	if daemonSet.Spec.Selector != nil {
+		var err error
+		selector, err = metav1.LabelSelectorAsSelector(daemonSet.Spec.Selector)
+		if err != nil {
+			return err
+		}
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.client.List(
+		ctx,
+		pods,
+		client.InNamespace(daemonSet.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return err
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		controller := metav1.GetControllerOf(pod)
+		if controller == nil ||
+			controller.Kind != "DaemonSet" ||
+			controller.Name != daemonSet.Name ||
+			(daemonSet.UID != "" && controller.UID != daemonSet.UID) {
+			continue
+		}
+		if err := r.setEDSPodLabel(ctx, pod, edsName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) labelOrphanedDaemonSetPodsForEDS(ctx context.Context, eds *edsv1alpha1.ExtendedDaemonSet) error {
+	selectorLabels := map[string]string{}
+	for _, key := range []string{
+		kubernetes.AppKubernetesInstanceLabelKey,
+		apicommon.AgentDeploymentComponentLabelKey,
+	} {
+		if value := eds.Spec.Template.Labels[key]; value != "" {
+			selectorLabels[key] = value
+		}
+	}
+	if len(selectorLabels) == 0 {
+		return nil
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.client.List(
+		ctx,
+		pods,
+		client.InNamespace(eds.Namespace),
+		client.MatchingLabels(selectorLabels),
+	); err != nil {
+		return err
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		controller := metav1.GetControllerOf(pod)
+		if controller != nil && !(controller.Kind == "DaemonSet" && controller.Name == eds.Name) {
+			continue
+		}
+		if err := r.setEDSPodLabel(ctx, pod, eds.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) setEDSPodLabel(ctx context.Context, pod *corev1.Pod, edsName string) error {
+	if pod.Labels[edsv1alpha1.ExtendedDaemonSetNameLabelKey] == edsName {
+		return nil
+	}
+	updated := pod.DeepCopy()
+	if updated.Labels == nil {
+		updated.Labels = map[string]string{}
+	}
+	updated.Labels[edsv1alpha1.ExtendedDaemonSetNameLabelKey] = edsName
+	return r.client.Patch(ctx, updated, client.MergeFrom(pod))
+}
+
+// prepareOrphanedEDSPodsForDaemonSet makes EDS pods match the native
+// DaemonSet selector before it is created. Kubernetes then adopts them during
+// the first DaemonSet reconciliation. Selectors that cannot be satisfied by
+// adding MatchLabels fall back to deleting the old pod.
+func (r *Reconciler) prepareOrphanedEDSPodsForDaemonSet(ctx context.Context, daemonSet *appsv1.DaemonSet) (bool, error) {
+	selector, err := metav1.LabelSelectorAsSelector(daemonSet.Spec.Selector)
+	if err != nil {
+		return false, err
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.client.List(
+		ctx,
+		pods,
+		client.InNamespace(daemonSet.Namespace),
+		client.MatchingLabels{edsv1alpha1.ExtendedDaemonSetNameLabelKey: daemonSet.Name},
+	); err != nil {
+		return false, err
+	}
+
+	handled := false
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		controller := metav1.GetControllerOf(pod)
+		if controller != nil {
+			if controller.Kind == "ExtendedDaemonSetReplicaSet" {
+				// Orphan propagation has not removed the controller reference yet.
+				handled = true
+			}
+			continue
+		}
+		if selector.Matches(labels.Set(pod.Labels)) {
+			continue
+		}
+
+		updated := pod.DeepCopy()
+		if updated.Labels == nil {
+			updated.Labels = map[string]string{}
+		}
+		maps.Copy(updated.Labels, daemonSet.Spec.Selector.MatchLabels)
+		if selector.Matches(labels.Set(updated.Labels)) {
+			if err := r.client.Patch(ctx, updated, client.MergeFrom(pod)); err != nil {
+				return true, err
+			}
+		} else {
+			if err := r.client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+				return true, err
+			}
+		}
+		handled = true
+	}
+	return handled, nil
+}
+
+func workloadMigrationResult() reconcile.Result {
+	return reconcile.Result{RequeueAfter: workloadMigrationRequeuePeriod}
+}
+
+func resourceIsAbsent(err error) bool {
+	return apierrors.IsNotFound(err) || apimeta.IsNoMatchError(err) || k8sruntime.IsNotRegisteredError(err)
+}

--- a/internal/controller/datadogagentinternal/controller_reconcile_agent_migration_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_agent_migration_test.go
@@ -1,0 +1,366 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadogagentinternal
+
+import (
+	"context"
+	"testing"
+
+	edsv1alpha1 "github.com/DataDog/extendeddaemonset/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+)
+
+func TestMigrateDaemonSetToExtendedDaemonSet(t *testing.T) {
+	ctx := context.Background()
+	scheme := newMigrationTestScheme(t)
+	daemonSetUID := uuid.NewUUID()
+	ddai := newMigrationTestDDAI()
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent",
+			Namespace: "datadog",
+			UID:       daemonSetUID,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: migrationTestSelectorLabels("datadog-agent")},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type:          appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: migrationTestSelectorLabels("datadog-agent")},
+			},
+		},
+	}
+	controller := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent-old",
+			Namespace: "datadog",
+			Labels:    migrationTestSelectorLabels("datadog-agent"),
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "DaemonSet",
+				Name:       daemonSet.Name,
+				UID:        daemonSetUID,
+				Controller: &controller,
+			}},
+		},
+	}
+	eds := &edsv1alpha1.ExtendedDaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: daemonSet.Name, Namespace: daemonSet.Namespace},
+		Spec: edsv1alpha1.ExtendedDaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: migrationTestSelectorLabels("datadog-agent")},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(daemonSet, pod).Build()
+	reconciler := newMigrationTestReconciler(fakeClient, scheme)
+	status := &datadoghqv1alpha1.DatadogAgentInternalStatus{}
+
+	// First pass makes future DaemonSet pods discoverable by the EDS controller
+	// without rolling the pods that are already running.
+	handled, result, err := reconciler.migrateDaemonSetToExtendedDaemonSet(ctx, ddai, eds, status)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, workloadMigrationResult(), result)
+
+	currentDaemonSet := &appsv1.DaemonSet{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(daemonSet), currentDaemonSet))
+	assert.Equal(t, appsv1.OnDeleteDaemonSetStrategyType, currentDaemonSet.Spec.UpdateStrategy.Type)
+	assert.Nil(t, currentDaemonSet.Spec.UpdateStrategy.RollingUpdate)
+	assert.Equal(t, eds.Name, currentDaemonSet.Spec.Template.Labels[edsv1alpha1.ExtendedDaemonSetNameLabelKey])
+
+	// Second pass labels the existing pods and orphans them while deleting the
+	// old DaemonSet.
+	handled, result, err = reconciler.migrateDaemonSetToExtendedDaemonSet(ctx, ddai, eds, status)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, workloadMigrationResult(), result)
+	err = fakeClient.Get(ctx, client.ObjectKeyFromObject(daemonSet), &appsv1.DaemonSet{})
+	assert.True(t, apierrors.IsNotFound(err))
+
+	currentPod := &corev1.Pod{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(pod), currentPod))
+	assert.Equal(t, eds.Name, currentPod.Labels[edsv1alpha1.ExtendedDaemonSetNameLabelKey])
+
+	// Once the old workload is gone, reconciliation can create the EDS. A
+	// repeated pass remains a no-op, which also covers controller restarts at
+	// this point in the migration.
+	handled, result, err = reconciler.migrateDaemonSetToExtendedDaemonSet(ctx, ddai, eds, status)
+	require.NoError(t, err)
+	assert.False(t, handled)
+	assert.True(t, result.IsZero())
+	handled, _, err = reconciler.migrateDaemonSetToExtendedDaemonSet(ctx, ddai, eds, status)
+	require.NoError(t, err)
+	assert.False(t, handled)
+}
+
+func TestMigrateExtendedDaemonSetToDaemonSet(t *testing.T) {
+	ctx := context.Background()
+	scheme := newMigrationTestScheme(t)
+	ddai := newMigrationTestDDAI()
+	edsUID := uuid.NewUUID()
+	replicaSetUID := uuid.NewUUID()
+	eds := &edsv1alpha1.ExtendedDaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent",
+			Namespace: "datadog",
+			UID:       edsUID,
+		},
+	}
+	controller := true
+	replicaSet := &edsv1alpha1.ExtendedDaemonSetReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent-abcde",
+			Namespace: eds.Namespace,
+			UID:       replicaSetUID,
+			Labels: map[string]string{
+				edsv1alpha1.ExtendedDaemonSetNameLabelKey: eds.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "datadoghq.com/v1alpha1",
+				Kind:       "ExtendedDaemonSet",
+				Name:       eds.Name,
+				UID:        edsUID,
+				Controller: &controller,
+			}},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent-abcde-node",
+			Namespace: eds.Namespace,
+			Labels: map[string]string{
+				edsv1alpha1.ExtendedDaemonSetNameLabelKey: eds.Name,
+				kubernetes.AppKubernetesInstanceLabelKey:  "old-instance",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "datadoghq.com/v1alpha1",
+				Kind:       "ExtendedDaemonSetReplicaSet",
+				Name:       replicaSet.Name,
+				UID:        replicaSetUID,
+				Controller: &controller,
+			}},
+		},
+	}
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: eds.Name, Namespace: eds.Namespace},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: migrationTestSelectorLabels("datadog-agent")},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(eds, replicaSet, pod).Build()
+	reconciler := newMigrationTestReconciler(fakeClient, scheme)
+	status := &datadoghqv1alpha1.DatadogAgentInternalStatus{}
+
+	// The first two passes peel the EDS ownership chain while preserving pods.
+	handled, _, err := reconciler.migrateExtendedDaemonSetToDaemonSet(ctx, ddai, daemonSet, status)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(eds), &edsv1alpha1.ExtendedDaemonSet{})))
+
+	handled, _, err = reconciler.migrateExtendedDaemonSetToDaemonSet(ctx, ddai, daemonSet, status)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(replicaSet), &edsv1alpha1.ExtendedDaemonSetReplicaSet{})))
+
+	// The fake client does not run Kubernetes garbage collection, so explicitly
+	// model orphan propagation removing the ERS controller reference. Until that
+	// happens, the migration waits instead of creating a competing DaemonSet.
+	handled, _, err = reconciler.migrateExtendedDaemonSetToDaemonSet(ctx, ddai, daemonSet, status)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	currentPod := &corev1.Pod{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(pod), currentPod))
+	currentPod.OwnerReferences = nil
+	require.NoError(t, fakeClient.Update(ctx, currentPod))
+
+	// The next pass updates immutable-selector labels ahead of adoption, and the
+	// following pass allows the native DaemonSet to be created.
+	handled, _, err = reconciler.migrateExtendedDaemonSetToDaemonSet(ctx, ddai, daemonSet, status)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(pod), currentPod))
+	assert.Equal(t, "datadog-agent", currentPod.Labels[kubernetes.AppKubernetesInstanceLabelKey])
+	assert.Equal(t, "agent", currentPod.Labels[apicommon.AgentDeploymentComponentLabelKey])
+
+	handled, result, err := reconciler.migrateExtendedDaemonSetToDaemonSet(ctx, ddai, daemonSet, status)
+	require.NoError(t, err)
+	assert.False(t, handled)
+	assert.True(t, result.IsZero())
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{}))
+}
+
+func TestPrepareOrphanedEDSPodsForDaemonSetDeletesUnmatchablePod(t *testing.T) {
+	ctx := context.Background()
+	scheme := newMigrationTestScheme(t)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent-old",
+			Namespace: "datadog",
+			Labels: map[string]string{
+				edsv1alpha1.ExtendedDaemonSetNameLabelKey: "datadog-agent",
+			},
+		},
+	}
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-agent", Namespace: "datadog"},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "migration-ready",
+					Operator: metav1.LabelSelectorOpExists,
+				}},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	reconciler := newMigrationTestReconciler(fakeClient, scheme)
+
+	handled, err := reconciler.prepareOrphanedEDSPodsForDaemonSet(ctx, daemonSet)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	err = fakeClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{})
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestMigrateExtendedDaemonSetToDaemonSetWithoutEDSTypesInScheme(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, datadoghqv1alpha1.AddToScheme(scheme))
+
+	daemonSet := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-agent", Namespace: "datadog"},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: migrationTestSelectorLabels("datadog-agent")},
+		},
+	}
+	reconciler := newMigrationTestReconciler(fake.NewClientBuilder().WithScheme(scheme).Build(), scheme)
+
+	handled, result, err := reconciler.migrateExtendedDaemonSetToDaemonSet(
+		ctx,
+		newMigrationTestDDAI(),
+		daemonSet,
+		&datadoghqv1alpha1.DatadogAgentInternalStatus{},
+	)
+	require.NoError(t, err)
+	assert.False(t, handled)
+	assert.True(t, result.IsZero())
+}
+
+func TestMigrateDaemonSetToExtendedDaemonSetRollbackCleansStaleReplicaSet(t *testing.T) {
+	ctx := context.Background()
+	scheme := newMigrationTestScheme(t)
+	ddai := newMigrationTestDDAI()
+	replicaSet := &edsv1alpha1.ExtendedDaemonSetReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent-stale",
+			Namespace: "datadog",
+			Labels: map[string]string{
+				edsv1alpha1.ExtendedDaemonSetNameLabelKey: "datadog-agent",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog-agent-stale-node",
+			Namespace: "datadog",
+			Labels: map[string]string{
+				edsv1alpha1.ExtendedDaemonSetNameLabelKey: "datadog-agent",
+			},
+		},
+	}
+	eds := &edsv1alpha1.ExtendedDaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "datadog-agent", Namespace: "datadog"},
+		Spec: edsv1alpha1.ExtendedDaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: migrationTestSelectorLabels("datadog-agent")},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(replicaSet, pod).Build()
+	reconciler := newMigrationTestReconciler(fakeClient, scheme)
+
+	handled, _, err := reconciler.migrateDaemonSetToExtendedDaemonSet(
+		ctx,
+		ddai,
+		eds,
+		&datadoghqv1alpha1.DatadogAgentInternalStatus{},
+	)
+	require.NoError(t, err)
+	assert.True(t, handled)
+	assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(replicaSet), &edsv1alpha1.ExtendedDaemonSetReplicaSet{})))
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(pod), &corev1.Pod{}))
+
+	handled, _, err = reconciler.migrateDaemonSetToExtendedDaemonSet(
+		ctx,
+		ddai,
+		eds,
+		&datadoghqv1alpha1.DatadogAgentInternalStatus{},
+	)
+	require.NoError(t, err)
+	assert.False(t, handled)
+}
+
+func newMigrationTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, edsv1alpha1.AddToScheme(scheme))
+	require.NoError(t, datadoghqv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func newMigrationTestReconciler(c client.Client, scheme *runtime.Scheme) *Reconciler {
+	return &Reconciler{
+		client:   c,
+		scheme:   scheme,
+		recorder: record.NewFakeRecorder(20),
+	}
+}
+
+func newMigrationTestDDAI() *datadoghqv1alpha1.DatadogAgentInternal {
+	return &datadoghqv1alpha1.DatadogAgentInternal{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: datadoghqv1alpha1.GroupVersion.String(),
+			Kind:       "DatadogAgentInternal",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "datadog",
+			Namespace: "datadog",
+			UID:       types.UID("ddai-uid"),
+		},
+	}
+}
+
+func migrationTestSelectorLabels(instance string) map[string]string {
+	return map[string]string{
+		kubernetes.AppKubernetesInstanceLabelKey:   instance,
+		apicommon.AgentDeploymentComponentLabelKey: "agent",
+	}
+}


### PR DESCRIPTION
## What changed

- add an idempotent, state-driven handoff when `--supportExtendedDaemonset` changes
- orphan and preserve the previous workload's pods before creating the replacement controller
- clean up the EDS → ERS ownership chain before creating a native DaemonSet
- add rollback/restart handling, including clusters where EDS CRDs or client types are unavailable
- grant the Operator permission to delete stale ExtendedDaemonSetReplicaSets
- document migration, rollback, and convergence checks

## Why

Toggling ExtendedDaemonSet support previously left the old workload kind in place. The old and new controllers could then compete for nodes, or the replacement workload could fail to schedule.

This change serializes the handoff from the resources that remain in the cluster, so retries and Operator restarts resume safely.

## Migration behavior

- **DaemonSet → ExtendedDaemonSet:** switch the old DaemonSet to `OnDelete`, label its pods for EDS discovery, and delete it with orphan propagation. EDS treats the preserved pods as the previous revision and replaces them with its normal rolling policy.
- **ExtendedDaemonSet → DaemonSet:** orphan the EDS and its ReplicaSets, wait for pod owner references to clear, and make preserved pods match the native selector. Kubernetes then adopts matching pods; pods that cannot match are removed before the DaemonSet is created.

## User impact

Users can switch `--supportExtendedDaemonset` in either direction without leaving competing DaemonSet/ExtendedDaemonSet resources behind. Matching pods remain available through the handoff, while each target controller retains its normal rollout semantics.

## Validation

- `make manifests`
- `make lint`
- `make managergobuild`
- `go test ./internal/controller/datadogagentinternal ./internal/controller/datadogagent ./internal/controller/testutils/renderer ./internal/controller -count=1`
- all root-module Go packages passed locally except `pkg/controller/utils/condition`, whose existing first unit test hangs when run alone in this environment

Jira: https://datadoghq.atlassian.net/browse/CONTP-1890