### PR TITLE
Skip e2e stage on release-bundle branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,14 @@ stages:
     when: never
   - when: always
 
+# Release-bundle PRs are opened by the operator-release bot on `operator-release/*`
+# branches and only ever contain the regenerated bundle manifests plus
+# config/manager/kustomization.yaml. There is no operator code for e2e to
+# exercise, so skip the whole e2e stage to get them through CI quickly.
+.skip_e2e_on_release_bundle_branch: &skip_e2e_on_release_bundle_branch
+  if: '$CI_COMMIT_BRANCH =~ /^operator-release\//'
+  when: never
+
 build:
   stage: build
   tags: ["arch:amd64"]
@@ -262,6 +270,7 @@ go_e2e_deps:
     GOMEMLIMIT: 15GiB
     GOMAXPROCS: 4
   rules:
+    - *skip_e2e_on_release_bundle_branch
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
       variables:
         POLICY: pull-push
@@ -310,6 +319,7 @@ go_e2e_deps:
         - pulumi_plugins.tar.xz
 
 .on_run_e2e_base:
+  - *skip_e2e_on_release_bundle_branch
   # Skip if only .md files are changed
   - if: $CI_COMMIT_BRANCH
     changes:
@@ -333,6 +343,7 @@ go_e2e_deps:
   - when: on_success
 
 .on_run_e2e:
+  - *skip_e2e_on_release_bundle_branch
   # Skip if only .md files are changed
   - if: $CI_COMMIT_BRANCH
     changes:
@@ -522,6 +533,7 @@ e2e_autoscaling:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
   rules:
+    - *skip_e2e_on_release_bundle_branch
     # Disable on Conductor-triggered jobs (ex: nightly) - must be first so it wins
     - if: '$DDR == "true"'
       when: never
@@ -556,6 +568,7 @@ e2e_gke_autopilot:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
   rules:
+    - *skip_e2e_on_release_bundle_branch
     # Disable on Conductor-triggered jobs (ex: nightly) - must be first so it wins
     - if: '$DDR == "true"'
       when: never
@@ -586,6 +599,7 @@ e2e_untaint:
     K8S_VERSION: "1.30"
     TARGET_IMAGE: $E2E_DOCKER_REGISTRY:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   rules:
+    - *skip_e2e_on_release_bundle_branch
     # Skip when a root *.md file changed (docs-only *or* docs mixed with code).
     # This has to gate every rule below because the hard `needs` above
     # (trigger_e2e_operator_image, via .on_run_e2e_base) itself skips on any

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,13 @@ stages:
 # branches and only ever contain the regenerated bundle manifests plus
 # config/manager/kustomization.yaml. There is no operator code for e2e to
 # exercise, so skip the whole e2e stage to get them through CI quickly.
+#
+# The second clause covers the mergequeue: once queued, the pipeline runs on
+# `mq-working-branch-*` and the original branch name is gone, so match the
+# squashed commit title instead. The bot always produces
+# `chore(bundle): regenerate for vX.Y.Z`.
 .skip_e2e_on_release_bundle_branch: &skip_e2e_on_release_bundle_branch
-  if: '$CI_COMMIT_BRANCH =~ /^operator-release\//'
+  if: '$CI_COMMIT_BRANCH =~ /^operator-release\// || ($CI_COMMIT_BRANCH =~ /^mq-working-branch-/ && $CI_COMMIT_TITLE =~ /^chore\(bundle\): regenerate for v/)'
   when: never
 
 build:
@@ -510,6 +515,7 @@ e2e_mq:
   timeout: 60m
   retry: 0
   rules:
+    - *skip_e2e_on_release_bundle_branch
     # Skip if only .md files are changed
     - if: $CI_COMMIT_BRANCH
       changes:


### PR DESCRIPTION
### What does this PR do?

Skips every job in the `e2e` stage (plus the `go_e2e_deps` cache pre-warm) on `operator-release/*` branches.

### Motivation

Release-bundle PRs like #3339 are opened by the operator-release bot and only contain regenerated bundle manifests plus `config/manager/kustomization.yaml`. There is no operator code for e2e to exercise, so the 8-version e2e matrix just delays the merge.

### Additional Notes

Gated on the branch name rather than `changes:` paths because these PRs target a release branch (#3339 is `operator-release/v1.30.0-rc.1` → `v1.30`), so the existing `compare_to: refs/heads/main` diff is unrelated to the PR contents.

The three manual e2e jobs (`e2e_autoscaling`, `e2e_gke_autopilot`, `e2e_untaint`) are included even though they don't run automatically: they hard-`needs` `go_e2e_deps`/`trigger_e2e_operator_image`, and GitLab rejects a pipeline whose `needs` target is absent.

### Describe your test plan

Confirm the next `operator-release/*` PR has no `e2e` stage jobs, and that this PR's own pipeline still runs the full e2e matrix.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)