### PR TITLE
Update FIPS proxy version references to 1.1.29

### DIFF
--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -1044,7 +1044,7 @@ kind: DatadogAgentInternal
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: gke-autopilot
-    agent.datadoghq.com/ddaispechash: f4da8a2daaca56ee72517152fb8ea28c
+    agent.datadoghq.com/ddaispechash: d13d3f79908ea4001e0e3301265738d6
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
@@ -1189,7 +1189,7 @@ spec:
       enabled: true
       image:
         name: fips-proxy
-        tag: 1.1.28
+        tag: 1.1.29
       localAddress: 127.0.0.1
       port: 9803
       portRange: 15

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
@@ -1033,7 +1033,7 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
-    agent.datadoghq.com/ddaispechash: 42c22cc68bc435428d38fbc91176741f
+    agent.datadoghq.com/ddaispechash: 5eba754bd6a44be78e2dfde7b71c0aff
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
   labels:
@@ -1177,7 +1177,7 @@ spec:
       enabled: true
       image:
         name: fips-proxy
-        tag: 1.1.28
+        tag: 1.1.29
       localAddress: 127.0.0.1
       port: 9803
       portRange: 15
@@ -1205,7 +1205,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: eb5fbc72880b4780e588136890df831c
+    agent.datadoghq.com/agentspechash: acb48fbe8c2372dd9b731053c4a96f5f
   labels:
     agent.datadoghq.com/component: agent
     agent.datadoghq.com/name: datadog-agent
@@ -1641,7 +1641,7 @@ spec:
       - env:
         - name: DD_FIPS_LOCAL_ADDRESS
           value: 127.0.0.1
-        image: registry.datadoghq.com/fips-proxy:1.1.28
+        image: registry.datadoghq.com/fips-proxy:1.1.29
         imagePullPolicy: IfNotPresent
         name: fips-proxy
         ports:
@@ -1847,7 +1847,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 2dc2f35ed7b6ea6c9c37db3960096f81
+    agent.datadoghq.com/agentspechash: 213f10c811c401893367317e36fe443f
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -2086,7 +2086,7 @@ spec:
       - env:
         - name: DD_FIPS_LOCAL_ADDRESS
           value: 127.0.0.1
-        image: registry.datadoghq.com/fips-proxy:1.1.28
+        image: registry.datadoghq.com/fips-proxy:1.1.29
         imagePullPolicy: IfNotPresent
         name: fips-proxy
         ports:

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -22,7 +22,7 @@ const (
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
 	DdotCollectorLatestVersion = "7.81.1"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
-	FIPSProxyLatestVersion = "1.1.28"
+	FIPSProxyLatestVersion = "1.1.29"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.
 	// Note: the regular agent -fips image predates this; this constant only applies to ddot-collector.
 	// Add "-0" so that pre-release versions are considered sufficient. https://github.com/Masterminds/semver#working-with-prerelease-versions


### PR DESCRIPTION
### What does this PR do?

Update FIPS proxy version to 1.1.29 to match last release.

Ran `go test ./internal/controller/testutils/renderer/ -run TestRender_Golden -update` for changes in `suppression-baseline.golden.yaml` and `suppression-autopilot.golden.yaml`.

### Motivation

Fix CVEs and update packages.

### Additional Notes

### Minimum Agent Versions

### Describe your test plan

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits