### PR TITLE
Don't default DDA for controller revision

### DIFF
--- a/internal/controller/datadogagent/controller_experiment_integration_test.go
+++ b/internal/controller/datadogagent/controller_experiment_integration_test.go
@@ -161,10 +161,9 @@ func Test_Experiment_StoppedRollback(t *testing.T) {
 	reconcileN(t, r, ns, name, 2)
 
 	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
-	// The snapshot is taken from the defaulted spec (defaults.DefaultDatadogAgentSpec applies
-	// site="datadoghq.com" before snapshotting), so rollback restores that value.
-	assert.NotNil(t, dda.Spec.Global.Site, "spec should be restored to pre-experiment state")
-	assert.Equal(t, "datadoghq.com", *dda.Spec.Global.Site, "spec should be restored to pre-experiment state")
+	// The snapshot is taken from the raw, user-submitted spec, which never set
+	// Site, so rollback restores Site to nil rather than baking in a default.
+	assert.Nil(t, dda.Spec.Global.Site, "spec should be restored to pre-experiment state")
 	assert.NotNil(t, dda.Status.Experiment)
 	assert.Equal(t, v2alpha1.ExperimentPhaseTerminated, dda.Status.Experiment.Phase)
 	assert.Equal(t, ExperimentTerminationReasonStopped, dda.Status.Experiment.TerminationReason)
@@ -203,9 +202,9 @@ func Test_Experiment_TimeoutRollback(t *testing.T) {
 	reconcileN(t, r, ns, name, 2)
 
 	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
-	// The snapshot is taken from the defaulted spec, so rollback restores site="datadoghq.com".
-	assert.NotNil(t, dda.Spec.Global.Site, "spec should be restored after timeout")
-	assert.Equal(t, "datadoghq.com", *dda.Spec.Global.Site, "spec should be restored after timeout")
+	// The snapshot is taken from the raw, user-submitted spec, which never set
+	// Site, so rollback restores Site to nil rather than baking in a default.
+	assert.Nil(t, dda.Spec.Global.Site, "spec should be restored after timeout")
 	assert.NotNil(t, dda.Status.Experiment)
 	assert.Equal(t, v2alpha1.ExperimentPhaseTerminated, dda.Status.Experiment.Phase)
 	assert.Equal(t, ExperimentTerminationReasonTimedOut, dda.Status.Experiment.TerminationReason)
@@ -284,7 +283,8 @@ func Test_Experiment_TimeoutPhase_IsStable(t *testing.T) {
 	reconcileN(t, r, ns, name, 3)
 
 	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
-	assert.Equal(t, "datadoghq.com", *dda.Spec.Global.Site)
+	// Raw baseline never set Site, so it stays nil after rollback.
+	assert.Nil(t, dda.Spec.Global.Site)
 	assert.Equal(t, v2alpha1.ExperimentPhaseTerminated, mustGetExperimentPhase(t, r, ns, name))
 }
 
@@ -318,7 +318,8 @@ func Test_Experiment_TerminatedPhase_IsStable(t *testing.T) {
 	reconcileN(t, r, ns, name, 3)
 
 	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
-	assert.Equal(t, "datadoghq.com", *dda.Spec.Global.Site)
+	// Raw baseline never set Site, so it stays nil after rollback.
+	assert.Nil(t, dda.Spec.Global.Site)
 	assert.Equal(t, v2alpha1.ExperimentPhaseTerminated, mustGetExperimentPhase(t, r, ns, name))
 }
 
@@ -393,8 +394,9 @@ func Test_Experiment_StopAfterRollback(t *testing.T) {
 	reconcileN(t, r, ns, name, 2)
 
 	// Spec should still be the rolled-back spec; phase=terminated unchanged.
+	// Raw baseline never set Site, so it stays nil after rollback.
 	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
-	assert.Equal(t, "datadoghq.com", *dda.Spec.Global.Site)
+	assert.Nil(t, dda.Spec.Global.Site)
 	assert.Equal(t, v2alpha1.ExperimentPhaseTerminated, mustGetExperimentPhase(t, r, ns, name))
 }
 
@@ -1012,7 +1014,8 @@ func Test_Experiment_ReapplySameSpec_NoImmediateTimeout(t *testing.T) {
 	assert.Equal(t, v2alpha1.ExperimentPhaseTerminated, mustGetExperimentPhase(t, r, ns, name))
 	assert.Equal(t, ExperimentTerminationReasonTimedOut, mustGetTerminationReason(t, r, ns, name))
 	assert.NoError(t, r.client.Get(context.TODO(), nsName, dda))
-	assert.Equal(t, "datadoghq.com", *dda.Spec.Global.Site, "spec should be rolled back")
+	// Raw baseline never set Site, so it stays nil after rollback.
+	assert.Nil(t, dda.Spec.Global.Site, "spec should be rolled back")
 
 	// Verify the experiment revision is annotated as rolled back.
 	revs := listOwnedRevisions(t, r.client, ns, uid)

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -51,6 +51,7 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadogh
 	}
 
 	// 3. Set default values for GlobalConfig and Features
+	rawSpec := instance.Spec
 	instanceCopy := instance.DeepCopy()
 	defaults.DefaultDatadogAgentSpec(&instanceCopy.Spec)
 	if experimental.IsAutopilotEnabled(instanceCopy) {
@@ -58,7 +59,7 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadogh
 	}
 
 	// 4. Delegate to the main reconcile function.
-	return r.reconcileInstanceV3(ctx, reqLogger, instanceCopy)
+	return r.reconcileInstanceV3(ctx, reqLogger, instanceCopy, rawSpec)
 }
 
 // Force GCR registry if not set to avoid defaulting to Datadog registry
@@ -81,7 +82,7 @@ func ensureGCRAutopilotRegistry(spec *datadoghqv2alpha1.DatadogAgentSpec) {
 	spec.Global.Registry = ptr.To(images.GCRContainerRegistry)
 }
 
-func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent) (reconcile.Result, error) {
+func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent, rawSpec datadoghqv2alpha1.DatadogAgentSpec) (reconcile.Result, error) {
 	// Set up field manager for crd apply
 	if r.fieldManager == nil {
 		f, err := newFieldManager(r.client, r.scheme, getDDAIGVK())
@@ -112,10 +113,15 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 		if err != nil {
 			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, err, now)
 		}
-		if err := r.manageExperiment(ctx, instance, newDDAStatus, now, revList); err != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newDDAStatus, result, err, now)
+		// Use user-submitted instance instead of defaulted instance
+		rawInstance := instance.DeepCopy()
+		rawInstance.Spec = rawSpec
+		experimentErr := r.manageExperiment(ctx, rawInstance, newDDAStatus, now, revList)
+		instance.ResourceVersion = rawInstance.ResourceVersion
+		if experimentErr != nil {
+			return r.updateStatusIfNeededV2(logger, instance, newDDAStatus, result, experimentErr, now)
 		}
-		if err := r.manageRevision(ctx, instance, revList, newDDAStatus); err != nil {
+		if err := r.manageRevision(ctx, instance, rawSpec, revList, newDDAStatus); err != nil {
 			return r.updateStatusIfNeededV2(logger, instance, newDDAStatus, result, err, now)
 		}
 	}

--- a/internal/controller/datadogagent/controller_revision_integration_test.go
+++ b/internal/controller/datadogagent/controller_revision_integration_test.go
@@ -26,6 +26,7 @@ package datadogagent
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	assert "github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,8 +44,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/defaults"
 	agenttestutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/testutils"
+	"github.com/DataDog/datadog-operator/pkg/controllerrevisions"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	testutils "github.com/DataDog/datadog-operator/pkg/testutils"
 )
@@ -377,4 +382,86 @@ func Test_ControllerRevisions_UIDScoping(t *testing.T) {
 		"new DDA instance must start with a fresh revision history")
 	assert.Len(t, listOwnedRevisions(t, c, ns, "uid-old"), 1,
 		"old revision is still present (orphaned); not mistaken for new owner's history")
+}
+
+// Test_ControllerRevisions_SnapshotStoresRawSpec verifies that the snapshot
+// stored in a ControllerRevision is the raw, user-submitted spec rather than
+// the in-memory defaulted copy, and that reconciling repeatedly does not
+// create new revisions merely because defaulting recomputes fields like
+// Site on every reconcile.
+func Test_ControllerRevisions_SnapshotStoresRawSpec(t *testing.T) {
+	const ns, name = "default", "test-dda"
+	const uid = types.UID("uid-1")
+
+	r, c := newRevisionIntegrationReconciler(t)
+	dda := baseDDA(ns, name, uid)
+	createAndReconcile(t, r, dda)
+
+	revs := listOwnedRevisions(t, c, ns, uid)
+	assert.Len(t, revs, 1)
+
+	var snapshot revisionSnapshot
+	assert.NoError(t, json.Unmarshal(revs[0].Data.Raw, &snapshot))
+	assert.Nil(t, snapshot.Spec.Global.Site,
+		"snapshot must store the raw spec (Site unset), not the in-memory defaulted copy")
+
+	// A second reconcile must not create a new revision: defaulting recomputes
+	// Site="datadoghq.com" into the in-memory copy every time, but the snapshot
+	// is built from the unchanged raw spec, so no defaulting-driven churn occurs.
+	_, err := r.Reconcile(context.TODO(), dda)
+	assert.NoError(t, err)
+	assert.Len(t, listOwnedRevisions(t, c, ns, uid), 1, "defaulting recomputation alone must not create a new revision")
+}
+
+// Test_ControllerRevisions_MigrationFromDefaultedSnapshot simulates upgrading
+// from the old (pre-fix) code, which snapshotted the in-memory defaulted spec,
+// to the current code, which snapshots the raw spec. A pre-existing revision
+// holding defaulted-format bytes is seeded directly; the first reconcile after
+// the upgrade should create exactly one new raw-format revision alongside it,
+// and the second reconcile should create no further revisions.
+func Test_ControllerRevisions_MigrationFromDefaultedSnapshot(t *testing.T) {
+	const ns, name = "default", "test-dda"
+	const uid = types.UID("uid-1")
+
+	r, c := newRevisionIntegrationReconciler(t)
+
+	dda := baseDDA(ns, name, uid)
+	assert.NoError(t, c.Create(context.TODO(), dda))
+
+	// Seed a ControllerRevision as the old (pre-fix) code would have created
+	// it: snapshotting the defaulted spec instead of the raw one.
+	oldDefaultedSpec := dda.Spec.DeepCopy()
+	defaults.DefaultDatadogAgentSpec(oldDefaultedSpec)
+	oldSnapBytes, err := buildRevisionSnapshot(*oldDefaultedSpec, dda.GetAnnotations())
+	assert.NoError(t, err)
+
+	gvks, _, err := r.scheme.ObjectKinds(dda)
+	assert.NoError(t, err)
+	oldRev := controllerrevisions.NewControllerRevision(
+		dda, gvks[0],
+		map[string]string{apicommon.DatadogAgentNameLabelKey: name},
+		runtime.RawExtension{Raw: oldSnapBytes},
+		1, nil,
+	)
+	assert.NoError(t, c.Create(context.TODO(), oldRev))
+
+	// First reconcile after the upgrade: the raw-spec snapshot doesn't match
+	// the pre-existing defaulted-format revision, so exactly one new revision
+	// is created; the old one is kept as "previous".
+	_, err = r.Reconcile(context.TODO(), dda)
+	assert.NoError(t, err)
+
+	revs := listOwnedRevisions(t, c, ns, uid)
+	assert.Len(t, revs, 2, "expected the old defaulted-format revision plus one new raw-format revision")
+
+	names := map[string]bool{}
+	for _, rev := range revs {
+		names[rev.Name] = true
+	}
+	assert.True(t, names[oldRev.Name], "pre-existing defaulted-format revision must be preserved")
+
+	// Second reconcile: raw spec is unchanged, so no further revision is created.
+	_, err = r.Reconcile(context.TODO(), dda)
+	assert.NoError(t, err)
+	assert.Len(t, listOwnedRevisions(t, c, ns, uid), 2, "second reconcile after migration must not create additional revisions")
 }

