### PR TITLE
Enable config sync by default when CNM direct send is enabled

### DIFF
--- a/internal/controller/datadogagent/feature/npm/feature.go
+++ b/internal/controller/datadogagent/feature/npm/feature.go
@@ -189,6 +189,10 @@ func (f *npmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	}
 	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, cnmDirectSendEnvVar)
 
+	if f.directSend {
+		featureutils.EnableConfigSyncForDirectSend(managers, containersForEnvVars)
+	}
+
 	// env vars for Process Agent only
 	sysProbeExternalEnvVar := &corev1.EnvVar{
 		Name:  common.DDSystemProbeExternal,

--- a/internal/controller/datadogagent/feature/npm/feature_test.go
+++ b/internal/controller/datadogagent/feature/npm/feature_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
+	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 )
 
 func Test_npmFeature_Configure(t *testing.T) {
@@ -84,9 +85,20 @@ func Test_npmFeature_Configure(t *testing.T) {
 				Name:  DDSystemProbeCNMDirectSend,
 				Value: "true",
 			},
+			{
+				Name:  common.DDAgentIpcPort,
+				Value: featureutils.DefaultAgentIpcPort,
+			},
+			{
+				Name:  common.DDAgentIpcConfigRefreshInterval,
+				Value: featureutils.DefaultAgentIpcConfigRefreshInterval,
+			},
 		}
 		systemProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
 		assert.True(t, apiutils.IsEqualStruct(systemProbeEnvVars, sysProbeWantEnvVars), "4. System Probe envvars \ndiff = %s", cmp.Diff(systemProbeEnvVars, sysProbeWantEnvVars))
+
+		// config sync is served by the core agent, so it needs the same env vars
+		assertHasConfigSyncEnvVars(t, mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName])
 	}
 	npmAgentNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 		mgr := mgrInterface.(*fake.PodTemplateManagers)
@@ -209,6 +221,14 @@ func Test_npmFeature_Configure(t *testing.T) {
 				Name:  DDSystemProbeCNMDirectSend,
 				Value: "true",
 			},
+			{
+				Name:  common.DDAgentIpcPort,
+				Value: featureutils.DefaultAgentIpcPort,
+			},
+			{
+				Name:  common.DDAgentIpcConfigRefreshInterval,
+				Value: featureutils.DefaultAgentIpcConfigRefreshInterval,
+			},
 		}
 		sysProbeWantEnvVarsNPM := append(sysProbeWantEnvVars, npmFeatureEnvVar...)
 		systemProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
@@ -284,6 +304,8 @@ func Test_npmFeature_Configure(t *testing.T) {
 
 		processAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.ProcessAgentContainerName]
 		assert.True(t, apiutils.IsEqualStruct(processAgentEnvVars, processWantEnvVars), "Process Agent envvars \ndiff = %s", cmp.Diff(processAgentEnvVars, processWantEnvVars))
+
+		assertNoConfigSyncEnvVars(t, mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName])
 	}
 
 	tests := test.FeatureTestSuite{
@@ -319,4 +341,23 @@ func Test_npmFeature_Configure(t *testing.T) {
 	}
 
 	tests.Run(t, buildNPMFeature)
+}
+
+// configSyncEnvVars are the env vars direct send needs so that system-probe, which cannot resolve
+// secret handles itself, receives a resolved api_key from the core agent.
+func configSyncEnvVars() []*corev1.EnvVar {
+	return []*corev1.EnvVar{
+		{Name: common.DDAgentIpcPort, Value: featureutils.DefaultAgentIpcPort},
+		{Name: common.DDAgentIpcConfigRefreshInterval, Value: featureutils.DefaultAgentIpcConfigRefreshInterval},
+	}
+}
+
+func assertHasConfigSyncEnvVars(t testing.TB, envVars []*corev1.EnvVar) {
+	assert.Subset(t, envVars, configSyncEnvVars())
+}
+
+func assertNoConfigSyncEnvVars(t testing.TB, envVars []*corev1.EnvVar) {
+	for _, envVar := range configSyncEnvVars() {
+		assert.NotContains(t, envVars, envVar)
+	}
 }

--- a/internal/controller/datadogagent/feature/usm/feature.go
+++ b/internal/controller/datadogagent/feature/usm/feature.go
@@ -188,6 +188,10 @@ func (f *usmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) error
 	}
 	managers.EnvVar().AddEnvVarToContainers(containersForEnvVars, cnmDirectSendEnvVar)
 
+	if f.directSend {
+		featureutils.EnableConfigSyncForDirectSend(managers, containersForEnvVars)
+	}
+
 	// env vars for Process Agent only
 	sysProbeExternalEnvVar := &corev1.EnvVar{
 		Name:  common.DDSystemProbeExternal,

--- a/internal/controller/datadogagent/feature/usm/feature_test.go
+++ b/internal/controller/datadogagent/feature/usm/feature_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
+	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 )
 
 func Test_usmFeature_Configure(t *testing.T) {
@@ -166,10 +167,21 @@ func Test_usmFeature_Configure(t *testing.T) {
 				Name:  DDSystemProbeCNMDirectSend,
 				Value: "true",
 			},
+			{
+				Name:  common.DDAgentIpcPort,
+				Value: featureutils.DefaultAgentIpcPort,
+			},
+			{
+				Name:  common.DDAgentIpcConfigRefreshInterval,
+				Value: featureutils.DefaultAgentIpcConfigRefreshInterval,
+			},
 		}
 
 		systemProbeEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.SystemProbeContainerName]
 		assert.True(t, apiutils.IsEqualStruct(systemProbeEnvVars, wantEnvVars), "System Probe envvars \ndiff = %s", cmp.Diff(systemProbeEnvVars, wantEnvVars))
+
+		// config sync is served by the core agent, so it needs the same env vars
+		assertHasConfigSyncEnvVars(t, mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName])
 	}
 
 	usmDirectSendDisabledNodeWantFunc := func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
@@ -232,6 +244,8 @@ func Test_usmFeature_Configure(t *testing.T) {
 
 		processAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.ProcessAgentContainerName]
 		assert.True(t, apiutils.IsEqualStruct(processAgentEnvVars, processWantEnvVars), "Process Agent envvars \ndiff = %s", cmp.Diff(processAgentEnvVars, processWantEnvVars))
+
+		assertNoConfigSyncEnvVars(t, mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName])
 	}
 
 	tests := test.FeatureTestSuite{
@@ -261,4 +275,23 @@ func Test_usmFeature_Configure(t *testing.T) {
 	}
 
 	tests.Run(t, buildUSMFeature)
+}
+
+// configSyncEnvVars are the env vars direct send needs so that system-probe, which cannot resolve
+// secret handles itself, receives a resolved api_key from the core agent.
+func configSyncEnvVars() []*corev1.EnvVar {
+	return []*corev1.EnvVar{
+		{Name: common.DDAgentIpcPort, Value: featureutils.DefaultAgentIpcPort},
+		{Name: common.DDAgentIpcConfigRefreshInterval, Value: featureutils.DefaultAgentIpcConfigRefreshInterval},
+	}
+}
+
+func assertHasConfigSyncEnvVars(t testing.TB, envVars []*corev1.EnvVar) {
+	assert.Subset(t, envVars, configSyncEnvVars())
+}
+
+func assertNoConfigSyncEnvVars(t testing.TB, envVars []*corev1.EnvVar) {
+	for _, envVar := range configSyncEnvVars() {
+		assert.NotContains(t, envVars, envVar)
+	}
 }

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -6,11 +6,14 @@
 package utils
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	apiutils "github.com/DataDog/datadog-operator/api/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	"github.com/DataDog/datadog-operator/pkg/utils"
@@ -46,6 +49,11 @@ const (
 	EnablePrivateActionRunnerSystemdJournalVacuumAnnotation = "agent.datadoghq.com/private-action-runner-systemd-journal-vacuum-enabled"
 
 	EnableCNMDirectSendAnnotation = "agent.datadoghq.com/cnm-direct-send-enabled"
+
+	// DefaultAgentIpcPort and DefaultAgentIpcConfigRefreshInterval configure config sync, which
+	// serves resolved config (notably a secret-backed api_key) from the core agent to sub-processes.
+	DefaultAgentIpcPort                  = "5009"
+	DefaultAgentIpcConfigRefreshInterval = "60"
 
 	EnableClusterAgentPrivateActionRunnerAnnotation      = "cluster-agent.datadoghq.com/private-action-runner-enabled"
 	ClusterAgentPrivateActionRunnerConfigDataAnnotation  = "cluster-agent.datadoghq.com/private-action-runner-configdata"
@@ -137,4 +145,25 @@ func ShouldCreateLocalAgentService(ddaSpec *v2alpha1.DatadogAgentSpec, platformI
 	}
 
 	return common.ShouldCreateAgentLocalService(platformInfo.GetVersionInfo(), forceEnableLocalService)
+}
+
+// EnableConfigSyncForDirectSend sets the agent_ipc env vars that config sync requires, on the
+// given containers. system-probe wires the no-op secrets component, so with direct send it cannot
+// resolve an ENC[...] api_key itself; config sync is what supplies the resolved value from the
+// core agent. Both a refresh interval and an IPC transport are needed, since agent_ipc.port
+// defaults to 0 and is gated independently of agent_ipc.config_refresh_interval.
+//
+// Values match the otelcollector and hostprofiler features, which set the same core agent env
+// vars for the same reason; a mismatch there would leave the port up to feature ordering.
+// User-provided values win.
+func EnableConfigSyncForDirectSend(managers feature.PodTemplateManagers, containers []apicommon.AgentContainerName) {
+	keepCurrent := func(current, _ *corev1.EnvVar) (*corev1.EnvVar, error) { return current, nil }
+	for _, envVar := range []*corev1.EnvVar{
+		{Name: common.DDAgentIpcPort, Value: DefaultAgentIpcPort},
+		{Name: common.DDAgentIpcConfigRefreshInterval, Value: DefaultAgentIpcConfigRefreshInterval},
+	} {
+		for _, container := range containers {
+			managers.EnvVar().AddEnvVarToContainerWithMergeFunc(container, envVar, keepCurrent)
+		}
+	}
 }

--- a/internal/controller/datadogagent/feature/utils/utils_test.go
+++ b/internal/controller/datadogagent/feature/utils/utils_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
+)
+
+func TestEnableConfigSyncForDirectSend(t *testing.T) {
+	containers := []apicommon.AgentContainerName{
+		apicommon.CoreAgentContainerName,
+		apicommon.SystemProbeContainerName,
+	}
+
+	t.Run("sets both env vars on every container", func(t *testing.T) {
+		managers := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
+
+		EnableConfigSyncForDirectSend(managers, containers)
+
+		want := []*corev1.EnvVar{
+			{Name: common.DDAgentIpcPort, Value: DefaultAgentIpcPort},
+			{Name: common.DDAgentIpcConfigRefreshInterval, Value: DefaultAgentIpcConfigRefreshInterval},
+		}
+		for _, container := range containers {
+			assert.Equal(t, want, managers.EnvVarMgr.EnvVarsByC[container], "container %s", container)
+		}
+	})
+
+	t.Run("keeps a user-provided value", func(t *testing.T) {
+		managers := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{})
+		userPort := &corev1.EnvVar{Name: common.DDAgentIpcPort, Value: "1234"}
+		managers.EnvVar().AddEnvVarToContainer(apicommon.CoreAgentContainerName, userPort)
+
+		EnableConfigSyncForDirectSend(managers, containers)
+
+		want := []*corev1.EnvVar{
+			userPort,
+			{Name: common.DDAgentIpcConfigRefreshInterval, Value: DefaultAgentIpcConfigRefreshInterval},
+		}
+		assert.Equal(t, want, managers.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName])
+	})
+}


### PR DESCRIPTION
### What does this PR do?

When CNM direct send is enabled for NPM or USM, also set `DD_AGENT_IPC_PORT=5009` and `DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL=60` on the containers that carry the direct send flag, so that config sync is enabled by default alongside direct send. In practice that is the core agent and system-probe: with direct send enabled the process-agent container is no longer part of the node agent, so the write to it is a no-op.

Both env vars are applied with a merge func that keeps any value the user already provided, so an explicit `override.nodeAgent.env` entry still wins.

### Motivation

Direct send makes system-probe submit network payloads itself instead of routing them through process-agent. system-probe wires the no-op secrets component, so it cannot resolve an `ENC[...]` secret handle — if `api_key` comes from a secret backend, system-probe receives the handle verbatim and the direct sender fails to start, taking the whole `network_tracer` module (NPM and USM) down with it. Config sync is the mechanism that hands system-probe the api_key already resolved by the core agent.

Config sync is off by default and needs two independent settings: `agent_ipc.config_refresh_interval` must be positive, **and** there must be a transport (`agent_ipc.port` positive, or `agent_ipc.use_socket`). Both `config_refresh_interval` and `port` default to `0`, so neither is satisfied out of the box.

This matters here because the Operator enables direct send by default for NPM and USM on agents >= 7.81.0 (`agent.datadoghq.com/cnm-direct-send-enabled` is an opt-out, not an opt-in). Any customer on a secret-backed `api_key` with NPM or USM therefore loses network monitoring unless they know to turn config sync on themselves. Enabling it here by default removes that footgun.

Related agent-side change: DataDog/datadog-agent#55014, which turns the resulting failure into an explicit error naming the config sync settings, and scopes it to the direct send path so a secret-backed `api_key` no longer breaks unrelated system-probe modules.

### Additional Notes

The port and interval values match what the `otelcollector` and `hostprofiler` features already set, for exactly the same secrets reason. That consistency is deliberate: all of these land on the shared core agent container, so a mismatch would make the effective IPC port depend on feature ordering. The shared helper lives in `feature/utils` rather than being duplicated a third and fourth time.

Clusters that use socket-based IPC instead (`agent_ipc.use_socket: true`) are unaffected by the port var — both the config sync client (`comp/core/configsync/impl/module.go`) and the IPC listener (`comp/api/api/apiimpl/listener/common.go`) check `use_socket` first and never read `agent_ipc.port` when it is set, so no extra TCP listener is opened. The refresh interval is still required in that setup, since it is gated independently of the transport.

One precedence caveat for consumers that configure the agent through a `datadog.yaml` values file: env vars outrank file config, so `DD_AGENT_IPC_CONFIG_REFRESH_INTERVAL=60` will override an `agent_ipc.config_refresh_interval` set that way. Tuning the interval now requires `override.nodeAgent.env`. This is pre-existing behaviour for the otelcollector and hostprofiler features.

An equivalent change is needed in `DataDog/helm-charts`, which also enables direct send by default.

### Minimum Agent Versions

No new minimum. This only takes effect where direct send is already enabled, which the Operator gates on Agent >= 7.81.0.

* Agent: v7.81.0
* Cluster Agent: n/a

### Describe your test plan

Unit tests in `feature/npm` and `feature/usm` cover both directions: with direct send enabled (the default on a supported agent version) the two env vars are expected on the system-probe container and asserted present on the core agent container; with direct send disabled by annotation, or on an agent below 7.81.0, they are asserted absent. `feature/utils` has a test for the shared helper covering both containers and the user-value-wins merge.

`go test ./internal/... ./api/...` and `make lint` both pass locally.

#### Live verification

Verified against a live operator built from this branch, reconciling real `DatadogAgent` CRs in a local kind cluster (k8s v1.31.0):

| Case | `DD_NETWORK_CONFIG_DIRECT_SEND` | IPC env vars | Node agent containers |
|---|---|---|---|
| `features.npm.enabled`, default image | `true` | `PORT=5009`, `REFRESH=60` on `agent` + `system-probe` | agent, trace-agent, system-probe |
| `features.usm.enabled`, default image | `true` | same | same |
| NPM + `agent.datadoghq.com/cnm-direct-send-enabled: "false"` | `false` | absent | + `process-agent` |
| NPM + `override.nodeAgent.image.tag: 7.80.0` | `false` | absent | + `process-agent` |
| NPM + 7.81.0 + user `override` of `DD_AGENT_IPC_PORT=9999` | `true` | system-probe `9999`, agent `5009`, refresh `60`, no duplicate env names | agent, trace-agent, system-probe |

The agent pods then reached `3/3 Running` and config sync worked end to end — core agent serving IPC and system-probe consuming it:

```
CORE      | Started HTTP server 'IPC API Server' on 127.0.0.1:5009
SYS-PROBE | triggering configsync on init (will retry for 10s)
SYS-PROBE | Succeeded to fetch config from core agent
SYS-PROBE | triggering configsync on init succeeded
SYS-PROBE | configsync enabled (agent_ipc 'localhost:5009' | agent_ipc.config_refresh_interval: 60)
SYS-PROBE | Starting to sync config with core agent at https://localhost:5009/config/v1/
SYS-PROBE | direct sender started
```

Init sync completed in ~2s against the 10s `OnInitSync` deadline, and system-probe reached `ready=true` with zero restarts. Enabling config sync does make system-probe startup depend on reaching the core agent, so that headroom is worth confirming on a busier node than a single-node kind cluster.

Two caveats on what this does *not* cover. The cluster used a plain Kubernetes secret rather than a secret backend, so the original `ENC[...]` failure was not reproduced here — that path is covered by DataDog/datadog-agent#55014. And the operator ran as the real binary against the kind API server rather than as an in-cluster Deployment; the container image build was blocked by the local Docker setup (no BuildKit/buildx), and it would have exercised the same binary.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

