### PR TITLE
Support remote-config updates for OtelAgentGateway (DDOT cluster)

### DIFF
--- a/internal/controller/datadogagent/feature/otelagentgateway/feature.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature.go
@@ -57,7 +57,10 @@ func (f *otelAgentGatewayFeature) ID() feature.IDType {
 	return feature.OtelAgentGatewayIDType
 }
 
-func (f *otelAgentGatewayFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, _ *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
+func (f *otelAgentGatewayFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgentSpec, ddaRCStatus *v2alpha1.RemoteConfigConfiguration) (reqComp feature.RequiredComponents) {
+	// Merge configuration from Status.RemoteConfigConfiguration into the Spec
+	mergeConfigs(ddaSpec, ddaRCStatus)
+
 	if ddaSpec.Features.OtelAgentGateway == nil || !apiutils.BoolValue(ddaSpec.Features.OtelAgentGateway.Enabled) {
 		return reqComp
 	}
@@ -98,6 +101,22 @@ func (f *otelAgentGatewayFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1
 	f.featureGates = ddaSpec.Features.OtelAgentGateway.FeatureGates
 
 	return reqComp
+}
+
+func mergeConfigs(ddaSpec *v2alpha1.DatadogAgentSpec, ddaRCStatus *v2alpha1.RemoteConfigConfiguration) {
+	if ddaRCStatus == nil || ddaRCStatus.Features == nil || ddaRCStatus.Features.OtelAgentGateway == nil || ddaRCStatus.Features.OtelAgentGateway.Enabled == nil {
+		return
+	}
+
+	if ddaSpec.Features == nil {
+		ddaSpec.Features = &v2alpha1.DatadogFeatures{}
+	}
+
+	if ddaSpec.Features.OtelAgentGateway == nil {
+		ddaSpec.Features.OtelAgentGateway = &v2alpha1.OtelAgentGatewayFeatureConfig{}
+	}
+
+	ddaSpec.Features.OtelAgentGateway.Enabled = ddaRCStatus.Features.OtelAgentGateway.Enabled
 }
 
 func (f *otelAgentGatewayFeature) buildOTelAgentCoreConfigMap() (*corev1.ConfigMap, error) {

--- a/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
+++ b/internal/controller/datadogagent/feature/otelagentgateway/feature_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
@@ -196,6 +197,25 @@ func Test_otelAgentGatewayFeature_Configure(t *testing.T) {
 				defaultVolumeMounts,
 				defaultVolumes(defaultLocalObjectReferenceName),
 			),
+		},
+		{
+			Name: "otel agent gateway enabled via remote config",
+			DDA: func() *v2alpha1.DatadogAgent {
+				dda := testutils.NewDatadogAgentBuilder().
+					WithOTelAgentGatewayEnabled(false).
+					Build()
+				dda.Status.RemoteConfigConfiguration = &v2alpha1.RemoteConfigConfiguration{
+					Features: &v2alpha1.DatadogFeatures{
+						OtelAgentGateway: &v2alpha1.OtelAgentGatewayFeatureConfig{
+							Enabled: ptr.To(true),
+						},
+					},
+				}
+				return dda
+			}(),
+			WantConfigure:        true,
+			WantDependenciesFunc: testExpectedDepsCreatedCM,
+			OtelAgentGateway:     testExpectedOtelAgentGateway(apicommon.OtelAgent, defaultExpectedPorts, defaultAnnotations, defaultVolumeMounts, defaultVolumes(defaultLocalObjectReferenceName)),
 		},
 		{
 			Name: "otel agent gateway enabled with featureGates",

--- a/pkg/remoteconfig/updater.go
+++ b/pkg/remoteconfig/updater.go
@@ -81,11 +81,12 @@ type DatadogProductRemoteConfig interface {
 
 // DatadogAgentRemoteConfig contains the struct used to update DatadogAgent object from RemoteConfig
 type DatadogAgentRemoteConfig struct {
-	ID            string                       `json:"id,omitempty"`
-	Name          string                       `json:"name,omitempty"`
-	CoreAgent     *CoreAgentFeaturesConfig     `json:"config,omitempty"`
-	SystemProbe   *SystemProbeFeaturesConfig   `json:"system_probe,omitempty"`
-	SecurityAgent *SecurityAgentFeaturesConfig `json:"security_agent,omitempty"`
+	ID               string                       `json:"id,omitempty"`
+	Name             string                       `json:"name,omitempty"`
+	CoreAgent        *CoreAgentFeaturesConfig     `json:"config,omitempty"`
+	SystemProbe      *SystemProbeFeaturesConfig   `json:"system_probe,omitempty"`
+	SecurityAgent    *SecurityAgentFeaturesConfig `json:"security_agent,omitempty"`
+	OtelAgentGateway *FeatureEnabledConfig        `json:"otel_agent_gateway,omitempty"`
 }
 
 // GetID returns the ID of the configuration
@@ -490,6 +491,16 @@ func mergeConfigs(dst, src *DatadogAgentRemoteConfig) {
 		}
 	}
 
+	// OtelAgentGateway
+	if src.OtelAgentGateway != nil {
+		if dst.OtelAgentGateway == nil {
+			dst.OtelAgentGateway = &FeatureEnabledConfig{}
+		}
+		if src.OtelAgentGateway.Enabled != nil {
+			dst.OtelAgentGateway.Enabled = src.OtelAgentGateway.Enabled
+		}
+	}
+
 }
 
 func (r *RemoteConfigUpdater) updateInstanceStatus(dda v2alpha1.DatadogAgent, config DatadogProductRemoteConfig) error {
@@ -584,6 +595,19 @@ func (r *RemoteConfigUpdater) updateInstanceStatus(dda v2alpha1.DatadogAgent, co
 		newddaStatus.RemoteConfigConfiguration.Features.USM.Enabled = cfg.SystemProbe.USM.Enabled
 	} else {
 		newddaStatus.RemoteConfigConfiguration.Features.USM = nil
+	}
+
+	// OtelAgentGateway
+	if cfg.OtelAgentGateway != nil {
+		if newddaStatus.RemoteConfigConfiguration.Features.OtelAgentGateway == nil {
+			newddaStatus.RemoteConfigConfiguration.Features.OtelAgentGateway = &v2alpha1.OtelAgentGatewayFeatureConfig{}
+		}
+		if newddaStatus.RemoteConfigConfiguration.Features.OtelAgentGateway.Enabled == nil {
+			newddaStatus.RemoteConfigConfiguration.Features.OtelAgentGateway.Enabled = new(bool)
+		}
+		newddaStatus.RemoteConfigConfiguration.Features.OtelAgentGateway.Enabled = cfg.OtelAgentGateway.Enabled
+	} else {
+		newddaStatus.RemoteConfigConfiguration.Features.OtelAgentGateway = nil
 	}
 
 	if !apiequality.Semantic.DeepEqual(&dda.Status, newddaStatus) {


### PR DESCRIPTION
The RemoteConfigUpdater already merges AGENT_CONFIG remote-config payloads into DatadogAgent.Status.RemoteConfigConfiguration for CWS, CSPM, and USM, but had no handling for OtelAgentGateway (the cluster-level DDOT deployment). This adds an otel_agent_gateway field to DatadogAgentRemoteConfig, merges/records it the same way as the other Enabled-only features, and has the otelagentgateway feature merge Status.RemoteConfigConfiguration into the spec before checking whether the feature is enabled, matching the pattern used by cws/cspm/usm.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits