### PR TITLE
[CONTP-1927] Enable DatadogInstrumentation CRD controller by default

### DIFF
--- a/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
+++ b/internal/controller/datadogagent/feature/instrumentationcrd/feature.go
@@ -56,6 +56,11 @@ func (f *instrumentationCRDFeature) ID() feature.IDType {
 func (f *instrumentationCRDFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) feature.RequiredComponents {
 	f.owner = dda
 
+	// The feature is enabled by default; opt out via the annotation set to "false".
+	if featureutils.HasFeatureDisableAnnotation(dda, featureutils.EnableInstrumentationCRDAnnotation) {
+		return feature.RequiredComponents{}
+	}
+
 	// If the cluster agent version is explicitly set and below the minimum, skip enabling.
 	if clusterAgent, ok := ddaSpec.Override[v2alpha1.ClusterAgentComponentName]; ok && clusterAgent.Image != nil {
 		version := common.GetAgentVersionFromImage(*clusterAgent.Image)
@@ -73,10 +78,6 @@ func (f *instrumentationCRDFeature) Configure(dda metav1.Object, ddaSpec *v2alph
 			return feature.RequiredComponents{}
 		}
 	} else if !utils.IsAboveMinVersion(images.AgentLatestVersion, minVersion, nil) {
-		return feature.RequiredComponents{}
-	}
-
-	if !featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnableInstrumentationCRDAnnotation) {
 		return feature.RequiredComponents{}
 	}
 

--- a/internal/controller/datadogagent/feature/instrumentationcrd/feature_test.go
+++ b/internal/controller/datadogagent/feature/instrumentationcrd/feature_test.go
@@ -43,14 +43,15 @@ func Test_instrumentationCRDFeature_Configure(t *testing.T) {
 			Agent:         instrumentationCRDAgentFunc(false),
 		},
 		{
-			Name: "InstrumentationCRD disabled by default",
-			DDA: testutils.NewDatadogAgentBuilder().
+			Name: "InstrumentationCRD enabled by default when both agent versions meet minimum",
+			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
 				WithClusterAgentImage("cluster-agent:7.82.0").
 				WithNodeAgentImage("agent:7.82.0").
 				Build(),
-			WantConfigure: false,
-			ClusterAgent:  instrumentationCRDClusterAgentFunc(false),
-			Agent:         instrumentationCRDAgentFunc(false),
+			WantConfigure:        true,
+			WantDependenciesFunc: instrumentationCRDWantDepsFunc(),
+			ClusterAgent:         instrumentationCRDClusterAgentFunc(true),
+			Agent:                instrumentationCRDAgentFunc(true),
 		},
 		{
 			Name: "InstrumentationCRD enabled via annotation when both agent versions meet minimum",
@@ -80,6 +81,16 @@ func Test_instrumentationCRDFeature_Configure(t *testing.T) {
 			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
 				WithAnnotations(map[string]string{featureutils.EnableInstrumentationCRDAnnotation: "true"}).
 				WithClusterAgentImage("cluster-agent:7.82.0").
+				WithNodeAgentImage("agent:7.81.0").
+				Build(),
+			WantConfigure: false,
+			ClusterAgent:  instrumentationCRDClusterAgentFunc(false),
+			Agent:         instrumentationCRDAgentFunc(false),
+		},
+		{
+			Name: "InstrumentationCRD disabled by default when agent versions below minimum",
+			DDA: testutils.NewInitializedDatadogAgentBuilder(resourcesNamespace, resourcesName).
+				WithClusterAgentImage("cluster-agent:7.81.0").
 				WithNodeAgentImage("agent:7.81.0").
 				Build(),
 			WantConfigure: false,

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -32,6 +32,9 @@ const (
 	EnableHostProfilerLoggingSeccompAnnotation = "agent.datadoghq.com/host-profiler-logging-seccomp-enabled"
 	EnableKSMApiServerCacheAnnotation          = "agent.datadoghq.com/ksm-use-apiserver-cache"
 
+	// EnableInstrumentationCRDAnnotation controls whether the DatadogInstrumentation CRD controller
+	// is enabled in the Cluster Agent. Defaults to enabled on agent versions that support it;
+	// set to "false" to disable it.
 	EnableInstrumentationCRDAnnotation = "agent.datadoghq.com/instrumentation-crd-enabled"
 
 	EnableFlightRecorderAnnotation = "agent.datadoghq.com/flightrecorder-enabled"
@@ -68,6 +71,15 @@ func ShouldRunProcessChecksInCoreAgent(ddaSpec *v2alpha1.DatadogAgentSpec) bool 
 func HasFeatureEnableAnnotation(dda metav1.Object, annotation string) bool {
 	if value, ok := dda.GetAnnotations()[annotation]; ok {
 		return value == "true"
+	}
+	return false
+}
+
+// HasFeatureDisableAnnotation returns true if the annotation is explicitly set to "false".
+// It is used by features that are enabled by default and can be opted out of.
+func HasFeatureDisableAnnotation(dda metav1.Object, annotation string) bool {
+	if value, ok := dda.GetAnnotations()[annotation]; ok {
+		return value == "false"
 	}
 	return false
 }

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -32,9 +32,6 @@ const (
 	EnableHostProfilerLoggingSeccompAnnotation = "agent.datadoghq.com/host-profiler-logging-seccomp-enabled"
 	EnableKSMApiServerCacheAnnotation          = "agent.datadoghq.com/ksm-use-apiserver-cache"
 
-	// EnableInstrumentationCRDAnnotation controls whether the DatadogInstrumentation CRD controller
-	// is enabled in the Cluster Agent. Defaults to enabled on agent versions that support it;
-	// set to "false" to disable it.
 	EnableInstrumentationCRDAnnotation = "agent.datadoghq.com/instrumentation-crd-enabled"
 
 	EnableFlightRecorderAnnotation = "agent.datadoghq.com/flightrecorder-enabled"


### PR DESCRIPTION
### What does this PR do?

Flips the instrumentation CRD feature from opt-in to opt-out. It is now enabled by default, and `agent.datadoghq.com/instrumentation-crd-enabled: "false"` disables it. Adds a `HasFeatureDisableAnnotation` helper in `featureutils` for this default-on annotation pattern.

### Motivation

The DatadogInstrumentation CRD controller should be on by default now that the existing version gate (< 7.82) already disables it on agents that don't support it.

### Additional Notes

The default agent/cluster-agent image in the operator is currently 7.81.1, so with no image override the version gate still keeps the feature off until the default version is bumped to 7.82.

### Minimum Agent Versions

* Agent: v7.82.0
* Cluster Agent: v7.82.0

### Describe your test plan

`go test ./internal/... ./pkg/...` passes. Unit tests updated: default-on with 7.82 images (including RBAC dependencies), default-off with 7.81 images, and explicit opt-out via annotation.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
