### PR TITLE
[datadog-operator] Release v1.29.0

### DIFF
--- a/bundle-community-operators/manifests/datadog-operator.clusterserviceversion.yaml
+++ b/bundle-community-operators/manifests/datadog-operator.clusterserviceversion.yaml
@@ -243,7 +243,7 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Monitoring, Logging & Tracing
-    createdAt: "2026-07-29 15:31:16"
+    createdAt: "2026-08-04 20:33:01"
     description: |-
       Datadog provides a modern monitoring and analytics platform. Gather metrics, logs and traces for full observability of your Kubernetes cluster with Datadog Operator.
 
@@ -251,7 +251,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/DataDog/datadog-operator
-    containerImage: gcr.io/datadoghq/operator:1.29.0-rc.3
+    containerImage: gcr.io/datadoghq/operator:1.29.0
     support: Datadog, Inc.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
@@ -260,12 +260,12 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.7.0 <1.29.0-rc.3'
+    olm.skipRange: '>=1.7.0 <1.29.0'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: datadog-operator.v1.29.0-rc.3
+  name: datadog-operator.v1.29.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1001,7 +1001,7 @@ spec:
                             fieldPath: metadata.namespace
                       - name: DD_TOOL_VERSION
                         value: operatorhub
-                    image: gcr.io/datadoghq/operator:1.29.0-rc.3
+                    image: gcr.io/datadoghq/operator:1.29.0
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -1099,4 +1099,4 @@ spec:
   minKubeVersion: 1.16.0
   provider:
     name: Datadog
-  version: 1.29.0-rc.3
+  version: 1.29.0

--- a/bundle/manifests/datadog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/datadog-operator.clusterserviceversion.yaml
@@ -243,7 +243,7 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Monitoring, Logging & Tracing
-    createdAt: "2026-07-29 15:31:16"
+    createdAt: "2026-08-04 20:33:01"
     description: |-
       Datadog provides a modern monitoring and analytics platform. Gather metrics, logs and traces for full observability of your Kubernetes cluster with Datadog Operator.
 
@@ -251,7 +251,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/DataDog/datadog-operator
-    containerImage: gcr.io/datadoghq/operator:1.29.0-rc.3
+    containerImage: gcr.io/datadoghq/operator:1.29.0
     support: Datadog, Inc.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
@@ -260,12 +260,12 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=1.7.0 <1.29.0-rc.3'
+    olm.skipRange: '>=1.7.0 <1.29.0'
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
-  name: datadog-operator.v1.29.0-rc.3
+  name: datadog-operator.v1.29.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1001,7 +1001,7 @@ spec:
                             fieldPath: metadata.namespace
                       - name: DD_TOOL_VERSION
                         value: redhat-community-operators
-                    image: gcr.io/datadoghq/operator:1.29.0-rc.3
+                    image: gcr.io/datadoghq/operator:1.29.0
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       httpGet:
@@ -1099,5 +1099,5 @@ spec:
   minKubeVersion: 1.16.0
   provider:
     name: Datadog
-  version: 1.29.0-rc.3
+  version: 1.29.0
   replaces: datadog-operator.v1.28.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 images:
 - name: controller
   newName: gcr.io/datadoghq/operator
-  newTag: 1.29.0-rc.3
+  newTag: 1.29.0
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Operator bundle regenerated for the **v1.29.0 GA** release.

The bundle commit (`e915517e`) was produced by the OperatorRelease workflow itself — its `Operator Release - Make Bundle` job (run [30948213737](https://github.com/DataDog/datadog-operator/actions/runs/30948213737), dispatched by Atlas workflow `3c175b14-fea0-4019-af25-c51926666ad0`) ran `make bundle` and pushed as `github-actions[bot]`. No manual edits.

Only this pull request was opened by hand: the workflow dispatched the bundle job at 20:31:02 and attempted to create the PR at 20:31:03 — 90s before the job pushed its commit at 20:33:03 — so PR creation failed with `422 No commits between v1.29 and operator-release/v1.29.0` and was not retried.

Changes are version strings only (`1.29.0-rc.3` -> `1.29.0`), in both bundle directories plus `config/manager/kustomization.yaml`:

| field | value |
| --- | --- |
| CSV `name` | `datadog-operator.v1.29.0` |
| `version` | `1.29.0` |
| `replaces` | `datadog-operator.v1.28.0` |
| `olm.skipRange` | `>=1.7.0 <1.29.0` |
| `containerImage` / `newTag` | `1.29.0` |
