### PR TITLE
fix(ci): repair the publish_community_operators job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1035,9 +1035,12 @@ publish_community_operators:
     - dd-octo-sts version
     - dd-octo-sts debug --scope DataDog --policy datadog-operator.publish-community-bundles
     - dd-octo-sts token --scope DataDog --policy datadog-operator.publish-community-bundles > token.txt
-    - export GITHUB_TOKEN=$(cat token.txt)
+    # `gh auth login --with-token` exits non-zero when GITHUB_TOKEN is already set, so log in
+    # first and export the token afterwards. The token is still needed as an env var for the
+    # GitHub API call in hack/publish-community-bundles.sh.
     - gh auth login --with-token < token.txt
     - gh auth setup-git
+    - export GITHUB_TOKEN=$(cat token.txt)
     # create pull request for each marketplace repo
     - make publish-community-bundles
   after_script:

--- a/hack/publish-community-bundles.sh
+++ b/hack/publish-community-bundles.sh
@@ -5,13 +5,25 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "Missing GITHUB_TOKEN"
+    exit 1
+fi
+
 OPERATOR_SUBPATH="datadog-operator"
 BUNDLE_NAME="bundle"
 WORKING_DIR=$PWD
 PR_BRANCH_NAME="datadog-operator-$VERSION"
 REPOS=("community-operators" "community-operators-prod" "certified-operators" "redhat-marketplace-operators")
 
-mkdir tmp
+# Owner of the forks the pull requests are opened from.
+FORK_OWNER="DataDog"
+# Default the GitLab-provided variables so the script can also be run locally, which is the
+# documented fallback when the `publish_community_operators` CI job is unavailable.
+PROJECT_DIR="${CI_PROJECT_DIR:-$WORKING_DIR}"
+AUTHOR_EMAIL="${GITLAB_USER_EMAIL:-$(git config user.email)}"
+
+mkdir -p tmp
 
 clone_and_sync_fork() {
   echo "Cloning fork DataDog/$repo."
@@ -33,23 +45,26 @@ clone_and_sync_fork() {
 update_bundle() {
   dest_path=operators/$OPERATOR_SUBPATH/"$VERSION"
   echo "Updating bundle at \`$dest_path\` with source: \`$BUNDLE_NAME\`"
-  mkdir "$dest_path"
-  cp -R "$CI_PROJECT_DIR"/$BUNDLE_NAME/* "$dest_path"
+  mkdir -p "$dest_path"
+  cp -R "$PROJECT_DIR"/$BUNDLE_NAME/* "$dest_path"
 }
 
 create_pr() {
   echo "Creating pull request for repo: $ORG/$repo"
   message="operator $OPERATOR_SUBPATH ($VERSION)"
-  body="Update operator $OPERATOR_SUBPATH ($VERSION).<br><br>Pull request triggered by $GITLAB_USER_EMAIL."
+  body="Update operator $OPERATOR_SUBPATH ($VERSION).<br><br>Pull request triggered by $AUTHOR_EMAIL."
   git add -A
   git commit -s -m "$message"
   git push -f --set-upstream origin "$PR_BRANCH_NAME"
-  curl -L \
+  # The branch lives in our fork, so `head` must be qualified with the fork owner, otherwise
+  # GitHub rejects the request with `422 Validation Failed` on an "invalid" head.
+  # `--fail-with-body` makes a rejected request fail the script instead of passing silently.
+  curl -L --fail-with-body \
     -X POST \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $GITHUB_TOKEN" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    -d "{\"title\":\"$message\",\"body\":\"$body\",\"head\":\"$(git rev-parse --abbrev-ref HEAD)\",\"base\":\"main\"}" \
+    -d "{\"title\":\"$message\",\"body\":\"$body\",\"head\":\"$FORK_OWNER:$(git rev-parse --abbrev-ref HEAD)\",\"base\":\"main\"}" \
     "https://api.github.com/repos/$ORG/$repo/pulls"
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the `publish_community_operators` post-release job, which failed during the **v1.29.0** release, and makes the underlying script usable outside GitLab.

### Why it failed

The job ran successfully through skopeo, `make bundle-redhat` and the `dd-octo-sts` token, then died here ([job 1925883067](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/1925883067)):

```
$ gh auth login --with-token < token.txt
The value of the GITHUB_TOKEN environment variable is being used for authentication.
To have GitHub CLI store credentials instead, first clear the value from the environment.
ERROR: Job failed: command terminated with exit code 1
```

`gh auth login --with-token` exits non-zero when `GITHUB_TOKEN` is already set — and the preceding line exports exactly that. Nothing changed in this repo: these lines are untouched since #1036 (Feb 2024). `gh` is installed from apt on every run, so a newer `gh` (2.97.0) turned a warning into a fatal error. `make publish-community-bundles` never ran, so no community-operator pull requests were opened for 1.29.0.

Fix: log in **before** exporting the token. The env var is still required for the GitHub API call in the script.

### Additional fixes to `hack/publish-community-bundles.sh`

The runbook's fallback is to run this script manually when the job is broken. That did not work, so while verifying the fix I repaired it:

| problem | consequence |
| --- | --- |
| `$CI_PROJECT_DIR` unset outside GitLab | `cp -R /$BUNDLE_NAME/*` copies nothing -> empty commit -> no pull request |
| `$GITLAB_USER_EMAIL` unset outside GitLab | empty attribution in the pull request body |
| `head` sent unqualified | cross-fork requests are rejected with `422 Validation Failed` (`field: head, code: invalid`) |
| `curl` without `--fail-with-body` | a rejected API call still exits 0, so the job reports success having created nothing |

The `head` and `curl` issues mean this job has likely **never** successfully opened a pull request — the 1.28.0 community bundles were pushed from a manually created branch (`DataDog:khewonc/operator-1.28.0`), not the `datadog-operator-<version>` branch this script uses.

### Motivation

So 1.30.0 does not need the manual workaround, and so the documented fallback works when it is needed.

### Note on v1.29.0

This does not retroactively fix v1.29.0: tag pipelines read `.gitlab-ci.yml` and `hack/` from the tag. The two community bundles for 1.29.0 were published manually — k8s-operatorhub/community-operators#8944 and redhat-openshift-ecosystem/community-operators-prod#10723. `certified-operators` and `redhat-marketplace-operators` are still pending as they additionally require `make bundle-redhat`.

### Testing

* `bash -n hack/publish-community-bundles.sh` passes; `.gitlab-ci.yml` parses and the script steps are ordered login -> setup-git -> export -> publish.
* The `head` fix is verified empirically: the two 1.29.0 pull requests above were opened with `head=DataDog:<branch>`, the form this change now sends. The unqualified form returned `422`.
