### PR TITLE
enable CNM direct send if version unknown

### DIFF
--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -61,7 +61,7 @@ func (f *npmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 			directSendEnabled = value == "true"
 		}
 		const directSendMinVersion = "7.81.0-0"
-		defaultIfVersionUnknown := false
+		defaultIfVersionUnknown := true
 		if !utils.IsAboveMinVersion(common.GetComponentVersion(dda, v2alpha1.NodeAgentComponentName), directSendMinVersion, &defaultIfVersionUnknown) {
 			directSendEnabled = false
 		}

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -60,7 +60,7 @@ func (f *usmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 			directSendEnabled = value == "true"
 		}
 		const directSendMinVersion = "7.81.0-0"
-		defaultIfVersionUnknown := false
+		defaultIfVersionUnknown := true
 		if !utils.IsAboveMinVersion(common.GetComponentVersion(dda, v2alpha1.NodeAgentComponentName), directSendMinVersion, &defaultIfVersionUnknown) {
 			directSendEnabled = false
 		}


### PR DESCRIPTION
### What does this PR do?

enable CNM direct send if version unknown

### Motivation

CNM direct send has been supported since 7.81 so assume `latest` and other unparseable versions support it

### Additional Notes

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.81.0
* Cluster Agent: n/a

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits