### PR TITLE
Don't advance LastForceSyncTime on failed force-sync attempts

### DIFF
--- a/internal/controller/datadoggenericresource/controller.go
+++ b/internal/controller/datadoggenericresource/controller.go
@@ -159,10 +159,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogGe
 				if strings.Contains(err.Error(), ctrutils.NotFoundString) {
 					shouldCreate = true
 				}
+				// Do not advance LastForceSyncTime here: leaving it stale lets the next
+				// reconcile retry the force sync instead of waiting out a full forceSyncPeriod.
+				// create()/update() advance it themselves once the sync actually succeeds.
 			} else {
 				shouldUpdate = true
 			}
-			status.LastForceSyncTime = &now
 		} else if instance.Status.StateLastUpdateTime == nil || ((r.requeuePeriod - now.Sub(instance.Status.StateLastUpdateTime.Time)) <= 0) {
 			// Idle tick: refresh Datadog-side state for resource types that expose it.
 			// No-op for resource types without live state.

--- a/internal/controller/datadoggenericresource/controller_test.go
+++ b/internal/controller/datadoggenericresource/controller_test.go
@@ -548,6 +548,83 @@ func TestReconcileGenericResource_ForceSyncPeriodTriggersRemoteUpdate(t *testing
 	assert.Equal(t, 1, mockUpdateCalls)
 }
 
+func TestReconcileGenericResource_ForceSyncFailureDoesNotDeferRetry(t *testing.T) {
+	resetMockHandlerState()
+	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+	t.Setenv(ddGenericResourceForceSyncPeriodEnvVar, "1")
+
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "TestReconcileGenericResource_ForceSyncFailureDoesNotDeferRetry"})
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	logger := logf.Log.WithName("force-sync-failure-test")
+
+	s := scheme.Scheme
+	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogGenericResource{})
+
+	r := NewReconciler(
+		fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogGenericResource{}).Build(),
+		config.NewCredentialManager(fake.NewClientBuilder().Build()),
+		s,
+		logger,
+		recorder,
+	)
+	r.handlers = map[datadoghqv1alpha1.SupportedResourcesType]ResourceHandler{
+		mockSubresource: &MockHandler{},
+	}
+
+	err := r.client.Create(context.TODO(), mockGenericResource())
+	assert.NoError(t, err)
+
+	req := newRequest(resourcesNamespace, resourcesName)
+
+	// Add finalizer, then create the Datadog resource.
+	_, err = reconcileRequest(r, context.TODO(), req)
+	assert.NoError(t, err)
+	_, err = reconcileRequest(r, context.TODO(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, mockCreateCalls)
+
+	obj := &datadoghqv1alpha1.DatadogGenericResource{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, obj)
+	assert.NoError(t, err)
+	obj.Status.LastForceSyncTime = ptr.To(metav1.NewTime(time.Now().Add(-2 * time.Minute)))
+	err = r.client.Status().Update(context.TODO(), obj)
+	assert.NoError(t, err)
+
+	// Read back the round-tripped (second-precision) value as our baseline, since
+	// metav1.Time truncates to seconds on serialization.
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, obj)
+	assert.NoError(t, err)
+	staleLastForceSyncTime := *obj.Status.LastForceSyncTime
+
+	// Simulate a transient failure (e.g. a Datadog API timeout) on the force-synced update.
+	mockUpdateErr = fmt.Errorf("504 Gateway Timeout: stream timeout")
+
+	result, err := reconcileRequest(r, context.TODO(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, mockGetCalls)
+	assert.Equal(t, 1, mockUpdateCalls)
+	assert.Equal(t, ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, result)
+
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, obj)
+	assert.NoError(t, err)
+	// LastForceSyncTime must not advance on failure: advancing it would make the
+	// controller wait out a full forceSyncPeriod before retrying, instead of
+	// retrying on the fast error-requeue cadence.
+	assert.True(t, obj.Status.LastForceSyncTime.Equal(&staleLastForceSyncTime), "LastForceSyncTime should not advance when the force-synced update fails")
+
+	// The next reconcile should retry the force sync immediately rather than
+	// waiting out the (already-elapsed, but now-irrelevant) forceSyncPeriod window.
+	mockUpdateErr = nil
+	result, err = reconcileRequest(r, context.TODO(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, mockGetCalls)
+	assert.Equal(t, 2, mockUpdateCalls)
+	assert.Equal(t, reconcile.Result{RequeueAfter: defaultRequeuePeriod}, result)
+}
+
 func newRequest(ns, name string) reconcile.Request {
 	return reconcile.Request{
 		NamespacedName: types.NamespacedName{


### PR DESCRIPTION
> [!NOTE]
> This description/PR is copied verbatim from https://github.com/DataDog/datadog-operator/pull/3310 for CI purposes but commit remains from original author

### What does this PR do?

status.LastForceSyncTime was stamped unconditionally as soon as a periodic force-sync was attempted, before the resulting create/update was known to succeed. On a failed sync (e.g. a transient 504 from the Datadog API), this made the controller wait out a full forceSyncPeriod (60m by default) before retrying, instead of retrying on the fast error-requeue cadence used everywhere else in this reconciler. create()/update() already stamp LastForceSyncTime themselves on success, so the redundant early stamp is simply removed.

### Motivation

We observed this in practice on DatadogGenericResource monitors that received 504s from Datadog; waiting an hour (or doing a manual edit to the jsonSpec) was our only workaround. We would prefer a retry like with other errors.

### Additional Notes

The research and authorship of the PR was done via Claude, but to the degree that I was able to familiarize myself with the codebase, I agree with its analysis.

This may affect resources other than DatadogGenericResource but we have fully migrated to DGR because the others are deprecated.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

No, this code structure has been there for a while.

### Describe your test plan

Automated test added, hard to reproduce in practice with real Dd api.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits