### PR TITLE
[CONS-8497] - Fix DDAI metrics forwarder ignoring Operator-level credentials

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -282,7 +282,7 @@ func (mf *metricsForwarder) setup() error {
 			mf.logger.Error(err, "cannot retrieve DatadogAgentInternal to get Datadog credentials, will retry later...")
 			return err
 		}
-		return mf.setupFromDDAI(ddai)
+		return mf.setupFromDDAI(ddai, credsSet)
 	}
 
 	return nil
@@ -343,15 +343,17 @@ func (mf *metricsForwarder) setupFromDDA(dda *v2alpha1.DatadogAgent, credsSetFro
 	return nil
 }
 
-func (mf *metricsForwarder) setupFromDDAI(ddai *v1alpha1.DatadogAgentInternal) error {
-	mf.baseURL = getbaseURL(&ddai.Spec)
+func (mf *metricsForwarder) setupFromDDAI(ddai *v1alpha1.DatadogAgentInternal, credsSetFromOperator bool) error {
+	if !credsSetFromOperator {
+		mf.baseURL = getbaseURL(&ddai.Spec)
 
-	// set apiKey
-	apiKey, err := mf.getCredentialsFromDDAI(ddai)
-	if err != nil {
-		return err
+		// set apiKey
+		apiKey, err := mf.getCredentialsFromDDAI(ddai)
+		if err != nil {
+			return err
+		}
+		mf.apiKey = apiKey
 	}
-	mf.apiKey = apiKey
 
 	mf.labels = ddai.GetLabels()
 

--- a/pkg/controller/utils/datadog/metrics_forwarder_test.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder_test.go
@@ -17,6 +17,7 @@ import (
 
 	"k8s.io/utils/ptr"
 
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/pkg/config"
 	"github.com/DataDog/datadog-operator/pkg/constants"
@@ -457,6 +458,257 @@ func Test_setupFromDDA(t *testing.T) {
 			}
 			if !reflect.DeepEqual(mf.ccrStatus, tt.wantCcrStatus) {
 				t.Errorf("metricsForwarder.setupFromDDA() ccrStatus = %v, want %v", mf.ccrStatus, tt.wantCcrStatus)
+			}
+		})
+	}
+}
+
+func Test_setupFromDDAI(t *testing.T) {
+	apiVersion := fmt.Sprintf("%s/%s", v1alpha1.GroupVersion.Group, v1alpha1.GroupVersion.Version)
+	apiKey := "foundAPIKey"
+	labels := map[string]string{
+		"labelKey1": "labelValue1",
+	}
+
+	// DatadogAgentInternal credentials are always resolved via a Secret (never inline), so
+	// tests that expect the API key to be found must pre-create the backing Secret.
+	apiKeySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar-secret",
+			Namespace: "foo",
+		},
+		Data: map[string][]byte{
+			v2alpha1.DefaultAPIKeyKey: []byte(apiKey),
+		},
+	}
+
+	type args struct {
+		ddai                 *v1alpha1.DatadogAgentInternal
+		credsSetFromOperator bool
+		loadFunc             func(*metricsForwarder)
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantLabels      map[string]string
+		wantClusterName string
+		wantBaseURL     string
+		wantAPIKey      string
+		wantAgentStatus *v2alpha1.DaemonSetStatus
+		wantDcaStatus   *v2alpha1.DeploymentStatus
+		wantCcrStatus   *v2alpha1.DeploymentStatus
+		wantErr         bool
+	}{
+		{
+			name: "base URL, cluster name and API key",
+			args: args{
+				ddai: &v1alpha1.DatadogAgentInternal{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "DatadogAgentInternal",
+						APIVersion: apiVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "foo",
+						Name:       "bar",
+						Labels:     labels,
+						Finalizers: []string{"finalizer.agent.datadoghq.com"},
+					},
+					Spec: v2alpha1.DatadogAgentSpec{
+						Global: &v2alpha1.GlobalConfig{
+							ClusterName: ptr.To("test-cluster"),
+							Credentials: &v2alpha1.DatadogCredentials{
+								APIKey: ptr.To(apiKey),
+							},
+						},
+					},
+				},
+				credsSetFromOperator: false,
+				loadFunc: func(m *metricsForwarder) {
+					_ = m.k8sClient.Create(context.TODO(), apiKeySecret.DeepCopy())
+				},
+			},
+			wantLabels:      labels,
+			wantClusterName: "test-cluster",
+			wantBaseURL:     defaultbaseURL,
+			wantAPIKey:      "foundAPIKey",
+			wantErr:         false,
+		},
+		{
+			name: "creds set from operator, status and labels copied from DDAI",
+			args: args{
+				ddai: &v1alpha1.DatadogAgentInternal{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "DatadogAgentInternal",
+						APIVersion: apiVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "foo",
+						Name:       "bar",
+						Labels:     labels,
+						Finalizers: []string{"finalizer.agent.datadoghq.com"},
+					},
+					Spec: v2alpha1.DatadogAgentSpec{
+						Global: &v2alpha1.GlobalConfig{
+							ClusterName: ptr.To("test-cluster"),
+							Credentials: &v2alpha1.DatadogCredentials{
+								APIKey: ptr.To(apiKey),
+							},
+						},
+					},
+					Status: v1alpha1.DatadogAgentInternalStatus{
+						Agent: &v2alpha1.DaemonSetStatus{
+							DaemonsetName: "datadog-agent",
+							State:         "Running",
+							Desired:       3,
+							Available:     3,
+						},
+						ClusterAgent: &v2alpha1.DeploymentStatus{
+							State:             "Running",
+							Replicas:          1,
+							AvailableReplicas: 1,
+						},
+						ClusterChecksRunner: &v2alpha1.DeploymentStatus{
+							State:             "Running",
+							Replicas:          2,
+							AvailableReplicas: 2,
+						},
+					},
+				},
+				credsSetFromOperator: true,
+			},
+			wantLabels:      labels,
+			wantClusterName: "test-cluster",
+			wantBaseURL:     "", // Should not be set when credsSetFromOperator is true
+			wantAPIKey:      "", // Should not be set when credsSetFromOperator is true
+			wantAgentStatus: &v2alpha1.DaemonSetStatus{
+				DaemonsetName: "datadog-agent",
+				State:         "Running",
+				Desired:       3,
+				Available:     3,
+			},
+			wantDcaStatus: &v2alpha1.DeploymentStatus{
+				State:             "Running",
+				Replicas:          1,
+				AvailableReplicas: 1,
+			},
+			wantCcrStatus: &v2alpha1.DeploymentStatus{
+				State:             "Running",
+				Replicas:          2,
+				AvailableReplicas: 2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "creds not set from operator, status and labels copied from DDAI",
+			args: args{
+				ddai: &v1alpha1.DatadogAgentInternal{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "DatadogAgentInternal",
+						APIVersion: apiVersion,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  "foo",
+						Name:       "bar",
+						Labels:     labels,
+						Finalizers: []string{"finalizer.agent.datadoghq.com"},
+					},
+					Spec: v2alpha1.DatadogAgentSpec{
+						Global: &v2alpha1.GlobalConfig{
+							ClusterName: ptr.To("test-cluster"),
+							Credentials: &v2alpha1.DatadogCredentials{
+								APIKey: ptr.To(apiKey),
+							},
+						},
+					},
+					Status: v1alpha1.DatadogAgentInternalStatus{
+						Agent: &v2alpha1.DaemonSetStatus{
+							DaemonsetName: "datadog-agent",
+							State:         "Pending",
+							Desired:       2,
+							Available:     1,
+						},
+						ClusterAgent: &v2alpha1.DeploymentStatus{
+							State:             "Pending",
+							Replicas:          1,
+							AvailableReplicas: 0,
+						},
+						ClusterChecksRunner: &v2alpha1.DeploymentStatus{
+							State:             "Running",
+							Replicas:          1,
+							AvailableReplicas: 1,
+						},
+					},
+				},
+				credsSetFromOperator: false,
+				loadFunc: func(m *metricsForwarder) {
+					_ = m.k8sClient.Create(context.TODO(), apiKeySecret.DeepCopy())
+				},
+			},
+			wantLabels:      labels,
+			wantClusterName: "test-cluster",
+			wantBaseURL:     defaultbaseURL,
+			wantAPIKey:      "foundAPIKey",
+			wantAgentStatus: &v2alpha1.DaemonSetStatus{
+				DaemonsetName: "datadog-agent",
+				State:         "Pending",
+				Desired:       2,
+				Available:     1,
+			},
+			wantDcaStatus: &v2alpha1.DeploymentStatus{
+				State:             "Pending",
+				Replicas:          1,
+				AvailableReplicas: 0,
+			},
+			wantCcrStatus: &v2alpha1.DeploymentStatus{
+				State:             "Running",
+				Replicas:          1,
+				AvailableReplicas: 1,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &secrets.DummyDecryptor{}
+			mf := &metricsForwarder{
+				k8sClient:    fake.NewFakeClient(),
+				decryptor:    d,
+				creds:        sync.Map{},
+				credsManager: config.NewCredentialManager(fake.NewFakeClient()),
+			}
+			if tt.args.loadFunc != nil {
+				tt.args.loadFunc(mf)
+			}
+
+			err := mf.setupFromDDAI(tt.args.ddai, tt.args.credsSetFromOperator)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("metricsForwarder.setupFromDDAI() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if mf.apiKey != tt.wantAPIKey {
+				t.Errorf("metricsForwarder.setupFromDDAI() apiKey = %v, want %v", mf.apiKey, tt.wantAPIKey)
+			}
+			if mf.baseURL != tt.wantBaseURL {
+				t.Errorf("metricsForwarder.setupFromDDAI() baseURL = %v, want %v", mf.baseURL, tt.wantBaseURL)
+			}
+			if mf.clusterName != tt.wantClusterName {
+				t.Errorf("metricsForwarder.setupFromDDAI() clusterName = %v, want %v", mf.clusterName, tt.wantClusterName)
+			}
+			for k, v := range mf.labels {
+				if tt.wantLabels[k] != v {
+					t.Errorf("metricsForwarder.setupFromDDAI() label value = %v, want %v", v, tt.wantLabels[k])
+				}
+			}
+
+			// Check status fields are copied over
+			if !reflect.DeepEqual(mf.agentStatus, tt.wantAgentStatus) {
+				t.Errorf("metricsForwarder.setupFromDDAI() agentStatus = %v, want %v", mf.agentStatus, tt.wantAgentStatus)
+			}
+			if !reflect.DeepEqual(mf.dcaStatus, tt.wantDcaStatus) {
+				t.Errorf("metricsForwarder.setupFromDDAI() dcaStatus = %v, want %v", mf.dcaStatus, tt.wantDcaStatus)
+			}
+			if !reflect.DeepEqual(mf.ccrStatus, tt.wantCcrStatus) {
+				t.Errorf("metricsForwarder.setupFromDDAI() ccrStatus = %v, want %v", mf.ccrStatus, tt.wantCcrStatus)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where when the customer sets credentials in the Datadog Operator with the following Operator values:
```
apiKey: <set your api key>
appKey: <set your app key>
```
...and using the Datadog Agent's secret backend feature with an existing secret like:
```
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    clusterName: test-cluster
    kubelet:
      tlsVerify: false
    secretBackend:
      command: "/readsecret_multiple_providers.sh"
      enableGlobalPermissions: true
    credentials:
      apiKey: ENC[k8s_secret@default/test-secret/api_key]
      appKey: ENC[k8s_secret@default/test-secret/app_key]
```

The Operator's metric forwarder is unable to fetch credentials despite the credentials being correct in the Operator with the following errors:
```
{"level":"ERROR","ts":"2026-08-12T16:09:32.279Z","logger":"DatadogMetricForwarders","msg":"cannot decrypt secrets","kind":"DatadogAgentInternal","namespace":"default","name":"datadog","error":"secret backend command not configured","stacktrace":"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*metricsForwarder).resolveSecretsIfNeeded\n\t/workspace/pkg/controller/utils/datadog/metrics_forwarder.go:746\ngithub.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*metricsForwarder).getCredentialsFromDDAI\n\t/workspace/pkg/controller/utils/datadog/metrics_forwarder.go:727\ngithub.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*metricsForwarder).setupFromDDAI\n\t/workspace/pkg/controller/utils/datadog/metrics_forwarder.go:350\ngithub.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*metricsForwarder).setup\n\t/workspace/pkg/controller/utils/datadog/metrics_forwarder.go:285\ngithub.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*metricsForwarder).connectToDatadogAPI\n\t/workspace/pkg/controller/utils/datadog/metrics_forwarder.go:374\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/poll.go:33\ngithub.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*metricsForwarder).start\n\t/workspace/pkg/controller/utils/datadog/metrics_forwarder.go:187"}
{"level":"ERROR","ts":"2026-08-12T16:09:32.279Z","logger":"DatadogMetricForwarders","msg":"cannot get Datadog credentials, will retry later...","kind":"DatadogAgentInternal","namespace":"default","name":"datadog","error":"secret backend command not configured","stacktrace":"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog.(*metricsForwarder).connectToDatadogAPI\n\t/workspace/pkg/controller/utils/datadog/metrics_forwarder.go:378\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func2\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/loop.go:87\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/loop.go:88\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/wait/poll.go:33\ngithub.com
```
The DDA does have `credSet` passed in: https://github.com/DataDog/datadog-operator/blob/main/pkg/controller/utils/datadog/metrics_forwarder.go#L276

The issue is with this line where `credsSet` does not get passed in for DDAI: https://github.com/DataDog/datadog-operator/blob/main/pkg/controller/utils/datadog/metrics_forwarder.go#L285
- So even if the boolean for `credsSet` is `true`, it structurally has no way to receive that boolean.
Therefore, DDAI still unnecessarily tries to decrypt the DatadogAgent CR creds even though the credentials are correctly set in the Datadog Operator. This does not happen with the DDA.

This change mirrors the existing `setupFromDDA` guard in `setupFromDDAI`.

This fix doesn't introduce new semantics, it just makes `setupFromDDAI` consistent with that existing behavior. One side effect: once Operator credentials are configured, any CR-level site/API key override for the DDAI metrics forwarder will now be ignored, same as it already is for DDA today.

The actual trigger for this bug is the credentials.apiKey/appKey are ENC[...] wrapped values. If the CR's credentials were plain values instead (inline or via a Secret with non-encrypted data), this error would never occur, with or without this fix. This is because resolveSecretsIfNeeded only attempts decryption when it sees an ENC[...] formatted value. The Operator's own metrics forwarder decrypts these ENC[...] values using a separate mechanism from the Agent's secretBackend (its own -secretBackendCommand flag), which is what produces the error when the flag is not present (by default).

Note for reviewers: `setupFromDDA` already treats Operator-level credentials as taking precedence over CR-level credentials when both are set.

### Motivation

CONS-8497

### Describe your test plan

Wrote unit tests and tested this fix locally in a cluster with a locally built image with my code changes.

Used the following files to reproduce the issue:

Datadog Operator Helm values.yaml:
```
apiKey: <set your api key>
appKey: <set your app key>
```

DatadogAgent CR with the `ENC[]` notation for the credentials:
```
# dda.yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  global:
    clusterName: test-cluster
    kubelet:
      tlsVerify: false
    secretBackend:
      command: "/readsecret_multiple_providers.sh"
      enableGlobalPermissions: true
    credentials:
      apiKey: ENC[k8s_secret@default/test-secret/api_key]
      appKey: ENC[k8s_secret@default/test-secret/app_key]
```

Kubernetes Secret to store Datadog creds:
```
apiVersion: v1
kind: Secret
metadata:
  name: test-secret
  namespace: default
stringData:
  api_key: "<set your api key>"
  app_key: "<set your app key>"
```

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits