### PR TITLE
Remove redundant per-feature ConfigMap checksum annotations

### DIFF
--- a/internal/controller/datadogagent/feature/cspm/feature.go
+++ b/internal/controller/datadogagent/feature/cspm/feature.go
@@ -17,11 +17,9 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -52,10 +50,8 @@ type cspmFeature struct {
 	owner  metav1.Object
 	logger logr.Logger
 
-	customConfig                *v2alpha1.CustomConfig
-	configMapName               string
-	customConfigAnnotationKey   string
-	customConfigAnnotationValue string
+	customConfig  *v2alpha1.CustomConfig
+	configMapName string
 }
 
 // ID returns the ID of the Feature
@@ -82,14 +78,6 @@ func (f *cspmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgen
 
 		if cspmConfig.CustomBenchmarks != nil {
 			f.customConfig = cspmConfig.CustomBenchmarks
-			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
-			if err != nil {
-				f.logger.Error(err, "couldn't generate hash for cspm custom benchmarks config")
-			} else {
-				f.logger.V(2).Info("built cspm custom benchmarks from custom config", "hash", hash)
-			}
-			f.customConfigAnnotationValue = hash
-			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.CSPMIDType)
 		}
 		f.configMapName = constants.GetConfName(dda, f.customConfig, defaultCSPMConf)
 
@@ -153,12 +141,6 @@ func (f *cspmFeature) ManageDependencies(managers feature.ResourceManagers) erro
 		}
 
 		if cm != nil {
-			// Add md5 hash annotation for custom config
-			if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-				annotations := object.MergeAnnotationsLabels(f.logger, cm.GetAnnotations(), map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "*")
-				cm.SetAnnotations(annotations)
-			}
-
 			if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {
 				return err
 			}
@@ -177,10 +159,6 @@ func (f *cspmFeature) ManageClusterAgent(managers feature.PodTemplateManagers) e
 	if f.customConfig != nil {
 		var vol corev1.Volume
 		var volMount corev1.VolumeMount
-
-		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-			managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
-		}
 
 		if f.customConfig.ConfigMap != nil {
 			// Custom config is referenced via ConfigMap
@@ -262,10 +240,6 @@ func (f *cspmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) erro
 	if f.customConfig != nil {
 		var vol corev1.Volume
 		var volMount corev1.VolumeMount
-
-		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-			managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
-		}
 
 		if f.customConfig.ConfigMap != nil {
 			// Custom config is referenced via ConfigMap

--- a/internal/controller/datadogagent/feature/cspm/feature_test.go
+++ b/internal/controller/datadogagent/feature/cspm/feature_test.go
@@ -6,7 +6,6 @@
 package cspm
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -22,24 +21,10 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
-	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
-
-var customConfig = &v2alpha1.CustomConfig{
-	ConfigMap: &v2alpha1.ConfigMapConfig{
-		Name: "custom_test",
-		Items: []corev1.KeyToPath{
-			{
-				Key:  "key1",
-				Path: "some/path",
-			},
-		},
-	},
-}
 
 func Test_cspmFeature_Configure(t *testing.T) {
 	ddaCSPMDisabled := v2alpha1.DatadogAgent{
@@ -160,14 +145,8 @@ func cspmClusterAgentWantFunc() *test.ComponentTest {
 			volumes := mgr.VolumeMgr.Volumes
 			assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Cluster Agent volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 
-			// check annotations
-			hash, err := comparison.GenerateMD5ForSpec(customConfig)
-			assert.NoError(t, err)
-			wantAnnotations := map[string]string{
-				fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.CSPMIDType): hash,
-			}
 			annotations := mgr.AnnotationMgr.Annotations
-			assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+			assert.Empty(t, annotations)
 
 		},
 	)
@@ -311,14 +290,8 @@ func cspmAgentNodeWantFunc(runInSystemProbe bool) *test.ComponentTest {
 			volumes := mgr.VolumeMgr.Volumes
 			assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 
-			// check annotations
-			hash, err := comparison.GenerateMD5ForSpec(customConfig)
-			assert.NoError(t, err)
-			wantAnnotations := map[string]string{
-				fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.CSPMIDType): hash,
-			}
 			annotations := mgr.AnnotationMgr.Annotations
-			assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+			assert.Empty(t, annotations)
 		},
 	)
 }

--- a/internal/controller/datadogagent/feature/cws/feature.go
+++ b/internal/controller/datadogagent/feature/cws/feature.go
@@ -18,11 +18,9 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -55,10 +53,8 @@ type cwsFeature struct {
 	owner  metav1.Object
 	logger logr.Logger
 
-	customConfig                *v2alpha1.CustomConfig
-	configMapName               string
-	customConfigAnnotationKey   string
-	customConfigAnnotationValue string
+	customConfig  *v2alpha1.CustomConfig
+	configMapName string
 }
 
 // ID returns the ID of the Feature
@@ -81,14 +77,6 @@ func (f *cwsFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 
 		if cwsConfig.CustomPolicies != nil {
 			f.customConfig = cwsConfig.CustomPolicies
-			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
-			if err != nil {
-				f.logger.Error(err, "couldn't generate hash for cws custom policies config")
-			} else {
-				f.logger.V(2).Info("built cws custom policies from custom config", "hash", hash)
-			}
-			f.customConfigAnnotationValue = hash
-			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.CWSIDType)
 		}
 		f.configMapName = constants.GetConfName(dda, f.customConfig, defaultCWSConf)
 
@@ -160,12 +148,6 @@ func (f *cwsFeature) ManageDependencies(managers feature.ResourceManagers) error
 		}
 
 		if cm != nil {
-			// Add md5 hash annotation for custom config
-			if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-				annotations := object.MergeAnnotationsLabels(f.logger, cm.GetAnnotations(), map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "*")
-				cm.SetAnnotations(annotations)
-			}
-
 			if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {
 				return err
 			}
@@ -343,10 +325,6 @@ func (f *cwsFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	if f.customConfig != nil {
 		var vol corev1.Volume
 		var volMount corev1.VolumeMount
-
-		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-			managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
-		}
 
 		if f.customConfig.ConfigMap != nil {
 			// Custom config is referenced via ConfigMap

--- a/internal/controller/datadogagent/feature/cws/feature_test.go
+++ b/internal/controller/datadogagent/feature/cws/feature_test.go
@@ -6,15 +6,12 @@
 package cws
 
 import (
-	"fmt"
 	"testing"
 
 	"k8s.io/utils/ptr"
 
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/agent"
-	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	corev1 "k8s.io/api/core/v1"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -365,22 +362,8 @@ func cwsAgentNodeWantFunc(withSubFeatures bool, directSendFromSysProbe bool, enf
 			assert.True(t, apiutils.IsEqualStruct(volumes, wantVolumes), "Volumes \ndiff = %s", cmp.Diff(volumes, wantVolumes))
 
 			// check annotations
-			customConfig := &v2alpha1.CustomConfig{
-				ConfigMap: &v2alpha1.ConfigMapConfig{
-					Name: "custom_test",
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "key1",
-							Path: "some/path",
-						},
-					},
-				},
-			}
-			hash, err := comparison.GenerateMD5ForSpec(customConfig)
-			assert.NoError(t, err)
 			wantAnnotations := map[string]string{
-				fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.CWSIDType): hash,
-				common.SystemProbeAppArmorAnnotationKey:                            common.SystemProbeAppArmorAnnotationValue,
+				common.SystemProbeAppArmorAnnotationKey: common.SystemProbeAppArmorAnnotationValue,
 			}
 			annotations := mgr.AnnotationMgr.Annotations
 			assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))

--- a/internal/controller/datadogagent/feature/eventcollection/feature.go
+++ b/internal/controller/datadogagent/feature/eventcollection/feature.go
@@ -17,11 +17,9 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	common "github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/secrets"
 )
@@ -51,9 +49,6 @@ type eventCollectionFeature struct {
 	configMapName      string
 	unbundleEvents     bool
 	unbundleEventTypes []v2alpha1.EventTypes
-
-	cmAnnotationKey   string
-	cmAnnotationValue string
 
 	logger logr.Logger
 }
@@ -122,18 +117,6 @@ func (f *eventCollectionFeature) ManageDependencies(managers feature.ResourceMan
 			return err
 		}
 
-		// Add md5 hash annotation for configMap
-		f.cmAnnotationKey = object.GetChecksumAnnotationKey(feature.KubernetesAPIServerIDType)
-		f.cmAnnotationValue, err = comparison.GenerateMD5ForSpec(cm.Data)
-		if err != nil {
-			return err
-		}
-
-		if f.cmAnnotationKey != "" && f.cmAnnotationValue != "" {
-			annotations := object.MergeAnnotationsLabels(f.logger, cm.Annotations, map[string]string{f.cmAnnotationKey: f.cmAnnotationValue}, "*")
-			cm.SetAnnotations(annotations)
-		}
-
 		if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {
 			return err
 		}
@@ -177,11 +160,6 @@ func (f *eventCollectionFeature) ManageClusterAgent(managers feature.PodTemplate
 
 		managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.ClusterAgentContainerName)
 		managers.Volume().AddVolume(&vol)
-
-		// Add md5 hash annotation for configMap
-		if f.cmAnnotationKey != "" && f.cmAnnotationValue != "" {
-			managers.Annotation().AddAnnotation(f.cmAnnotationKey, f.cmAnnotationValue)
-		}
 	}
 
 	return nil

--- a/internal/controller/datadogagent/feature/helmcheck/feature.go
+++ b/internal/controller/datadogagent/feature/helmcheck/feature.go
@@ -17,10 +17,8 @@ import (
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -50,11 +48,9 @@ type helmCheckFeature struct {
 	serviceAccountName string
 	rbacSuffix         string
 
-	owner                 metav1.Object
-	config                *corev1.ConfigMap
-	configMapName         string
-	configAnnotationKey   string
-	configAnnotationValue string
+	owner         metav1.Object
+	config        *corev1.ConfigMap
+	configMapName string
 
 	logger logr.Logger
 }
@@ -94,17 +90,6 @@ func (f *helmCheckFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 			f.logger.Error(err, "couldn't generate configMap for helm check")
 		}
 		f.config = cm
-
-		// Create hash based on configMap.
-		hash, err := comparison.GenerateMD5ForSpec(cm.Data)
-		if err != nil {
-			f.logger.Error(err, "couldn't generate hash for helm check config")
-		} else {
-			f.logger.V(2).Info("built helm check from config", "hash", hash)
-		}
-
-		f.configAnnotationValue = hash
-		f.configAnnotationKey = object.GetChecksumAnnotationKey(feature.HelmCheckIDType)
 	}
 
 	return reqComp
@@ -114,11 +99,6 @@ func (f *helmCheckFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.Datado
 // Feature's dependencies should be added in the store.
 func (f *helmCheckFeature) ManageDependencies(managers feature.ResourceManagers) error {
 	if f.config != nil {
-		// Add md5 hash annotation for configMap
-		if f.configAnnotationKey != "" && f.configAnnotationValue != "" {
-			annotations := object.MergeAnnotationsLabels(f.logger, f.config.GetAnnotations(), map[string]string{f.configAnnotationKey: f.configAnnotationValue}, "*")
-			f.config.SetAnnotations(annotations)
-		}
 		if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, f.config); err != nil {
 			return err
 		}
@@ -146,11 +126,6 @@ func (f *helmCheckFeature) ManageClusterAgent(managers feature.PodTemplateManage
 
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.ClusterAgentContainerName)
 	managers.Volume().AddVolume(&vol)
-
-	// Add md5 hash annotation for configMap
-	if f.configAnnotationKey != "" && f.configAnnotationValue != "" {
-		managers.Annotation().AddAnnotation(f.configAnnotationKey, f.configAnnotationValue)
-	}
 
 	return nil
 }

--- a/internal/controller/datadogagent/feature/helmcheck/feature_test.go
+++ b/internal/controller/datadogagent/feature/helmcheck/feature_test.go
@@ -7,7 +7,6 @@ package helmcheck
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -23,8 +22,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
-	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 )
@@ -52,7 +49,7 @@ func Test_helmCheckFeature_Configure(t *testing.T) {
 				Build(),
 			WantConfigure:        true,
 			WantDependenciesFunc: helmCheckWantDepsFunc(false, true, valuesAsTags, "dca"),
-			ClusterAgent:         helmCheckWantResourcesFunc(false, true),
+			ClusterAgent:         helmCheckWantResourcesFunc(),
 		},
 		{
 			Name: "Helm check enabled and runs on cluster checks runner",
@@ -65,7 +62,7 @@ func Test_helmCheckFeature_Configure(t *testing.T) {
 				Build(),
 			WantConfigure:        true,
 			WantDependenciesFunc: helmCheckWantDepsFunc(true, true, valuesAsTags, "ccr"),
-			ClusterAgent:         helmCheckWantResourcesFunc(true, true),
+			ClusterAgent:         helmCheckWantResourcesFunc(),
 		},
 	}
 
@@ -134,7 +131,7 @@ func helmCheckWantDepsFunc(ccr bool, collectEvents bool, valuesAsTags map[string
 	}
 }
 
-func helmCheckWantResourcesFunc(ccr bool, collectEvents bool) *test.ComponentTest {
+func helmCheckWantResourcesFunc() *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -178,27 +175,7 @@ func helmCheckWantResourcesFunc(ccr bool, collectEvents bool) *test.ComponentTes
 				"DCA VolumeMounts \ndiff = %s", cmp.Diff(dcaVolMounts, expectedVolMounts),
 			)
 
-			// Validate configMap annotations
-			config := map[string]string{
-				"helm.yaml": fmt.Sprintf(`---
-cluster_check: %s
-init_config:
-instances:
-  - collect_events: %s
-    helm_values_as_tags:
-      foo: bar
-      zip: zap
-`, strconv.FormatBool(ccr), strconv.FormatBool(collectEvents)),
-			}
-
-			hash, err := comparison.GenerateMD5ForSpec(config)
-			assert.NoError(t, err)
-
-			wantAnnotations := map[string]string{
-				fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.HelmCheckIDType): hash,
-			}
-
 			annotations := mgr.AnnotationMgr.Annotations
-			assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+			assert.Empty(t, annotations)
 		})
 }

--- a/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
+++ b/internal/controller/datadogagent/feature/kubernetesstatecore/feature.go
@@ -19,10 +19,8 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/utils"
 )
@@ -57,11 +55,9 @@ type ksmFeature struct {
 	rbacSuffix         string
 	serviceAccountName string
 
-	owner                       metav1.Object
-	customConfig                *v2alpha1.CustomConfig
-	configConfigMapName         string
-	customConfigAnnotationKey   string
-	customConfigAnnotationValue string
+	owner               metav1.Object
+	customConfig        *v2alpha1.CustomConfig
+	configConfigMapName string
 
 	logger logr.Logger
 }
@@ -148,31 +144,6 @@ func (f *ksmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 
 		if ddaSpec.Features.KubeStateMetricsCore.Conf != nil {
 			f.customConfig = ddaSpec.Features.KubeStateMetricsCore.Conf
-			hash, err := comparison.GenerateMD5ForSpec(f.customConfig)
-			if err != nil {
-				f.logger.Error(err, "couldn't generate hash for ksm core custom config")
-			} else {
-				f.logger.V(2).Info("built ksm core from custom config", "hash", hash)
-			}
-			f.customConfigAnnotationValue = hash
-			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.KubernetesStateCoreIDType)
-		} else {
-			// Generate dynamic checksum for default configuration (based on user provided collectCrMetrics field and whether or not APIServices/CRD metrics are collected)
-			defaultConfigData := map[string]any{
-				"collect_crds":        f.collectCRDMetrics,
-				"collect_apiservices": f.collectAPIServiceMetrics,
-				"collect_cr_metrics":  f.collectCrMetrics,
-				"use_apiserver_cache": f.useApiServerCache,
-			}
-
-			hash, err := comparison.GenerateMD5ForSpec(defaultConfigData)
-			if err != nil {
-				f.logger.Error(err, "couldn't generate hash for default ksm core config")
-			} else {
-				f.logger.V(2).Info("generated default ksm core config hash", "hash", hash, "config", defaultConfigData)
-			}
-			f.customConfigAnnotationValue = hash
-			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.KubernetesStateCoreIDType)
 		}
 
 		f.configConfigMapName = constants.GetConfName(dda, f.customConfig, defaultKubeStateMetricsCoreConf)
@@ -209,11 +180,6 @@ func (f *ksmFeature) ManageDependencies(managers feature.ResourceManagers) error
 		return err
 	}
 	if configCM != nil {
-		// Add md5 hash annotation for custom config
-		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-			annotations := object.MergeAnnotationsLabels(f.logger, configCM.GetAnnotations(), map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "*")
-			configCM.SetAnnotations(annotations)
-		}
 		if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, configCM); err != nil {
 			return err
 		}
@@ -247,9 +213,6 @@ func (f *ksmFeature) ManageClusterAgent(managers feature.PodTemplateManagers) er
 			MountPath: fmt.Sprintf("%s%s/%s", common.ConfigVolumePath, common.ConfdVolumePath, ksmCoreCheckFolderName),
 			ReadOnly:  true,
 		}
-	}
-	if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-		managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
 	}
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.ClusterAgentContainerName)
 	managers.Volume().AddVolume(&vol)

--- a/internal/controller/datadogagent/feature/kubernetesstatecore/feature_test.go
+++ b/internal/controller/datadogagent/feature/kubernetesstatecore/feature_test.go
@@ -6,21 +6,15 @@
 package kubernetesstatecore
 
 import (
-	"fmt"
 	"testing"
 
-	"k8s.io/utils/ptr"
-
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
-	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 	mergerfake "github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger/fake"
-	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
 	"github.com/google/go-cmp/cmp"
@@ -59,7 +53,7 @@ func Test_ksmFeature_Configure(t *testing.T) {
 				WithKSMEnabled(true).
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  ksmClusterAgentWantFunc(false),
+			ClusterAgent:  ksmClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
 		},
 		{
@@ -69,7 +63,7 @@ func Test_ksmFeature_Configure(t *testing.T) {
 				WithSingleContainerStrategy(true).
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  ksmClusterAgentWantFunc(false),
+			ClusterAgent:  ksmClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentSingleAgentWantFunc),
 		},
 		{
@@ -79,7 +73,7 @@ func Test_ksmFeature_Configure(t *testing.T) {
 				WithKSMCustomConf(customData).
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  ksmClusterAgentWantFunc(true),
+			ClusterAgent:  ksmClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
 		},
 		{
@@ -90,7 +84,7 @@ func Test_ksmFeature_Configure(t *testing.T) {
 				WithSingleContainerStrategy(true).
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  ksmClusterAgentWantFunc(true),
+			ClusterAgent:  ksmClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentSingleAgentWantFunc),
 		},
 		{
@@ -100,7 +94,7 @@ func Test_ksmFeature_Configure(t *testing.T) {
 				WithClusterAgentImage("gcr.io/datadoghq/agent:7.72.0").
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  ksmClusterAgentWantFunc(false),
+			ClusterAgent:  ksmClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
 		},
 		{
@@ -110,7 +104,7 @@ func Test_ksmFeature_Configure(t *testing.T) {
 				WithClusterAgentImage("gcr.io/datadoghq/agent:7.71.0").
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  ksmClusterAgentWantFunc(false),
+			ClusterAgent:  ksmClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(ksmAgentNodeWantFunc),
 		},
 		{
@@ -154,7 +148,7 @@ func Test_ksmFeature_Configure(t *testing.T) {
 	tests.Run(t, buildKSMFeature)
 }
 
-func ksmClusterAgentWantFunc(hasCustomConfig bool) *test.ComponentTest {
+func ksmClusterAgentWantFunc() *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -172,33 +166,8 @@ func ksmClusterAgentWantFunc(hasCustomConfig bool) *test.ComponentTest {
 			}
 			assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, want), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, want))
 
-			if hasCustomConfig {
-				customConfig := v2alpha1.CustomConfig{
-					ConfigData: ptr.To(customData),
-				}
-				hash, err := comparison.GenerateMD5ForSpec(&customConfig)
-				assert.NoError(t, err)
-				wantAnnotations := map[string]string{
-					fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.KubernetesStateCoreIDType): hash,
-				}
-				annotations := mgr.AnnotationMgr.Annotations
-				assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
-			} else {
-				// Verify default config annotation - CRDs and APIServices collected, no custom resource metrics
-				defaultConfigData := map[string]any{
-					"collect_crds":        true,
-					"collect_apiservices": true,
-					"collect_cr_metrics":  nil,
-					"use_apiserver_cache": false,
-				}
-				hash, err := comparison.GenerateMD5ForSpec(defaultConfigData)
-				assert.NoError(t, err)
-				wantAnnotations := map[string]string{
-					fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.KubernetesStateCoreIDType): hash,
-				}
-				annotations := mgr.AnnotationMgr.Annotations
-				assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Default config annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
-			}
+			annotations := mgr.AnnotationMgr.Annotations
+			assert.Empty(t, annotations)
 		},
 	)
 }
@@ -207,19 +176,8 @@ func ksmClusterAgentApiServerCacheWantFunc() *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
-			defaultConfigData := map[string]any{
-				"collect_crds":        true,
-				"collect_apiservices": true,
-				"collect_cr_metrics":  nil,
-				"use_apiserver_cache": true,
-			}
-			hash, err := comparison.GenerateMD5ForSpec(defaultConfigData)
-			assert.NoError(t, err)
-			wantAnnotations := map[string]string{
-				fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.KubernetesStateCoreIDType): hash,
-			}
 			annotations := mgr.AnnotationMgr.Annotations
-			assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+			assert.Empty(t, annotations)
 		},
 	)
 }

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature.go
@@ -19,10 +19,8 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/utils"
 )
@@ -65,9 +63,7 @@ type orchestratorExplorerFeature struct {
 	customResources                   []string
 	configConfigMapName               string
 
-	logger                      logr.Logger
-	customConfigAnnotationKey   string
-	customConfigAnnotationValue string
+	logger logr.Logger
 
 	processAgentRequired bool
 }
@@ -95,17 +91,6 @@ func (f *orchestratorExplorerFeature) Configure(dda metav1.Object, ddaSpec *v2al
 
 		if orchestratorExplorer.Conf != nil || len(orchestratorExplorer.CustomResources) > 0 {
 			f.customConfig = orchestratorExplorer.Conf
-
-			// Used to force restart of DCA
-			// use entire orchestratorExplorer to handle custom config and CRDs
-			hash, err := comparison.GenerateMD5ForSpec(orchestratorExplorer)
-			if err != nil {
-				f.logger.Error(err, "couldn't generate hash for orchestrator explorer custom config")
-			} else {
-				f.logger.V(2).Info("built orchestrator explorer from custom config", "hash", hash)
-			}
-			f.customConfigAnnotationValue = hash
-			f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.OrchestratorExplorerIDType)
 		}
 
 		f.customResources = ddaSpec.Features.OrchestratorExplorer.CustomResources
@@ -195,11 +180,6 @@ func (f *orchestratorExplorerFeature) ManageDependencies(managers feature.Resour
 		return err
 	}
 	if configCM != nil {
-		// Add md5 hash annotation for custom config
-		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-			annotations := object.MergeAnnotationsLabels(f.logger, configCM.GetAnnotations(), map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "*")
-			configCM.SetAnnotations(annotations)
-		}
 		if err := managers.Store().AddOrUpdate(kubernetes.ConfigMapKind, configCM); err != nil {
 			return err
 		}
@@ -245,10 +225,6 @@ func (f *orchestratorExplorerFeature) ManageClusterAgent(managers feature.PodTem
 
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.ClusterAgentContainerName)
 	managers.Volume().AddVolume(&vol)
-
-	if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-		managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
-	}
 
 	for _, env := range f.getEnvVars() {
 		managers.EnvVar().AddEnvVar(env)

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
@@ -6,10 +6,7 @@
 package orchestratorexplorer
 
 import (
-	"fmt"
 	"testing"
-
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -19,8 +16,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
 	mergerfake "github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
-	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/testutils"
 
@@ -252,27 +247,8 @@ func orchestratorExplorerClusterAgentWantFuncV2() *test.ComponentTest {
 			dcaEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
 			assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, expectedOrchestratorEnvsV2), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, expectedOrchestratorEnvsV2))
 
-			// check annotation
-			customConfig := v2alpha1.CustomConfig{
-				ConfigData: ptr.To(customConfDataV2),
-			}
-			trueValue := true
-			url := "https://foo.bar"
-			orchExp := v2alpha1.OrchestratorExplorerFeatureConfig{
-				Enabled:         &trueValue,
-				Conf:            &customConfig,
-				ScrubContainers: &trueValue,
-				CustomResources: []string{},
-				ExtraTags:       []string{"a:z", "b:y", "c:x"},
-				DDUrl:           &url,
-			}
-			hash, err := comparison.GenerateMD5ForSpec(&orchExp)
-			assert.NoError(t, err)
-			wantAnnotations := map[string]string{
-				fmt.Sprintf(constants.MD5ChecksumAnnotationKey, feature.OrchestratorExplorerIDType): hash,
-			}
 			annotations := mgr.AnnotationMgr.Annotations
-			assert.True(t, apiutils.IsEqualStruct(annotations, wantAnnotations), "Annotations \ndiff = %s", cmp.Diff(annotations, wantAnnotations))
+			assert.Empty(t, annotations)
 		},
 	)
 }

--- a/internal/controller/datadogagent/feature/otelagentgateway/configmap_test.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/configmap_test.go
@@ -21,9 +21,6 @@ func Test_buildOtelAgentGatewayConfigMap(t *testing.T) {
 	configMapWant := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "-otel-agent-gateway-config",
-			Annotations: map[string]string{
-				"checksum/otel_agent_gateway-custom-config": "2fdb890243586329dc7af899ae02d5ca",
-			},
 		},
 		Data: map[string]string{
 			"otel-gateway-config.yaml": defaultconfig.DefaultOtelAgentGatewayConfig,

--- a/internal/controller/datadogagent/feature/otelagentgateway/feature.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature.go
@@ -21,11 +21,9 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/otelagentgateway/defaultconfig"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -37,15 +35,13 @@ func init() {
 }
 
 type otelAgentGatewayFeature struct {
-	owner                       metav1.Object
-	logger                      logr.Logger
-	ports                       []*corev1.ContainerPort
-	localServiceName            string
-	customConfig                *v2alpha1.CustomConfig
-	configMapName               string
-	customConfigAnnotationKey   string
-	customConfigAnnotationValue string
-	featureGates                *string
+	owner            metav1.Object
+	logger           logr.Logger
+	ports            []*corev1.ContainerPort
+	localServiceName string
+	customConfig     *v2alpha1.CustomConfig
+	configMapName    string
+	featureGates     *string
 }
 
 func buildOtelAgentGatewayFeature(options *feature.Options) feature.Feature {
@@ -109,18 +105,6 @@ func (f *otelAgentGatewayFeature) buildOTelAgentCoreConfigMap() (*corev1.ConfigM
 		cm, err := configmap.BuildConfigMapConfigData(f.owner.GetNamespace(), f.customConfig.ConfigData, f.configMapName, otelConfigFileName)
 		if err != nil {
 			return nil, err
-		}
-
-		// Add md5 hash annotation for configMap
-		f.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.OtelAgentGatewayIDType)
-		f.customConfigAnnotationValue, err = comparison.GenerateMD5ForSpec(f.customConfig.ConfigData)
-		if err != nil {
-			return cm, err
-		}
-
-		if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-			annotations := object.MergeAnnotationsLabels(f.logger, cm.Annotations, map[string]string{f.customConfigAnnotationKey: f.customConfigAnnotationValue}, "*")
-			cm.SetAnnotations(annotations)
 		}
 
 		return cm, nil
@@ -244,11 +228,6 @@ func (f *otelAgentGatewayFeature) ManageOtelAgentGateway(managers feature.PodTem
 		// - when no config is passed (we use DefaultOtelAgentGatewayConfig)
 		volMount := volume.GetVolumeMountWithSubPath(otelAgentVolumeName, common.ConfigVolumePath+"/"+otelConfigFileName, otelConfigFileName)
 		managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.OtelAgent)
-	}
-
-	// Add md5 hash annotation for configMap
-	if f.customConfigAnnotationKey != "" && f.customConfigAnnotationValue != "" {
-		managers.Annotation().AddAnnotation(f.customConfigAnnotationKey, f.customConfigAnnotationValue)
 	}
 
 	// Add ports

--- a/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
@@ -57,7 +57,7 @@ var (
 	}
 )
 
-var defaultAnnotations = map[string]string{"checksum/otel_agent_gateway-custom-config": "2fdb890243586329dc7af899ae02d5ca"}
+var defaultAnnotations = map[string]string{}
 
 func Test_otelAgentGatewayFeature_Configure(t *testing.T) {
 	tests := test.FeatureTestSuite{
@@ -156,7 +156,7 @@ func Test_otelAgentGatewayFeature_Configure(t *testing.T) {
 				grpcPort: 4444,
 				httpPort: 5555,
 			},
-				map[string]string{"checksum/otel_agent_gateway-custom-config": "a5f82f402ace53fe25e2680792fccb9f"},
+				map[string]string{},
 				defaultVolumeMounts,
 				defaultVolumes(defaultLocalObjectReferenceName),
 			),

--- a/internal/controller/datadogagent/feature/otelcollector/configmap_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/configmap_test.go
@@ -21,9 +21,6 @@ func Test_buildOtelCollectorConfigMap(t *testing.T) {
 	configMapWant := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "-otel-config",
-			Annotations: map[string]string{
-				"checksum/otel_agent-custom-config": "8e715f9526c27c6cd06ba9a9d8913451",
-			},
 		},
 		Data: map[string]string{
 			"otel-config.yaml": defaultconfig.DefaultOtelCollectorConfig,
@@ -53,9 +50,6 @@ func Test_buildOtelCollectorConfigMapWithGateway(t *testing.T) {
 	configMapWant := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ddaName + "-otel-config",
-			Annotations: map[string]string{
-				"checksum/otel_agent-custom-config": "9a9429a6e4d1662ef90e6e84b6416fa6",
-			},
 		},
 		Data: map[string]string{
 			"otel-config.yaml": gatewayConfig,

--- a/internal/controller/datadogagent/feature/otelcollector/feature.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature.go
@@ -19,11 +19,9 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/otelcollector/defaultconfig"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/utils"
@@ -67,9 +65,6 @@ type otelCollectorFeature struct {
 	configMapName   string
 	ports           []*corev1.ContainerPort
 	coreAgentConfig coreAgentConfig
-
-	customConfigAnnotationKey   string
-	customConfigAnnotationValue string
 
 	incompatibleImage bool
 
@@ -165,18 +160,6 @@ func (o *otelCollectorFeature) buildOTelAgentCoreConfigMap() (*corev1.ConfigMap,
 		cm, err := configmap.BuildConfigMapConfigData(o.owner.GetNamespace(), o.customConfig.ConfigData, o.configMapName, otelConfigFileName)
 		if err != nil {
 			return nil, err
-		}
-
-		// Add md5 hash annotation for configMap
-		o.customConfigAnnotationKey = object.GetChecksumAnnotationKey(feature.OtelAgentIDType)
-		o.customConfigAnnotationValue, err = comparison.GenerateMD5ForSpec(o.customConfig.ConfigData)
-		if err != nil {
-			return cm, err
-		}
-
-		if o.customConfigAnnotationKey != "" && o.customConfigAnnotationValue != "" {
-			annotations := object.MergeAnnotationsLabels(o.logger, cm.Annotations, map[string]string{o.customConfigAnnotationKey: o.customConfigAnnotationValue}, "*")
-			cm.SetAnnotations(annotations)
 		}
 
 		return cm, nil
@@ -372,11 +355,6 @@ func (o *otelCollectorFeature) ManageNodeAgent(managers feature.PodTemplateManag
 			}
 
 		}
-	}
-
-	// Add md5 hash annotation for configMap
-	if o.customConfigAnnotationKey != "" && o.customConfigAnnotationValue != "" {
-		managers.Annotation().AddAnnotation(o.customConfigAnnotationKey, o.customConfigAnnotationValue)
 	}
 
 	// add ports

--- a/internal/controller/datadogagent/feature/otelcollector/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelcollector/feature_test.go
@@ -110,7 +110,7 @@ var (
 	}
 )
 
-var defaultAnnotations = map[string]string{"checksum/otel_agent-custom-config": "8e715f9526c27c6cd06ba9a9d8913451"}
+var defaultAnnotations = map[string]string{}
 
 func Test_otelCollectorFeature_Configure(t *testing.T) {
 	tests := test.FeatureTestSuite{
@@ -211,7 +211,7 @@ func Test_otelCollectorFeature_Configure(t *testing.T) {
 				httpPort: 5555,
 			},
 				defaultExpectedEnvVars,
-				map[string]string{"checksum/otel_agent-custom-config": "1b4f73fd3576db6a939bbfe788cc1f80"},
+				map[string]string{},
 				defaultVolumeMounts,
 				defaultVolumes(defaultLocalObjectReferenceName),
 			),
@@ -250,7 +250,7 @@ func Test_otelCollectorFeature_Configure(t *testing.T) {
 						value:   "kubernetes",
 					},
 				},
-				map[string]string{"checksum/otel_agent-custom-config": "b4ea5ecc5c7901d3b48c58622379ecfb"},
+				map[string]string{},
 				defaultVolumeMounts,
 				defaultVolumes(defaultLocalObjectReferenceName),
 			),
@@ -292,7 +292,7 @@ func Test_otelCollectorFeature_Configure(t *testing.T) {
 						value:   "kubernetes",
 					},
 				},
-				map[string]string{"checksum/otel_agent-custom-config": "d9c73c9017a4fcb811da0e51f5044b3c"},
+				map[string]string{},
 				defaultVolumeMounts,
 				defaultVolumes(defaultLocalObjectReferenceName),
 			),

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -17,10 +17,8 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -124,19 +122,11 @@ func (f *privateActionRunnerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 func (f *privateActionRunnerFeature) ManageDependencies(managers feature.ResourceManagers) error {
 	// Handle Node Agent dependencies (ConfigMap for annotation-based config)
 	if f.nodeEnabled {
-		checksumKey, checksumValue, err := checksumAnnotation(f.nodeConfigData)
-		if err != nil {
-			return err
-		}
-
 		// Create ConfigMap with the config content (either from annotation or default)
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      f.getConfigMapName(),
 				Namespace: f.owner.GetNamespace(),
-				Annotations: map[string]string{
-					checksumKey: checksumValue,
-				},
 			},
 			Data: map[string]string{
 				privateActionRunnerFileName: f.nodeConfigData,
@@ -150,19 +140,11 @@ func (f *privateActionRunnerFeature) ManageDependencies(managers feature.Resourc
 
 	// Handle Cluster Agent dependencies (ConfigMap for config and RBAC for secret access)
 	if f.clusterConfig != nil && f.clusterConfig.Enabled {
-		checksumKey, checksumValue, err := checksumAnnotation(f.clusterConfigData)
-		if err != nil {
-			return err
-		}
-
 		// Create ConfigMap with the config content (either from annotation or default)
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      f.getClusterAgentConfigMapName(),
 				Namespace: f.owner.GetNamespace(),
-				Annotations: map[string]string{
-					checksumKey: checksumValue,
-				},
 			},
 			Data: map[string]string{
 				privateActionRunnerFileName: f.clusterConfigData,
@@ -254,13 +236,6 @@ func (f *privateActionRunnerFeature) ManageClusterAgent(managers feature.PodTemp
 		}
 	}
 
-	// Add checksum annotation to force pod restart on config changes
-	checksumKey, checksumValue, err := checksumAnnotation(f.clusterConfigData)
-	if err != nil {
-		return err
-	}
-	managers.Annotation().AddAnnotation(checksumKey, checksumValue)
-
 	return nil
 }
 
@@ -286,12 +261,6 @@ func (f *privateActionRunnerFeature) ManageNodeAgent(managers feature.PodTemplat
 		ReadOnly:  true,
 	}
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.PrivateActionRunnerContainerName)
-
-	checksumKey, checksumValue, err := checksumAnnotation(f.nodeConfigData)
-	if err != nil {
-		return err
-	}
-	managers.Annotation().AddAnnotation(checksumKey, checksumValue)
 
 	// procdir volume mount
 	procdirVol, procdirVolMount := volume.GetVolumes(common.ProcdirVolumeName, common.ProcdirHostPath, common.ProcdirMountPath, true)
@@ -333,12 +302,4 @@ func (f *privateActionRunnerFeature) ManageClusterChecksRunner(managers feature.
 func (f *privateActionRunnerFeature) ManageOtelAgentGateway(managers feature.PodTemplateManagers) error {
 	// Private Action Runner doesn't run in OTel Agent Gateway
 	return nil
-}
-
-func checksumAnnotation(configData string) (string, string, error) {
-	checksum, err := comparison.GenerateMD5ForSpec(configData)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to generate MD5 for Private Action Runner config: %w", err)
-	}
-	return object.GetChecksumAnnotationKey(feature.PrivateActionRunnerIDType), checksum, nil
 }

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -149,10 +148,7 @@ func Test_privateActionRunnerFeature_ManageNodeAgent(t *testing.T) {
 	capabilities := managers.SecurityContextMgr.CapabilitiesByC[apicommon.PrivateActionRunnerContainerName]
 	assert.Contains(t, capabilities, corev1.Capability("NET_RAW"))
 
-	// Verify hash
-	assert.NotEmpty(t, managers.AnnotationMgr.Annotations)
-	assert.NotEmpty(t, managers.AnnotationMgr.Annotations["checksum/private_action_runner-custom-config"])
-	assert.Equal(t, "7aca0ab8a2cb083533a5552c17a50aa3", managers.AnnotationMgr.Annotations["checksum/private_action_runner-custom-config"])
+	assert.Empty(t, managers.AnnotationMgr.Annotations)
 }
 
 // Test_privateActionRunnerFeature_ProfileDDAI_ConfigMapNames verifies that when PAR is
@@ -214,7 +210,6 @@ func Test_privateActionRunnerFeature_ConfigMapContent(t *testing.T) {
 		annotations     map[string]string
 		expectConfigMap bool
 		expectedYAML    string
-		expectedHash    string
 	}{
 		{
 			name: "feature disabled",
@@ -230,7 +225,6 @@ func Test_privateActionRunnerFeature_ConfigMapContent(t *testing.T) {
 			},
 			expectConfigMap: true,
 			expectedYAML:    defaultConfigData,
-			expectedHash:    "57aedff9cb18bcec9b12a3974ef6fc55",
 		},
 		{
 			name: "enabled with configdata - passes through directly",
@@ -252,7 +246,6 @@ func Test_privateActionRunnerFeature_ConfigMapContent(t *testing.T) {
     actions_allowlist:
         - com.datadoghq.script.testConnection
         - com.datadoghq.script.enrichScript`,
-			expectedHash: "76f45ac891d62eb42272bbe26f32fb7c",
 		},
 	}
 
@@ -300,10 +293,7 @@ func Test_privateActionRunnerFeature_ConfigMapContent(t *testing.T) {
 			// Verify content matches expected
 			assert.Equal(t, tt.expectedYAML, yamlContent, "ConfigMap content should match expected output")
 
-			// Verify hash
-			assert.NotEmpty(t, configMap.Annotations)
-			assert.NotEmpty(t, configMap.Annotations["checksum/private_action_runner-custom-config"])
-			assert.Equal(t, tt.expectedHash, configMap.Annotations["checksum/private_action_runner-custom-config"])
+			assert.Empty(t, configMap.Annotations)
 		})
 	}
 }
@@ -591,11 +581,7 @@ func Test_privateActionRunnerFeature_ManageClusterAgent_ConfigMap(t *testing.T) 
 			}
 			assert.True(t, containerFound, "Cluster agent container should be found")
 
-			// Verify checksum annotation was added
-			annotations := managers.AnnotationMgr.Annotations
-			checksumKey := object.GetChecksumAnnotationKey(feature.PrivateActionRunnerIDType)
-			_, foundAnnotation := annotations[checksumKey]
-			assert.True(t, foundAnnotation, "Checksum annotation should be present")
+			assert.Empty(t, managers.AnnotationMgr.Annotations)
 		})
 	}
 }

--- a/internal/controller/datadogagent/global/dependencies.go
+++ b/internal/controller/datadogagent/global/dependencies.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
@@ -78,7 +77,6 @@ func addComponentDependencies(logger logr.Logger, ddaMeta metav1.Object, ddaSpec
 		for _, containerName := range rc.Containers {
 			if containerName == apicommon.SystemProbeContainerName {
 				var seccompConfigData map[string]string
-				useCustomSeccompConfigData := false
 
 				if componentOverride, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok {
 					if spContainer, ok := componentOverride.Containers[apicommon.SystemProbeContainerName]; ok {
@@ -89,7 +87,6 @@ func addComponentDependencies(logger logr.Logger, ddaMeta metav1.Object, ddaSpec
 							seccompConfigData = map[string]string{
 								common.SystemProbeSeccompKey: *spContainer.SeccompConfig.CustomProfile.ConfigData,
 							}
-							useCustomSeccompConfigData = true
 						}
 					}
 				}
@@ -104,15 +101,6 @@ func addComponentDependencies(logger logr.Logger, ddaMeta metav1.Object, ddaSpec
 						ddaMeta.GetNamespace(),
 						seccompConfigData,
 					)
-
-					if err == nil && useSystemProbeCustomSeccomp(ddaSpec) && useCustomSeccompConfigData {
-						// Add checksum annotation to the configMap
-						if seccompCM, ok := manager.Store().Get(kubernetes.ConfigMapKind, ddaMeta.GetNamespace(), common.GetDefaultSeccompConfigMapName(ddaMeta)); ok {
-							configHash, _ := comparison.GenerateMD5ForSpec(seccompConfigData)
-							annotations := object.MergeAnnotationsLabels(logger, seccompCM.GetAnnotations(), map[string]string{object.GetChecksumAnnotationKey(common.SystemProbeSeccompKey): configHash}, "*")
-							seccompCM.SetAnnotations(annotations)
-						}
-					}
 					errs = append(errs, err)
 				}
 			}

--- a/internal/controller/datadogagent/global/fips.go
+++ b/internal/controller/datadogagent/global/fips.go
@@ -17,10 +17,8 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
@@ -81,16 +79,6 @@ func applyFIPSConfig(logger logr.Logger, manager feature.PodTemplateManagers, dd
 			SubPath:   FIPSProxyCustomConfigFileName,
 			ReadOnly:  true,
 		}
-		// Add md5 hash annotation to component for custom config
-		hash, err := comparison.GenerateMD5ForSpec(fipsConfig.CustomFIPSConfig)
-		if err != nil {
-			logger.Error(err, "couldn't generate hash for custom config", "filename", FIPSProxyCustomConfigFileName)
-		}
-		annotationKey := object.GetChecksumAnnotationKey(string(FIPSProxyCustomConfigFileName))
-		if annotationKey != "" && hash != "" {
-			manager.Annotation().AddAnnotation(annotationKey, hash)
-		}
-
 		// configMap takes priority over configData
 		if fipsConfig.CustomFIPSConfig.ConfigMap != nil {
 			vol = volume.GetVolumeFromConfigMap(
@@ -111,10 +99,6 @@ func applyFIPSConfig(logger logr.Logger, manager feature.PodTemplateManagers, dd
 			}
 
 			if cm != nil {
-				// Add custom config hash annotation to configMap
-				annotations := object.MergeAnnotationsLabels(logger, cm.GetAnnotations(), map[string]string{annotationKey: hash}, "*")
-				cm.SetAnnotations(annotations)
-
 				resourcesManager.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm)
 			}
 		}

--- a/internal/controller/datadogagent/override/container.go
+++ b/internal/controller/datadogagent/override/container.go
@@ -16,10 +16,8 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 )
 
 // Container use to override a corev1.Container with a v2alpha1.DatadogAgentGenericContainer.
@@ -221,13 +219,6 @@ func overrideSeccompProfile(containerName apicommon.AgentContainerName, manager 
 			// }
 		}
 
-		// Adds checksum annotation to DaemonSet when configData is used
-		if utils.UseCustomSeccompConfigData(override.SeccompConfig) {
-			annotationValue, _ := comparison.GenerateMD5ForSpec(map[string]string{
-				common.SystemProbeSeccompKey: *override.SeccompConfig.CustomProfile.ConfigData})
-			annotationKey := object.GetChecksumAnnotationKey(common.SystemProbeSeccompKey)
-			manager.Annotation().AddAnnotation(annotationKey, annotationValue)
-		}
 	}
 }
 

--- a/internal/controller/datadogagent/override/container_test.go
+++ b/internal/controller/datadogagent/override/container_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -1154,7 +1152,7 @@ func TestContainer(t *testing.T) {
 			},
 		},
 		{
-			name:          "seccomp inline ConfigData adds checksum annotation",
+			name:          "seccomp inline ConfigData has no checksum annotation",
 			containerName: apicommon.SystemProbeContainerName,
 			existingManager: func() *fake.PodTemplateManagers {
 				return fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
@@ -1171,10 +1169,7 @@ func TestContainer(t *testing.T) {
 				},
 			},
 			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers, _ string) {
-				annotationKey := object.GetChecksumAnnotationKey(string(common.SystemProbeSeccompKey))
-				expectedHash, _ := comparison.GenerateMD5ForSpec(map[string]string{
-					common.SystemProbeSeccompKey: "inline-seccomp-data"})
-				assert.Equal(t, expectedHash, manager.AnnotationMgr.Annotations[annotationKey])
+				assert.Empty(t, manager.AnnotationMgr.Annotations)
 			},
 		},
 		{
@@ -1206,9 +1201,7 @@ func TestContainer(t *testing.T) {
 					},
 				}
 				assert.Equal(t, expectedVolumes, manager.VolumeMgr.Volumes)
-				annotationKey := object.GetChecksumAnnotationKey(common.SystemProbeSeccompKey)
-				_, found := manager.AnnotationMgr.Annotations[annotationKey]
-				assert.False(t, found)
+				assert.Empty(t, manager.AnnotationMgr.Annotations)
 			},
 		},
 		{
@@ -1223,9 +1216,7 @@ func TestContainer(t *testing.T) {
 			},
 			override: v2alpha1.DatadogAgentGenericContainer{},
 			validateManager: func(t *testing.T, manager *fake.PodTemplateManagers, _ string) {
-				annotationKey := object.GetChecksumAnnotationKey(string(common.SystemProbeSeccompKey))
-				_, found := manager.AnnotationMgr.Annotations[annotationKey]
-				assert.False(t, found)
+				assert.Empty(t, manager.AnnotationMgr.Annotations)
 			},
 		},
 	}

--- a/internal/controller/datadogagent/override/dependencies.go
+++ b/internal/controller/datadogagent/override/dependencies.go
@@ -17,10 +17,8 @@ import (
 	componentdca "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusteragent"
 	componentccr "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusterchecksrunner"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/configmap"
 	"github.com/DataDog/datadog-operator/pkg/constants"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -36,15 +34,15 @@ func Dependencies(logger logr.Logger, manager feature.ResourceManagers, ddaMeta 
 		}
 
 		// Handle custom agent configurations (datadog.yaml, cluster-agent.yaml, etc.)
-		errs = append(errs, overrideCustomConfigs(logger, manager, override.CustomConfigurations, component, ddaMeta.GetName(), namespace)...)
+		errs = append(errs, overrideCustomConfigs(manager, override.CustomConfigurations, component, ddaMeta.GetName(), namespace)...)
 
 		// Handle custom check configurations
 		confdCMName := fmt.Sprintf(extraConfdConfigMapName, strings.ToLower((string(component))))
-		errs = append(errs, overrideExtraConfigs(logger, manager, override.ExtraConfd, namespace, confdCMName, true)...)
+		errs = append(errs, overrideExtraConfigs(manager, override.ExtraConfd, namespace, confdCMName, true)...)
 
 		// Handle custom check files
 		checksdCMName := fmt.Sprintf(extraChecksdConfigMapName, strings.ToLower((string(component))))
-		errs = append(errs, overrideExtraConfigs(logger, manager, override.ExtraChecksd, namespace, checksdCMName, false)...)
+		errs = append(errs, overrideExtraConfigs(manager, override.ExtraChecksd, namespace, checksdCMName, false)...)
 
 		errs = append(errs, overridePodDisruptionBudget(logger, manager, ddaMeta, ddaSpec, override.CreatePodDisruptionBudget, component)...)
 	}
@@ -97,7 +95,7 @@ func overrideRBAC(logger logr.Logger, manager feature.ResourceManagers, override
 	return errors.NewAggregate(errs)
 }
 
-func overrideCustomConfigs(logger logr.Logger, manager feature.ResourceManagers, customConfigMap map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig, componentName v2alpha1.ComponentName, ddaName, namespace string) (errs []error) {
+func overrideCustomConfigs(manager feature.ResourceManagers, customConfigMap map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig, componentName v2alpha1.ComponentName, ddaName, namespace string) (errs []error) {
 	for fileName, customConfig := range customConfigMap {
 		// Favor ConfigMap setting; if it is specified, then move on
 		if customConfig.ConfigMap != nil {
@@ -109,15 +107,6 @@ func overrideCustomConfigs(logger logr.Logger, manager feature.ResourceManagers,
 				errs = append(errs, err)
 			}
 
-			// Add md5 hash annotation for custom config
-			hash, err := comparison.GenerateMD5ForSpec(customConfig)
-			if err != nil {
-				logger.Error(err, "couldn't generate hash for custom config", "filename", fileName)
-			}
-			annotationKey := object.GetChecksumAnnotationKey(string(fileName))
-			annotations := object.MergeAnnotationsLabels(logger, cm.GetAnnotations(), map[string]string{annotationKey: hash}, "*")
-			cm.SetAnnotations(annotations)
-
 			if cm != nil {
 				if err := manager.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {
 					errs = append(errs, err)
@@ -128,21 +117,12 @@ func overrideCustomConfigs(logger logr.Logger, manager feature.ResourceManagers,
 	return errs
 }
 
-func overrideExtraConfigs(logger logr.Logger, manager feature.ResourceManagers, multiCustomConfig *v2alpha1.MultiCustomConfig, namespace, configMapName string, isYaml bool) (errs []error) {
+func overrideExtraConfigs(manager feature.ResourceManagers, multiCustomConfig *v2alpha1.MultiCustomConfig, namespace, configMapName string, isYaml bool) (errs []error) {
 	if multiCustomConfig != nil && multiCustomConfig.ConfigMap == nil && len(multiCustomConfig.ConfigDataMap) > 0 {
 		cm, err := configmap.BuildConfigMapMulti(namespace, multiCustomConfig.ConfigDataMap, configMapName, isYaml)
 		if err != nil {
 			errs = append(errs, err)
 		}
-
-		// Add md5 hash annotation for custom config
-		hash, err := comparison.GenerateMD5ForSpec(multiCustomConfig)
-		if err != nil {
-			logger.Error(err, "couldn't generate hash for extra custom config")
-		}
-		annotationKey := object.GetChecksumAnnotationKey(configMapName)
-		annotations := object.MergeAnnotationsLabels(logger, cm.GetAnnotations(), map[string]string{annotationKey: hash}, "*")
-		cm.SetAnnotations(annotations)
 
 		if cm != nil {
 			if err := manager.Store().AddOrUpdate(kubernetes.ConfigMapKind, cm); err != nil {

--- a/internal/controller/datadogagent/override/podtemplatespec.go
+++ b/internal/controller/datadogagent/override/podtemplatespec.go
@@ -19,9 +19,7 @@ import (
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
-	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
-	"github.com/DataDog/datadog-operator/pkg/controller/utils/comparison"
 	"github.com/DataDog/datadog-operator/pkg/images"
 )
 
@@ -121,7 +119,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 	}
 
 	// Override agent configurations such as datadog.yaml, system-probe.yaml, etc.
-	overrideCustomConfigVolumes(logger, manager, override.CustomConfigurations, componentName, ddaName)
+	overrideCustomConfigVolumes(manager, override.CustomConfigurations, componentName, ddaName)
 
 	// For ExtraConfd and ExtraChecksd, the ConfigMap contents to an init container. This allows use of
 	// the workaround to merge existing config and check files with custom ones. The VolumeMount is already
@@ -131,16 +129,6 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		cmName := fmt.Sprintf(extraConfdConfigMapName, strings.ToLower((string(componentName))))
 		vol := volume.GetVolumeFromMultiCustomConfig(override.ExtraConfd, common.ConfdVolumeName, cmName)
 		manager.Volume().AddVolume(&vol)
-
-		// Add md5 hash annotation for custom config
-		hash, err := comparison.GenerateMD5ForSpec(override.ExtraConfd)
-		if err != nil {
-			logger.Error(err, "couldn't generate hash for extra confd custom config")
-		} else {
-			logger.V(2).Info("built extra confd from custom config", "hash", hash)
-		}
-		annotationKey := object.GetChecksumAnnotationKey(cmName)
-		manager.Annotation().AddAnnotation(annotationKey, hash)
 	}
 
 	// If both ConfigMap and ConfigData exist, ConfigMap has higher priority.
@@ -148,16 +136,6 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 		cmName := fmt.Sprintf(extraChecksdConfigMapName, strings.ToLower((string(componentName))))
 		vol := volume.GetVolumeFromMultiCustomConfig(override.ExtraChecksd, common.ChecksdVolumeName, cmName)
 		manager.Volume().AddVolume(&vol)
-
-		// Add md5 hash annotation for custom config
-		hash, err := comparison.GenerateMD5ForSpec(override.ExtraChecksd)
-		if err != nil {
-			logger.Error(err, "couldn't generate hash for extra checksd custom config")
-		} else {
-			logger.V(2).Info("built extra checksd from custom config", "hash", hash)
-		}
-		annotationKey := object.GetChecksumAnnotationKey(cmName)
-		manager.Annotation().AddAnnotation(annotationKey, hash)
 	}
 
 	for agentContainerName, containerOverride := range override.Containers {
@@ -228,7 +206,7 @@ func PodTemplateSpec(logger logr.Logger, manager feature.PodTemplateManagers, ov
 	manager.PodTemplateSpec().Spec.TopologySpreadConstraints = append(manager.PodTemplateSpec().Spec.TopologySpreadConstraints, override.TopologySpreadConstraints...)
 }
 
-func overrideCustomConfigVolumes(logger logr.Logger, manager feature.PodTemplateManagers, customConfs map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig, componentName v2alpha1.ComponentName, ddaName string) {
+func overrideCustomConfigVolumes(manager feature.PodTemplateManagers, customConfs map[v2alpha1.AgentConfigFileName]v2alpha1.CustomConfig, componentName v2alpha1.ComponentName, ddaName string) {
 	sortedKeys := sortKeys(customConfs)
 	for _, fileName := range sortedKeys {
 		customConfig := customConfs[fileName]
@@ -260,16 +238,6 @@ func overrideCustomConfigVolumes(logger logr.Logger, manager feature.PodTemplate
 			)
 			manager.VolumeMount().AddVolumeMount(&volumeMount)
 		}
-
-		// Add md5 hash annotation for custom config
-		hash, err := comparison.GenerateMD5ForSpec(customConfig)
-		if err != nil {
-			logger.Error(err, "couldn't generate hash for custom config", "filename", fileName)
-		} else {
-			logger.V(2).Info("built file from custom config", "filename", fileName, "hash", hash)
-		}
-		annotationKey := object.GetChecksumAnnotationKey(string(fileName))
-		manager.Annotation().AddAnnotation(annotationKey, hash)
 	}
 }
 

--- a/internal/controller/testutils/renderer/renderer.go
+++ b/internal/controller/testutils/renderer/renderer.go
@@ -228,7 +228,8 @@ func Render(opts Options) ([]client.Object, *runtime.Scheme, error) {
 	}
 
 	ddaiOpts := datadogagentinternal.ReconcilerOptions{
-		SupportCilium: opts.SupportCilium,
+		SupportCilium:                   opts.SupportCilium,
+		RolloutOnConfigMapChangeEnabled: true,
 	}
 	ddaiReconciler := datadogagentinternal.NewReconciler(ddaiOpts, fakeClient, platformInfo, scheme, recorder, noopForwarder{})
 

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -961,8 +961,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1329,7 +1327,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 1b432aa517965949bdc4b6a3048ed626
+    agent.datadoghq.com/agentspechash: 688c72983fcbb751ef471ef10a1f32d9
   labels:
     agent.datadoghq.com/component: agent
     agent.datadoghq.com/name: datadog-agent
@@ -1355,6 +1353,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1910,7 +1909,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 5fdc2283d407ca7a0747a1c5852e0c97
+    agent.datadoghq.com/agentspechash: 09f5e1af85f4e02545bdc53dbea3c4dc
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1938,9 +1937,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 4bb0ce42b5c97687
         checksum/cluster_checks-custom-config: dd67482b385a64075d38f42c9ae04554
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent
@@ -2168,7 +2167,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 796858400c16bcf92c5b81a3a03388e0
+    agent.datadoghq.com/agentspechash: 9f9cc18615463016b51e37676cc4b72a
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2195,6 +2194,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 6281aebca1be6a93
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
       labels:
         agent.datadoghq.com/component: cluster-checks-runner

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -971,8 +971,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1340,7 +1338,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 40f352e6a33aa574cad33bbbb260b69f
+    agent.datadoghq.com/agentspechash: 3d559495a5d61788e11fc24c7cc24829
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1368,6 +1366,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1883,7 +1882,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: db0adca8a42b3c8f026d678026996ccd
+    agent.datadoghq.com/agentspechash: 8a31a7295887debaf6b7dcd2b916b306
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1911,9 +1910,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 4bb0ce42b5c97687
         checksum/cluster_checks-custom-config: dd67482b385a64075d38f42c9ae04554
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent
@@ -2133,7 +2132,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 787a0c5a069bf277220d16eb69031348
+    agent.datadoghq.com/agentspechash: 9bb3d4e42d99fde0ef482717a4d139d7
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2160,6 +2159,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 6281aebca1be6a93
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
       labels:
         agent.datadoghq.com/component: cluster-checks-runner

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -961,8 +961,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1328,7 +1326,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 1b432aa517965949bdc4b6a3048ed626
+    agent.datadoghq.com/agentspechash: 688c72983fcbb751ef471ef10a1f32d9
   labels:
     agent.datadoghq.com/component: agent
     agent.datadoghq.com/name: datadog-agent
@@ -1354,6 +1352,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1909,7 +1908,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 0f13eccae0579833f12952a73bb95477
+    agent.datadoghq.com/agentspechash: fd950d2f8911d79cd148f6229fd41897
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1937,9 +1936,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 4bb0ce42b5c97687
         checksum/cluster_checks-custom-config: dd67482b385a64075d38f42c9ae04554
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent
@@ -2165,7 +2164,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 796858400c16bcf92c5b81a3a03388e0
+    agent.datadoghq.com/agentspechash: 9f9cc18615463016b51e37676cc4b72a
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2192,6 +2191,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 6281aebca1be6a93
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
       labels:
         agent.datadoghq.com/component: cluster-checks-runner

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -961,8 +961,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1329,7 +1327,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: c4dcfc54e3f9effd696cac3776787e94
+    agent.datadoghq.com/agentspechash: 1f3e60d7c221c0aa36af2bd31b48d3d6
   labels:
     agent.datadoghq.com/component: agent
     agent.datadoghq.com/name: datadog-agent
@@ -1355,6 +1353,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1931,7 +1930,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 0f13eccae0579833f12952a73bb95477
+    agent.datadoghq.com/agentspechash: fd950d2f8911d79cd148f6229fd41897
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1959,9 +1958,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 4bb0ce42b5c97687
         checksum/cluster_checks-custom-config: dd67482b385a64075d38f42c9ae04554
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent
@@ -2187,7 +2186,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 796858400c16bcf92c5b81a3a03388e0
+    agent.datadoghq.com/agentspechash: 9f9cc18615463016b51e37676cc4b72a
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2214,6 +2213,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 6281aebca1be6a93
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
       labels:
         agent.datadoghq.com/component: cluster-checks-runner

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -844,8 +844,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1203,7 +1201,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 129d6cb34d5eed88fe3c3a54d9df38ea
+    agent.datadoghq.com/agentspechash: a7ecd949579bc5e539f172707c537607
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1231,6 +1229,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1680,7 +1679,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 9043440171910cf2df3ebe993cf7d282
+    agent.datadoghq.com/agentspechash: 5b9923ebe7efa58afe1d48703603949c
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1708,9 +1707,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: f4da1a5e704c25db
         checksum/cluster_checks-custom-config: f7dc31a1080204b2a0f72ea0cc314033
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
@@ -834,8 +834,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1191,7 +1189,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: f49774ecd7160265babf011a50817808
+    agent.datadoghq.com/agentspechash: ce9a214dfda4e08df1d66d624dcd5b73
   labels:
     agent.datadoghq.com/component: agent
     agent.datadoghq.com/name: datadog-agent
@@ -1217,6 +1215,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1700,7 +1699,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: cb8ce58d52ddd7dbc0a4478ec21f890c
+    agent.datadoghq.com/agentspechash: 41473d90b0a13a8f221447ea0ba6e878
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1728,9 +1727,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: f4da1a5e704c25db
         checksum/cluster_checks-custom-config: f7dc31a1080204b2a0f72ea0cc314033
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -844,8 +844,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1220,7 +1218,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 472babab8fddeb061c4e62f705740ce5
+    agent.datadoghq.com/agentspechash: 46a80d21a4e52d3b5438144fe2bdda0e
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1248,6 +1246,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1710,7 +1709,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 9043440171910cf2df3ebe993cf7d282
+    agent.datadoghq.com/agentspechash: 5b9923ebe7efa58afe1d48703603949c
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1738,9 +1737,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: f4da1a5e704c25db
         checksum/cluster_checks-custom-config: f7dc31a1080204b2a0f72ea0cc314033
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
@@ -834,8 +834,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1208,7 +1206,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: ccab6f58305053bd239f376066b30adf
+    agent.datadoghq.com/agentspechash: ad92c61dd8522af1d39e4da21371e824
   labels:
     agent.datadoghq.com/component: agent
     agent.datadoghq.com/name: datadog-agent
@@ -1234,6 +1232,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
       labels:
@@ -1720,7 +1719,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: cb8ce58d52ddd7dbc0a4478ec21f890c
+    agent.datadoghq.com/agentspechash: 41473d90b0a13a8f221447ea0ba6e878
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1748,9 +1747,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: f4da1a5e704c25db
         checksum/cluster_checks-custom-config: f7dc31a1080204b2a0f72ea0cc314033
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -844,8 +844,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1219,7 +1217,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 0ee2c361b43a0e9063c7ba8ad6acf62d
+    agent.datadoghq.com/agentspechash: f3c1afb98f9d3ba167f0ef89f856ffb6
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1247,6 +1245,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/agent: unconfined
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
@@ -1753,7 +1752,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 9043440171910cf2df3ebe993cf7d282
+    agent.datadoghq.com/agentspechash: 5b9923ebe7efa58afe1d48703603949c
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1781,9 +1780,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: f4da1a5e704c25db
         checksum/cluster_checks-custom-config: f7dc31a1080204b2a0f72ea0cc314033
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
@@ -834,8 +834,6 @@ data:
         - customresourcedefinitions
 kind: ConfigMap
 metadata:
-  annotations:
-    checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
   labels:
     app.kubernetes.io/instance: datadog-agent
     app.kubernetes.io/managed-by: datadog-operator
@@ -1207,7 +1205,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 991a9023c2a9804566061b6bbb151821
+    agent.datadoghq.com/agentspechash: eb5fbc72880b4780e588136890df831c
   labels:
     agent.datadoghq.com/component: agent
     agent.datadoghq.com/name: datadog-agent
@@ -1233,6 +1231,7 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: 2e0fb9e7949d41a5
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
         container.apparmor.security.beta.kubernetes.io/agent: unconfined
         container.apparmor.security.beta.kubernetes.io/system-probe: unconfined
@@ -1848,7 +1847,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: b7df54572e178ff567c8cfd4f03a51ec
+    agent.datadoghq.com/agentspechash: 2dc2f35ed7b6ea6c9c37db3960096f81
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1876,9 +1875,9 @@ spec:
   template:
     metadata:
       annotations:
+        agent.datadoghq.com/configmapshash: f4da1a5e704c25db
         checksum/cluster_checks-custom-config: f7dc31a1080204b2a0f72ea0cc314033
         checksum/dca-token-custom-config: 3f6998966e6de63b16d45512e01ccc84
-        checksum/ksm-custom-config: 7078d4e77dfdf37ca618d148c6c7af2b
       labels:
         agent.datadoghq.com/component: cluster-agent
         agent.datadoghq.com/name: datadog-agent


### PR DESCRIPTION
### What does this PR do?

Removes the ad-hoc MD5 checksum annotations that several features and the generic override/global paths stamped onto ConfigMaps/pod templates to force a rollout on config change. #3294 now covers all configmap diffs to auto trigger rollouts.

### Motivation

Follow-up to #3294. That PR added a generic, flag-gated mechanism (`rolloutOnConfigMapChangeEnabled`) that hashes every ConfigMap referenced by a pod template's volumes and stamps the result as an annotation, so Kubernetes' native pod-template diffing triggers a rollout on out-of-band ConfigMap content changes. This also covers the configmaps that the Operator itself creates/manages in the Agent stack so there's no need to double the hashing work.

### Describe your test plan

Using the golden test files we can see that the annotation is generated and added onto all the files as expected. Can test manually via:


`kubectl apply -f datadogagent-before.yaml`
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  features:
    kubeStateMetricsCore:
      enabled: true
      conf:
        configData: |
          init_config:
          instances:
              collectors:
              - pods
```

```
kubectl -n system get deployment datadog-cluster-agent -o json | jq -r '.spec.template.metadata.annotations["agent.datadoghq.com/configmapshash"]'
```

Then, `kubectl apply -f datadogagent-after.yaml` or `kubectl edit dd datadog`
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  features:
    kubeStateMetricsCore:
      enabled: true
      conf:
        configData: |
          init_config:
          instances:
              collectors:
              - deployments
```
Check to see that the annotation on the deployment/pods has been updated:
```
kubectl -n system get deployment datadog-cluster-agent -o json | jq -r '.spec.template.metadata.annotations["agent.datadoghq.com/configmapshash"]'
```
and you should see a new rollout of the underlying pods.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)