### PR TITLE
[CONTP-1961] Fix metadata cluster UID initialization race

### DIFF
--- a/pkg/controller/utils/metadata/crd_metadata_test.go
+++ b/pkg/controller/utils/metadata/crd_metadata_test.go
@@ -6,8 +6,10 @@
 package metadata
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -232,5 +234,40 @@ func Test_HashCRD(t *testing.T) {
 	// Different labels should produce different hash
 	if hash1 == hash4 {
 		t.Errorf("Expected different hash for different labels, both got %s", hash1)
+	}
+}
+
+func TestSharedMetadataGetOrCreateClusterUIDConcurrent(t *testing.T) {
+	h := newCRDTestHarness(t)
+	const workers = 32
+
+	start := make(chan struct{})
+	results := make(chan string, workers)
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			<-start
+			clusterUID, err := h.cmf.GetOrCreateClusterUID(context.Background())
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- clusterUID
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("GetOrCreateClusterUID() error = %v", err)
+	}
+	for clusterUID := range results {
+		if clusterUID != "kube-system-uid" {
+			t.Errorf("GetOrCreateClusterUID() = %q, want %q", clusterUID, "kube-system-uid")
+		}
 	}
 }

--- a/pkg/controller/utils/metadata/shared_metadata.go
+++ b/pkg/controller/utils/metadata/shared_metadata.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -45,6 +46,7 @@ type SharedMetadata struct {
 	logger    logr.Logger
 
 	// Shared metadata fields
+	clusterUIDMu      sync.Mutex
 	clusterUID        string
 	operatorVersion   string
 	kubernetesVersion string
@@ -88,6 +90,9 @@ func (sm *SharedMetadata) createRequest(payload []byte) (*http.Request, error) {
 
 // GetOrCreateClusterUID retrieves the cluster UID from kube-system namespace
 func (sm *SharedMetadata) GetOrCreateClusterUID(ctx context.Context) (string, error) {
+	sm.clusterUIDMu.Lock()
+	defer sm.clusterUIDMu.Unlock()
+
 	if sm.clusterUID != "" {
 		return sm.clusterUID, nil
 	}


### PR DESCRIPTION
## What

Synchronize lazy initialization of the shared Kubernetes cluster UID used by metadata forwarder workers.

## Why

Concurrent CRD metadata-forwarder workers could read and write `SharedMetadata.clusterUID` at the same time, producing a Go race-detector report. https://ddstaging.datadoghq.com/logs?query=host%3Aip-10-128-196-132.ec2.internal-entei%20service%3Adatadog-operator%20container_id%3A199e4361cedff4abef54b07dda6c072671c2464f7d71ba5abd25f8f53ec328e4%20filename%3A0.log&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZ_XB9KJAAAs6yuutNwo6AA5&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&to_event=AwAAAZ_XB8hXSvP2XQAAABhBWl9YQjlLSkFBQXM2eXV1dE53bzZBQkQAAAAkMDE5ZmQ3MGMtMzE5ZS00YTE5LTgxOWYtNWUyZTM4MDUwYTkyAAAO1A&viz=stream&from_ts=1786018739317&to_ts=1786019039320&live=false

<img width="1449" height="117" alt="image" src="https://github.com/user-attachments/assets/6a064d8b-313e-4e89-aa1a-f5fb4e97a759" />


## Validation

- `go test -race ./pkg/controller/utils/metadata`