### PR TITLE
Rename functions that use v2 or v3

### DIFF
--- a/internal/controller/datadogagent/controller.go
+++ b/internal/controller/datadogagent/controller.go
@@ -151,7 +151,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, dda *v2alpha1.DatadogAgent) 
 	var resp reconcile.Result
 	var err error
 
-	resp, err = r.internalReconcileV2(ctx, dda)
+	resp, err = r.internalReconcile(ctx, dda)
 
 	r.metricsForwarderProcessError(dda, err)
 	return resp, err

--- a/internal/controller/datadogagent/controller_reconcile_v2.go
+++ b/internal/controller/datadogagent/controller_reconcile_v2.go
@@ -34,7 +34,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
-func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadoghqv2alpha1.DatadogAgent) (reconcile.Result, error) {
+func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv2alpha1.DatadogAgent) (reconcile.Result, error) {
 	reqLogger := r.log.WithValues("datadogagent", pkgutils.GetNamespacedName(instance))
 	reqLogger.Info("Reconciling DatadogAgent")
 	var result reconcile.Result
@@ -59,7 +59,7 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *datadogh
 	}
 
 	// 4. Delegate to the main reconcile function.
-	return r.reconcileInstanceV3(ctx, reqLogger, instanceCopy, rawSpec)
+	return r.reconcileInstance(ctx, reqLogger, instanceCopy, rawSpec)
 }
 
 // Force GCR registry if not set to avoid defaulting to Datadog registry
@@ -82,7 +82,7 @@ func ensureGCRAutopilotRegistry(spec *datadoghqv2alpha1.DatadogAgentSpec) {
 	spec.Global.Registry = ptr.To(images.GCRContainerRegistry)
 }
 
-func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent, rawSpec datadoghqv2alpha1.DatadogAgentSpec) (reconcile.Result, error) {
+func (r *Reconciler) reconcileInstance(ctx context.Context, logger logr.Logger, instance *datadoghqv2alpha1.DatadogAgent, rawSpec datadoghqv2alpha1.DatadogAgentSpec) (reconcile.Result, error) {
 	// Set up field manager for crd apply
 	if r.fieldManager == nil {
 		f, err := newFieldManager(r.client, r.scheme, getDDAIGVK())
@@ -111,7 +111,7 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 	if r.options.CreateControllerRevisions {
 		revList, err := r.listRevisions(ctx, instance)
 		if err != nil {
-			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, err, now)
+			return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, err, now)
 		}
 		// Use user-submitted instance instead of defaulted instance
 		rawInstance := instance.DeepCopy()
@@ -119,17 +119,17 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 		experimentErr := r.manageExperiment(ctx, rawInstance, newDDAStatus, now, revList)
 		instance.ResourceVersion = rawInstance.ResourceVersion
 		if experimentErr != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newDDAStatus, result, experimentErr, now)
+			return r.updateStatusIfNeeded(logger, instance, newDDAStatus, result, experimentErr, now)
 		}
 		if err := r.manageRevision(ctx, instance, rawSpec, revList, newDDAStatus); err != nil {
-			return r.updateStatusIfNeededV2(logger, instance, newDDAStatus, result, err, now)
+			return r.updateStatusIfNeeded(logger, instance, newDDAStatus, result, err, now)
 		}
 	}
 
 	// Generate default DDAI object from DDA
 	ddai, err := r.generateDDAIFromDDA(instance, provider)
 	if err != nil {
-		return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, err, now)
+		return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, err, now)
 	}
 	ddais = append(ddais, ddai)
 
@@ -149,11 +149,11 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 		defaultDDAI := ddai.DeepCopy()
 		appliedProfiles, e := r.reconcileProfiles(ctx, dsNSName, maxUnavailable, defaultDDAI)
 		if e != nil {
-			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
+			return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, e, now)
 		}
 		profileDDAIs, e := r.applyProfilesToDDAISpec(ddai, defaultDDAI, appliedProfiles)
 		if e != nil {
-			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
+			return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, e, now)
 		}
 		ddais = profileDDAIs
 	}
@@ -161,44 +161,44 @@ func (r *Reconciler) reconcileInstanceV3(ctx context.Context, logger logr.Logger
 	// Manage dependencies after DDAIs are computed to include profile changes
 	err = r.manageDDADependenciesWithDDAI(ctx, logger, instance, newDDAStatus, ddais)
 	if err != nil {
-		return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, err, now)
+		return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, err, now)
 	}
 
 	// Create or update the DDAI object in k8s
 	for _, ddai := range ddais {
 		if e := r.createOrUpdateDDAI(ddai); e != nil {
-			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
+			return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, e, now)
 		}
 
 		// Add DDAI status to DDA status
 		if e := r.addDDAIStatusToDDAStatus(newDDAStatus, ddai.ObjectMeta, now); e != nil {
-			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
+			return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, e, now)
 		}
 
 		// Add DDA remote config status to DDAI status
 		if res, e := r.addRemoteConfigStatusToDDAIStatus(ctx, newDDAStatus, ddai.ObjectMeta); utils.ShouldReturn(res, e) {
-			return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
+			return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, e, now)
 		}
 	}
 
 	// Clean up unused DDAI objects
 	if e := r.cleanUpUnusedDDAIs(ctx, ddais); e != nil {
-		return r.updateStatusIfNeededV2(logger, instance, ddaStatusCopy, result, e, now)
+		return r.updateStatusIfNeeded(logger, instance, ddaStatusCopy, result, e, now)
 	}
 
 	// Prevent the reconcile loop from stopping by requeueing the DDAI object after a period of time
 	result.RequeueAfter = defaultRequeuePeriod
-	return r.updateStatusIfNeededV2(logger, instance, newDDAStatus, result, err, now)
+	return r.updateStatusIfNeeded(logger, instance, newDDAStatus, result, err, now)
 }
 
-func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus, result reconcile.Result, currentError error, now metav1.Time) (reconcile.Result, error) {
+func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, agentdeployment *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus, result reconcile.Result, currentError error, now metav1.Time) (reconcile.Result, error) {
 	if currentError == nil {
 		condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionFalse, "DatadogAgent_reconcile_ok", "DatadogAgent reconcile ok", false)
 	} else {
 		condition.UpdateDatadogAgentStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionTrue, "DatadogAgent_reconcile_error", "DatadogAgent reconcile error", false)
 	}
 
-	r.setMetricsForwarderStatusV2(logger, agentdeployment, newStatus)
+	r.setMetricsForwarderStatus(logger, agentdeployment, newStatus)
 
 	if !IsEqualStatus(&agentdeployment.Status, newStatus) {
 		updateAgentDeployment := agentdeployment.DeepCopy()
@@ -221,7 +221,7 @@ func (r *Reconciler) updateStatusIfNeededV2(logger logr.Logger, agentdeployment 
 }
 
 // setMetricsForwarderStatus sets the metrics forwarder status condition if enabled
-func (r *Reconciler) setMetricsForwarderStatusV2(logger logr.Logger, agentdeployment *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus) {
+func (r *Reconciler) setMetricsForwarderStatus(logger logr.Logger, agentdeployment *datadoghqv2alpha1.DatadogAgent, newStatus *datadoghqv2alpha1.DatadogAgentStatus) {
 	if r.options.OperatorMetricsEnabled {
 		if forwarderCondition := r.forwarders.MetricsForwarderStatusForObj(agentdeployment); forwarderCondition != nil {
 			condition.UpdateDatadogAgentStatusConditions(

--- a/internal/controller/datadogagent/controller_revision_integration_test.go
+++ b/internal/controller/datadogagent/controller_revision_integration_test.go
@@ -67,7 +67,7 @@ func newRevisionIntegrationReconciler(t *testing.T) (*Reconciler, client.Client)
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(s, corev1.EventSource{Component: "test"})
 
-	// Load DDAI CRD — required for reconcileInstanceV3 (which is where
+	// Load DDAI CRD — required for reconcileInstance (which is where
 	// manageRevision is called) to check CRD existence before creating DDAIs.
 	crd, err := getDDAICRDFromConfig(s)
 	assert.NoError(t, err)

--- a/internal/controller/datadogagent/controller_v2_test.go
+++ b/internal/controller/datadogagent/controller_v2_test.go
@@ -108,7 +108,7 @@ func runTestCases(t *testing.T, tests []testCase, testFunc func(t *testing.T, tt
 
 // runDDAReconcilerTest runs test case using both DDA and DDAI reconcilers.
 // Since DDAI is always enabled, the DDA controller delegates resource creation
-// to the DDAI controller via reconcileInstanceV3, so the DDAI reconciler must
+// to the DDAI controller via reconcileInstance, so the DDAI reconciler must
 // also run for resources (DaemonSets, Deployments, etc.) to be created.
 func runDDAReconcilerTest(t *testing.T, tt testCase, opts ReconcilerOptions) {
 	t.Helper()
@@ -2158,7 +2158,7 @@ func verifyPDB(t *testing.T, c client.Client) {
 	assert.Equal(t, intstr.FromInt(1), *ccrPDB.Spec.MaxUnavailable)
 	assert.Nil(t, ccrPDB.Spec.MinAvailable)
 }
-func Test_DDAI_ReconcileV3(t *testing.T) {
+func Test_DDAI_Reconcile(t *testing.T) {
 	const resourcesName = "foo"
 	const resourcesNamespace = "bar"
 
@@ -2407,8 +2407,8 @@ func Test_DDAI_ReconcileV3(t *testing.T) {
 
 // Test_StaleAgentPodCleanup tests that agent pods whose profile assignment has changed are deleted.
 // It exercises both code paths:
-//   - DDA-only path via runDDAReconcilerTest: reconcileInstanceV3
-//   - Full path via runFullReconcilerTest (DDA + DDAI reconcilers): reconcileInstanceV3 → reconcileProfiles → cleanupPodsForProfilesThatNoLongerApply
+//   - DDA-only path via runDDAReconcilerTest: reconcileInstance
+//   - Full path via runFullReconcilerTest (DDA + DDAI reconcilers): reconcileInstance → reconcileProfiles → cleanupPodsForProfilesThatNoLongerApply
 func Test_StaleAgentPodCleanup(t *testing.T) {
 	const resourcesName = "foo"
 	const resourcesNamespace = "bar"

--- a/internal/controller/datadogagent/experiment_events.go
+++ b/internal/controller/datadogagent/experiment_events.go
@@ -38,7 +38,7 @@ const (
 
 // emitExperimentTransitionEvent records a single Kubernetes event on the
 // DDA describing the experiment phase transition observed in this
-// reconcile, if any. Called from updateStatusIfNeededV2 after the status
+// reconcile, if any. Called from updateStatusIfNeeded after the status
 // write succeeds — emitting at the commit point guarantees we don't
 // announce a transition that then 409s and never lands.
 //

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/feature_test.go
@@ -24,14 +24,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var customConfDataV2 = `cluster_check: false
+var customConfData = `cluster_check: false
 init_config:
 instances:
   - skip_leader_election: false
     collectors:
       - clusterrolebindings`
 
-var expectedOrchestratorEnvsV2 = []*corev1.EnvVar{
+var expectedOrchestratorEnvs = []*corev1.EnvVar{
 	{
 		Name:  DDOrchestratorExplorerEnabled,
 		Value: "true",
@@ -66,11 +66,11 @@ func Test_orchestratorExplorerFeature_Configure(t *testing.T) {
 				WithOrchestratorExplorerScrubContainers(true).
 				WithOrchestratorExplorerExtraTags([]string{"a:z", "b:y", "c:x"}).
 				WithOrchestratorExplorerDDUrl("https://foo.bar").
-				WithOrchestratorExplorerCustomConfigData(customConfDataV2).
+				WithOrchestratorExplorerCustomConfigData(customConfData).
 				WithComponentOverride(v2alpha1.NodeAgentComponentName, v2alpha1.DatadogAgentComponentOverride{Image: &v2alpha1.AgentImageConfig{Tag: "7.51.0"}}).
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  orchestratorExplorerClusterAgentWantFuncV2(),
+			ClusterAgent:  orchestratorExplorerClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(orchestratorExplorerNodeAgentNoProcessAgentWantFunc),
 		},
 		{
@@ -139,13 +139,13 @@ instances:
 				WithOrchestratorExplorerScrubContainers(true).
 				WithOrchestratorExplorerExtraTags([]string{"a:z", "b:y", "c:x"}).
 				WithOrchestratorExplorerDDUrl("https://foo.bar").
-				WithOrchestratorExplorerCustomConfigData(customConfDataV2).
+				WithOrchestratorExplorerCustomConfigData(customConfData).
 				WithClusterChecksEnabled(true).
 				WithClusterChecksUseCLCEnabled(true).
 				WithComponentOverride(v2alpha1.NodeAgentComponentName, v2alpha1.DatadogAgentComponentOverride{Image: &v2alpha1.AgentImageConfig{Tag: "7.51.0"}}).
 				Build(),
 			WantConfigure:       true,
-			ClusterAgent:        orchestratorExplorerClusterAgentWantFuncV2(),
+			ClusterAgent:        orchestratorExplorerClusterAgentWantFunc(),
 			Agent:               test.NewDefaultComponentTest().WithWantFunc(orchestratorExplorerNodeAgentNoProcessAgentWantFunc),
 			ClusterChecksRunner: test.NewDefaultComponentTest().WithWantFunc(orchestratorExplorerClusterChecksRunnerWantFunc),
 		},
@@ -156,11 +156,11 @@ instances:
 				WithOrchestratorExplorerScrubContainers(true).
 				WithOrchestratorExplorerExtraTags([]string{"a:z", "b:y", "c:x"}).
 				WithOrchestratorExplorerDDUrl("https://foo.bar").
-				WithOrchestratorExplorerCustomConfigData(customConfDataV2).
+				WithOrchestratorExplorerCustomConfigData(customConfData).
 				WithComponentOverride(v2alpha1.NodeAgentComponentName, v2alpha1.DatadogAgentComponentOverride{Image: &v2alpha1.AgentImageConfig{Tag: "7.50.0"}}).
 				Build(),
 			WantConfigure: true,
-			ClusterAgent:  orchestratorExplorerClusterAgentWantFuncV2(),
+			ClusterAgent:  orchestratorExplorerClusterAgentWantFunc(),
 			Agent:         test.NewDefaultComponentTest().WithWantFunc(orchestratorExplorerNodeAgentWantFunc),
 		},
 		{
@@ -182,26 +182,26 @@ instances:
 func orchestratorExplorerNodeAgentWantFunc(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 	mgr := mgrInterface.(*fake.PodTemplateManagers)
 	agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.ProcessAgentContainerName]
-	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorEnvsV2), "Process agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvsV2))
+	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorEnvs), "Process agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvs))
 	agentEnvVars = mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
-	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorEnvsV2), "Core agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvsV2))
+	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorEnvs), "Core agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvs))
 }
 
 func orchestratorExplorerNodeAgentNoProcessAgentWantFunc(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 	mgr := mgrInterface.(*fake.PodTemplateManagers)
 	agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.ProcessAgentContainerName]
-	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, nil), "Process agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvsV2))
+	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, nil), "Process agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvs))
 	agentEnvVars = mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
-	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorEnvsV2), "Core agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvsV2))
+	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorEnvs), "Core agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorEnvs))
 }
 
 func orchestratorExplorerClusterChecksRunnerWantFunc(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 	mgr := mgrInterface.(*fake.PodTemplateManagers)
 	runnerEnvs := append(mgr.EnvVarMgr.EnvVarsByC[apicommon.AllContainers], mgr.EnvVarMgr.EnvVarsByC[apicommon.ClusterChecksRunnersContainerName]...)
-	assert.True(t, apiutils.IsEqualStruct(runnerEnvs, expectedOrchestratorEnvsV2), "Cluster Checks Runner envvars \ndiff = %s", cmp.Diff(runnerEnvs, expectedOrchestratorEnvsV2))
+	assert.True(t, apiutils.IsEqualStruct(runnerEnvs, expectedOrchestratorEnvs), "Cluster Checks Runner envvars \ndiff = %s", cmp.Diff(runnerEnvs, expectedOrchestratorEnvs))
 }
 
-var expectedOrchestratorNetworkCRDEnvsV2 = []*corev1.EnvVar{
+var expectedOrchestratorNetworkCRDEnvs = []*corev1.EnvVar{
 	{
 		Name:  DDOrchestratorExplorerEnabled,
 		Value: "true",
@@ -227,7 +227,7 @@ var expectedOrchestratorNetworkCRDEnvsV2 = []*corev1.EnvVar{
 func orchestratorExplorerNodeAgentWithNetworkCRDsWantFunc(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 	mgr := mgrInterface.(*fake.PodTemplateManagers)
 	agentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
-	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorNetworkCRDEnvsV2), "Core agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorNetworkCRDEnvsV2))
+	assert.True(t, apiutils.IsEqualStruct(agentEnvVars, expectedOrchestratorNetworkCRDEnvs), "Core agent envvars \ndiff = %s", cmp.Diff(agentEnvVars, expectedOrchestratorNetworkCRDEnvs))
 }
 
 func orchestratorExplorerClusterAgentWithNetworkCRDsWantFunc() *test.ComponentTest {
@@ -235,17 +235,17 @@ func orchestratorExplorerClusterAgentWithNetworkCRDsWantFunc() *test.ComponentTe
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
 			dcaEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
-			assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, expectedOrchestratorNetworkCRDEnvsV2), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, expectedOrchestratorNetworkCRDEnvsV2))
+			assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, expectedOrchestratorNetworkCRDEnvs), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, expectedOrchestratorNetworkCRDEnvs))
 		},
 	)
 }
 
-func orchestratorExplorerClusterAgentWantFuncV2() *test.ComponentTest {
+func orchestratorExplorerClusterAgentWantFunc() *test.ComponentTest {
 	return test.NewDefaultComponentTest().WithWantFunc(
 		func(t testing.TB, mgrInterface feature.PodTemplateManagers) {
 			mgr := mgrInterface.(*fake.PodTemplateManagers)
 			dcaEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
-			assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, expectedOrchestratorEnvsV2), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, expectedOrchestratorEnvsV2))
+			assert.True(t, apiutils.IsEqualStruct(dcaEnvVars, expectedOrchestratorEnvs), "DCA envvars \ndiff = %s", cmp.Diff(dcaEnvVars, expectedOrchestratorEnvs))
 
 			annotations := mgr.AnnotationMgr.Annotations
 			assert.Empty(t, annotations)

--- a/internal/controller/datadogagent/finalizer.go
+++ b/internal/controller/datadogagent/finalizer.go
@@ -24,11 +24,11 @@ const (
 
 func (r *Reconciler) deleteResource(reqLogger logr.Logger) finalizer.ResourceDeleteFunc {
 	return func(ctx context.Context, k8sObj client.Object, datadogID string) error {
-		return r.finalizeDadV2(reqLogger, k8sObj)
+		return r.finalizeDad(reqLogger, k8sObj)
 	}
 }
 
-func (r *Reconciler) finalizeDadV2(reqLogger logr.Logger, obj client.Object) error {
+func (r *Reconciler) finalizeDad(reqLogger logr.Logger, obj client.Object) error {
 	if r.options.OperatorMetricsEnabled {
 		r.forwarders.Unregister(obj)
 	}

--- a/internal/controller/datadogagent/finalizer_test.go
+++ b/internal/controller/datadogagent/finalizer_test.go
@@ -138,7 +138,7 @@ func Test_handleFinalizer(t *testing.T) {
 
 	reconciler := reconcilerForFinalizerTest(initialKubeObjects)
 
-	err := reconciler.finalizeDadV2(logf.Log.WithName("Handle Finalizer V2 test"), dda)
+	err := reconciler.finalizeDad(logf.Log.WithName("Handle Finalizer V2 test"), dda)
 	assert.NoError(t, err)
 
 	// With DDAI always enabled, the DDA finalizer no longer deletes cluster-level resources

--- a/internal/controller/datadogagentinternal/controller.go
+++ b/internal/controller/datadogagentinternal/controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, ddai *v1alpha1.DatadogAgentI
 	var resp reconcile.Result
 	var err error
 
-	resp, err = r.internalReconcileV2(ctx, ddai)
+	resp, err = r.internalReconcile(ctx, ddai)
 
 	r.metricsForwarderProcessError(ddai, err)
 	return resp, err

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2.go
@@ -28,7 +28,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
-func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *v1alpha1.DatadogAgentInternal) (reconcile.Result, error) {
+func (r *Reconciler) internalReconcile(ctx context.Context, instance *v1alpha1.DatadogAgentInternal) (reconcile.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info("Reconciling DatadogAgentInternal")
 	// var result reconcile.Result
@@ -50,10 +50,10 @@ func (r *Reconciler) internalReconcileV2(ctx context.Context, instance *v1alpha1
 	defaults.DefaultDatadogAgentSpec(&instanceCopy.Spec)
 
 	// 4. Delegate to the main reconcile function.
-	return r.reconcileInstanceV2(ctx, instanceCopy)
+	return r.reconcileInstance(ctx, instanceCopy)
 }
 
-func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1.DatadogAgentInternal) (reconcile.Result, error) {
+func (r *Reconciler) reconcileInstance(ctx context.Context, instance *v1alpha1.DatadogAgentInternal) (reconcile.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	var result reconcile.Result
 	newStatus := instance.Status.DeepCopy()
@@ -67,7 +67,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	// (mirrors Helm's install-time fail) before any dependency/resource is created; a degraded
 	// feature only warns. Evaluated on the verdict BuildFeatures returned.
 	if r.providerSupportBlocks(logger, instance, unsupportedFeatures, newStatus, now) {
-		return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, nil, now)
+		return r.updateStatusIfNeeded(ctx, instance, newStatus, reconcile.Result{}, nil, now)
 	}
 
 	// 1. Manage dependencies.
@@ -78,17 +78,17 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	// only manage dependencies for default DDAIs
 	if !isDDAILabeledWithProfile(instance) {
 		if err = r.manageGlobalDependencies(ctx, instance, resourceManagers, requiredComponents); err != nil {
-			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
+			return r.updateStatusIfNeeded(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
 		if err = r.manageFeatureDependencies(enabledFeatures, resourceManagers); err != nil {
-			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
+			return r.updateStatusIfNeeded(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
 		if err = r.overrideDependencies(ctx, resourceManagers, instance); err != nil {
-			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
+			return r.updateStatusIfNeeded(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
 		// 1. Apply and cleanup dependencies before reconciling components to ensure deps exist at reconciliation time.
 		if err = r.applyAndCleanupDependencies(ctx, depsStore); err != nil {
-			return r.updateStatusIfNeededV2(ctx, instance, newStatus, reconcile.Result{}, err, now)
+			return r.updateStatusIfNeeded(ctx, instance, newStatus, reconcile.Result{}, err, now)
 		}
 	}
 
@@ -108,7 +108,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 
 		result, err = r.componentRegistry.ReconcileComponents(ctx, params)
 		if utils.ShouldReturn(result, err) {
-			return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
+			return r.updateStatusIfNeeded(ctx, instance, newStatus, result, err, now)
 		}
 	}
 
@@ -116,20 +116,20 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	// controller stamps gke-autopilot there for both the OOTB and experimental opt-in paths.
 	result, err = r.reconcileV2Agent(ctx, requiredComponents, append(configuredFeatures, enabledFeatures...), instance, resourceManagers, newStatus, provider)
 	if utils.ShouldReturn(result, err) {
-		return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
+		return r.updateStatusIfNeeded(ctx, instance, newStatus, result, err, now)
 	}
 	condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.AgentReconcileConditionType, metav1.ConditionTrue, "reconcile_succeed", "reconcile succeed", false)
 
 	// 3. Cleanup extraneous resources.
 	if err = r.cleanupExtraneousResources(ctx, instance, newStatus, resourceManagers); err != nil {
 		logger.Error(err, "Error cleaning up extraneous resources")
-		return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
+		return r.updateStatusIfNeeded(ctx, instance, newStatus, result, err, now)
 	}
 
 	// 4. Cleanup stale dependencies (only for default DDAIs).
 	if !isDDAILabeledWithProfile(instance) {
 		if cleanupErrs := depsStore.Cleanup(ctx, r.client, true); len(cleanupErrs) > 0 {
-			return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, cleanupErrs[0], now)
+			return r.updateStatusIfNeeded(ctx, instance, newStatus, result, cleanupErrs[0], now)
 		}
 	}
 
@@ -137,7 +137,7 @@ func (r *Reconciler) reconcileInstanceV2(ctx context.Context, instance *v1alpha1
 	if result.IsZero() {
 		result.RequeueAfter = defaultRequeuePeriod
 	}
-	return r.updateStatusIfNeededV2(ctx, instance, newStatus, result, err, now)
+	return r.updateStatusIfNeeded(ctx, instance, newStatus, result, err, now)
 }
 
 // providerSupportBlocks acts on the provider-support verdict returned by BuildFeatures. Features
@@ -178,7 +178,7 @@ func (r *Reconciler) providerSupportBlocks(logger logr.Logger, instance *v1alpha
 	return false
 }
 
-func (r *Reconciler) updateStatusIfNeededV2(ctx context.Context, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus, result reconcile.Result, currentError error, now metav1.Time) (reconcile.Result, error) {
+func (r *Reconciler) updateStatusIfNeeded(ctx context.Context, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus, result reconcile.Result, currentError error, now metav1.Time) (reconcile.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	if currentError == nil {
 		condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionFalse, "DatadogAgent_reconcile_ok", "DatadogAgent reconcile ok", false)
@@ -186,7 +186,7 @@ func (r *Reconciler) updateStatusIfNeededV2(ctx context.Context, agentdeployment
 		condition.UpdateDatadogAgentInternalStatusConditions(newStatus, now, common.DatadogAgentReconcileErrorConditionType, metav1.ConditionTrue, "DatadogAgent_reconcile_error", currentError.Error(), false)
 	}
 
-	r.setMetricsForwarderStatusV2(ctx, agentdeployment, newStatus)
+	r.setMetricsForwarderStatus(ctx, agentdeployment, newStatus)
 
 	if !IsEqualStatus(&agentdeployment.Status, newStatus) {
 		updateAgentDeployment := agentdeployment.DeepCopy()
@@ -205,7 +205,7 @@ func (r *Reconciler) updateStatusIfNeededV2(ctx context.Context, agentdeployment
 }
 
 // setMetricsForwarderStatus sets the metrics forwarder status condition if enabled
-func (r *Reconciler) setMetricsForwarderStatusV2(ctx context.Context, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus) {
+func (r *Reconciler) setMetricsForwarderStatus(ctx context.Context, agentdeployment *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus) {
 	if r.options.OperatorMetricsEnabled {
 		if forwarderCondition := r.forwarders.MetricsForwarderStatusForObj(agentdeployment); forwarderCondition != nil {
 			condition.UpdateDatadogAgentInternalStatusConditions(

--- a/internal/controller/datadogagentinternal/controller_reconcile_v2_common_test.go
+++ b/internal/controller/datadogagentinternal/controller_reconcile_v2_common_test.go
@@ -111,7 +111,7 @@ func Test_ensureSelectorInPodTemplateLabels(t *testing.T) {
 	}
 }
 
-func Test_updateStatusIfNeededV2_ReconcileErrorCondition(t *testing.T) {
+func Test_updateStatusIfNeeded_ReconcileErrorCondition(t *testing.T) {
 	sch := runtime.NewScheme()
 	_ = scheme.AddToScheme(sch)
 	_ = v1alpha1.AddToScheme(sch)
@@ -174,7 +174,7 @@ func Test_updateStatusIfNeededV2_ReconcileErrorCondition(t *testing.T) {
 				newStatus.Conditions = append(newStatus.Conditions, *tt.existingCondition)
 			}
 
-			_, err := r.updateStatusIfNeededV2(context.Background(), currentDDAI, newStatus, reconcile.Result{}, tt.currentError, now)
+			_, err := r.updateStatusIfNeeded(context.Background(), currentDDAI, newStatus, reconcile.Result{}, tt.currentError, now)
 			assert.Equal(t, tt.currentError, err)
 
 			cond := condition.GetDDAICondition(newStatus, common.DatadogAgentReconcileErrorConditionType)

--- a/internal/controller/testutils/renderer/renderer.go
+++ b/internal/controller/testutils/renderer/renderer.go
@@ -159,7 +159,7 @@ func Render(opts Options) ([]client.Object, *runtime.Scheme, error) {
 	}
 
 	// Build fake client pre-populated with DDA, DAPs, and the DDAI CRD.
-	// The DDAI CRD is required by newFieldManager() inside reconcileInstanceV3.
+	// The DDAI CRD is required by newFieldManager() inside reconcileInstance.
 	// StatusSubresource registration ensures Status().Update() calls work correctly.
 	initObjs := []client.Object{opts.DDA, crd}
 	for _, dap := range opts.DAPs {


### PR DESCRIPTION
### What does this PR do?

Rename functions that have v2 or v3 suffix and are the only instance of those functions

### Motivation

https://datadoghq.atlassian.net/browse/CONTP-1538

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits