### PR TITLE
Update FIPS proxy version references to 1.1.30

### DIFF
--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -22,7 +22,7 @@ const (
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
 	DdotCollectorLatestVersion = "7.81.1"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
-	FIPSProxyLatestVersion = "1.1.29"
+	FIPSProxyLatestVersion = "1.1.30"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.
 	// Note: the regular agent -fips image predates this; this constant only applies to ddot-collector.
 	// Add "-0" so that pre-release versions are considered sufficient. https://github.com/Masterminds/semver#working-with-prerelease-versions


### PR DESCRIPTION
### What does this PR do?

Update FIPS proxy version to 1.1.30 to match last release.

### Motivation

Fix CVEs.

### Additional Notes

### Minimum Agent Versions

### Describe your test plan

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
