### PR TITLE
[v1.29] Update default Agent/ClusterAgent/DdotCollector image version to 7.81.2

### DIFF
--- a/internal/controller/datadogagent/feature/test/factory_test.go
+++ b/internal/controller/datadogagent/feature/test/factory_test.go
@@ -105,7 +105,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM enabled, 4 agents",
+			name: "APM, NPM enabled, 3 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithAPMEnabled(true).
 				WithNPMEnabled(true).
@@ -113,7 +113,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           false,
@@ -124,7 +124,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM enabled with single container strategy, 4 agents",
+			name: "APM, NPM enabled with single container strategy, 3 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithSingleContainerStrategy(true).
 				WithAPMEnabled(true).
@@ -133,7 +133,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           false,
@@ -144,7 +144,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM, CSPM enabled, 5 agents",
+			name: "APM, NPM, CSPM enabled, 4 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithAPMEnabled(true).
 				WithNPMEnabled(true).
@@ -153,7 +153,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           true,
@@ -164,7 +164,7 @@ func TestBuilder(t *testing.T) {
 			},
 		},
 		{
-			name: "APM, NPM, CSPM enabled with single container strategy, 5 agents",
+			name: "APM, NPM, CSPM enabled with single container strategy, 4 agents",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithSingleContainerStrategy(true).
 				WithAPMEnabled(true).
@@ -174,7 +174,7 @@ func TestBuilder(t *testing.T) {
 			wantAgentContainer: map[common.AgentContainerName]bool{
 				common.UnprivilegedSingleAgentContainerName: false,
 				common.CoreAgentContainerName:               true,
-				common.ProcessAgentContainerName:            true,
+				common.ProcessAgentContainerName:            false,
 				common.TraceAgentContainerName:              true,
 				common.SystemProbeContainerName:             true,
 				common.SecurityAgentContainerName:           true,

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -2160,7 +2160,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 60baa72c89bba480e44da7d5c0a1fb6d
+    agent.datadoghq.com/agentspechash: 00a30e62ffb68e2d3ed0772d0715bd0b
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2279,7 +2279,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.2
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2334,7 +2334,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.2
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -2125,7 +2125,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 396747e4e69c910aa70f8f5d5cc909e9
+    agent.datadoghq.com/agentspechash: cdeff88b8f6b4fde1d1499c36315e7eb
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2248,7 +2248,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: gcr.io/datadoghq/agent:7.80.4
+        image: gcr.io/datadoghq/agent:7.81.2
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2303,7 +2303,7 @@ spec:
         command:
         - bash
         - -c
-        image: gcr.io/datadoghq/agent:7.80.4
+        image: gcr.io/datadoghq/agent:7.81.2
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -2157,7 +2157,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 60baa72c89bba480e44da7d5c0a1fb6d
+    agent.datadoghq.com/agentspechash: 00a30e62ffb68e2d3ed0772d0715bd0b
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2276,7 +2276,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.2
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2331,7 +2331,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.2
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -2179,7 +2179,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 60baa72c89bba480e44da7d5c0a1fb6d
+    agent.datadoghq.com/agentspechash: 00a30e62ffb68e2d3ed0772d0715bd0b
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2298,7 +2298,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.2
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2353,7 +2353,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.80.4
+        image: registry.datadoghq.com/agent:7.81.2
         name: init-config
         resources: {}
         volumeMounts:

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.80.4"
+	AgentLatestVersion = "7.81.2"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.80.4"
+	ClusterAgentLatestVersion = "7.81.2"
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
-	DdotCollectorLatestVersion = "7.80.4"
+	DdotCollectorLatestVersion = "7.81.2"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.28"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.


### PR DESCRIPTION
## What does this PR do?

Bumps the default Agent / Cluster Agent / DDOT Collector image version on the `v1.29` release branch from `7.80.4` to **`7.81.2`** for `1.29.0-rc.3`.

`7.80.4` is two patch releases behind the current stable Agent (`7.81.2`, published 2026-07-22). Both `datadog/agent` and `datadog/cluster-agent` `7.81.2` are published as stable on Docker Hub, so default installs won't hit image-pull failures.

## Motivation

Ship rc.3 with the current stable Agent default instead of a stale one. This is the release-branch counterpart of #3276 (which bumped `main` to 7.81.1).

## Additional Notes

Bumping past the NPM direct-send gate (`directSendMinVersion = 7.81.0-0`) drops the `process-agent` container for NPM, which ripples into tests:
- Golden fixtures regenerated via `make golden-update` (the `agent.datadoghq.com/agentspechash` annotation is derived from the pod spec, so it changes with the image tag).
- NPM `TestBuilder` cases in `factory_test.go` updated (`ProcessAgentContainerName: true -> false`, agent counts decremented).

Must merge to `v1.29` **before** rc.3 is tagged so the operator image builds with the new default.