### PR TITLE
fix(gpu): force disable eBPF probes

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -734,7 +734,10 @@ type GPUFeatureConfig struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
-	// PrivilegedMode enables GPU Probe module in System Probe.
+	// PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF
+	// probes are disabled; privileged mode is retained for cgroup permission patching.
+	// To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the
+	// core agent and system-probe containers via spec.override.nodeAgent.containers.
 	// Default: false
 	// +optional
 	PrivilegedMode *bool `json:"privilegedMode,omitempty"`

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -1697,7 +1697,10 @@ spec:
                           type: boolean
                         privilegedMode:
                           description: |-
-                            PrivilegedMode enables GPU Probe module in System Probe.
+                            PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF
+                            probes are disabled; privileged mode is retained for cgroup permission patching.
+                            To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the
+                            core agent and system-probe containers via spec.override.nodeAgent.containers.
                             Default: false
                           type: boolean
                         requiredRuntimeClassName:
@@ -10462,7 +10465,10 @@ spec:
                               type: boolean
                             privilegedMode:
                               description: |-
-                                PrivilegedMode enables GPU Probe module in System Probe.
+                                PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF
+                                probes are disabled; privileged mode is retained for cgroup permission patching.
+                                To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the
+                                core agent and system-probe containers via spec.override.nodeAgent.containers.
                                 Default: false
                               type: boolean
                             requiredRuntimeClassName:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -1702,7 +1702,7 @@
                   "type": "boolean"
                 },
                 "privilegedMode": {
-                  "description": "PrivilegedMode enables GPU Probe module in System Probe.\nDefault: false",
+                  "description": "PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF\nprobes are disabled; privileged mode is retained for cgroup permission patching.\nTo re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the\ncore agent and system-probe containers via spec.override.nodeAgent.containers.\nDefault: false",
                   "type": "boolean"
                 },
                 "requiredRuntimeClassName": {
@@ -10183,7 +10183,7 @@
                       "type": "boolean"
                     },
                     "privilegedMode": {
-                      "description": "PrivilegedMode enables GPU Probe module in System Probe.\nDefault: false",
+                      "description": "PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF\nprobes are disabled; privileged mode is retained for cgroup permission patching.\nTo re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the\ncore agent and system-probe containers via spec.override.nodeAgent.containers.\nDefault: false",
                       "type": "boolean"
                     },
                     "requiredRuntimeClassName": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -1697,7 +1697,10 @@ spec:
                               type: boolean
                             privilegedMode:
                               description: |-
-                                PrivilegedMode enables GPU Probe module in System Probe.
+                                PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF
+                                probes are disabled; privileged mode is retained for cgroup permission patching.
+                                To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the
+                                core agent and system-probe containers via spec.override.nodeAgent.containers.
                                 Default: false
                               type: boolean
                             requiredRuntimeClassName:

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -1706,7 +1706,7 @@
                       "type": "boolean"
                     },
                     "privilegedMode": {
-                      "description": "PrivilegedMode enables GPU Probe module in System Probe.\nDefault: false",
+                      "description": "PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF\nprobes are disabled; privileged mode is retained for cgroup permission patching.\nTo re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the\ncore agent and system-probe containers via spec.override.nodeAgent.containers.\nDefault: false",
                       "type": "boolean"
                     },
                     "requiredRuntimeClassName": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1701,7 +1701,10 @@ spec:
                           type: boolean
                         privilegedMode:
                           description: |-
-                            PrivilegedMode enables GPU Probe module in System Probe.
+                            PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF
+                            probes are disabled; privileged mode is retained for cgroup permission patching.
+                            To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the
+                            core agent and system-probe containers via spec.override.nodeAgent.containers.
                             Default: false
                           type: boolean
                         requiredRuntimeClassName:
@@ -10561,7 +10564,10 @@ spec:
                               type: boolean
                             privilegedMode:
                               description: |-
-                                PrivilegedMode enables GPU Probe module in System Probe.
+                                PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF
+                                probes are disabled; privileged mode is retained for cgroup permission patching.
+                                To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the
+                                core agent and system-probe containers via spec.override.nodeAgent.containers.
                                 Default: false
                               type: boolean
                             requiredRuntimeClassName:

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1702,7 +1702,7 @@
                   "type": "boolean"
                 },
                 "privilegedMode": {
-                  "description": "PrivilegedMode enables GPU Probe module in System Probe.\nDefault: false",
+                  "description": "PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF\nprobes are disabled; privileged mode is retained for cgroup permission patching.\nTo re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the\ncore agent and system-probe containers via spec.override.nodeAgent.containers.\nDefault: false",
                   "type": "boolean"
                 },
                 "requiredRuntimeClassName": {
@@ -10286,7 +10286,7 @@
                       "type": "boolean"
                     },
                     "privilegedMode": {
-                      "description": "PrivilegedMode enables GPU Probe module in System Probe.\nDefault: false",
+                      "description": "PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF\nprobes are disabled; privileged mode is retained for cgroup permission patching.\nTo re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the\ncore agent and system-probe containers via spec.override.nodeAgent.containers.\nDefault: false",
                       "type": "boolean"
                     },
                     "requiredRuntimeClassName": {

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -167,7 +167,7 @@ spec:
 | features.externalMetricsServer.wpaController | WPAController enables the informer and controller of the Watermark Pod Autoscaler. NOTE: The Watermark Pod Autoscaler controller needs to be installed. See also: https://github.com/DataDog/watermarkpodautoscaler. Default: false |
 | features.gpu.enabled | Enables GPU monitoring core check. Default: false |
 | features.gpu.patchCgroupPermissions | PatchCgroupPermissions enables the patch of cgroup permissions for GPU monitoring, in case the container runtime is not properly configured and the Agent containers lose access to GPU devices. Default: false |
-| features.gpu.privilegedMode | PrivilegedMode enables GPU Probe module in System Probe. Default: false |
+| features.gpu.privilegedMode | PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF probes are disabled; privileged mode is retained for cgroup permission patching. To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the core agent and system-probe containers via spec.override.nodeAgent.containers. Default: false |
 | features.gpu.requiredRuntimeClassName | PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature. If the value is an empty string, the runtime class is not set. Default: nvidia |
 | features.helmCheck.collectEvents | CollectEvents set to `true` enables event collection in the Helm check (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+) Default: false |
 | features.helmCheck.enabled | Enables the Helm check. Default: false |

--- a/docs/configuration_public.md
+++ b/docs/configuration_public.md
@@ -248,7 +248,7 @@ spec:
 : PatchCgroupPermissions enables the patch of cgroup permissions for GPU monitoring, in case the container runtime is not properly configured and the Agent containers lose access to GPU devices. Default: false
 
 `features.gpu.privilegedMode`
-: PrivilegedMode enables GPU Probe module in System Probe. Default: false
+: PrivilegedMode enables GPU Probe module in System Probe. The module's eBPF probes are disabled; privileged mode is retained for cgroup permission patching. To re-enable the eBPF probes, set DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on the core agent and system-probe containers via spec.override.nodeAgent.containers. Default: false
 
 `features.gpu.requiredRuntimeClassName`
 : PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature. If the value is an empty string, the runtime class is not set. Default: nvidia

--- a/internal/controller/datadogagent/feature/gpu/envvar.go
+++ b/internal/controller/datadogagent/feature/gpu/envvar.go
@@ -17,3 +17,6 @@ const NVIDIAVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"
 
 // DDPatchCgroupPermissionsEnvVar is the name of the system-probe gpu_monitoring module cgroup permissions patch knob
 const DDPatchCgroupPermissionsEnvVar = "DD_GPU_MONITORING_CONFIGURE_CGROUP_PERMS"
+
+// DDEnableEBPFProbesEnvVar is the name of the system-probe gpu_monitoring module eBPF probes enablement knob
+const DDEnableEBPFProbesEnvVar = "DD_GPU_MONITORING_ENABLE_EBPF_PROBES"

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -127,6 +127,13 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 	// add the env var to the core agent as well, to prevent config mismatches in runtime
 	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, enableSPEnvVar)
 
+	// In privileged mode the eBPF probes are disabled, as GPU monitoring relies on
+	// the privileged host access rather than the eBPF probes.
+	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, &corev1.EnvVar{
+		Name:  DDEnableEBPFProbesEnvVar,
+		Value: "false",
+	})
+
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)
 

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -129,10 +129,18 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 
 	// In privileged mode the eBPF probes are disabled, as GPU monitoring relies on
 	// the privileged host access rather than the eBPF probes.
-	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, &corev1.EnvVar{
+	disableEBPFProbesEnvVar := &corev1.EnvVar{
 		Name:  DDEnableEBPFProbesEnvVar,
 		Value: "false",
-	})
+	}
+
+	// disable the eBPF probes in system-probe
+	managers.EnvVar().AddEnvVarToContainer(apicommon.SystemProbeContainerName, disableEBPFProbesEnvVar)
+
+	// add the env var to the core agent as well, so both containers agree that the
+	// eBPF probes are disabled and the core GPU check does not poll a system-probe
+	// module that has the probes turned off
+	managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, disableEBPFProbesEnvVar)
 
 	// annotations
 	managers.Annotation().AddAnnotation(common.SystemProbeAppArmorAnnotationKey, common.SystemProbeAppArmorAnnotationValue)

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -129,6 +129,9 @@ func configureSystemProbe(managers feature.PodTemplateManagers) {
 
 	// In privileged mode the eBPF probes are disabled, as GPU monitoring relies on
 	// the privileged host access rather than the eBPF probes.
+	// This runs before spec.override is applied, and env vars merge last-writer-wins by
+	// name, so a user who still needs the probes can re-enable them by setting
+	// DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true via spec.override.nodeAgent.containers.
 	disableEBPFProbesEnvVar := &corev1.EnvVar{
 		Name:  DDEnableEBPFProbesEnvVar,
 		Value: "false",

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -221,6 +221,10 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				Value: "true",
 			},
 			{
+				Name:  DDEnableEBPFProbesEnvVar,
+				Value: "false",
+			},
+			{
 				Name:  common.DDSystemProbeSocket,
 				Value: common.DefaultSystemProbeSocketPath,
 			},

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -194,6 +194,10 @@ func Test_GPUMonitoringFeature_Configure(t *testing.T) {
 				Value: "true",
 			},
 			{
+				Name:  DDEnableEBPFProbesEnvVar,
+				Value: "false",
+			},
+			{
 				Name:  NVIDIAVisibleDevicesEnvVar,
 				Value: "all",
 			},

--- a/internal/controller/datadogagent/feature/gpu/feature_test.go
+++ b/internal/controller/datadogagent/feature/gpu/feature_test.go
@@ -6,9 +6,11 @@ import (
 
 	"k8s.io/utils/ptr"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -18,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/override"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/providercaps"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -502,4 +505,61 @@ func Test_GPUFeature_NodeAgentProviderCapabilities(t *testing.T) {
 		assert.Empty(t, getContainer(tmpl, apicommon.CoreAgentContainerName).VolumeMounts)
 		assert.Empty(t, getContainer(tmpl, apicommon.SystemProbeContainerName).VolumeMounts)
 	})
+}
+
+// Test_GPUMonitoringFeature_EBPFProbesOverride documents the escape hatch for the
+// force-disabled eBPF probes: feature configuration runs before spec.override, and env
+// vars merge last-writer-wins by name, so an override re-enables the probes cleanly and
+// without leaving a duplicate env var behind.
+func Test_GPUMonitoringFeature_EBPFProbesOverride(t *testing.T) {
+	newPodTemplate := func() *corev1.PodTemplateSpec {
+		return &corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: string(apicommon.CoreAgentContainerName)},
+					{Name: string(apicommon.SystemProbeContainerName)},
+				},
+			},
+		}
+	}
+
+	envVarValues := func(tmpl *corev1.PodTemplateSpec, name apicommon.AgentContainerName) []string {
+		var values []string
+		for _, c := range tmpl.Spec.Containers {
+			if c.Name != string(name) {
+				continue
+			}
+			for _, e := range c.Env {
+				if e.Name == DDEnableEBPFProbesEnvVar {
+					values = append(values, e.Value)
+				}
+			}
+		}
+		return values
+	}
+
+	tmpl := newPodTemplate()
+	mgr := feature.NewPodTemplateManagers(tmpl)
+
+	configureSystemProbe(mgr)
+
+	assert.Equal(t, []string{"false"}, envVarValues(tmpl, apicommon.CoreAgentContainerName))
+	assert.Equal(t, []string{"false"}, envVarValues(tmpl, apicommon.SystemProbeContainerName))
+
+	reEnableProbes := &v2alpha1.DatadogAgentComponentOverride{
+		Containers: map[apicommon.AgentContainerName]*v2alpha1.DatadogAgentGenericContainer{
+			apicommon.CoreAgentContainerName: {
+				Env: []corev1.EnvVar{{Name: DDEnableEBPFProbesEnvVar, Value: "true"}},
+			},
+			apicommon.SystemProbeContainerName: {
+				Env: []corev1.EnvVar{{Name: DDEnableEBPFProbesEnvVar, Value: "true"}},
+			},
+		},
+	}
+	override.PodTemplateSpec(logr.Discard(), mgr, reEnableProbes, v2alpha1.NodeAgentComponentName, "dda")
+
+	// the override wins, and there is exactly one env var per container
+	assert.Equal(t, []string{"true"}, envVarValues(tmpl, apicommon.CoreAgentContainerName))
+	assert.Equal(t, []string{"true"}, envVarValues(tmpl, apicommon.SystemProbeContainerName))
 }


### PR DESCRIPTION
### What does this PR do?

In privileged mode the GPU eBPF probes are now force-disabled (DD_GPU_MONITORING_ENABLE_EBPF_PROBES=false) on both the core agent and system-probe; privileged mode is retained for cgroup permission patching. Clusters that still need the probes can re-enable them by setting DD_GPU_MONITORING_ENABLE_EBPF_PROBES=true on those containers under spec.override.nodeAgent.containers — overrides are applied after feature config and env vars merge last-writer-wins by name, so the override wins with no duplicate env var.

### Motivation

The eBPF probes for GPU Monitoring are deprecated. Some customers still have the previously recommended setting gpu.privilegedMode enabled. These probes have caused crashes on NVIDIA GB300 Grace Blackwell Ultra machines. We want to disable the probes by default moving forward so they no longer cause problems. We still need to support `privilegedMode` in some environments for cgroup permission patching.

### Additional Notes

We've had two customer cases of this and we want to prevent further cases.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

The additional unit tests.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits