### PR TITLE
Strip managed fields from controller-runtime cache

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -246,6 +246,7 @@ func CacheOptions(logger logr.Logger, opts WatchOptions) cache.Options {
 		// DefaultNamespaces is set to DatadogAgent CRD namespaces so all resources needed for DatadogAgent reconciliation
 		// are cached from the same namespace(s) as the DatadogAgent.
 		DefaultNamespaces: GetWatchNamespacesFromEnv(logger, AgentWatchNamespaceEnvVar),
+		DefaultTransform:  cache.TransformStripManagedFields(),
 		ByObject:          byObject,
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -290,4 +292,21 @@ func verifyResourceNamespace(t *testing.T, resource client.Object, wantConfig ob
 			assert.Nil(t, byObjectOptions.Label)
 		}
 	}
+}
+
+func TestCacheConfigStripsManagedFields(t *testing.T) {
+	cacheOptions := CacheOptions(logf.Log.WithName(t.Name()), WatchOptions{})
+	requireTransform := cacheOptions.DefaultTransform
+	if !assert.NotNil(t, requireTransform) {
+		return
+	}
+
+	obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "test-manager"}},
+	}}
+	transformed, err := requireTransform(obj)
+
+	assert.NoError(t, err)
+	assert.Same(t, obj, transformed)
+	assert.Nil(t, obj.ManagedFields)
 }


### PR DESCRIPTION
### What does this PR do?

Strips `metadata.managedFields` from objects before storing them in the controller-runtime cache.

### Motivation

The operator does not inspect cached managed fields. The [controller-runtime documentation](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/cache#TransformStripManagedFields) notes that using this transform can significantly reduce cache memory usage. Live Kubernetes objects and field ownership are unchanged.

### Additional Notes

The initial version also registered controller-runtime field indexes for the `app.kubernetes.io/part-of` label on resource types managed by the DatadogAgent reconcilers. Stale-resource cleanup then used `client.MatchingFields` to avoid scanning every cached object of each type.

Staging profiling on `genesect` and `entei` showed no consistent memory or CPU improvement, while reconcile p99 improved only on `genesect` and regressed on `entei`. The indexing changes were therefore removed to avoid the additional manager setup, fake-client wiring, and test complexity.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

Automated coverage verifies that the default cache transform removes managed fields. `go test ./pkg/config` and `make lint` pass.

QA: This will be tested in staging by validating normal reconciliation and cache behavior.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
