### PR TITLE
Fix YAML mapper for helm2dda for Helm's configmap based configurations

### DIFF
--- a/cmd/yaml-mapper/mapper/map_processors.go
+++ b/cmd/yaml-mapper/mapper/map_processors.go
@@ -34,6 +34,7 @@ func mapFuncRegistry() map[string]MappingRunFunc {
 		mapAppendEnvVar,
 		mapMergeEnvs,
 		mapOverrideType,
+		mapCustomConfigFile,
 	} {
 		registry[p.name] = p.runFunc
 	}
@@ -293,6 +294,44 @@ var mapOverrideType = MappingProcessor{
 				}
 			}
 		}
+	},
+}
+
+// mapCustomConfigFile serializes an object-shaped Helm value (e.g. custom datadog.yaml settings)
+// into a YAML string and stores it under CustomConfig's `configData` field, keyed by the given
+// filename. The filename is passed via `args` instead of `newPath` since it can contain dots
+// (e.g. "datadog.yaml") that shouldn't be split into nested path segments.
+// args:
+//   - fileName: datadog.yaml
+var mapCustomConfigFile = MappingProcessor{
+	name: "mapCustomConfigFile",
+	runFunc: func(interim map[string]any, newPath string, pathVal any, args []any) {
+		if len(args) != 1 {
+			return
+		}
+		fileName, ok := utils.GetPathString(args[0], "fileName")
+		if !ok || fileName == "" {
+			return
+		}
+
+		var configData string
+		switch v := pathVal.(type) {
+		case string:
+			configData = v
+		default:
+			out, err := yaml.Marshal(pathVal)
+			if err != nil {
+				slog.Error("failed to marshal custom config content", "path", newPath, "fileName", fileName, "error", err)
+				return
+			}
+			configData = string(out)
+		}
+
+		utils.MergeOrSet(interim, newPath, map[string]any{
+			fileName: map[string]any{
+				"configData": configData,
+			},
+		})
 	},
 }
 

--- a/cmd/yaml-mapper/mapper/mapper.go
+++ b/cmd/yaml-mapper/mapper/mapper.go
@@ -201,7 +201,7 @@ func (m *Mapper) mapValues(sourceValues chartutil.Values, mappingValues chartuti
 		if pathVal == nil {
 			if mapVal, ok := utils.GetPathMap(sourceValues[sourceKey]); ok && mapVal != nil {
 				pathVal = mapVal
-			} else if tableVal, err := sourceValues.Table(sourceKey); err == nil && len(tableVal) == 1 {
+			} else if tableVal, err := sourceValues.Table(sourceKey); err == nil && len(tableVal) > 0 {
 				pathVal = tableVal
 			} else {
 				continue

--- a/cmd/yaml-mapper/mapper/mapper.go
+++ b/cmd/yaml-mapper/mapper/mapper.go
@@ -197,11 +197,16 @@ func (m *Mapper) mapValues(sourceValues chartutil.Values, mappingValues chartuti
 
 	// Map values.yaml => DDA
 	for _, sourceKey := range mappingKeys {
+		destKey, _ := mappingValues[sourceKey]
+		// Only mapFunc destinations can safely handle a multi-key table; plain string/list
+		// destinations expect a single scalar and can collide with separate leaf mappings.
+		_, destIsMapFunc := destKey.(map[string]any)
+
 		pathVal, _ := sourceValues.PathValue(sourceKey)
 		if pathVal == nil {
 			if mapVal, ok := utils.GetPathMap(sourceValues[sourceKey]); ok && mapVal != nil {
 				pathVal = mapVal
-			} else if tableVal, err := sourceValues.Table(sourceKey); err == nil && len(tableVal) > 0 {
+			} else if tableVal, err := sourceValues.Table(sourceKey); err == nil && len(tableVal) > 0 && (len(tableVal) == 1 || destIsMapFunc) {
 				pathVal = tableVal
 			} else {
 				continue
@@ -210,7 +215,6 @@ func (m *Mapper) mapValues(sourceValues chartutil.Values, mappingValues chartuti
 
 		utils.MergeOrSet(sourceKeysRef, sourceKey, map[string]any{"visited": true})
 
-		destKey, _ := mappingValues[sourceKey]
 		if (destKey == "" || destKey == nil) && !shouldSkipMappingKey(sourceKey) {
 			slog.Error("DDA destination key not found", "sourceKey", sourceKey)
 			errorCount++

--- a/cmd/yaml-mapper/mapper/mapper.go
+++ b/cmd/yaml-mapper/mapper/mapper.go
@@ -198,22 +198,25 @@ func (m *Mapper) mapValues(sourceValues chartutil.Values, mappingValues chartuti
 	// Map values.yaml => DDA
 	for _, sourceKey := range mappingKeys {
 		destKey, _ := mappingValues[sourceKey]
-		// Only mapFunc destinations can safely handle a multi-key table; plain string/list
-		// destinations expect a single scalar and can collide with separate leaf mappings.
-		_, destIsMapFunc := destKey.(map[string]any)
+		// Only copy a whole table if none of its sub-keys are mapped separately
+		// (e.g. agents.podSecurity.seLinuxContext.rule has its own mapping entry,
+		// so seLinuxContext itself shouldn't be copied as one big table).
+		hasMappedDescendant := hasDescendantMappingKey(mappingKeys, sourceKey)
 
 		pathVal, _ := sourceValues.PathValue(sourceKey)
 		if pathVal == nil {
 			if mapVal, ok := utils.GetPathMap(sourceValues[sourceKey]); ok && mapVal != nil {
 				pathVal = mapVal
-			} else if tableVal, err := sourceValues.Table(sourceKey); err == nil && len(tableVal) > 0 && (len(tableVal) == 1 || destIsMapFunc) {
+			} else if tableVal, err := sourceValues.Table(sourceKey); err == nil && len(tableVal) > 0 && !hasMappedDescendant {
 				pathVal = tableVal
 			} else {
 				continue
 			}
 		}
 
-		utils.MergeOrSet(sourceKeysRef, sourceKey, map[string]any{"visited": true})
+		// Mark this key and everything nested under it as visited, since copying the
+		// whole table also covers all of its nested values.
+		markVisited(sourceKeysRef, sourceKey)
 
 		if (destKey == "" || destKey == nil) && !shouldSkipMappingKey(sourceKey) {
 			slog.Error("DDA destination key not found", "sourceKey", sourceKey)
@@ -385,6 +388,33 @@ func (m *Mapper) updateMapping(sourceValues chartutil.Values, mappingValues char
 	slog.Info("mapping file successfully updated", "path", m.MapConfig.MappingPath)
 
 	return nil
+}
+
+// hasDescendantMappingKey returns true if mappingKeys contains an entry that is a strict
+// descendant of sourceKey (i.e. prefixed with "sourceKey."). Such entries indicate that
+// sub-fields of the table at sourceKey are mapped individually, so the table itself must
+// not be copied wholesale.
+func hasDescendantMappingKey(mappingKeys []string, sourceKey string) bool {
+	prefix := sourceKey + "."
+	for _, k := range mappingKeys {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// markVisited marks sourceKey, and every flattened key nested beneath it, as visited in
+// sourceKeysRef. This is used when a table value is consumed as a whole (either copied
+// directly or passed to a mapFunc), which implicitly consumes all of its nested values too.
+func markVisited(sourceKeysRef map[string]any, sourceKey string) {
+	utils.MergeOrSet(sourceKeysRef, sourceKey, map[string]any{"visited": true})
+	prefix := sourceKey + "."
+	for k := range sourceKeysRef {
+		if strings.HasPrefix(k, prefix) {
+			utils.MergeOrSet(sourceKeysRef, k, map[string]any{"visited": true})
+		}
+	}
 }
 
 // flattenValues builds a mapping of dotted-key paths from a provided Values source.

--- a/cmd/yaml-mapper/mapper/mapper_test.go
+++ b/cmd/yaml-mapper/mapper/mapper_test.go
@@ -1083,7 +1083,7 @@ func TestApplyDeprecationRules(t *testing.T) {
 func TestMappingProcessors(t *testing.T) {
 	// Test that all mapping processors are properly registered
 	t.Run("mapFuncRegistry_dict", func(t *testing.T) {
-		expectedFuncs := []string{"mapSecretKeyName", "mapSeccompProfile", "mapSystemProbeAppArmor", "mapLocalServiceName", "mapAppendEnvVar", "mapMergeEnvs", "mapOverrideType"}
+		expectedFuncs := []string{"mapSecretKeyName", "mapSeccompProfile", "mapSystemProbeAppArmor", "mapLocalServiceName", "mapAppendEnvVar", "mapMergeEnvs", "mapOverrideType", "mapCustomConfigFile"}
 		mapFuncs := mapFuncRegistry()
 
 		for _, funcName := range expectedFuncs {

--- a/cmd/yaml-mapper/mapper/mapper_test.go
+++ b/cmd/yaml-mapper/mapper/mapper_test.go
@@ -1721,6 +1721,139 @@ func TestMappingProcessors(t *testing.T) {
 				"spec.features.foo.bar": 8080,
 			},
 		},
+		// mapCustomConfigFile tests
+		{
+			name:     "mapCustomConfigFile_string_value",
+			funcName: "mapCustomConfigFile",
+			interim:  map[string]any{},
+			newPath:  "spec.override.nodeAgent.customConfigurations",
+			pathVal:  "log_level: debug\ntags:\n  - foo:bar\n",
+			mapFuncArgs: []any{
+				map[string]any{
+					"fileName": "datadog.yaml",
+				},
+			},
+			expectedMap: map[string]any{
+				"spec.override.nodeAgent.customConfigurations": map[string]any{
+					"datadog.yaml": map[string]any{
+						"configData": "log_level: debug\ntags:\n  - foo:bar\n",
+					},
+				},
+			},
+		},
+		{
+			name:     "mapCustomConfigFile_object_value_marshaled_to_yaml",
+			funcName: "mapCustomConfigFile",
+			interim:  map[string]any{},
+			newPath:  "spec.override.clusterAgent.customConfigurations",
+			pathVal: map[string]any{
+				"log_level": "debug",
+				"tags":      []any{"foo:bar"},
+			},
+			mapFuncArgs: []any{
+				map[string]any{
+					"fileName": "datadog-cluster.yaml",
+				},
+			},
+			expectedMap: map[string]any{
+				"spec.override.clusterAgent.customConfigurations": map[string]any{
+					"datadog-cluster.yaml": map[string]any{
+						"configData": "log_level: debug\ntags:\n- foo:bar\n",
+					},
+				},
+			},
+		},
+		{
+			name:     "mapCustomConfigFile_merges_with_existing_customConfigurations",
+			funcName: "mapCustomConfigFile",
+			interim: map[string]any{
+				"spec.override.nodeAgent.customConfigurations": map[string]any{
+					"other-file.yaml": map[string]any{
+						"configData": "foo: bar\n",
+					},
+				},
+			},
+			newPath: "spec.override.nodeAgent.customConfigurations",
+			pathVal: "log_level: debug\n",
+			mapFuncArgs: []any{
+				map[string]any{
+					"fileName": "datadog.yaml",
+				},
+			},
+			expectedMap: map[string]any{
+				"spec.override.nodeAgent.customConfigurations": map[string]any{
+					"other-file.yaml": map[string]any{
+						"configData": "foo: bar\n",
+					},
+					"datadog.yaml": map[string]any{
+						"configData": "log_level: debug\n",
+					},
+				},
+			},
+		},
+		{
+			name:     "mapCustomConfigFile_no_args_is_noop",
+			funcName: "mapCustomConfigFile",
+			interim: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+			newPath:     "spec.override.nodeAgent.customConfigurations",
+			pathVal:     "log_level: debug\n",
+			mapFuncArgs: []any{},
+			expectedMap: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+		},
+		{
+			name:     "mapCustomConfigFile_missing_fileName_is_noop",
+			funcName: "mapCustomConfigFile",
+			interim: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+			newPath: "spec.override.nodeAgent.customConfigurations",
+			pathVal: "log_level: debug\n",
+			mapFuncArgs: []any{
+				map[string]any{},
+			},
+			expectedMap: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+		},
+		{
+			name:     "mapCustomConfigFile_empty_fileName_is_noop",
+			funcName: "mapCustomConfigFile",
+			interim: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+			newPath: "spec.override.nodeAgent.customConfigurations",
+			pathVal: "log_level: debug\n",
+			mapFuncArgs: []any{
+				map[string]any{
+					"fileName": "",
+				},
+			},
+			expectedMap: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+		},
+		{
+			name:     "mapCustomConfigFile_unmarshalable_value_is_noop",
+			funcName: "mapCustomConfigFile",
+			interim: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+			newPath: "spec.override.nodeAgent.customConfigurations",
+			// funcs can't be marshaled to YAML/JSON, exercising the yaml.Marshal error branch.
+			pathVal: func() {},
+			mapFuncArgs: []any{
+				map[string]any{
+					"fileName": "datadog.yaml",
+				},
+			},
+			expectedMap: map[string]any{
+				"spec.global.site": "datadoghq.com",
+			},
+		},
 	}
 
 	mapFuncs := mapFuncRegistry()

--- a/cmd/yaml-mapper/mapper/mapper_test.go
+++ b/cmd/yaml-mapper/mapper/mapper_test.go
@@ -136,6 +136,142 @@ datadog:
 	}
 }
 
+// TestMapValuesMultiKeyTable covers two real-world helm2dda bug reports:
+//  1. clusterAgent.confd/datadog.confd with multiple files must map wholesale into
+//     their configDataMap destination, instead of being silently dropped.
+//  2. agents.customAgentConfig/clusterAgent.datadog_cluster_yaml with nested fields
+//     must not report the flattened nested keys as "not found in mapping" errors,
+//     since they're already fully consumed by the mapCustomConfigFile mapFunc.
+//
+// It also guards against regressing the fix for agents.podSecurity.seLinuxContext,
+// whose sub-fields (e.g. seLinuxOptions.level) have their own separate mapping
+// entries and must therefore NOT be copied wholesale as a multi-key table.
+// fileConfigDataCheck verifies the configData content of a single file entry within a
+// MultiCustomConfig/customConfigurations-style map, whose filename key may itself
+// contain literal dots (e.g. "datadog.yaml"), making PathValue/Table unusable for it.
+type fileConfigDataCheck struct {
+	fileName string
+	want     string
+}
+
+func TestMapValuesMultiKeyTable(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name                string
+		inputValues         string
+		expectNoErrors      bool
+		expectedDDA         map[string]any
+		checkTables         map[string]map[string]any
+		checkFileConfigData map[string]fileConfigDataCheck
+		missingPaths        []string
+	}{
+		{
+			name: "clusterAgent.confd with multiple files maps wholesale",
+			inputValues: `clusterAgent:
+  confd:
+    mysql.yaml: |-
+      cluster_check: true
+    kubernetes_state.yaml: |-
+      ad_identifiers:
+        - kube-state-metrics
+`,
+			expectNoErrors: true,
+			checkTables: map[string]map[string]any{
+				"spec.override.clusterAgent.extraConfd.configDataMap": {
+					"mysql.yaml":            "cluster_check: true",
+					"kubernetes_state.yaml": "ad_identifiers:\n  - kube-state-metrics",
+				},
+			},
+		},
+		{
+			name: "customAgentConfig and datadog_cluster_yaml do not report spurious leaf errors",
+			inputValues: `agents:
+  customAgentConfig:
+    log_level: "debug"
+    jmx_use_container_support: true
+clusterAgent:
+  datadog_cluster_yaml:
+    log_level: "debug"
+    cluster_checks:
+      enabled: true
+`,
+			expectNoErrors: true,
+			checkFileConfigData: map[string]fileConfigDataCheck{
+				"spec.override.nodeAgent.customConfigurations": {
+					fileName: "datadog.yaml",
+					want:     "jmx_use_container_support: true\nlog_level: debug\n",
+				},
+				"spec.override.clusterAgent.customConfigurations": {
+					fileName: "datadog-cluster.yaml",
+					want:     "cluster_checks:\n  enabled: true\nlog_level: debug\n",
+				},
+			},
+		},
+		{
+			name: "seLinuxContext sub-fields stay individually mapped, not copied wholesale",
+			inputValues: `agents:
+  podSecurity:
+    seLinuxContext:
+      seLinuxOptions:
+        level: "s0:c123,c456"
+        role: "system_r"
+        type: "spc_t"
+        user: "system_u"
+`,
+			expectNoErrors: true,
+			expectedDDA: map[string]any{
+				"spec.override.nodeAgent.containers.agent.securityContext.seLinuxOptions.level": "s0:c123,c456",
+				"spec.override.nodeAgent.containers.agent.securityContext.seLinuxOptions.role":  "system_r",
+				"spec.override.nodeAgent.containers.agent.securityContext.seLinuxOptions.type":  "spc_t",
+				"spec.override.nodeAgent.containers.agent.securityContext.seLinuxOptions.user":  "system_u",
+			},
+			// seLinuxOptions itself must not also appear as a flat, wholesale-copied value.
+			missingPaths: []string{"spec.override.nodeAgent.containers.agent.securityContext.seLinuxOptions.rule"},
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valuesPath := filepath.Join(tempDir, fmt.Sprintf("multikey-values-%d.yaml", i+1))
+			ddaPath := filepath.Join(tempDir, fmt.Sprintf("multikey-dda-%d.yaml", i+1))
+			writeTestFile(t, valuesPath, tt.inputValues)
+
+			mapper := NewMapper(MapConfig{
+				MappingPath: "mapping_datadog_helm_to_datadogagent_crd.yaml",
+				SourcePath:  valuesPath,
+				DestPath:    ddaPath,
+			})
+			err := mapper.Run()
+			if tt.expectNoErrors {
+				require.NoError(t, err, "run %s failed", tt.name)
+			}
+
+			dda, err := chartutil.ReadValuesFile(ddaPath)
+			require.NoError(t, err, "run %s failed to read output", tt.name)
+
+			assertValues(t, dda, tt.expectedDDA)
+			for _, missingPath := range tt.missingPaths {
+				assertMissingPath(t, dda, missingPath, "run %s should not contain %s", tt.name, missingPath)
+			}
+			for path, want := range tt.checkTables {
+				got, tableErr := dda.Table(path)
+				require.NoError(t, tableErr, "run %s: expected table at path %q", tt.name, path)
+				for k, v := range want {
+					assert.Equal(t, v, got[k], "run %s: unexpected value at %q[%q]", tt.name, path, k)
+				}
+			}
+			for path, check := range tt.checkFileConfigData {
+				parent, tableErr := dda.Table(path)
+				require.NoError(t, tableErr, "run %s: expected table at path %q", tt.name, path)
+				fileEntry, ok := utils.GetPathMap(parent[check.fileName])
+				require.True(t, ok, "run %s: expected %q[%q] to be a map", tt.name, path, check.fileName)
+				assert.Equal(t, check.want, fileEntry["configData"], "run %s: unexpected configData at %q[%q]", tt.name, path, check.fileName)
+			}
+		})
+	}
+}
+
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0644))

--- a/cmd/yaml-mapper/mapper/mapping_datadog_helm_to_datadogagent_crd.yaml
+++ b/cmd/yaml-mapper/mapper/mapping_datadog_helm_to_datadogagent_crd.yaml
@@ -180,7 +180,7 @@ clusterAgent.admissionController.webhookName: spec.features.admissionController.
 clusterAgent.advancedConfd: spec.override.clusterAgent.extraConfd.configData
 clusterAgent.affinity: spec.override.clusterAgent.affinity
 clusterAgent.command: spec.override.clusterAgent.containers.cluster-agent.command
-clusterAgent.confd: spec.override.clusterAgent.extraConfd
+clusterAgent.confd: spec.override.clusterAgent.extraConfd.configDataMap
 clusterAgent.containerExclude: ""
 clusterAgent.containerInclude: ""
 clusterAgent.containers.clusterAgent.securityContext: spec.override.clusterAgent.containers.clusterAgent.securityContext
@@ -485,10 +485,7 @@ datadog.orchestratorExplorer.customResources: spec.features.orchestratorExplorer
 datadog.orchestratorExplorer.enabled: spec.features.orchestratorExplorer.enabled
 datadog.originDetectionUnified.enabled: spec.global.originDetectionUnified.enabled
 datadog.osReleasePath: ""
-datadog.otelCollector.config:
-- spec.features.otelCollector.conf.configMap.items
-- spec.features.otelCollector.conf.configMap.name
-- spec.features.otelCollector.conf.configData
+datadog.otelCollector.config: spec.features.otelCollector.conf.configData
 datadog.otelCollector.configMap.items: spec.features.otelCollector.conf.configMap.items
 datadog.otelCollector.configMap.key: ""
 datadog.otelCollector.configMap.name: spec.features.otelCollector.conf.configMap.name

--- a/cmd/yaml-mapper/mapper/mapping_datadog_helm_to_datadogagent_crd.yaml
+++ b/cmd/yaml-mapper/mapper/mapping_datadog_helm_to_datadogagent_crd.yaml
@@ -90,7 +90,11 @@ agents.containers.traceAgent.logLevel: spec.override.nodeAgent.containers.trace-
 agents.containers.traceAgent.ports: spec.override.nodeAgent.containers.trace-agent.ports
 agents.containers.traceAgent.resources: spec.override.nodeAgent.containers.trace-agent.resources
 agents.containers.traceAgent.securityContext: spec.override.nodeAgent.containers.trace-agent.securityContext
-agents.customAgentConfig: spec.override.nodeAgent.customConfigurations.datadog.yaml.configData
+agents.customAgentConfig:
+  mapFunc: mapCustomConfigFile
+  newPath: spec.override.nodeAgent.customConfigurations
+  args:
+  - fileName: datadog.yaml
 agents.daemonsetAnnotations: spec.override.nodeAgent.annotations
 agents.dnsConfig: spec.override.nodeAgent.dnsConfig
 agents.enabled: ""
@@ -188,7 +192,11 @@ clusterAgent.containers.clusterAgent.securityContext.allowPrivilegeEscalation: s
 clusterAgent.containers.clusterAgent.securityContext.readOnlyRootFilesystem: spec.override.clusterAgent.containers.clusterAgent.securityContext.readOnlyRootFilesystem
 clusterAgent.containers.initContainer.securityContext: spec.override.clusterAgent.containers.init-config.securityContext
 clusterAgent.createPodDisruptionBudget: ""
-clusterAgent.datadog_cluster_yaml: spec.override.clusterAgent.customConfigurations.datadog-cluster.yaml.configData
+clusterAgent.datadog_cluster_yaml:
+  mapFunc: mapCustomConfigFile
+  newPath: spec.override.clusterAgent.customConfigurations
+  args:
+  - fileName: datadog-cluster.yaml
 clusterAgent.deploymentAnnotations: spec.override.clusterAgent.annotations
 clusterAgent.dnsConfig: spec.override.clusterAgent.dnsConfig
 clusterAgent.enabled: ""

--- a/cmd/yaml-mapper/mapper/testdata/dda_no_errors.yaml
+++ b/cmd/yaml-mapper/mapper/testdata/dda_no_errors.yaml
@@ -29,11 +29,28 @@ spec:
     site: datadoghq.com
   override:
     clusterAgent:
+      customConfigurations:
+        datadog-cluster.yaml:
+          configData: |
+            cluster_checks:
+              enabled: true
+            log_level: debug
+      extraConfd:
+        configDataMap:
+          kubernetes_state.yaml: |-
+            ad_identifiers:
+              - kube-state-metrics
+          mysql.yaml: 'cluster_check: true'
       image:
         name: cluster-agent
         tag: 7.50.0
       replicas: 2
     nodeAgent:
+      customConfigurations:
+        datadog.yaml:
+          configData: |
+            jmx_use_container_support: true
+            log_level: debug
       image:
         name: agent
         tag: 7.50.0

--- a/cmd/yaml-mapper/mapper/testdata/values_no_errors.yaml
+++ b/cmd/yaml-mapper/mapper/testdata/values_no_errors.yaml
@@ -27,9 +27,22 @@ agents:
   tolerations:
     - key: "node-role.kubernetes.io/master"
       effect: "NoSchedule"
+  customAgentConfig:
+    log_level: "debug"
+    jmx_use_container_support: true
 
 clusterAgent:
   replicas: 2
   image:
     name: "cluster-agent"
     tag: "7.50.0"
+  confd:
+    mysql.yaml: |-
+      cluster_check: true
+    kubernetes_state.yaml: |-
+      ad_identifiers:
+        - kube-state-metrics
+  datadog_cluster_yaml:
+    log_level: "debug"
+    cluster_checks:
+      enabled: true


### PR DESCRIPTION
### What does this PR do?

Fixes the following issues when the `helm2dda` flag is run for the Datadog Plugin for `kubectl`.

When using `datadog.otelCollector.config` in Helm like:
```
datadog:
  otelCollector:
    config: |
      receivers:
        otlp:
          protocols:
            grpc:
              endpoint: 0.0.0.0:4317
```
As a result, the mappings come out with three duplicate entries which the latter two are invalid:
```
spec:
  features:
    otelCollector:
      conf:
        configData: |
          receivers:
            otlp:
              protocols:
                grpc:
                  endpoint: 0.0.0.0:4317
        configMap:
          items: |
            receivers:
              otlp:
                protocols:
                  grpc:
                    endpoint: 0.0.0.0:4317
          name: |
            receivers:
              otlp:
                protocols:
                  grpc:
                    endpoint: 0.0.0.0:4317
```

In addition, using `clusterAgent.confd` like:
```
clusterAgent:
  confd:
    mysql.yaml: |
      cluster_check: true
      instances:
        - host: 1.2.3.4
          port: 3306

```
As a result, the mappings for `extraConfd` are missing the `configDataMap` like:
```
  override:
    clusterAgent:
      extraConfd:
        mysql.yaml: |-
          cluster_check: true
          instances:
            - host: 1.2.3.4
              port: 3306
```
- Of note `datadog.confd` is unaffected.

In addition, `agents.customAgentConfig` and `clusterAgent.datadog_cluster_yaml` does not render in the generated DatadogAgent at all and errors out with:
```
2026/08/19 16:08:37 ERROR source value key was not found in mapping key=agents.customAgentConfig.log_level
2026/08/19 16:08:37 ERROR source value key was not found in mapping key=agents.customAgentConfig.tags
2026/08/19 16:08:37 ERROR source value key was not found in mapping key=clusterAgent.datadog_cluster_yaml.log_level
```

### Motivation

CONS-8504

### Additional Notes

Some things to flag which was not covered in this PR:
`clusterAgent.advancedConfd` is also broken as it would render something like the following which isn't valid:
```
  override:
    clusterAgent:
      extraConfd:
        configData:
          mysql.d:
            1.yaml: |
              cluster_check: true
              instances:
                - host: 1.2.3.4
                  port: 3306
            2.yaml: |-
              cluster_check: true
              instances:
                - host: 5.6.7.8
                  port: 3306
```
- I noticed in the README.md: https://github.com/DataDog/datadog-operator/blob/main/cmd/yaml-mapper/README.md, it was mentioned that "If the key does not have a corresponding value in the Datadog Operator configuration, leave the mapping as is with an empty string.". I would think that `clusterAgent.advancedConfd` would belong here as it does not have a corresponding configuration in the `DatadogAgent` CR so not sure if we should also make this an empty string: https://github.com/DataDog/datadog-operator/blob/main/cmd/yaml-mapper/mapper/mapping_datadog_helm_to_datadogagent_crd.yaml#L180

Despite my changes rendering the DatadogAgent CR properly, it still produced these phantom errors (first error might be expected as there is no equivalent in the DatadogAgent):
```
026/08/19 16:18:00 ERROR DDA destination key not found sourceKey=agents.useConfigMap
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=clusterAgent.confd.mysql.yaml
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=agents.customAgentConfig.log_level
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=agents.customAgentConfig.tags
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=datadog.confd.mysql.yaml
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=clusterAgent.datadog_cluster_yaml.log_level
```
- Furthermore, did not want to make further changes to the error handling as I don't want to potentially prevent the plugin from suppressing legitimate errors.

### Describe your test plan

Tested changes locally with the following values.yaml:
```
datadog:
  apiKey: <your api key>
  otelCollector:
    enabled: true
    config: |
      receivers:
        otlp:
          protocols:
            grpc:
              endpoint: 0.0.0.0:4317
  operator:
    enabled: true
    migration:
      preview: true
  confd:
    mysql.yaml: |
      instances:
        - host: 1.2.3.4
          port: 3306
agents:
  useConfigMap: true
  customAgentConfig:
    log_level: debug
    tags: [foo:bar]
clusterAgent:
  confd:
    mysql.yaml: |
      cluster_check: true
      instances:
        - host: 1.2.3.4
          port: 3306
  datadog_cluster_yaml:
    log_level: debug
```


Then run the `helm2dda` flag with:
```
# run this in the root of the repo
make kubectl-datadog
export PATH="<path to datadog operator repo>/datadog-operator/bin:$PATH"

# then ran
kubectl datadog helm2dda \
  --sourcePath=values.yaml \
  --destPath=helm2dda.yaml \
  --namespace=datadog

```

Desired Output:
```
2026/08/19 16:18:00 ERROR DDA destination key not found sourceKey=agents.useConfigMap
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=clusterAgent.confd.mysql.yaml
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=agents.customAgentConfig.log_level
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=agents.customAgentConfig.tags
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=datadog.confd.mysql.yaml
2026/08/19 16:18:00 ERROR source value key was not found in mapping key=clusterAgent.datadog_cluster_yaml.log_level

Mapped DatadogAgent custom resource:

apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
  namespace: datadog
spec:
  features:
    otelCollector:
      conf:
        configData: |
          receivers:
            otlp:
              protocols:
                grpc:
                  endpoint: 0.0.0.0:4317
      enabled: true
  global:
    credentials:
      apiKey: <api key>
  override:
    clusterAgent:
      customConfigurations:
        datadog-cluster.yaml:
          configData: |
            log_level: debug
      extraConfd:
        configDataMap:
          mysql.yaml: |
            cluster_check: true
            instances:
              - host: 1.2.3.4
                port: 3306
    nodeAgent:
      customConfigurations:
        datadog.yaml:
          configData: |
            log_level: debug
            tags:
            - foo:bar
      extraConfd:
        configDataMap:
          mysql.yaml: |
            instances:
              - host: 1.2.3.4
                port: 3306

2026/08/19 16:18:00 INFO YAML file successfully written path=helm2dda.yaml
2026/08/19 16:18:00 ERROR mapper run failed error="mapping completed with 6 error(s): the mapped DDA may contain misconfigurations"
```
- The errors are expected as this PR does not fix those, see Additional Notes above.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits