### PR TITLE
[NEEDS SIGN-OFF] otelcollector: stop injecting raw DD_API_KEY/DD_SITE into otel-agent (sidecar mode)

### DIFF
--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -405,6 +405,28 @@ func (o *otelCollectorFeature) ManageNodeAgent(managers feature.PodTemplateManag
 		managers.EnvVar().AddEnvVarToContainerWithMergeFunc(container, agentIpcConfigRefreshIntervalEnvVar, mergeFunc)
 	}
 
+	// Pod-wide credential wiring (global.go's credentialResource) sets DD_API_KEY/DD_SITE on every
+	// agent container, including otel-agent. That raw value can be an unresolved secrets-backend
+	// placeholder (e.g. "ENC[...]"), which otel-agent's internal Datadog exporter/extension config
+	// would read verbatim since it has no secrets-resolution step of its own. Strip it here: the IPC
+	// env vars set above make config sync mirror the core agent's already-resolved api_key/site at a
+	// higher config priority than a raw env var, so the synced value is sufficient on its own.
+	// Do not apply this to standalone Gateway mode, which has no core agent to sync from and relies
+	// on these env vars directly (see otelagentgateway/global.go).
+	for id, container := range managers.PodTemplateSpec().Spec.Containers {
+		if container.Name != string(apicommon.OtelAgent) {
+			continue
+		}
+		filteredEnv := make([]corev1.EnvVar, 0, len(container.Env))
+		for _, envVar := range container.Env {
+			if envVar.Name == constants.DDAPIKey || envVar.Name == constants.DDSite {
+				continue
+			}
+			filteredEnv = append(filteredEnv, envVar)
+		}
+		managers.PodTemplateSpec().Spec.Containers[id].Env = filteredEnv
+	}
+
 	var enableEnvVar *corev1.EnvVar
 	if o.coreAgentConfig.enabled != nil {
 		if *o.coreAgentConfig.enabled {

--- a/internal/controller/datadogagent/feature/otelcollector/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/otelcollector/defaultconfig"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
@@ -460,6 +461,63 @@ func Test_otelCollectorFeature_Configure(t *testing.T) {
 		},
 	}
 	tests.Run(t, buildOtelCollectorFeature)
+}
+
+// TestOtelCollectorFeature_StripsRawAPIKeyAndSiteEnvVars guards against otel-agent silently sending
+// an unresolved secrets-backend placeholder (e.g. "ENC[...]") as its API key. Pod-wide credential
+// wiring (global.go's credentialResource) sets DD_API_KEY/DD_SITE on every agent container,
+// including otel-agent, before this feature's ManageNodeAgent runs. Since otel-agent's config sync
+// (enabled unconditionally via the IPC env vars) mirrors the core agent's already-resolved values at
+// a higher priority, the raw env vars on otel-agent are both redundant and, when DD_API_KEY still
+// holds an unresolved placeholder, actively harmful. ManageNodeAgent must remove them from the
+// otel-agent container while leaving the core agent container untouched.
+func TestOtelCollectorFeature_StripsRawAPIKeyAndSiteEnvVars(t *testing.T) {
+	dda := testutils.NewDatadogAgentBuilder().
+		WithOTelCollectorEnabled(true).
+		WithOTelCollectorConfig().
+		Build()
+
+	feat := buildOtelCollectorFeature(&feature.Options{})
+	feat.Configure(dda, &dda.Spec, dda.Status.RemoteConfigConfiguration)
+
+	// Simulate global.go's credentialResource having already run pod-wide.
+	seededEnv := []corev1.EnvVar{
+		{Name: constants.DDAPIKey, Value: "ENC[vault://secret/path]"},
+		{Name: constants.DDSite, Value: "datadoghq.com"},
+	}
+	newPTS := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: string(apicommon.CoreAgentContainerName),
+					Env:  append([]corev1.EnvVar{}, seededEnv...),
+				},
+				{
+					Name: string(apicommon.OtelAgent),
+					Env:  append([]corev1.EnvVar{}, seededEnv...),
+				},
+			},
+		},
+	}
+	tplManager := fake.NewPodTemplateManagers(t, newPTS)
+
+	err := feat.ManageNodeAgent(tplManager)
+	assert.NoError(t, err)
+
+	for _, container := range tplManager.PodTemplateSpec().Spec.Containers {
+		envNames := make(map[string]bool, len(container.Env))
+		for _, e := range container.Env {
+			envNames[e.Name] = true
+		}
+		switch container.Name {
+		case string(apicommon.OtelAgent):
+			assert.False(t, envNames[constants.DDAPIKey], "otel-agent container should not keep a raw DD_API_KEY")
+			assert.False(t, envNames[constants.DDSite], "otel-agent container should not keep a raw DD_SITE")
+		case string(apicommon.CoreAgentContainerName):
+			assert.True(t, envNames[constants.DDAPIKey], "core agent container should keep DD_API_KEY")
+			assert.True(t, envNames[constants.DDSite], "core agent container should keep DD_SITE")
+		}
+	}
 }
 
 func TestApplyOTelCollectorDDASharedDependencies(t *testing.T) {


### PR DESCRIPTION
### ⚠️ Needs operator-team sign-off before merging

This changes pod spec behavior for **all sidecar-mode otel-agent users**. Opening as a draft
specifically to get eyes on the risk called out below before this is considered mergeable — please
do not merge without explicit sign-off from the operator team.

### What does this PR do?

Stops injecting the raw `DD_API_KEY`/`DD_SITE` environment variables into the `otel-agent`
container when running in sidecar (node agent) mode. `ManageNodeAgent` now strips them from the
`otel-agent` container's env right after the IPC env vars are set, leaving the `agent` container
untouched.

Standalone Gateway mode (`ManageOtelAgentGateway`) is intentionally **not** changed — it has no core
agent to sync from, config sync is explicitly disabled there, and its default config relies on
`${env:DD_API_KEY}`/`${env:DD_SITE}` directly.

### Motivation

Found while investigating a production incident. `global.go`'s `credentialResource` sets
`DD_API_KEY`/`DD_SITE` on every container in `AllAgentContainers`, including `otel-agent`, as a
side effect of generic pod-wide credential wiring — otel-agent has no code path that actually reads
these env vars itself.

In sidecar mode, `otelcollector/feature.go` already unconditionally enables config sync for
otel-agent via `DD_AGENT_IPC_PORT`/`DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL` (see the comment a few
lines above this change), which mirrors the core agent's already-resolved `api_key`/`site` into
otel-agent's own config. That synced value is set at a higher config-source priority than a raw env
var, so the raw `DD_API_KEY`/`DD_SITE` on otel-agent is redundant in the common case.

It's actively harmful, though, when the secrets backend is in use: `DD_API_KEY` in the container env
can be an **unresolved** placeholder (e.g. `ENC[vault://...]`), because secrets resolution happens
inside the core agent's own config pipeline, not at the Kubernetes Secret level. otel-agent's
internal Datadog exporter/extension config (vendored from
`opentelemetry-collector-contrib/pkg/datadog/agentcomponents`) reads `DD_API_KEY` directly from the
process environment with no secrets-resolution step of its own — so it can end up sending the
literal, unresolved placeholder string as its API key on every outgoing request to the Datadog
backend, causing persistent 403s. (A related fix for how that vendored config resolves precedence
is up at open-telemetry/opentelemetry-collector-contrib#49957 — that fix prevents env vars in
general from clobbering an explicitly-configured value, but this PR removes the specific env vars
that can carry an unresolved secret in the first place.)

### Known risk / why this needs sign-off

Any user with a custom `Features.OtelCollector.Conf` that references `${env:DD_API_KEY}` or
`${env:DD_SITE}` directly (bypassing the `dd-autoconfigured` extension) in sidecar mode will have
those substitutions start failing once this env var is removed. We don't have visibility into how
common that customization is.

### Describe your test plan

Added `TestOtelCollectorFeature_StripsRawAPIKeyAndSiteEnvVars`, which seeds both the `agent` and
`otel-agent` containers with `DD_API_KEY`/`DD_SITE` (simulating `credentialResource` having already
run) and asserts `ManageNodeAgent` strips them from `otel-agent` only. Confirmed the test fails
without the fix and passes with it. Full package test suite passes:

```
go test ./internal/controller/datadogagent/feature/otelcollector/...
```

### Minimum Agent Versions

No agent-side change required; this only affects the operator's generated pod spec.