--- a/internal/controller/datadogagent/experiment.go
+++ b/internal/controller/datadogagent/experiment.go
@@ -548,12 +548,15 @@ func (r *Reconciler) rollback(
 	if err := r.client.Get(ctx, nsn, current); err != nil {
 		return fmt.Errorf("failed to get current DDA for rollback: %w", err)
 	}
-	currentSnap, err := json.Marshal(revisionSnapshot{Spec: current.Spec, Annotations: datadogAnnotations(current.GetAnnotations())})
+	currentSnap, err := buildRevisionSnapshot(current.Spec, current.GetAnnotations())
 	if err != nil {
 		return fmt.Errorf("failed to marshal current snapshot for comparison: %w", err)
 	}
 	if bytes.Equal(currentSnap, cr.Data.Raw) {
 		ctrl.LoggerFrom(ctx).Info("Rollback spec already matches target, skipping update", "rollbackTarget", rollbackTarget)
+		// No update happened, but still sync the re-fetched ResourceVersion so
+		// the caller's status update doesn't 409 against a concurrent write.
+		instance.ResourceVersion = current.ResourceVersion
 		return nil
 	}
 
@@ -609,9 +612,12 @@ func findRollbackTarget(revisions []appsv1.ControllerRevision) string {
 //     The matching revision is the pre-experiment one (old timestamp), so elapsed is
 //     large, timeout fires, and the idempotent rollback path sets phase=terminated cleanly
 //     without a spec-update conflict (ResourceVersion unchanged → status write succeeds).
+//
+// instance.Spec must be the raw, user-submitted spec, not the in-memory
+// defaulted copy — pass rawInstance, not instance. Stored revisions are raw,
+// so a defaulted spec never matches any of them.
 func findMostRecentMatchingRevision(revisions []appsv1.ControllerRevision, instance *v2alpha1.DatadogAgent) *appsv1.ControllerRevision {
-	snap := revisionSnapshot{Spec: instance.Spec, Annotations: datadogAnnotations(instance.GetAnnotations())}
-	snapBytes, err := json.Marshal(snap)
+	snapBytes, err := buildRevisionSnapshot(instance.Spec, instance.GetAnnotations())
 	if err != nil {
 		return nil
 	}

--- a/internal/controller/datadogagent/experiment_test.go
+++ b/internal/controller/datadogagent/experiment_test.go
@@ -23,11 +23,11 @@ func TestManageExperiment_AbortsOnManualChange(t *testing.T) {
 
 	// Create two revisions: pre-experiment (specA) and experiment (specB).
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 
 	// Simulate a manual spec change: specC doesn't match any revision.
 	instanceC := newRevisionTestOwner("test-dda", "default")
@@ -66,12 +66,12 @@ func TestManageExperiment_ManualRevertToBaselineTerminatesViaTimeout(t *testing.
 
 	// Rev1: pre-experiment spec (specA).
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	// Rev2: experiment spec (specB).
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 	require.NoError(t, c.Create(context.Background(), instanceA))
 
 	// User manually reverts to specA. The spec matches rev1 (the baseline),
@@ -98,7 +98,7 @@ func TestRollback_RestoresSpec(t *testing.T) {
 
 	// Create a revision for specA.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	err := r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil)
+	err := r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil)
 	require.NoError(t, err)
 
 	revListA := mustListRevisions(t, r, instanceA)
@@ -108,7 +108,7 @@ func TestRollback_RestoresSpec(t *testing.T) {
 	// Create a second revision for specB.
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	err = r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil)
+	err = r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil)
 	require.NoError(t, err)
 
 	// rollback fetches the current DDA to compare specs; it must exist in the fake client.
@@ -116,6 +116,34 @@ func TestRollback_RestoresSpec(t *testing.T) {
 
 	// Rollback from instanceB to prevRevision (specA).
 	require.NoError(t, r.rollback(context.Background(), instanceB, prevRevision))
+}
+
+// TestRollback_SkipsUpdateWhenSpecAlreadyMatchesTarget verifies that if the
+// raw spec has already been independently reverted to match the rollback
+// target (e.g. a manual kubectl/GitOps revert) before rollback() runs, the
+// short-circuit compares the raw current spec against the target and skips
+// the Update entirely rather than re-pinning defaulted values onto the CR.
+func TestRollback_SkipsUpdateWhenSpecAlreadyMatchesTarget(t *testing.T) {
+	r, c := newRevisionTestReconciler(t)
+
+	// Create the rollback target revision (specA).
+	instanceA := newRevisionTestOwner("test-dda", "default")
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
+	revListA := mustListRevisions(t, r, instanceA)
+	require.Len(t, revListA, 1)
+	target := revListA[0].Name
+
+	// current already matches specA (manually reverted before rollback() ran).
+	current := newRevisionTestOwner("test-dda", "default")
+	require.NoError(t, c.Create(context.Background(), current))
+	rvBefore := current.ResourceVersion
+
+	require.NoError(t, r.rollback(context.Background(), current, target))
+
+	updated := &v2alpha1.DatadogAgent{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "test-dda"}, updated))
+	assert.Equal(t, rvBefore, updated.ResourceVersion,
+		"rollback must skip the Update when the raw spec already matches the target revision")
 }
 
 func TestRollback_NoPreviousRevision(t *testing.T) {
@@ -131,11 +159,11 @@ func TestProcessExperimentSignal_RollbackSignalRollsBack(t *testing.T) {
 
 	// Create two revisions so we have a previous to roll back to.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 
 	// Set annotations to signal rollback (different task ID), and status to running
 	// (controller already processed start with a different ID).
@@ -168,7 +196,7 @@ func TestRollback_PreservesNonDatadogAnnotations(t *testing.T) {
 	instanceA.Annotations = map[string]string{
 		"some.datadoghq.com/key": "old-value",
 	}
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 	revListA := mustListRevisions(t, r, instanceA)
 	require.Len(t, revListA, 1)
 	prevRevision := revListA[0].Name
@@ -199,11 +227,11 @@ func TestRestorePreviousSpec_PhaseSetOnlyOnSuccess(t *testing.T) {
 
 	// Create two revisions so rollback has a target.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 
 	newStatus := &v2alpha1.DatadogAgentStatus{Experiment: &v2alpha1.ExperimentStatus{Phase: v2alpha1.ExperimentPhaseRunning}}
 
@@ -226,11 +254,11 @@ func TestManageExperiment_ManualChangeAbortsInsteadOfTimeout(t *testing.T) {
 
 	// Create two revisions so rollback has a target.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 
 	// Simulate: phase=running, the spec was manually changed so it doesn't match
 	// any revision, AND timeout has elapsed. With the fix, handleRollback defers
@@ -259,7 +287,7 @@ func TestHandleRollback_NoTimeoutOnFirstReconcile(t *testing.T) {
 
 	// Only one revision exists — for the pre-experiment spec — with an old timestamp.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 	revList := mustListRevisions(t, r, instanceA)
 	require.Len(t, revList, 1)
 	revList[0].CreationTimestamp = metav1.NewTime(time.Now().Add(-ExperimentDefaultTimeout - time.Hour))
@@ -288,12 +316,12 @@ func TestHandleRollback_PostRollbackSetsTerminated(t *testing.T) {
 
 	// rev1: pre-experiment spec (instanceA).
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	// rev2: experiment spec (instanceB).
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 
 	// The DDA in the cluster already has the rolled-back spec (instanceA's spec),
 	// as if reconcile-1 restored it but its status write 409'd. StartedAt sits
@@ -328,11 +356,11 @@ func TestReapplySameSpecAfterRollback_NoImmediateTimeout(t *testing.T) {
 
 	// Setup: create revisions for spec A (pre-experiment) and spec B (experiment).
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 	require.NoError(t, c.Create(context.Background(), instanceB))
 
 	// Backdate rev2 (B) to simulate a long-running experiment whose revision
@@ -377,7 +405,7 @@ func TestReapplySameSpecAfterRollback_NoImmediateTimeout(t *testing.T) {
 	instanceB2.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
 	// Step 1: ensureRevision recreates the annotated revision (fresh, no annotation).
-	_, err := r.ensureRevision(context.Background(), instanceB2, mustListRevisions(t, r, instanceB2), false)
+	_, err := r.ensureRevision(context.Background(), instanceB2, instanceB2.Spec, mustListRevisions(t, r, instanceB2), false)
 	require.NoError(t, err)
 
 	finalRevs := mustListRevisions(t, r, instanceB2)
@@ -410,18 +438,18 @@ func TestRestorePreviousSpec_ThreeRevisions_AnnotatesOnlyHighest(t *testing.T) {
 
 	// Build 3 revisions using ensureRevision directly (bypasses GC).
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	rev1Name, err := r.ensureRevision(context.Background(), instanceA, nil, false)
+	rev1Name, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, nil, false)
 	require.NoError(t, err)
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	rev2Name, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	rev2Name, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	experimentSite := "datadoghq.eu"
 	instanceC := newRevisionTestOwner("test-dda", "default")
 	instanceC.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{Site: &experimentSite}}
-	rev3Name, err := r.ensureRevision(context.Background(), instanceC, mustListRevisions(t, r, instanceC), false)
+	rev3Name, err := r.ensureRevision(context.Background(), instanceC, instanceC.Spec, mustListRevisions(t, r, instanceC), false)
 	require.NoError(t, err)
 
 	revList := mustListRevisions(t, r, instanceA)
@@ -460,18 +488,18 @@ func TestAbortExperiment_ThreeRevisions_AnnotatesOnlyHighest(t *testing.T) {
 
 	// Build 3 revisions using ensureRevision directly (bypasses GC).
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	rev1Name, err := r.ensureRevision(context.Background(), instanceA, nil, false)
+	rev1Name, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, nil, false)
 	require.NoError(t, err)
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	rev2Name, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	rev2Name, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	experimentSite := "datadoghq.eu"
 	instanceC := newRevisionTestOwner("test-dda", "default")
 	instanceC.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{Site: &experimentSite}}
-	rev3Name, err := r.ensureRevision(context.Background(), instanceC, mustListRevisions(t, r, instanceC), false)
+	rev3Name, err := r.ensureRevision(context.Background(), instanceC, instanceC.Spec, mustListRevisions(t, r, instanceC), false)
 	require.NoError(t, err)
 
 	revList := mustListRevisions(t, r, instanceA)
@@ -511,11 +539,11 @@ func TestHandleRollback_Timeout(t *testing.T) {
 
 	// Create two revisions so rollback has a target.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 
 	// rollback fetches the current DDA to compare specs; it must exist in the fake client.
 	require.NoError(t, c.Create(context.Background(), instanceB))
@@ -640,11 +668,11 @@ func TestProcessExperimentSignal_PromoteRunning(t *testing.T) {
 
 	// Create a revision matching the instance spec so promote sees a matching revision.
 	instance := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instance, mustListRevisions(t, r, instance), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), nil))
 	// Create a second revision to satisfy len(revisions) >= 2.
 	instance2 := newRevisionTestOwner("test-dda", "default")
 	instance2.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instance2, mustListRevisions(t, r, instance2), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instance2, instance2.Spec, mustListRevisions(t, r, instance2), nil))
 
 	// Now promote back to the first spec (which has a matching revision).
 	// The promote signal has its own task ID, different from the start experiment ID.
@@ -669,11 +697,11 @@ func TestProcessExperimentSignal_PromoteBeatsTimeout(t *testing.T) {
 
 	// Create two revisions.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 	require.NoError(t, c.Create(context.Background(), instanceB))
 
 	// Set promote annotation (different task ID) and running phase with timeout elapsed.
@@ -718,11 +746,11 @@ func TestProcessExperimentSignal_RollbackBeatsTimeout(t *testing.T) {
 
 	// Create two revisions.
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	require.NoError(t, r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil))
 
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
-	require.NoError(t, r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil))
+	require.NoError(t, r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil))
 	require.NoError(t, c.Create(context.Background(), instanceB))
 
 	// Set rollback annotation (different task ID) and running phase with timeout elapsed.
@@ -803,7 +831,7 @@ func TestRevisionState_SingleAnnotation(t *testing.T) {
 	r, _ := newRevisionTestReconciler(t)
 
 	instance := newRevisionTestOwner("test-dda", "default")
-	revName, err := r.ensureRevision(context.Background(), instance, nil, false)
+	revName, err := r.ensureRevision(context.Background(), instance, instance.Spec, nil, false)
 	require.NoError(t, err)
 	revList := mustListRevisions(t, r, instance)
 	require.Len(t, revList, 1)
@@ -839,7 +867,7 @@ func TestHandleRollback_StartedAt_AnchorsTimeout(t *testing.T) {
 
 	// Build a baseline revision with an ancient CreationTimestamp.
 	instance := newRevisionTestOwner("test-dda", "default")
-	_, err := r.ensureRevision(context.Background(), instance, nil, false)
+	_, err := r.ensureRevision(context.Background(), instance, instance.Spec, nil, false)
 	require.NoError(t, err)
 	revList := mustListRevisions(t, r, instance)
 	require.Len(t, revList, 1)

--- a/internal/controller/datadogagent/revision.go
+++ b/internal/controller/datadogagent/revision.go
@@ -32,6 +32,14 @@ type revisionSnapshot struct {
 	Annotations map[string]string         `json:"annotations,omitempty"`
 }
 
+// buildRevisionSnapshot marshals a revisionSnapshot from spec and annotations.
+// Spec must be the raw, user-submitted spec (not the in-memory defaulted
+// copy) so that snapshot comparisons are unaffected by defaulting.
+func buildRevisionSnapshot(spec v2alpha1.DatadogAgentSpec, allAnnotations map[string]string) ([]byte, error) {
+	snap := revisionSnapshot{Spec: spec, Annotations: datadogAnnotations(allAnnotations)}
+	return json.Marshal(snap)
+}
+
 // skipRevisionBump returns true when the revision bump should be suppressed.
 // During experiment rollback the spec is restored to an older revision; bumping
 // its revision number to "latest" would make it appear newer than the experiment
@@ -47,8 +55,13 @@ func skipRevisionBump(newStatus *v2alpha1.DatadogAgentStatus) bool {
 
 // manageRevision creates a ControllerRevision snapshot of the current spec and
 // garbage collects old revisions. Must be called after manageExperiment.
-func (r *Reconciler) manageRevision(ctx context.Context, instance *v2alpha1.DatadogAgent, revList []appsv1.ControllerRevision, newStatus *v2alpha1.DatadogAgentStatus) error {
-	revName, err := r.ensureRevision(ctx, instance, revList, skipRevisionBump(newStatus))
+//
+// rawSpec is the user-submitted spec (before in-memory defaulting is applied)
+// and is what gets stored in the ControllerRevision snapshot; instance is
+// still used for labels, annotations, and object identity, which are
+// unaffected by defaulting.
+func (r *Reconciler) manageRevision(ctx context.Context, instance *v2alpha1.DatadogAgent, rawSpec v2alpha1.DatadogAgentSpec, revList []appsv1.ControllerRevision, newStatus *v2alpha1.DatadogAgentStatus) error {
+	revName, err := r.ensureRevision(ctx, instance, rawSpec, revList, skipRevisionBump(newStatus))
 	if err != nil {
 		return err
 	}
@@ -84,21 +97,24 @@ func (r *Reconciler) listRevisions(ctx context.Context, instance *v2alpha1.Datad
 	return revList.Items, nil
 }
 
-// ensureRevision creates a ControllerRevision snapshot of the instance spec and
+// ensureRevision creates a ControllerRevision snapshot of the raw spec and
 // annotations if it does not already exist, and returns the revision name.
+//
+// rawSpec (not instance.Spec, which may carry in-memory defaults) is what
+// gets stored, so that revisions reflect only user-intended changes.
 //
 // The Revision field is a monotonic creation counter. If skipBump is true the
 // existing revision is returned as-is without bumping its Revision number.
 func (r *Reconciler) ensureRevision(
 	ctx context.Context,
 	instance *v2alpha1.DatadogAgent,
+	rawSpec v2alpha1.DatadogAgentSpec,
 	revList []appsv1.ControllerRevision,
 	skipBump bool,
 ) (string, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	snap := revisionSnapshot{Spec: instance.Spec, Annotations: datadogAnnotations(instance.GetAnnotations())}
-	specBytes, err := json.Marshal(snap)
+	specBytes, err := buildRevisionSnapshot(rawSpec, instance.GetAnnotations())
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal snapshot: %w", err)
 	}

--- a/internal/controller/datadogagent/revision_test.go
+++ b/internal/controller/datadogagent/revision_test.go
@@ -7,6 +7,7 @@ package datadogagent
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"k8s.io/utils/ptr"
@@ -71,7 +72,7 @@ func TestEnsureRevision_CreatesOnFirstCall(t *testing.T) {
 	r, c := newRevisionTestReconciler(t)
 	instance := newRevisionTestOwner("test-dda", "default")
 
-	name, err := r.ensureRevision(context.Background(), instance, mustListRevisions(t, r, instance), false)
+	name, err := r.ensureRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), false)
 	require.NoError(t, err)
 	assert.NotEmpty(t, name)
 
@@ -87,9 +88,9 @@ func TestEnsureRevision_Idempotent(t *testing.T) {
 	instance := newRevisionTestOwner("test-dda", "default")
 	instance.Annotations = map[string]string{"foo": "bar"}
 
-	name1, err := r.ensureRevision(context.Background(), instance, mustListRevisions(t, r, instance), false)
+	name1, err := r.ensureRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), false)
 	require.NoError(t, err)
-	name2, err := r.ensureRevision(context.Background(), instance, mustListRevisions(t, r, instance), false)
+	name2, err := r.ensureRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, name1, name2)
@@ -99,6 +100,27 @@ func TestEnsureRevision_Idempotent(t *testing.T) {
 	assert.Len(t, revList.Items, 1)
 }
 
+// TestEnsureRevision_StoresRawSpecNotInstanceSpec catches a regression where
+// ensureRevision snapshots instance.Spec instead of the rawSpec parameter.
+// Every other test passes instance.Spec as rawSpec, so raw == defaulted
+// everywhere else and wouldn't catch this; here the two deliberately differ.
+func TestEnsureRevision_StoresRawSpecNotInstanceSpec(t *testing.T) {
+	r, c := newRevisionTestReconciler(t)
+	instance := newRevisionTestOwner("test-dda", "default")
+
+	rawSpec := *instance.Spec.DeepCopy()
+	// instance.Spec carries a defaulted field the raw spec never set.
+	instance.Spec.Global = &v2alpha1.GlobalConfig{Site: ptr.To("datadoghq.com")}
+
+	name, err := r.ensureRevision(context.Background(), instance, rawSpec, mustListRevisions(t, r, instance), false)
+	require.NoError(t, err)
+
+	rev := fetchRevisionByName(t, c, "default", name)
+	var snapshot revisionSnapshot
+	require.NoError(t, json.Unmarshal(rev.Data.Raw, &snapshot))
+	assert.Nil(t, snapshot.Spec.Global, "snapshot must reflect rawSpec, not instance.Spec's defaulted Global.Site")
+}
+
 func TestEnsureRevision_DifferentSpecsDifferentNames(t *testing.T) {
 	r, _ := newRevisionTestReconciler(t)
 
@@ -106,9 +128,9 @@ func TestEnsureRevision_DifferentSpecsDifferentNames(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	name1, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	name1, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	name2, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	name2, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, name1, name2)
@@ -121,9 +143,9 @@ func TestEnsureRevision_DifferentAnnotationsDifferentNames(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Annotations = map[string]string{"feature.datadoghq.com/beta": "true"}
 
-	name1, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	name1, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	name2, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	name2, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, name1, name2)
@@ -143,9 +165,9 @@ func TestEnsureRevision_NonDatadogAnnotationsIgnored(t *testing.T) {
 		"some-other-tool/annotation":                       "value",
 	}
 
-	name1, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	name1, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	name2, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	name2, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	assert.Equal(t, name1, name2, "non-datadoghq annotations should not affect the revision snapshot")
@@ -169,7 +191,7 @@ func TestGCOldRevisions_KeepsCurrentAndPrevious(t *testing.T) {
 	}
 	names := make([]string, len(instances))
 	for i, inst := range instances {
-		name, err := r.ensureRevision(context.Background(), inst, mustListRevisions(t, r, inst), false)
+		name, err := r.ensureRevision(context.Background(), inst, inst.Spec, mustListRevisions(t, r, inst), false)
 		require.NoError(t, err)
 		names[i] = name
 	}
@@ -197,13 +219,13 @@ func TestEnsureRevision_RevertBumpsRevision(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	name1, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	name1, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	_, err = r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	_, err = r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	// Revert to spec A — should reuse name1 but bump its Revision.
-	name3, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	name3, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
 	assert.Equal(t, name1, name3, "revert should reuse same CR name")
 
@@ -218,9 +240,9 @@ func TestGCOldRevisions_KeepsTwoRevisions(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	_, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	_, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	name2, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	name2, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	err = r.gcOldRevisions(context.Background(), name2, mustListRevisions(t, r, instanceB))
@@ -250,7 +272,7 @@ func TestEnsureRevision_RevisionNumbersMonotonic(t *testing.T) {
 
 	names := make([]string, len(instances))
 	for i, inst := range instances {
-		name, err := r.ensureRevision(context.Background(), inst, mustListRevisions(t, r, inst), false)
+		name, err := r.ensureRevision(context.Background(), inst, inst.Spec, mustListRevisions(t, r, inst), false)
 		require.NoError(t, err)
 		names[i] = name
 	}
@@ -265,7 +287,7 @@ func TestGCOldRevisions_NoPreviousWhenOnlyCurrent(t *testing.T) {
 	r, c := newRevisionTestReconciler(t)
 	instance := newRevisionTestOwner("test-dda", "default")
 
-	revName, err := r.ensureRevision(context.Background(), instance, mustListRevisions(t, r, instance), false)
+	revName, err := r.ensureRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), false)
 	require.NoError(t, err)
 
 	err = r.gcOldRevisions(context.Background(), revName, mustListRevisions(t, r, instance))
@@ -285,7 +307,7 @@ func TestGCOldRevisions_DeletesMultipleOld(t *testing.T) {
 	for i, site := range sites {
 		inst := newRevisionTestOwner("test-dda", "default")
 		inst.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{Site: ptr.To(site)}}
-		name, err := r.ensureRevision(context.Background(), inst, mustListRevisions(t, r, inst), false)
+		name, err := r.ensureRevision(context.Background(), inst, inst.Spec, mustListRevisions(t, r, inst), false)
 		require.NoError(t, err)
 		names[i] = name
 	}
@@ -313,7 +335,7 @@ func TestManageRevision_CreatesRevision(t *testing.T) {
 	r, _ := newRevisionTestReconciler(t)
 
 	instanceA := newRevisionTestOwner("test-dda", "default")
-	err := r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil)
+	err := r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil)
 	require.NoError(t, err)
 
 	revList := mustListRevisions(t, r, instanceA)
@@ -323,7 +345,7 @@ func TestManageRevision_CreatesRevision(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	err = r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil)
+	err = r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil)
 	require.NoError(t, err)
 
 	revList = mustListRevisions(t, r, instanceB)
@@ -334,9 +356,9 @@ func TestManageRevision_Idempotent(t *testing.T) {
 	r, _ := newRevisionTestReconciler(t)
 	instance := newRevisionTestOwner("test-dda", "default")
 
-	err := r.manageRevision(context.Background(), instance, mustListRevisions(t, r, instance), nil)
+	err := r.manageRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), nil)
 	require.NoError(t, err)
-	err = r.manageRevision(context.Background(), instance, mustListRevisions(t, r, instance), nil)
+	err = r.manageRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), nil)
 	require.NoError(t, err)
 
 	revList := mustListRevisions(t, r, instance)
@@ -350,7 +372,7 @@ func TestManageRevision_CurrentDeletedIsRecreated(t *testing.T) {
 	r, c := newRevisionTestReconciler(t)
 	instance := newRevisionTestOwner("test-dda", "default")
 
-	err := r.manageRevision(context.Background(), instance, mustListRevisions(t, r, instance), nil)
+	err := r.manageRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), nil)
 	require.NoError(t, err)
 
 	revList := mustListRevisions(t, r, instance)
@@ -361,7 +383,7 @@ func TestManageRevision_CurrentDeletedIsRecreated(t *testing.T) {
 	require.NoError(t, c.Delete(context.Background(), &revList[0]))
 
 	// Next reconcile should re-create the revision.
-	err = r.manageRevision(context.Background(), instance, mustListRevisions(t, r, instance), nil)
+	err = r.manageRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), nil)
 	require.NoError(t, err)
 
 	revList = mustListRevisions(t, r, instance)
@@ -382,9 +404,9 @@ func TestManageRevision_PreviousDeletedContinuesNormally(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	err := r.manageRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), nil)
+	err := r.manageRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), nil)
 	require.NoError(t, err)
-	err = r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil)
+	err = r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil)
 	require.NoError(t, err)
 
 	revList := mustListRevisions(t, r, instanceB)
@@ -400,7 +422,7 @@ func TestManageRevision_PreviousDeletedContinuesNormally(t *testing.T) {
 	require.NoError(t, c.Delete(context.Background(), &prev))
 
 	// Next reconcile on the same spec should succeed and keep only the current.
-	err = r.manageRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), nil)
+	err = r.manageRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), nil)
 	require.NoError(t, err)
 
 	revList = mustListRevisions(t, r, instanceB)
@@ -419,9 +441,9 @@ func TestEnsureRevision_RecreatesRolledBackRevision(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	_, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	_, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	nameB, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	nameB, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	// Annotate revB as rolled back (simulating what restorePreviousSpec does).
@@ -434,7 +456,7 @@ func TestEnsureRevision_RecreatesRolledBackRevision(t *testing.T) {
 	// (In real Kubernetes the CreationTimestamp is set server-side on create;
 	// the fake client doesn't refresh it, so we verify the annotation and
 	// revision number instead.)
-	nameB2, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	nameB2, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 	assert.Equal(t, nameB, nameB2, "should reuse same name (same data hash)")
 
@@ -453,9 +475,9 @@ func TestEnsureRevision_SkipsRecreateWhenSkipBump(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	_, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	_, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	nameB, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	nameB, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	// Annotate revB as rolled back.
@@ -464,7 +486,7 @@ func TestEnsureRevision_SkipsRecreateWhenSkipBump(t *testing.T) {
 	require.NoError(t, c.Update(context.Background(), revB))
 
 	// With skipBump=true, the annotated revision should be returned as-is.
-	nameB2, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), true)
+	nameB2, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), true)
 	require.NoError(t, err)
 	assert.Equal(t, nameB, nameB2)
 
@@ -482,9 +504,9 @@ func TestGCOldRevisions_AlwaysKeepsPrevious(t *testing.T) {
 	instanceB := newRevisionTestOwner("test-dda", "default")
 	instanceB.Spec = v2alpha1.DatadogAgentSpec{Global: &v2alpha1.GlobalConfig{}}
 
-	_, err := r.ensureRevision(context.Background(), instanceA, mustListRevisions(t, r, instanceA), false)
+	_, err := r.ensureRevision(context.Background(), instanceA, instanceA.Spec, mustListRevisions(t, r, instanceA), false)
 	require.NoError(t, err)
-	nameB, err := r.ensureRevision(context.Background(), instanceB, mustListRevisions(t, r, instanceB), false)
+	nameB, err := r.ensureRevision(context.Background(), instanceB, instanceB.Spec, mustListRevisions(t, r, instanceB), false)
 	require.NoError(t, err)
 
 	err = r.gcOldRevisions(context.Background(), nameB, mustListRevisions(t, r, instanceB))
@@ -541,7 +563,7 @@ func TestEnsureRevision_CommonLabelsApplied(t *testing.T) {
 		},
 	}
 
-	name, err := r.ensureRevision(context.Background(), instance, mustListRevisions(t, r, instance), false)
+	name, err := r.ensureRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), false)
 	require.NoError(t, err)
 
 	rev := fetchRevisionByName(t, c, "default", name)
@@ -561,7 +583,7 @@ func TestEnsureRevision_CommonLabels_CannotOverrideOperatorKey(t *testing.T) {
 		},
 	}
 
-	name, err := r.ensureRevision(context.Background(), instance, mustListRevisions(t, r, instance), false)
+	name, err := r.ensureRevision(context.Background(), instance, instance.Spec, mustListRevisions(t, r, instance), false)
 	require.NoError(t, err)
 
 	rev := fetchRevisionByName(t, c, "default", name)


### PR DESCRIPTION
### What does this PR do?

Don't default DDA when creating controller revisions

### Motivation

https://datadoghq.atlassian.net/browse/CONTP-1910

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

1. Deploy the operator with `DD_CREATE_CONTROLLER_REVISIONS=true`: `--set env[0].name=DD_CREATE_CONTROLLER_REVISIONS --set env[0].value=true`
2. Create a DDA with `spec.global.site` unset and annotations set:
```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  annotations:
    some.datadoghq.com/key: "tracked-value"
    some-other-tool/annotation: "should-be-excluded"
spec:
  global:
    credentials:
      apiKey: xxx
```
3. Check the DDA controller revision `kubectl get controllerrevisions` and make sure the data matches the spec in 2 (`spec.global.site` is unset) and only annotation `some.datadoghq.com/key: "tracked-value"` is kept:
```yaml
  annotations:
    some.datadoghq.com/key: tracked-value
  spec:
    global:
      credentials:
        apiKey: xxx
```


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits