### PR TITLE
feat(apm): add on-demand SSI for Cluster Agent

### DIFF
--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -205,6 +205,13 @@ type SingleStepInstrumentation struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
+	// OnDemand keeps the SSI admission webhook available for runtime workload
+	// selection (annotations and Remote Config APM_POLICIES) when cluster-wide
+	// instrumentation is disabled. Matches the Agent and Helm chart default (true).
+	// Default: true
+	// +optional
+	OnDemand *bool `json:"onDemand,omitempty"`
+
 	// EnabledNamespaces enables injecting the Datadog APM libraries into pods in specific namespaces.
 	// +optional
 	// +listType=set

--- a/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
+++ b/api/datadoghq/v2alpha1/zz_generated.deepcopy.go
@@ -3699,6 +3699,11 @@ func (in *SingleStepInstrumentation) DeepCopyInto(out *SingleStepInstrumentation
 		*out = new(bool)
 		**out = **in
 	}
+	if in.OnDemand != nil {
+		in, out := &in.OnDemand, &out.OnDemand
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnabledNamespaces != nil {
 		in, out := &in.EnabledNamespaces, &out.EnabledNamespaces
 		*out = make([]string, len(*in))

--- a/cmd/yaml-mapper/mapper/mapping_datadog_helm_to_datadogagent_crd.yaml
+++ b/cmd/yaml-mapper/mapper/mapping_datadog_helm_to_datadogagent_crd.yaml
@@ -348,6 +348,7 @@ datadog.apm.errorTrackingStandalone.enabled: spec.features.apm.errorTrackingStan
 datadog.apm.hostSocketPath: spec.features.apm.unixDomainSocketConfig.path
 datadog.apm.instrumentation.disabledNamespaces: spec.features.apm.instrumentation.disabledNamespaces
 datadog.apm.instrumentation.enabled: spec.features.apm.instrumentation.enabled
+datadog.apm.instrumentation.onDemand: spec.features.apm.instrumentation.onDemand
 datadog.apm.instrumentation.enabledNamespaces: spec.features.apm.instrumentation.enabledNamespaces
 datadog.apm.instrumentation.injector.imageTag: spec.features.apm.instrumentation.injector.imageTag
 datadog.apm.instrumentation.language_detection.enabled: spec.features.apm.instrumentation.languageDetection.enabled

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -840,6 +840,13 @@ spec:
                                 <Library>: <Version>
                                 ex: "java": "v1.18.0"
                               type: object
+                            onDemand:
+                              description: |-
+                                OnDemand keeps the SSI admission webhook available for runtime workload
+                                selection (annotations and Remote Config APM_POLICIES) when cluster-wide
+                                instrumentation is disabled. Matches the Agent and Helm chart default (true).
+                                Default: true
+                              type: boolean
                             targets:
                               description: |-
                                 Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
@@ -9605,6 +9612,13 @@ spec:
                                     <Library>: <Version>
                                     ex: "java": "v1.18.0"
                                   type: object
+                                onDemand:
+                                  description: |-
+                                    OnDemand keeps the SSI admission webhook available for runtime workload
+                                    selection (annotations and Remote Config APM_POLICIES) when cluster-wide
+                                    instrumentation is disabled. Matches the Agent and Helm chart default (true).
+                                    Default: true
+                                  type: boolean
                                 targets:
                                   description: |-
                                     Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -790,6 +790,10 @@
                       "description": "LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.\n\u003cLibrary\u003e: \u003cVersion\u003e\nex: \"java\": \"v1.18.0\"",
                       "type": "object"
                     },
+                    "onDemand": {
+                      "description": "OnDemand keeps the SSI admission webhook available for runtime workload\nselection (annotations and Remote Config APM_POLICIES) when cluster-wide\ninstrumentation is disabled. Matches the Agent and Helm chart default (true).\nDefault: true",
+                      "type": "boolean"
+                    },
                     "targets": {
                       "description": "Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be\nused. If no target matches, the auto instrumentation will not be applied.\n(Requires Cluster Agent 7.64.0+)",
                       "items": {
@@ -9270,6 +9274,10 @@
                           },
                           "description": "LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.\n\u003cLibrary\u003e: \u003cVersion\u003e\nex: \"java\": \"v1.18.0\"",
                           "type": "object"
+                        },
+                        "onDemand": {
+                          "description": "OnDemand keeps the SSI admission webhook available for runtime workload\nselection (annotations and Remote Config APM_POLICIES) when cluster-wide\ninstrumentation is disabled. Matches the Agent and Helm chart default (true).\nDefault: true",
+                          "type": "boolean"
                         },
                         "targets": {
                           "description": "Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be\nused. If no target matches, the auto instrumentation will not be applied.\n(Requires Cluster Agent 7.64.0+)",

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -840,6 +840,13 @@ spec:
                                     <Library>: <Version>
                                     ex: "java": "v1.18.0"
                                   type: object
+                                onDemand:
+                                  description: |-
+                                    OnDemand keeps the SSI admission webhook available for runtime workload
+                                    selection (annotations and Remote Config APM_POLICIES) when cluster-wide
+                                    instrumentation is disabled. Matches the Agent and Helm chart default (true).
+                                    Default: true
+                                  type: boolean
                                 targets:
                                   description: |-
                                     Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -794,6 +794,10 @@
                           "description": "LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.\n\u003cLibrary\u003e: \u003cVersion\u003e\nex: \"java\": \"v1.18.0\"",
                           "type": "object"
                         },
+                        "onDemand": {
+                          "description": "OnDemand keeps the SSI admission webhook available for runtime workload\nselection (annotations and Remote Config APM_POLICIES) when cluster-wide\ninstrumentation is disabled. Matches the Agent and Helm chart default (true).\nDefault: true",
+                          "type": "boolean"
+                        },
                         "targets": {
                           "description": "Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be\nused. If no target matches, the auto instrumentation will not be applied.\n(Requires Cluster Agent 7.64.0+)",
                           "items": {

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -844,6 +844,13 @@ spec:
                                 <Library>: <Version>
                                 ex: "java": "v1.18.0"
                               type: object
+                            onDemand:
+                              description: |-
+                                OnDemand keeps the SSI admission webhook available for runtime workload
+                                selection (annotations and Remote Config APM_POLICIES) when cluster-wide
+                                instrumentation is disabled. Matches the Agent and Helm chart default (true).
+                                Default: true
+                              type: boolean
                             targets:
                               description: |-
                                 Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
@@ -9704,6 +9711,13 @@ spec:
                                     <Library>: <Version>
                                     ex: "java": "v1.18.0"
                                   type: object
+                                onDemand:
+                                  description: |-
+                                    OnDemand keeps the SSI admission webhook available for runtime workload
+                                    selection (annotations and Remote Config APM_POLICIES) when cluster-wide
+                                    instrumentation is disabled. Matches the Agent and Helm chart default (true).
+                                    Default: true
+                                  type: boolean
                                 targets:
                                   description: |-
                                     Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -790,6 +790,10 @@
                       "description": "LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.\n\u003cLibrary\u003e: \u003cVersion\u003e\nex: \"java\": \"v1.18.0\"",
                       "type": "object"
                     },
+                    "onDemand": {
+                      "description": "OnDemand keeps the SSI admission webhook available for runtime workload\nselection (annotations and Remote Config APM_POLICIES) when cluster-wide\ninstrumentation is disabled. Matches the Agent and Helm chart default (true).\nDefault: true",
+                      "type": "boolean"
+                    },
                     "targets": {
                       "description": "Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be\nused. If no target matches, the auto instrumentation will not be applied.\n(Requires Cluster Agent 7.64.0+)",
                       "items": {
@@ -9373,6 +9377,10 @@
                           },
                           "description": "LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.\n\u003cLibrary\u003e: \u003cVersion\u003e\nex: \"java\": \"v1.18.0\"",
                           "type": "object"
+                        },
+                        "onDemand": {
+                          "description": "OnDemand keeps the SSI admission webhook available for runtime workload\nselection (annotations and Remote Config APM_POLICIES) when cluster-wide\ninstrumentation is disabled. Matches the Agent and Helm chart default (true).\nDefault: true",
+                          "type": "boolean"
                         },
                         "targets": {
                           "description": "Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be\nused. If no target matches, the auto instrumentation will not be applied.\n(Requires Cluster Agent 7.64.0+)",

--- a/docs/configuration.v2alpha1.md
+++ b/docs/configuration.v2alpha1.md
@@ -106,6 +106,7 @@ spec:
 | features.apm.instrumentation.injector.imageTag | Set the image tag to use for the APM Injector. (Requires Cluster Agent 7.57.0+) |
 | features.apm.instrumentation.languageDetection.enabled | Enables Language Detection to automatically detect languages of user workloads (beta). Requires SingleStepInstrumentation.Enabled to be true. Default: true |
 | features.apm.instrumentation.libVersions | LibVersions configures injection of specific tracing library versions with Single Step Instrumentation. <Library>: <Version> ex: "java": "v1.18.0" |
+| features.apm.instrumentation.onDemand | OnDemand keeps the SSI admission webhook available for runtime workload selection (annotations and Remote Config APM_POLICIES) when cluster-wide instrumentation is disabled. Matches the Agent and Helm chart default (true). Default: true |
 | features.apm.instrumentation.targets | Is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be used. If no target matches, the auto instrumentation will not be applied. (Requires Cluster Agent 7.64.0+) |
 | features.apm.unixDomainSocketConfig.enabled | Enables Unix Domain Socket. Default: true |
 | features.apm.unixDomainSocketConfig.path | Defines the socket path used when enabled. |

--- a/internal/controller/datadogagent/defaults/datadogagent_default.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default.go
@@ -47,6 +47,7 @@ const (
 	defaultAPMSocketEnabled             bool   = true
 	defaultAPMSocketHostPath            string = common.DogstatsdAPMSocketHostPath + "/" + common.APMSocketName
 	defaultAPMSingleStepInstrEnabled    bool   = false
+	defaultAPMOnDemandEnabled           bool   = true
 	defaultLanguageDetectionEnabled     bool   = true
 	defaultCSPMEnabled                  bool   = false
 	defaultCSPMHostBenchmarksEnabled    bool   = true
@@ -327,6 +328,7 @@ func defaultFeaturesConfig(ddaSpec *v2alpha1.DatadogAgentSpec) {
 		}
 
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.APM.SingleStepInstrumentation.Enabled, defaultAPMSingleStepInstrEnabled)
+		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.APM.SingleStepInstrumentation.OnDemand, defaultAPMOnDemandEnabled)
 		apiutils.DefaultBooleanIfUnset(&ddaSpec.Features.APM.SingleStepInstrumentation.LanguageDetection.Enabled, defaultLanguageDetectionEnabled)
 
 		if ddaSpec.Features.APM.ErrorTrackingStandalone == nil {

--- a/internal/controller/datadogagent/defaults/datadogagent_default_test.go
+++ b/internal/controller/datadogagent/defaults/datadogagent_default_test.go
@@ -201,6 +201,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -585,6 +586,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -747,6 +749,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -904,6 +907,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -1061,6 +1065,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -1220,6 +1225,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -1384,6 +1390,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -1541,6 +1548,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -1701,6 +1709,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -1852,6 +1861,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -2030,6 +2040,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -2188,6 +2199,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -2369,6 +2381,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -2529,6 +2542,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},
@@ -2704,6 +2718,7 @@ func Test_defaultFeatures(t *testing.T) {
 						},
 						SingleStepInstrumentation: &v2alpha1.SingleStepInstrumentation{
 							Enabled:           ptr.To(defaultAPMSingleStepInstrEnabled),
+							OnDemand:          ptr.To(defaultAPMOnDemandEnabled),
 							LanguageDetection: &v2alpha1.LanguageDetectionConfig{Enabled: ptr.To(defaultLanguageDetectionEnabled)},
 							Injector:          &v2alpha1.InjectorConfig{},
 						},

--- a/internal/controller/datadogagent/feature/apm/envvar.go
+++ b/internal/controller/datadogagent/feature/apm/envvar.go
@@ -10,6 +10,7 @@ const (
 	DDAPMReceiverPort                      = "DD_APM_RECEIVER_PORT"
 	DDAPMReceiverSocket                    = "DD_APM_RECEIVER_SOCKET"
 	DDAPMInstrumentationEnabled            = "DD_APM_INSTRUMENTATION_ENABLED"
+	DDAPMInstrumentationOnDemand           = "DD_APM_INSTRUMENTATION_ON_DEMAND"
 	DDAPMInstrumentationInjectorImageTag   = "DD_APM_INSTRUMENTATION_INJECTOR_IMAGE_TAG"
 	DDAPMInstrumentationInjectionMode      = "DD_APM_INSTRUMENTATION_INJECTION_MODE"
 	DDAPMInstrumentationEnabledNamespaces  = "DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES"

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -94,6 +94,7 @@ type apmFeature struct {
 
 type instrumentationConfig struct {
 	enabled            bool
+	onDemand           bool
 	enabledNamespaces  []string
 	disabledNamespaces []string
 	libVersions        map[string]string
@@ -200,6 +201,11 @@ func (f *apmFeature) Configure(dda metav1.Object, ddaSpec *v2alpha1.DatadogAgent
 	if shouldConfigureSSI(apm, ddaSpec) {
 		f.singleStepInstrumentation = &instrumentationConfig{}
 		f.singleStepInstrumentation.enabled = apiutils.BoolValue(apm.SingleStepInstrumentation.Enabled)
+		// Unset OnDemand matches the Agent/Helm default (true).
+		f.singleStepInstrumentation.onDemand = true
+		if apm.SingleStepInstrumentation.OnDemand != nil {
+			f.singleStepInstrumentation.onDemand = apiutils.BoolValue(apm.SingleStepInstrumentation.OnDemand)
+		}
 		f.singleStepInstrumentation.disabledNamespaces = apm.SingleStepInstrumentation.DisabledNamespaces
 		f.singleStepInstrumentation.enabledNamespaces = apm.SingleStepInstrumentation.EnabledNamespaces
 		f.singleStepInstrumentation.libVersions = apm.SingleStepInstrumentation.LibVersions
@@ -397,6 +403,10 @@ func (f *apmFeature) ManageClusterAgent(managers feature.PodTemplateManagers) er
 		managers.EnvVar().AddEnvVarToContainer(apicommon.ClusterAgentContainerName, &corev1.EnvVar{
 			Name:  DDAPMInstrumentationEnabled,
 			Value: apiutils.BoolToString(&f.singleStepInstrumentation.enabled),
+		})
+		managers.EnvVar().AddEnvVarToContainer(apicommon.ClusterAgentContainerName, &corev1.EnvVar{
+			Name:  DDAPMInstrumentationOnDemand,
+			Value: apiutils.BoolToString(&f.singleStepInstrumentation.onDemand),
 		})
 
 		if f.shouldSetCustomInjectorImage() {

--- a/internal/controller/datadogagent/feature/apm/feature_test.go
+++ b/internal/controller/datadogagent/feature/apm/feature_test.go
@@ -561,6 +561,22 @@ func TestAPMFeature(t *testing.T) {
 			WantConfigure: true,
 			ClusterAgent:  testAPMInstrumentationWithInjectionMode("init_container"),
 		},
+		{
+			Name: "single step instrumentation on-demand disabled",
+			DDA: func() *v2alpha1.DatadogAgent {
+				dda := testutils.NewDatadogAgentBuilder().
+					WithAPMEnabled(true).
+					WithAPMHostPortEnabled(true, ptr.To[int32](8126)).
+					WithAPMUDSEnabled(true, apmSocketHostPath).
+					WithAPMSingleStepInstrumentationEnabled(true, nil, nil, nil, false, "", nil, "").
+					WithAdmissionControllerEnabled(true).
+					Build()
+				dda.Spec.Features.APM.SingleStepInstrumentation.OnDemand = ptr.To(false)
+				return dda
+			}(),
+			WantConfigure: true,
+			ClusterAgent:  testAPMInstrumentationOnDemand(false),
+		},
 	}
 
 	tests.Run(t, buildAPMFeature)
@@ -825,6 +841,10 @@ func testAPMInstrumentationFull() *test.ComponentTest {
 					Value: "true",
 				},
 				{
+					Name:  DDAPMInstrumentationOnDemand,
+					Value: "true",
+				},
+				{
 					Name:  DDAPMInstrumentationDisabledNamespaces,
 					Value: "[\"foo\",\"bar\"]",
 				},
@@ -892,6 +912,10 @@ func testAPMInstrumentationNamespaces() *test.ComponentTest {
 					Value: "false",
 				},
 				{
+					Name:  DDAPMInstrumentationOnDemand,
+					Value: "true",
+				},
+				{
 					Name:  DDAPMInstrumentationEnabledNamespaces,
 					Value: "[\"foo\",\"bar\"]",
 				},
@@ -928,6 +952,43 @@ func testAPMInstrumentation() *test.ComponentTest {
 					Name:  DDAPMInstrumentationEnabled,
 					Value: "true",
 				},
+				{
+					Name:  DDAPMInstrumentationOnDemand,
+					Value: "true",
+				},
+			}
+			assert.True(
+				t,
+				apiutils.IsEqualStruct(agentEnvs, expectedAgentEnvs),
+				"Cluster Agent ENVs \ndiff = %s", cmp.Diff(agentEnvs, expectedAgentEnvs),
+			)
+		},
+	)
+}
+
+func testAPMInstrumentationOnDemand(onDemand bool) *test.ComponentTest {
+	return test.NewDefaultComponentTest().WithWantFunc(
+		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
+			mgr := mgrInterface.(*fake.PodTemplateManagers)
+
+			agentEnvs := mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterAgentContainerName]
+			expectedAgentEnvs := []*corev1.EnvVar{
+				{
+					Name:  DDTraceAgentHostSocketPath,
+					Value: common.DogstatsdAPMSocketHostPath,
+				},
+				{
+					Name:  DDAPMReceiverSocket,
+					Value: apmSocketHostPath,
+				},
+				{
+					Name:  DDAPMInstrumentationEnabled,
+					Value: "true",
+				},
+				{
+					Name:  DDAPMInstrumentationOnDemand,
+					Value: apiutils.BoolToString(&onDemand),
+				},
 			}
 			assert.True(
 				t,
@@ -947,6 +1008,10 @@ func testAPMInstrumentationWithoutUDS() *test.ComponentTest {
 			expectedAgentEnvs := []*corev1.EnvVar{
 				{
 					Name:  DDAPMInstrumentationEnabled,
+					Value: "true",
+				},
+				{
+					Name:  DDAPMInstrumentationOnDemand,
 					Value: "true",
 				},
 			}
@@ -977,6 +1042,10 @@ func testAPMInstrumentationWithLanguageDetectionEnabledForClusterAgent() *test.C
 				},
 				{
 					Name:  DDAPMInstrumentationEnabled,
+					Value: "true",
+				},
+				{
+					Name:  DDAPMInstrumentationOnDemand,
 					Value: "true",
 				},
 				{
@@ -1017,6 +1086,10 @@ func testAPMInstrumentationWithCustomInjectorImage() *test.ComponentTest {
 					Value: "true",
 				},
 				{
+					Name:  DDAPMInstrumentationOnDemand,
+					Value: "true",
+				},
+				{
 					Name:  DDAPMInstrumentationInjectorImageTag,
 					Value: "0.27.0",
 				},
@@ -1047,6 +1120,10 @@ func testAPMInstrumentationWithInjectionMode(injectionMode string) *test.Compone
 				},
 				{
 					Name:  DDAPMInstrumentationEnabled,
+					Value: "true",
+				},
+				{
+					Name:  DDAPMInstrumentationOnDemand,
 					Value: "true",
 				},
 				{

--- a/internal/controller/datadogagent/feature/apm/profile_overlay.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay.go
@@ -181,6 +181,9 @@ func mergeSSI(dst, src *v2alpha1.SingleStepInstrumentation) error {
 	if err := mergeInjectionMode(dst, src); err != nil {
 		return err
 	}
+	if err := mergeOnDemand(dst, src); err != nil {
+		return err
+	}
 	if err := mergeSSITargets(&dst.Targets, src.Targets); err != nil {
 		return err
 	}
@@ -255,6 +258,13 @@ func mergeInjector(dst, src *v2alpha1.SingleStepInstrumentation) error {
 
 func mergeInjectionMode(dst, src *v2alpha1.SingleStepInstrumentation) error {
 	return mergeStringLikeField(&dst.InjectionMode, src.InjectionMode, "features.apm.instrumentation.injectionMode")
+}
+
+func mergeOnDemand(dst, src *v2alpha1.SingleStepInstrumentation) error {
+	if src.OnDemand == nil {
+		return nil
+	}
+	return mergeBoolPtr(&dst.OnDemand, src.OnDemand, "features.apm.instrumentation.onDemand")
 }
 
 // mergeBoolPtr copies an explicit profile bool into the shared config and

--- a/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
+++ b/internal/controller/datadogagent/feature/apm/profile_overlay_test.go
@@ -120,6 +120,19 @@ func TestAPMProfileSharedConfigOverlay(t *testing.T) {
 			wantErr: `features.apm.instrumentation.injectionMode has conflicting values "init_container" and "csi"`,
 		},
 		{
+			name: "on-demand conflict rejects profile",
+			dst: func() *v2alpha1.DatadogAgentSpec {
+				spec := testProfileOverlayBaseSpec(true)
+				spec.Features.APM.SingleStepInstrumentation.OnDemand = ptr.To(true)
+				return spec
+			}(),
+			profile: testProfileOverlayProfileSpec(&v2alpha1.SingleStepInstrumentation{
+				Enabled:  ptr.To(true),
+				OnDemand: ptr.To(false),
+			}),
+			wantErr: "features.apm.instrumentation.onDemand has conflicting values",
+		},
+		{
 			name: "targets append in order",
 			dst: func() *v2alpha1.DatadogAgentSpec {
 				spec := testProfileOverlayBaseSpec(true)

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -1161,7 +1161,7 @@ kind: DatadogAgentInternal
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: aks
-    agent.datadoghq.com/ddaispechash: 4aa209cbf559d486dc4dfdf461eaba01
+    agent.datadoghq.com/ddaispechash: a811780b5101a4cf4da455e86d3b3648
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
   labels:
@@ -1200,6 +1200,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1909,7 +1910,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 09f5e1af85f4e02545bdc53dbea3c4dc
+    agent.datadoghq.com/agentspechash: 036ad1ded60354949809c9b225620fec
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -2052,6 +2053,8 @@ spec:
           value: /var/run/datadog/apm.socket
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -1171,7 +1171,7 @@ kind: DatadogAgentInternal
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: gke-autopilot
-    agent.datadoghq.com/ddaispechash: a7db4d33f3ddfb4710ce07ee801b6444
+    agent.datadoghq.com/ddaispechash: e942d133ee0446d338a3a0d440b26b17
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
@@ -1211,6 +1211,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1882,7 +1883,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 8a31a7295887debaf6b7dcd2b916b306
+    agent.datadoghq.com/agentspechash: fc299c0141ec1aa4c652a4e529f8fc91
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -2021,6 +2022,8 @@ spec:
           value: datadog-webhook
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -1160,7 +1160,7 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
-    agent.datadoghq.com/ddaispechash: 4aa209cbf559d486dc4dfdf461eaba01
+    agent.datadoghq.com/ddaispechash: a811780b5101a4cf4da455e86d3b3648
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
   labels:
@@ -1199,6 +1199,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1908,7 +1909,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: fd950d2f8911d79cd148f6229fd41897
+    agent.datadoghq.com/agentspechash: 02ff6b53885359e7a2b505c739faffec
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -2049,6 +2050,8 @@ spec:
           value: /var/run/datadog/apm.socket
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -1161,7 +1161,7 @@ kind: DatadogAgentInternal
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: eks-ec2-use-hostname-from-file
-    agent.datadoghq.com/ddaispechash: 4aa209cbf559d486dc4dfdf461eaba01
+    agent.datadoghq.com/ddaispechash: a811780b5101a4cf4da455e86d3b3648
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
   labels:
@@ -1200,6 +1200,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1930,7 +1931,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: fd950d2f8911d79cd148f6229fd41897
+    agent.datadoghq.com/agentspechash: 02ff6b53885359e7a2b505c739faffec
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -2071,6 +2072,8 @@ spec:
           value: /var/run/datadog/apm.socket
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -1044,7 +1044,7 @@ kind: DatadogAgentInternal
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: gke-autopilot
-    agent.datadoghq.com/ddaispechash: a28a2523c1d919bda559301b793425d2
+    agent.datadoghq.com/ddaispechash: 5f578065350e6d7e31f154e799b52050
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
@@ -1084,6 +1084,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1679,7 +1680,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 5b9923ebe7efa58afe1d48703603949c
+    agent.datadoghq.com/agentspechash: 23ec5d4a956d68fad6f33ca42c0d0db0
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1818,6 +1819,8 @@ spec:
           value: datadog-webhook
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
@@ -1033,7 +1033,7 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
-    agent.datadoghq.com/ddaispechash: 213e774cbfb2ee5dccded3cdc0672609
+    agent.datadoghq.com/ddaispechash: 8ab943f9bb818248a2512d687ce95cff
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
   labels:
@@ -1072,6 +1072,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1701,7 +1702,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 41473d90b0a13a8f221447ea0ba6e878
+    agent.datadoghq.com/agentspechash: 5a8914c4c5bc653a073d466b016e4759
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1842,6 +1843,8 @@ spec:
           value: /var/run/datadog/apm.socket
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -1044,7 +1044,7 @@ kind: DatadogAgentInternal
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: gke-autopilot
-    agent.datadoghq.com/ddaispechash: 59d625679eb87482020db1fc1278911c
+    agent.datadoghq.com/ddaispechash: 8137535a6466f17dcab23421508c8167
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
@@ -1084,6 +1084,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1709,7 +1710,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 5b9923ebe7efa58afe1d48703603949c
+    agent.datadoghq.com/agentspechash: 23ec5d4a956d68fad6f33ca42c0d0db0
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1848,6 +1849,8 @@ spec:
           value: datadog-webhook
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
@@ -1033,7 +1033,7 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
-    agent.datadoghq.com/ddaispechash: e8770506cd8992e368d4c1bbd3261064
+    agent.datadoghq.com/ddaispechash: 7decf99a1ee1e0c36138be4e68b174f7
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
   labels:
@@ -1072,6 +1072,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1721,7 +1722,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 41473d90b0a13a8f221447ea0ba6e878
+    agent.datadoghq.com/agentspechash: 5a8914c4c5bc653a073d466b016e4759
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1862,6 +1863,8 @@ spec:
           value: /var/run/datadog/apm.socket
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -1044,7 +1044,7 @@ kind: DatadogAgentInternal
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: gke-autopilot
-    agent.datadoghq.com/ddaispechash: d13d3f79908ea4001e0e3301265738d6
+    agent.datadoghq.com/ddaispechash: d540556a052cf8a848aee34831d50f01
     experimental.agent.datadoghq.com/autopilot: "true"
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
@@ -1084,6 +1084,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1752,7 +1753,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 5b9923ebe7efa58afe1d48703603949c
+    agent.datadoghq.com/agentspechash: 23ec5d4a956d68fad6f33ca42c0d0db0
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1891,6 +1892,8 @@ spec:
           value: datadog-webhook
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
@@ -1033,7 +1033,7 @@ apiVersion: datadoghq.com/v1alpha1
 kind: DatadogAgentInternal
 metadata:
   annotations:
-    agent.datadoghq.com/ddaispechash: 5eba754bd6a44be78e2dfde7b71c0aff
+    agent.datadoghq.com/ddaispechash: e18f29a6ccd3a74ff1213994b249d051
   finalizers:
   - finalizer.datadoghq.com/datadogagentinternal
   labels:
@@ -1072,6 +1072,7 @@ spec:
         injector: {}
         languageDetection:
           enabled: true
+        onDemand: true
       unixDomainSocketConfig:
         enabled: true
         path: /var/run/datadog/apm.socket
@@ -1849,7 +1850,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 213f10c811c401893367317e36fe443f
+    agent.datadoghq.com/agentspechash: e67d0c1c6c01fb30e7d3d19d2906c2e9
   labels:
     agent.datadoghq.com/component: cluster-agent
     agent.datadoghq.com/name: datadog-agent
@@ -1998,6 +1999,8 @@ spec:
           value: /var/run/datadog/apm.socket
         - name: DD_APM_INSTRUMENTATION_ENABLED
           value: "false"
+        - name: DD_APM_INSTRUMENTATION_ON_DEMAND
+          value: "true"
         - name: DD_CLUSTER_CHECKS_ENABLED
           value: "true"
         - name: DD_EXTRA_CONFIG_PROVIDERS


### PR DESCRIPTION
## Description

On-demand SSI policies are delivered over Remote Config (`APM_POLICIES`). The
Cluster Agent subscribes to that product when `apm_config.instrumentation.on_demand`
is true (Agent default), but the Operator did not expose that setting or set
`DD_APM_INSTRUMENTATION_ON_DEMAND` on the Cluster Agent.

This PR:

* adds `spec.features.apm.instrumentation.onDemand` (default `true`, matching the Agent and Helm chart)
* sets `DD_APM_INSTRUMENTATION_ON_DEMAND` on the Cluster Agent from that value
* maps `datadog.apm.instrumentation.onDemand` in yaml-mapper

Unlike [helm-charts#2868](https://github.com/DataDog/helm-charts/pull/2868), Remote Configuration is already enabled on the Cluster Agent by default (`features.remoteConfiguration.enabled=true`). This change does not gate `DD_REMOTE_CONFIGURATION_ENABLED`.

With Operator defaults (APM, admission controller, Remote Config, and `onDemand` all true; cluster-wide SSI off), the Cluster Agent is configured for annotation- and RC-based workload selection without enabling cluster-wide injection.

## Related Issue

Counterpart of https://github.com/DataDog/helm-charts/pull/2868
Follow-up to SSI on-demand RC E2E work in datadog-agent.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [x] Documentation updated if needed
- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- `go test ./internal/controller/datadogagent/feature/apm/ ./internal/controller/datadogagent/defaults/ ./api/datadoghq/v2alpha1/`
- `make generate && make manifests`
- `make golden-update` (Cluster Agent goldens now include `DD_APM_INSTRUMENTATION_ON_DEMAND=true`)

## Minimum Agent Versions

* Agent: n/a
* Cluster Agent: 7.83.0+ (`apm_config.instrumentation.on_demand` / `APM_POLICIES`)

The Operator currently pins Cluster Agent `7.81.1`. Extra env vars are ignored on older images; policies start working once the Cluster Agent image is 7.83+.

## Additional Notes

Default DDA install after this PR:

* `DD_REMOTE_CONFIGURATION_ENABLED=true` (already the Operator default)
* `DD_APM_INSTRUMENTATION_ENABLED=false`
* `DD_APM_INSTRUMENTATION_ON_DEMAND=true`