### PR TITLE
Onboard off public-images GitLab job-token trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -437,6 +437,7 @@ go_e2e_deps:
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  tags: ["arch:amd64"]
   variables:
     IMG_SIGNING: "false"
     PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"
@@ -636,6 +637,7 @@ publish_public_main:
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: operator:main
+    IMG_REGISTRIES: public
     IMG_SIGNING: "false"
     IMG_MERGE_STRATEGY: "index_oci"
 
@@ -657,6 +659,7 @@ publish_public_tag:
     IMG_DESTINATIONS: operator:$CI_COMMIT_TAG
     IMG_DESTINATIONS_REGEX: ":v"
     IMG_DESTINATIONS_REGEX_REPL: ":"
+    IMG_REGISTRIES: public
     IMG_SIGNING: "false"
     IMG_MERGE_STRATEGY: "index_oci"
 
@@ -701,6 +704,7 @@ publish_public_latest:
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:latest
+    IMG_REGISTRIES: public
     IMG_SIGNING: "false"
     IMG_MERGE_STRATEGY: "index_oci"
 
@@ -724,6 +728,7 @@ publish_public_rc_latest:
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:rc-latest
+    IMG_REGISTRIES: public
     IMG_SIGNING: "false"
     IMG_MERGE_STRATEGY: "index_oci"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -435,15 +435,31 @@ go_e2e_deps:
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.e2e_tests_gcp_credentials --with-decryption --query "Parameter.Value" --out text > ~/gcp-credentials.json
     - export GOOGLE_APPLICATION_CREDENTIALS=~/gcp-credentials.json
 
+.docker_publish_job_definition:
+  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  variables:
+    IMG_SIGNING: "false"
+    PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"
+  script:
+    - |
+      set -euo pipefail
+      dd-pkg version
+      args=(publish-image --timeout "${PUBLIC_IMAGES_PUBLISH_TIMEOUT}" --poll-interval 30 --signing="${IMG_SIGNING}")
+      if [[ -n "${IMG_REGISTRIES:-}" ]]; then args+=(--registries "${IMG_REGISTRIES}"); fi
+      if [[ -n "${IMG_SOURCES:-}" ]]; then args+=(--sources "${IMG_SOURCES}"); fi
+      if [[ -n "${IMG_DESTINATIONS:-}" ]]; then args+=(--destinations "${IMG_DESTINATIONS}"); fi
+      if [[ -n "${IMG_DESTINATIONS_REGEX:-}" ]]; then args+=(--regex-expression "${IMG_DESTINATIONS_REGEX}"); fi
+      if [[ -n "${IMG_DESTINATIONS_REGEX_REPL:-}" ]]; then args+=(--regex-replacement "${IMG_DESTINATIONS_REGEX_REPL}"); fi
+      if [[ -n "${IMG_TAG_REFERENCE:-}" ]]; then args+=(--tag-reference "${IMG_TAG_REFERENCE}"); fi
+      if [[ -n "${IMG_NEW_TAGS:-}" ]]; then args+=(--new-tags "${IMG_NEW_TAGS}"); fi
+      dd-pkg "${args[@]}"
+
 trigger_e2e_operator_image:
   stage: e2e
   rules: !reference [.on_run_e2e_base]
   needs:
     - build_operator_image_amd64
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     IMG_DESTINATIONS: operator:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
@@ -616,10 +632,7 @@ publish_public_main:
     - if: '$CI_COMMIT_BRANCH == "main" && $DDR != "true"'
       when: on_success
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: operator:main
@@ -638,10 +651,7 @@ publish_public_tag:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:$CI_COMMIT_TAG
@@ -662,10 +672,7 @@ publish_redhat_public_tag:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:$CI_COMMIT_TAG
@@ -690,10 +697,7 @@ publish_public_latest:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:latest
@@ -716,10 +720,7 @@ publish_public_rc_latest:
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
       when: on_success
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: operator:rc-latest
@@ -749,10 +750,7 @@ publish_redhat_public_latest:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
     IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -437,7 +437,7 @@ go_e2e_deps:
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
-  tags: ["arch:amd64"]
+  tags: ["arch:arm64"]
   variables:
     IMG_SIGNING: "false"
     PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"


### PR DESCRIPTION
Replaces the legacy `trigger: project: DataDog/public-images` job with a direct `dd-pkg publish-image` call against artifact-gateway.

## Why

The GitLab job-token bridge cannot tell **who** triggered a publish — any project holding a token could publish anything. Calling artifact-gateway instead adds:

- **Authentication** — the caller's identity is verified.
- **Authorization** — a policy states which Directory Service group may release each image tier (dev vs prod).
- An audit trail of every publication.

**Authorization is in audit-only mode for now** — nothing is blocked, publications are only recorded. So this is safe to merge, and the rollout stays reversible behind a feature flag.

Publish cadence, tags and destinations are unchanged; this is an onboarding change only.

- Jira: [BARX-1948](https://datadoghq.atlassian.net/browse/BARX-1948)
- How-to: [Publish public images with dd-pkg](https://datadoghq.atlassian.net/wiki/x/ooQkngE)

[BARX-1948]: https://datadoghq.atlassian.net/browse/BARX-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