### PR TITLE
Gate remote agent registry on vsock by resolved agent version

### DIFF
--- a/internal/controller/datadogagent/global/agent.go
+++ b/internal/controller/datadogagent/global/agent.go
@@ -38,8 +38,7 @@ func applyNodeAgentResources(manager feature.PodTemplateManagers, ddaSpec *v2alp
 		if override, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok && override.Image != nil {
 			agentVersion = common.GetAgentVersionFromImage(*override.Image)
 		}
-		defaultIfVersionUnknown := false
-		if !utils.IsAboveMinVersion(agentVersion, remoteAgentRegistryVSockMinVersion, &defaultIfVersionUnknown) {
+		if !utils.IsAboveMinVersion(agentVersion, remoteAgentRegistryVSockMinVersion, new(false)) {
 			manager.EnvVar().AddEnvVar(&corev1.EnvVar{
 				Name:  DDRemoteAgentRegistryEnabled,
 				Value: "false",

--- a/internal/controller/datadogagent/global/agent.go
+++ b/internal/controller/datadogagent/global/agent.go
@@ -16,7 +16,14 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
+	"github.com/DataDog/datadog-operator/pkg/images"
+	"github.com/DataDog/datadog-operator/pkg/utils"
 )
+
+// remoteAgentRegistryVSockMinVersion is the first agent version where the Remote Agent Registry
+// supports AF_VSOCK. Below this version, RAR must stay disabled on vsock clusters to avoid
+// crash-looping system-probe/trace-agent/process-agent.
+const remoteAgentRegistryVSockMinVersion = "7.83.0-0"
 
 func applyNodeAgentResources(manager feature.PodTemplateManagers, ddaSpec *v2alpha1.DatadogAgentSpec, singleContainerStrategyEnabled bool) {
 	config := ddaSpec.Global
@@ -26,6 +33,18 @@ func applyNodeAgentResources(manager feature.PodTemplateManagers, ddaSpec *v2alp
 			Name:  DDVSockAddr,
 			Value: "host",
 		})
+
+		agentVersion := images.AgentLatestVersion
+		if override, ok := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; ok && override.Image != nil {
+			agentVersion = common.GetAgentVersionFromImage(*override.Image)
+		}
+		defaultIfVersionUnknown := false
+		if !utils.IsAboveMinVersion(agentVersion, remoteAgentRegistryVSockMinVersion, &defaultIfVersionUnknown) {
+			manager.EnvVar().AddEnvVar(&corev1.EnvVar{
+				Name:  DDRemoteAgentRegistryEnabled,
+				Value: "false",
+			})
+		}
 
 		authVol := common.GetVolumeForAuth(true)
 		manager.Volume().AddVolume(&authVol)

--- a/internal/controller/datadogagent/global/agent.go
+++ b/internal/controller/datadogagent/global/agent.go
@@ -27,12 +27,6 @@ func applyNodeAgentResources(manager feature.PodTemplateManagers, ddaSpec *v2alp
 			Value: "host",
 		})
 
-		// Remote agent doesn't work with vsock yet.
-		manager.EnvVar().AddEnvVar(&corev1.EnvVar{
-			Name:  DDRemoteAgentRegistryEnabled,
-			Value: "false",
-		})
-
 		authVol := common.GetVolumeForAuth(true)
 		manager.Volume().AddVolume(&authVol)
 	}

--- a/internal/controller/datadogagent/global/envvar.go
+++ b/internal/controller/datadogagent/global/envvar.go
@@ -36,4 +36,5 @@ const (
 	DDCSIEnabled                           = "DD_CSI_ENABLED"
 	DDVSockAddr                            = "DD_VSOCK_ADDR"
 	DDProviderKind                         = "DD_PROVIDER_KIND"
+	DDRemoteAgentRegistryEnabled           = "DD_REMOTE_AGENT_REGISTRY_ENABLED"
 )

--- a/internal/controller/datadogagent/global/envvar.go
+++ b/internal/controller/datadogagent/global/envvar.go
@@ -35,6 +35,5 @@ const (
 	DDKubernetesResourcesAnnotationsAsTags = "DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS"
 	DDCSIEnabled                           = "DD_CSI_ENABLED"
 	DDVSockAddr                            = "DD_VSOCK_ADDR"
-	DDRemoteAgentRegistryEnabled           = "DD_REMOTE_AGENT_REGISTRY_ENABLED"
 	DDProviderKind                         = "DD_PROVIDER_KIND"
 )

--- a/internal/controller/datadogagent/global/global_test.go
+++ b/internal/controller/datadogagent/global/global_test.go
@@ -135,11 +135,71 @@ func TestNodeAgentComponenGlobalSettings(t *testing.T) {
 			want:                      assertAll,
 		},
 		{
-			name:                           "VSock enabled",
+			name:                           "VSock enabled, agent version below RAR vsock support",
 			singleContainerStrategyEnabled: false,
 			dda: func() *v2alpha1.DatadogAgent {
 				dda := testutils.NewDatadogAgentBuilder().
 					WithCredentials("apiKey", "appKey").
+					BuildWithDefaults()
+				dda.Spec.Global.UseVSock = ptr.To(true)
+				return dda
+			}(),
+			wantCoreAgentEnvVars: nil,
+			wantEnvVars: getExpectedEnvVars([]*corev1.EnvVar{
+				{
+					Name: constants.DDAPIKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "-secret",
+							},
+							Key: v2alpha1.DefaultAPIKeyKey,
+						},
+					},
+				},
+				{
+					Name: constants.DDAppKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "-secret",
+							},
+							Key: v2alpha1.DefaultAPPKeyKey,
+						},
+					},
+				},
+				{
+					Name: DDClusterAgentAuthToken,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "-token",
+							},
+							Key: common.DefaultTokenKey,
+						},
+					},
+				},
+				{
+					Name:  DDVSockAddr,
+					Value: "host",
+				},
+				{
+					Name:  DDRemoteAgentRegistryEnabled,
+					Value: "false",
+				},
+			}...),
+			wantCoreAgentVolumeMounts: nil,
+			wantVolumeMounts:          nil,
+			wantVolumes:               getExpectedVolumes(authVolume),
+			want:                      assertAll,
+		},
+		{
+			name:                           "VSock enabled, agent version supports RAR vsock",
+			singleContainerStrategyEnabled: false,
+			dda: func() *v2alpha1.DatadogAgent {
+				dda := testutils.NewDatadogAgentBuilder().
+					WithCredentials("apiKey", "appKey").
+					WithNodeAgentImage("gcr.io/datadoghq/agent:7.83.0").
 					BuildWithDefaults()
 				dda.Spec.Global.UseVSock = ptr.To(true)
 				return dda

--- a/internal/controller/datadogagent/global/global_test.go
+++ b/internal/controller/datadogagent/global/global_test.go
@@ -183,10 +183,6 @@ func TestNodeAgentComponenGlobalSettings(t *testing.T) {
 					Name:  DDVSockAddr,
 					Value: "host",
 				},
-				{
-					Name:  DDRemoteAgentRegistryEnabled,
-					Value: "false",
-				},
 			}...),
 			wantCoreAgentVolumeMounts: nil,
 			wantVolumeMounts:          nil,


### PR DESCRIPTION
### What does this PR do?

Instead of unconditionally dropping the `DD_REMOTE_AGENT_REGISTRY_ENABLED=false` override on vsock clusters, only drop it when the node agent's resolved image tag is `7.83+`.

### Motivation

RAR's AF_VSOCK support (DataDog/datadog-agent#54474) only ships from agent 7.83. Since customers can upgrade the operator and agent versions independently, there's no point at which the operator can assume the agent is 7.83+ — so the override must stay version-gated rather than removed outright, or older agents on vsock clusters would crash-loop.

### Describe how you validated your changes

Added test cases covering both below- and at-minimum-version scenarios; `go test ./internal/controller/datadogagent/...` passes.