### PR TITLE
Add Jira component for dynamic instrumentation team

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -259,6 +259,7 @@ github_labels = ["team/agent-release-management"]
 
 [teams."Dynamic Instrumentation"]
 jira_project = "DEBUG"
+jira_component = "datadog-agent"
 jira_issue_type = "Task"
 jira_statuses = ["To Do", "In Progress", "Done"]
 github_team = "debugger-go"


### PR DESCRIPTION
### What does this PR do?

Add Jira component (`datadog-agent`) for dynamic instrumentation team

### Motivation

to be able to create QA cards


### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits