### PR TITLE
[CONTP-2023] Improve DatadogMonitor reconciliation at scale

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,6 +65,8 @@ import (
 
 const (
 	defaultMaximumGoroutines                             = 500
+	defaultDatadogMonitorMaxConcurrentReconciles         = 1
+	defaultDatadogMonitorRequeuePeriod                   = 60 * time.Second
 	defaultDatadogGenericResourceMaxConcurrentReconciles = 1
 	defaultDatadogGenericResourceRequeuePeriod           = 60 * time.Second
 	podNamespaceEnvVar                                   = "POD_NAMESPACE"
@@ -142,6 +144,8 @@ type options struct {
 	datadogAgentEnabled                    bool
 	createControllerRevisions              bool
 	datadogMonitorEnabled                  bool
+	datadogMonitorMaxWorkers               int
+	datadogMonitorRequeuePeriod            time.Duration
 	datadogSLOEnabled                      bool
 	operatorMetricsEnabled                 bool
 	maximumGoroutines                      int
@@ -187,6 +191,8 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.supportCilium, "supportCilium", false, "Support usage of Cilium network policies.")
 	flag.BoolVar(&opts.datadogAgentEnabled, "datadogAgentEnabled", true, "Enable the DatadogAgent controller")
 	flag.BoolVar(&opts.datadogMonitorEnabled, "datadogMonitorEnabled", false, "Enable the DatadogMonitor controller")
+	flag.IntVar(&opts.datadogMonitorMaxWorkers, "datadogMonitorMaxConcurrentReconciles", defaultDatadogMonitorMaxConcurrentReconciles, "Maximum number of concurrent DatadogMonitor reconciles")
+	flag.DurationVar(&opts.datadogMonitorRequeuePeriod, "datadogMonitorRequeuePeriod", defaultDatadogMonitorRequeuePeriod, "DatadogMonitor status polling requeue period, for example 5m")
 	flag.BoolVar(&opts.datadogSLOEnabled, "datadogSLOEnabled", false, "Enable the DatadogSLO controller")
 	flag.BoolVar(&opts.operatorMetricsEnabled, "operatorMetricsEnabled", true, "Enable sending operator metrics to Datadog")
 	flag.IntVar(&opts.maximumGoroutines, "maximumGoroutines", defaultMaximumGoroutines, "Override health check threshold for maximum number of goroutines.")
@@ -234,6 +240,8 @@ func (opts *options) Parse() {
 		boolEnv(&opts.supportCilium, "DD_SUPPORT_CILIUM"),
 		boolEnv(&opts.datadogAgentEnabled, "DD_AGENT_CONTROLLER_ENABLED"),
 		boolEnv(&opts.datadogMonitorEnabled, "DD_MONITOR_CONTROLLER_ENABLED"),
+		intEnv(&opts.datadogMonitorMaxWorkers, "DD_MONITOR_MAX_CONCURRENT_RECONCILES"),
+		durationEnv(&opts.datadogMonitorRequeuePeriod, "DD_MONITOR_REQUEUE_PERIOD"),
 		boolEnv(&opts.datadogSLOEnabled, "DD_SLO_CONTROLLER_ENABLED"),
 		boolEnv(&opts.operatorMetricsEnabled, "DD_OPERATOR_METRICS_ENABLED"),
 		intEnv(&opts.maximumGoroutines, "DD_MAXIMUM_GOROUTINES"),
@@ -527,6 +535,8 @@ func run(opts *options) error {
 		DatadogAgentEnabled:               opts.datadogAgentEnabled,
 		CreateControllerRevisions:         opts.createControllerRevisions && opts.datadogAgentEnabled,
 		DatadogMonitorEnabled:             opts.datadogMonitorEnabled,
+		DatadogMonitorMaxWorkers:          opts.datadogMonitorMaxWorkers,
+		DatadogMonitorRequeue:             opts.datadogMonitorRequeuePeriod,
 		DatadogSLOEnabled:                 opts.datadogSLOEnabled,
 		OperatorMetricsEnabled:            opts.operatorMetricsEnabled,
 		V2APIEnabled:                      true,

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -87,7 +87,7 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
 
 By default, the Operator ensures that the API monitor definition stays in sync with the DatadogMonitor resource every **60** minutes (per monitor). This interval can be adjusted using the environment variable `DD_MONITOR_FORCE_SYNC_PERIOD`, which specifies the number of minutes. For example, setting this variable to `"30"` changes the interval to 30 minutes.
 
-The controller requeues each `DatadogMonitor` every 60 seconds by default. Configure this interval with `--datadogMonitorRequeuePeriod` or `DD_MONITOR_REQUEUE_PERIOD`; both accept Go duration strings such as `30s` or `5m`. Configure the number of monitors reconciled concurrently with `--datadogMonitorMaxConcurrentReconciles` or `DD_MONITOR_MAX_CONCURRENT_RECONCILES` (default `1`). Increasing concurrency can improve throughput for large monitor collections, but increases Operator CPU usage and concurrent Datadog API requests.
+The controller requeues each `DatadogMonitor` every 60 seconds by default. Configure this interval with `--datadogMonitorRequeuePeriod` or `DD_MONITOR_REQUEUE_PERIOD`; both accept Go duration strings such as `30s` or `5m`. Configure the number of monitors reconciled concurrently with `--datadogMonitorMaxConcurrentReconciles` or `DD_MONITOR_MAX_CONCURRENT_RECONCILES` (default `1`). Increasing concurrency can improve throughput for large monitor collections, but increases Operator CPU usage and concurrent Datadog API requests. Scheduled status polling is lower priority than create, update, and delete work, so state fields are eventually consistent while the controller queue is busy.
 
 ## Cleanup
 

--- a/docs/datadog_monitor.md
+++ b/docs/datadog_monitor.md
@@ -87,6 +87,8 @@ To deploy a `DatadogMonitor` with the Datadog Operator, use the [`datadog-operat
 
 By default, the Operator ensures that the API monitor definition stays in sync with the DatadogMonitor resource every **60** minutes (per monitor). This interval can be adjusted using the environment variable `DD_MONITOR_FORCE_SYNC_PERIOD`, which specifies the number of minutes. For example, setting this variable to `"30"` changes the interval to 30 minutes.
 
+The controller requeues each `DatadogMonitor` every 60 seconds by default. Configure this interval with `--datadogMonitorRequeuePeriod` or `DD_MONITOR_REQUEUE_PERIOD`; both accept Go duration strings such as `30s` or `5m`. Configure the number of monitors reconciled concurrently with `--datadogMonitorMaxConcurrentReconciles` or `DD_MONITOR_MAX_CONCURRENT_RECONCILES` (default `1`). Increasing concurrency can improve throughput for large monitor collections, but increases Operator CPU usage and concurrent Datadog API requests.
+
 ## Cleanup
 
 The following commands delete the monitor from your Datadog account and all the Kubernetes resources created by the above instructions:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -186,6 +186,8 @@ Other operator startup options can also be configured via environment variable:
 | Leader election lease      | `--leader-election-lease-duration`   | `DD_LEADER_ELECTION_LEASE_DURATION`   | `60s`   |
 | Cilium network policies    | `--supportCilium`                    | `DD_SUPPORT_CILIUM`                   | `false` |
 | Maximum goroutines         | `--maximumGoroutines`                | `DD_MAXIMUM_GOROUTINES`               | `500`   |
+| Monitor max concurrent reconciles | `--datadogMonitorMaxConcurrentReconciles` | `DD_MONITOR_MAX_CONCURRENT_RECONCILES` | `1` |
+| Monitor requeue period     | `--datadogMonitorRequeuePeriod`      | `DD_MONITOR_REQUEUE_PERIOD`            | `60s`   |
 | DDGR max concurrent reconciles | `--datadogGenericResourceMaxConcurrentReconciles` | `DD_GENERIC_RESOURCE_MAX_CONCURRENT_RECONCILES` | `1` |
 | DDGR requeue period        | `--datadogGenericResourceRequeuePeriod` | `DD_GENERIC_RESOURCE_REQUEUE_PERIOD` | `60s`   |
 | Controller revisions       | `--createControllerRevisions`        | `DD_CREATE_CONTROLLER_REVISIONS`      | `false` |

--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -75,10 +75,20 @@ type Reconciler struct {
 	recorder               record.EventRecorder
 	operatorMetricsEnabled bool
 	forwarders             pkgutils.MetricsForwardersManager
+	requeuePeriod          time.Duration
+}
+
+type ReconcilerOptions struct {
+	RequeuePeriod time.Duration
 }
 
 // NewReconciler returns a new Reconciler object
-func NewReconciler(client client.Client, credsManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder, operatorMetricsEnabled bool, metricForwardersMgr pkgutils.MetricsForwardersManager) *Reconciler {
+func NewReconciler(client client.Client, credsManager *config.CredentialManager, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder, operatorMetricsEnabled bool, metricForwardersMgr pkgutils.MetricsForwardersManager, opts ...ReconcilerOptions) *Reconciler {
+	options := ReconcilerOptions{}
+	if len(opts) > 0 {
+		options = opts[0]
+	}
+
 	return &Reconciler{
 		client:                 client,
 		datadogClient:          datadogclient.InitMonitorClient(),
@@ -88,7 +98,23 @@ func NewReconciler(client client.Client, credsManager *config.CredentialManager,
 		recorder:               recorder,
 		operatorMetricsEnabled: operatorMetricsEnabled,
 		forwarders:             metricForwardersMgr,
+		requeuePeriod:          requeuePeriod(log, options.RequeuePeriod),
 	}
+}
+
+func requeuePeriod(logger logr.Logger, configured time.Duration) time.Duration {
+	if configured <= 0 {
+		configured = defaultRequeuePeriod
+	}
+	logger.Info("Setting monitor requeue period", "duration", configured.String())
+	return configured
+}
+
+func (r *Reconciler) resolvedRequeuePeriod() time.Duration {
+	if r.requeuePeriod <= 0 {
+		return defaultRequeuePeriod
+	}
+	return r.requeuePeriod
 }
 
 // Reconcile is similar to reconciler.Reconcile interface, but taking a context
@@ -130,7 +156,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 
 	newStatus := instance.Status.DeepCopy()
 
-	final := finalizer.NewFinalizer(logger, r.client, r.deleteResource(logger, auth), defaultRequeuePeriod, defaultErrRequeuePeriod)
+	final := finalizer.NewFinalizer(logger, r.client, r.deleteResource(logger, auth), r.resolvedRequeuePeriod(), defaultErrRequeuePeriod)
 	if result, err = final.HandleFinalizer(ctx, instance, fmt.Sprint(instance.Status.ID), datadogMonitorFinalizer); ctrutils.ShouldReturn(result, err) {
 		return result, err
 	}
@@ -186,8 +212,8 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 			} else {
 				shouldUpdate = true
 			}
-		} else if instance.Status.MonitorStateLastUpdateTime == nil || (defaultRequeuePeriod-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
-			// If other conditions aren't met, and we have passed the defaultRequeuePeriod, then update monitor state
+		} else if instance.Status.MonitorStateLastUpdateTime == nil || (r.resolvedRequeuePeriod()-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
+			// If other conditions aren't met, and we have passed the configured requeue period, then update monitor state
 			// Get monitor to make sure it exists before trying any updates. If it doesn't, set shouldCreate
 			m, err = r.get(auth, instance, newStatus)
 			if err != nil {
@@ -247,9 +273,9 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 		}
 	}
 
-	// If reconcile was successful, requeue with period defaultRequeuePeriod
+	// If reconcile was successful, requeue with the configured period.
 	if result.IsZero() {
-		result.RequeueAfter = defaultRequeuePeriod
+		result.RequeueAfter = r.resolvedRequeuePeriod()
 	}
 
 	// Update the status
@@ -380,7 +406,7 @@ func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, datadogMonitor *da
 		// not an issue, but if a monitor has many groups and is "flapping", then it can cause a flood of updates to
 		// the Status.TriggeredState and put pressure on the controller. As a safeguard against this, the maximum number
 		// of groups stored in Status.TriggeredState should be conservative.
-		return ctrl.Result{RequeueAfter: defaultRequeuePeriod}, nil
+		return ctrl.Result{RequeueAfter: r.resolvedRequeuePeriod()}, nil
 	}
 
 	return result, nil

--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -24,8 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlhandler "sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
@@ -179,12 +181,13 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 
 	shouldCreate := false
 	shouldUpdate := false
+	shouldRefreshState := false
+	var m datadogV1.Monitor
 
 	// Check if we need to create the monitor, update the monitor definition, or update monitor state
 	if instance.Status.ID == 0 {
 		shouldCreate = true
 	} else {
-		var m datadogV1.Monitor
 		if instanceSpecHash != statusSpecHash {
 			// Custom resource manifest has changed; verify the monitor still
 			// exists before updating. If it was deleted out-of-band (e.g. from
@@ -213,17 +216,24 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 				shouldUpdate = true
 			}
 		} else if instance.Status.MonitorStateLastUpdateTime == nil || (r.resolvedRequeuePeriod()-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
-			// If other conditions aren't met, and we have passed the configured requeue period, then update monitor state
-			// Get monitor to make sure it exists before trying any updates. If it doesn't, set shouldCreate
-			m, err = r.get(auth, instance, newStatus)
-			if err != nil {
-				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
-				if strings.Contains(err.Error(), ctrutils.NotFoundString) {
-					shouldCreate = true
-				}
-			}
-			updateMonitorState(m, now, newStatus)
+			// If other conditions aren't met, and we have passed the configured requeue period, refresh monitor state.
+			shouldRefreshState = true
 		}
+	}
+
+	if shouldRefreshState {
+		// State polling is eventual-consistency work. Keep lifecycle and spec changes ahead of it.
+		result.Priority = ptr.To(ctrlhandler.LowPriority)
+		m, err = r.get(auth, instance, newStatus)
+		if err != nil {
+			logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
+			if strings.Contains(err.Error(), ctrutils.NotFoundString) {
+				shouldCreate = true
+				// A missing remote monitor needs lifecycle work, not background polling.
+				result.Priority = nil
+			}
+		}
+		updateMonitorState(m, now, newStatus)
 	}
 
 	// Create and update actions
@@ -274,7 +284,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 	}
 
 	// If reconcile was successful, requeue with the configured period.
-	if result.IsZero() {
+	if result.RequeueAfter == 0 {
 		result.RequeueAfter = r.resolvedRequeuePeriod()
 	}
 
@@ -406,7 +416,7 @@ func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, datadogMonitor *da
 		// not an issue, but if a monitor has many groups and is "flapping", then it can cause a flood of updates to
 		// the Status.TriggeredState and put pressure on the controller. As a safeguard against this, the maximum number
 		// of groups stored in Status.TriggeredState should be conservative.
-		return ctrl.Result{RequeueAfter: r.resolvedRequeuePeriod()}, nil
+		return ctrl.Result{RequeueAfter: r.resolvedRequeuePeriod(), Priority: result.Priority}, nil
 	}
 
 	return result, nil

--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -112,13 +112,6 @@ func requeuePeriod(logger logr.Logger, configured time.Duration) time.Duration {
 	return configured
 }
 
-func (r *Reconciler) resolvedRequeuePeriod() time.Duration {
-	if r.requeuePeriod <= 0 {
-		return defaultRequeuePeriod
-	}
-	return r.requeuePeriod
-}
-
 // Reconcile is similar to reconciler.Reconcile interface, but taking a context
 func (r *Reconciler) Reconcile(ctx context.Context, instance *datadoghqv1alpha1.DatadogMonitor) (reconcile.Result, error) {
 	res, err := r.internalReconcile(ctx, instance)
@@ -158,7 +151,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 
 	newStatus := instance.Status.DeepCopy()
 
-	final := finalizer.NewFinalizer(logger, r.client, r.deleteResource(logger, auth), r.resolvedRequeuePeriod(), defaultErrRequeuePeriod)
+	final := finalizer.NewFinalizer(logger, r.client, r.deleteResource(logger, auth), r.requeuePeriod, defaultErrRequeuePeriod)
 	if result, err = final.HandleFinalizer(ctx, instance, fmt.Sprint(instance.Status.ID), datadogMonitorFinalizer); ctrutils.ShouldReturn(result, err) {
 		return result, err
 	}
@@ -199,6 +192,8 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
 				if strings.Contains(err.Error(), ctrutils.NotFoundString) {
 					shouldCreate = true
+				} else {
+					result.RequeueAfter = defaultErrRequeuePeriod
 				}
 			} else {
 				shouldUpdate = true
@@ -211,11 +206,13 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
 				if strings.Contains(err.Error(), ctrutils.NotFoundString) {
 					shouldCreate = true
+				} else {
+					result.RequeueAfter = defaultErrRequeuePeriod
 				}
 			} else {
 				shouldUpdate = true
 			}
-		} else if instance.Status.MonitorStateLastUpdateTime == nil || (r.resolvedRequeuePeriod()-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
+		} else if instance.Status.MonitorStateLastUpdateTime == nil || (r.requeuePeriod-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
 			// If other conditions aren't met, and we have passed the configured requeue period, refresh monitor state.
 			shouldRefreshState = true
 		}
@@ -253,10 +250,12 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 			}
 			if err = r.create(auth, logger, instance, newStatus, now, instanceSpecHash); err != nil {
 				logger.Error(err, "error creating monitor")
+				result.RequeueAfter = defaultErrRequeuePeriod
 			}
 		} else {
 			err = fmt.Errorf("monitor type %v not supported", instance.Spec.Type)
 			logger.Error(err, "error creating monitor")
+			result.RequeueAfter = defaultErrRequeuePeriod
 		}
 	} else if shouldUpdate {
 		logger.V(1).Info("Updating monitor in Datadog")
@@ -273,6 +272,7 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 		}
 		if err = r.update(auth, logger, instance, newStatus, now, instanceSpecHash); err != nil {
 			logger.Error(err, "error updating monitor", "Monitor ID", instance.Status.ID)
+			result.RequeueAfter = defaultErrRequeuePeriod
 			// If the monitor was deleted between our existence check and this
 			// update (TOCTOU), clear status.ID so the next reconcile takes the
 			// create path and recreates the monitor.
@@ -283,13 +283,40 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 		}
 	}
 
-	// If reconcile was successful, requeue with the configured period.
+	// Schedule background reconciliation at low priority, without delaying the independent force-sync deadline.
 	if result.RequeueAfter == 0 {
-		result.RequeueAfter = r.resolvedRequeuePeriod()
+		result.RequeueAfter = nextRequeueAfter(newStatus, now, r.requeuePeriod, forceSyncPeriod)
+		if err == nil {
+			result.Priority = ptr.To(ctrlhandler.LowPriority)
+		}
 	}
 
 	// Update the status
 	return r.updateStatusIfNeeded(logger, instance, now, newStatus, err, result)
+}
+
+func nextRequeueAfter(status *datadoghqv1alpha1.DatadogMonitorStatus, now metav1.Time, statePollingPeriod, forceSyncPeriod time.Duration) time.Duration {
+	next := statePollingPeriod
+	if status.ID == 0 {
+		return next
+	}
+
+	lastForceSync := status.MonitorLastForceSyncTime
+	if lastForceSync == nil {
+		lastForceSync = status.Created
+	}
+	if lastForceSync == nil {
+		if forceSyncPeriod > 0 && forceSyncPeriod < next {
+			return forceSyncPeriod
+		}
+		return next
+	}
+
+	untilForceSync := forceSyncPeriod - now.Sub(lastForceSync.Time)
+	if untilForceSync > 0 && untilForceSync < next {
+		return untilForceSync
+	}
+	return next
 }
 
 func (r *Reconciler) create(auth context.Context, logger logr.Logger, datadogMonitor *datadoghqv1alpha1.DatadogMonitor, status *datadoghqv1alpha1.DatadogMonitorStatus, now metav1.Time, instanceSpecHash string) error {
@@ -416,7 +443,10 @@ func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, datadogMonitor *da
 		// not an issue, but if a monitor has many groups and is "flapping", then it can cause a flood of updates to
 		// the Status.TriggeredState and put pressure on the controller. As a safeguard against this, the maximum number
 		// of groups stored in Status.TriggeredState should be conservative.
-		return ctrl.Result{RequeueAfter: r.resolvedRequeuePeriod(), Priority: result.Priority}, nil
+		if result.RequeueAfter == 0 {
+			result.RequeueAfter = r.requeuePeriod
+		}
+		return result, nil
 	}
 
 	return result, nil

--- a/internal/controller/datadogmonitor/controller.go
+++ b/internal/controller/datadogmonitor/controller.go
@@ -177,7 +177,8 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 	shouldRefreshState := false
 	var m datadogV1.Monitor
 
-	// Check if we need to create the monitor, update the monitor definition, or update monitor state
+	// Decide which remote work is due. Lifecycle and specification work takes
+	// precedence over the eventual-consistency state poll.
 	if instance.Status.ID == 0 {
 		shouldCreate = true
 	} else {
@@ -199,8 +200,9 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 				shouldUpdate = true
 			}
 		} else if instance.Status.MonitorLastForceSyncTime == nil || (forceSyncPeriod-now.Sub(instance.Status.MonitorLastForceSyncTime.Time)) <= 0 {
-			// Periodically force a sync with the API monitor to ensure parity
-			// Get monitor to make sure it exists before trying any updates. If it doesn't, set shouldCreate
+			// A force sync periodically reapplies the desired monitor definition
+			// to correct out-of-band changes. Check that the remote monitor still
+			// exists first so an out-of-band deletion takes the create path.
 			_, err = r.get(auth, instance, newStatus)
 			if err != nil {
 				logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
@@ -213,20 +215,23 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 				shouldUpdate = true
 			}
 		} else if instance.Status.MonitorStateLastUpdateTime == nil || (r.requeuePeriod-now.Sub(instance.Status.MonitorStateLastUpdateTime.Time)) <= 0 {
-			// If other conditions aren't met, and we have passed the configured requeue period, refresh monitor state.
+			// Refresh state only when no lifecycle or specification operation is
+			// due and the configured polling period has elapsed.
 			shouldRefreshState = true
 		}
 	}
 
 	if shouldRefreshState {
-		// State polling is eventual-consistency work. Keep lifecycle and spec changes ahead of it.
+		// State polling is eventual-consistency work, so its scheduled follow-up
+		// stays behind lifecycle and specification changes in the work queue.
 		result.Priority = ptr.To(ctrlhandler.LowPriority)
 		m, err = r.get(auth, instance, newStatus)
 		if err != nil {
 			logger.Error(err, "error getting monitor", "Monitor ID", instance.Status.ID)
 			if strings.Contains(err.Error(), ctrutils.NotFoundString) {
 				shouldCreate = true
-				// A missing remote monitor needs lifecycle work, not background polling.
+				// A missing remote monitor promotes this reconciliation from state
+				// polling to lifecycle work, which must return at normal priority.
 				result.Priority = nil
 			}
 		}
@@ -283,7 +288,12 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 		}
 	}
 
-	// Schedule background reconciliation at low priority, without delaying the independent force-sync deadline.
+	// Delayed polling and force-sync requeues are controller-scheduled maintenance,
+	// not new informer events. Successful work is assigned low priority here;
+	// state polling is assigned low priority before its API call above. Informer
+	// events, including the initial list at startup, retain the controller-runtime
+	// default priority and can overtake this background work. Preserve a delay
+	// already set by an error path so lifecycle failures keep their short retry.
 	if result.RequeueAfter == 0 {
 		result.RequeueAfter = nextRequeueAfter(newStatus, now, r.requeuePeriod, forceSyncPeriod)
 		if err == nil {
@@ -296,6 +306,9 @@ func (r *Reconciler) internalReconcile(ctx context.Context, instance *datadoghqv
 }
 
 func nextRequeueAfter(status *datadoghqv1alpha1.DatadogMonitorStatus, now metav1.Time, statePollingPeriod, forceSyncPeriod time.Duration) time.Duration {
+	// State polling and force sync are independent schedules. Use the earlier
+	// deadline so a long polling period cannot postpone reapplying the desired
+	// monitor definition. Creation time anchors the first force-sync deadline.
 	next := statePollingPeriod
 	if status.ID == 0 {
 		return next
@@ -436,13 +449,12 @@ func (r *Reconciler) updateStatusIfNeeded(logger logr.Logger, datadogMonitor *da
 
 			return ctrl.Result{}, err
 		}
-		// This is brittle; typically if a Spec or Status is updated in the API, the result gets requeued without additional action.
-		// However, sometimes apiequality.Semantic.DeepEqual() is false even when the API thinks they are equal (and no update is made).
-		// Thus, the result does not get requeued after entering this `if` block. To safeguard this, we will always requeue the result
-		// here. The danger of this is potentially requeueing twice for every status update. In most circumstances this is
-		// not an issue, but if a monitor has many groups and is "flapping", then it can cause a flood of updates to
-		// the Status.TriggeredState and put pressure on the controller. As a safeguard against this, the maximum number
-		// of groups stored in Status.TriggeredState should be conservative.
+		// A status write usually emits an informer event, but the API server may
+		// consider the update a no-op even when Semantic.DeepEqual reported a
+		// difference. Ensure another reconciliation is scheduled in that case.
+		// Preserve any delay and priority selected above: in particular, lifecycle
+		// errors must retain their short retry and background work must remain low
+		// priority. Default to the state-polling period only when no schedule exists.
 		if result.RequeueAfter == 0 {
 			result.RequeueAfter = r.requeuePeriod
 		}

--- a/internal/controller/datadogmonitor/controller_test.go
+++ b/internal/controller/datadogmonitor/controller_test.go
@@ -26,9 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -160,6 +162,67 @@ func TestRequeuePeriod(t *testing.T) {
 
 	assert.Equal(t, defaultRequeuePeriod, requeuePeriod(logger, 0))
 	assert.Equal(t, 2*time.Minute, requeuePeriod(logger, 2*time.Minute))
+}
+
+func TestReconcileDatadogMonitor_StatePollingUsesLowPriority(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/monitor/12345" {
+			fmt.Fprint(w, `{"id":12345,"name":"test monitor","query":"q","type":"metric alert"}`)
+			return
+		}
+		http.Error(w, "unexpected request", http.StatusNotFound)
+	}))
+	defer httpServer.Close()
+
+	t.Setenv("DD_URL", httpServer.URL)
+	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+
+	s := scheme.Scheme
+	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogMonitor{})
+	testConfig := datadogapi.NewConfiguration()
+	testConfig.HTTPClient = httpServer.Client()
+	ddClient := datadogV1.NewMonitorsApi(datadogapi.NewAPIClient(testConfig))
+
+	requeuePeriod := 2 * time.Minute
+	now := metav1.Now()
+	dm := &datadoghqv1alpha1.DatadogMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       resourcesName,
+			Namespace:  resourcesNamespace,
+			Finalizers: []string{datadogMonitorFinalizer},
+		},
+		Spec: datadoghqv1alpha1.DatadogMonitorSpec{
+			Query:   "avg(last_10m):avg:system.cpu.user{*} > 1",
+			Type:    datadoghqv1alpha1.DatadogMonitorTypeMetric,
+			Name:    "test monitor",
+			Message: "something is wrong",
+		},
+		Status: datadoghqv1alpha1.DatadogMonitorStatus{
+			ID:                         12345,
+			MonitorLastForceSyncTime:   &now,
+			MonitorStateLastUpdateTime: &metav1.Time{Time: now.Add(-2 * requeuePeriod)},
+		},
+	}
+	dm.Status.CurrentHash, _ = comparison.GenerateMD5ForSpec(&dm.Spec)
+
+	client := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogMonitor{}).WithObjects(dm).Build()
+	r := &Reconciler{
+		client:        client,
+		datadogClient: ddClient,
+		credsManager:  config.NewCredentialManager(fake.NewClientBuilder().Build()),
+		scheme:        s,
+		recorder:      record.NewFakeRecorder(1),
+		log:           logf.Log.WithName("state-polling-priority"),
+		requeuePeriod: requeuePeriod,
+	}
+
+	result, err := r.Reconcile(context.Background(), dm)
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeuePeriod, Priority: ptr.To(handler.LowPriority)}, result)
 }
 
 func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {

--- a/internal/controller/datadogmonitor/controller_test.go
+++ b/internal/controller/datadogmonitor/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
@@ -151,6 +152,14 @@ func TestReconcileDatadogMonitor_RetriesCreatedStatusAfterConflict(t *testing.T)
 	_, err = r.Reconcile(context.TODO(), dm)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(1), createCount.Load(), "a status conflict must not cause a second Datadog create")
+}
+
+func TestRequeuePeriod(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	logger := logf.Log.WithName("requeue-period-test")
+
+	assert.Equal(t, defaultRequeuePeriod, requeuePeriod(logger, 0))
+	assert.Equal(t, 2*time.Minute, requeuePeriod(logger, 2*time.Minute))
 }
 
 func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {

--- a/internal/controller/datadogmonitor/controller_test.go
+++ b/internal/controller/datadogmonitor/controller_test.go
@@ -46,6 +46,10 @@ const (
 	resourcesNamespace = "bar"
 )
 
+func lowPriorityResult(requeueAfter time.Duration) reconcile.Result {
+	return reconcile.Result{RequeueAfter: requeueAfter, Priority: ptr.To(handler.LowPriority)}
+}
+
 type conflictOnceClient struct {
 	client.Client
 	remainingConflicts atomic.Int32
@@ -132,6 +136,7 @@ func TestReconcileDatadogMonitor_RetriesCreatedStatusAfterConflict(t *testing.T)
 		scheme:        s,
 		recorder:      recorder,
 		log:           logf.Log.WithName("created-status-conflict"),
+		requeuePeriod: defaultRequeuePeriod,
 	}
 
 	dm := genericDatadogMonitor(r.client)
@@ -143,7 +148,7 @@ func TestReconcileDatadogMonitor_RetriesCreatedStatusAfterConflict(t *testing.T)
 	conflictingClient.remainingConflicts.Store(1)
 	result, err := r.Reconcile(context.TODO(), dm)
 	assert.NoError(t, err)
-	assert.Equal(t, ctrl.Result{RequeueAfter: defaultRequeuePeriod}, result)
+	assert.Equal(t, lowPriorityResult(defaultRequeuePeriod), result)
 	assert.Equal(t, int32(0), conflictingClient.remainingConflicts.Load(), "the injected status conflict should be consumed")
 
 	assert.NoError(t, r.client.Get(context.TODO(), client.ObjectKeyFromObject(dm), dm))
@@ -162,6 +167,102 @@ func TestRequeuePeriod(t *testing.T) {
 
 	assert.Equal(t, defaultRequeuePeriod, requeuePeriod(logger, 0))
 	assert.Equal(t, 2*time.Minute, requeuePeriod(logger, 2*time.Minute))
+}
+
+func TestNextRequeueAfter(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	lastForceSync := metav1.NewTime(now.Add(-50 * time.Minute))
+	created := metav1.NewTime(now.Add(-30 * time.Minute))
+
+	tests := []struct {
+		name               string
+		status             *datadoghqv1alpha1.DatadogMonitorStatus
+		statePollingPeriod time.Duration
+		forceSyncPeriod    time.Duration
+		want               time.Duration
+	}{
+		{
+			name:               "state polling is sooner",
+			status:             &datadoghqv1alpha1.DatadogMonitorStatus{ID: 1, MonitorLastForceSyncTime: &now},
+			statePollingPeriod: time.Minute,
+			forceSyncPeriod:    time.Hour,
+			want:               time.Minute,
+		},
+		{
+			name:               "force sync is sooner",
+			status:             &datadoghqv1alpha1.DatadogMonitorStatus{ID: 1, MonitorLastForceSyncTime: &lastForceSync},
+			statePollingPeriod: time.Hour,
+			forceSyncPeriod:    time.Hour,
+			want:               10 * time.Minute,
+		},
+		{
+			name:               "creation time is force sync fallback",
+			status:             &datadoghqv1alpha1.DatadogMonitorStatus{ID: 1, Created: &created},
+			statePollingPeriod: time.Hour,
+			forceSyncPeriod:    time.Hour,
+			want:               30 * time.Minute,
+		},
+		{
+			name:               "resource without remote ID uses polling period",
+			status:             &datadoghqv1alpha1.DatadogMonitorStatus{},
+			statePollingPeriod: 24 * time.Hour,
+			forceSyncPeriod:    time.Hour,
+			want:               24 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextRequeueAfter(tt.status, now, tt.statePollingPeriod, tt.forceSyncPeriod))
+		})
+	}
+}
+
+func TestReconcileDatadogMonitor_CreateErrorUsesErrorRequeuePeriod(t *testing.T) {
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "temporary failure", http.StatusInternalServerError)
+	}))
+	defer httpServer.Close()
+
+	t.Setenv("DD_URL", httpServer.URL)
+	t.Setenv("DD_API_KEY", "DUMMY_API_KEY")
+	t.Setenv("DD_APP_KEY", "DUMMY_APP_KEY")
+
+	s := scheme.Scheme
+	s.AddKnownTypes(datadoghqv1alpha1.GroupVersion, &datadoghqv1alpha1.DatadogMonitor{})
+	testConfig := datadogapi.NewConfiguration()
+	testConfig.HTTPClient = httpServer.Client()
+	ddClient := datadogV1.NewMonitorsApi(datadogapi.NewAPIClient(testConfig))
+	dm := &datadoghqv1alpha1.DatadogMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       resourcesName,
+			Namespace:  resourcesNamespace,
+			Finalizers: []string{datadogMonitorFinalizer},
+		},
+		Spec: datadoghqv1alpha1.DatadogMonitorSpec{
+			Query:   "avg(last_5m):avg:system.load.1{*} > 100000",
+			Type:    datadoghqv1alpha1.DatadogMonitorTypeMetric,
+			Name:    "test monitor",
+			Message: "load test",
+			Tags:    []string{requiredTag},
+		},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&datadoghqv1alpha1.DatadogMonitor{}).WithObjects(dm).Build()
+	r := &Reconciler{
+		client:        kubeClient,
+		datadogClient: ddClient,
+		credsManager:  config.NewCredentialManager(fake.NewClientBuilder().Build()),
+		scheme:        s,
+		recorder:      record.NewFakeRecorder(1),
+		log:           logf.Log.WithName("create-error-requeue"),
+		requeuePeriod: 24 * time.Hour,
+	}
+
+	result, err := r.Reconcile(context.Background(), dm)
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, result)
 }
 
 func TestReconcileDatadogMonitor_StatePollingUsesLowPriority(t *testing.T) {
@@ -278,7 +379,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				loadFunc:            genericDatadogMonitor,
 				firstReconcileCount: 3,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
 				if err := c.Get(context.TODO(), types.NamespacedName{Name: resourcesName, Namespace: resourcesNamespace}, dm); err != nil {
@@ -392,7 +493,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -411,7 +512,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -430,7 +531,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -449,7 +550,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -468,7 +569,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -487,7 +588,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -506,7 +607,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -525,7 +626,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -543,7 +644,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				loadFunc:            testAuditMonitor,
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -561,7 +662,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				loadFunc:            testErrorTrackingMonitor,
 				firstReconcileCount: 10,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: lowPriorityResult(defaultRequeuePeriod),
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -598,7 +699,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				},
 				firstReconcileCount: 2,
 			},
-			wantResult: reconcile.Result{RequeueAfter: defaultRequeuePeriod},
+			wantResult: reconcile.Result{RequeueAfter: defaultErrRequeuePeriod},
 			wantErr:    false,
 			wantFunc: func(c client.Client) error {
 				dm := &datadoghqv1alpha1.DatadogMonitor{}
@@ -640,6 +741,7 @@ func TestReconcileDatadogMonitor_Reconcile(t *testing.T) {
 				scheme:        s,
 				recorder:      recorder,
 				log:           logf.Log.WithName(tt.name),
+				requeuePeriod: defaultRequeuePeriod,
 			}
 			_ = testAuth
 
@@ -726,6 +828,7 @@ func TestReconcileDatadogMonitor_CredentialRefresh(t *testing.T) {
 		scheme:        s,
 		recorder:      recorder,
 		log:           logf.Log.WithName("credential-refresh-test"),
+		requeuePeriod: defaultRequeuePeriod,
 	}
 
 	dm := genericDatadogMonitor(r.client)
@@ -1341,6 +1444,7 @@ func TestReconcileDatadogMonitor_RecreatesOnOutOfBandDelete(t *testing.T) {
 		scheme:        s,
 		recorder:      recorder,
 		log:           logf.Log.WithName("recreate-on-404"),
+		requeuePeriod: defaultRequeuePeriod,
 	}
 
 	dm := genericDatadogMonitor(r.client)
@@ -1439,6 +1543,7 @@ func TestReconcileDatadogMonitor_ClearsIDOnUpdate404(t *testing.T) {
 		scheme:        s,
 		recorder:      recorder,
 		log:           logf.Log.WithName("clears-id-on-update-404"),
+		requeuePeriod: defaultRequeuePeriod,
 	}
 
 	dm := genericDatadogMonitor(rec.client)

--- a/internal/controller/datadogmonitor/finalizer_test.go
+++ b/internal/controller/datadogmonitor/finalizer_test.go
@@ -34,6 +34,7 @@ func Test_handleFinalizer(t *testing.T) {
 	metaNow := metav1.NewTime(time.Now())
 
 	r := &Reconciler{
+		requeuePeriod: defaultRequeuePeriod,
 		client: fake.NewClientBuilder().
 			WithRuntimeObjects(
 				&datadoghqv1alpha1.DatadogMonitor{

--- a/internal/controller/datadogmonitor_controller.go
+++ b/internal/controller/datadogmonitor_controller.go
@@ -7,6 +7,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -32,7 +34,13 @@ type DatadogMonitorReconciler struct {
 	Scheme                 *runtime.Scheme
 	Recorder               record.EventRecorder
 	operatorMetricsEnabled bool
+	Options                DatadogMonitorReconcilerOptions
 	internal               *datadogmonitor.Reconciler
+}
+
+type DatadogMonitorReconcilerOptions struct {
+	MaxConcurrentReconciles int
+	RequeuePeriod           time.Duration
 }
 
 // +kubebuilder:rbac:groups=datadoghq.com,resources=datadogmonitors,verbs=get;list;watch;create;update;patch;delete
@@ -46,7 +54,9 @@ func (r *DatadogMonitorReconciler) Reconcile(ctx context.Context, instance *data
 
 // SetupWithManager creates a new DatadogMonitor controller.
 func (r *DatadogMonitorReconciler) SetupWithManager(mgr ctrl.Manager, metricForwardersMgr datadog.MetricsForwardersManager) error {
-	r.internal = datadogmonitor.NewReconciler(r.Client, r.CredsManager, r.Scheme, r.Log, r.Recorder, r.operatorMetricsEnabled, metricForwardersMgr)
+	r.internal = datadogmonitor.NewReconciler(r.Client, r.CredsManager, r.Scheme, r.Log, r.Recorder, r.operatorMetricsEnabled, metricForwardersMgr, datadogmonitor.ReconcilerOptions{
+		RequeuePeriod: r.Options.RequeuePeriod,
+	})
 
 	builder := ctrl.NewControllerManagedBy(mgr)
 
@@ -61,7 +71,9 @@ func (r *DatadogMonitorReconciler) SetupWithManager(mgr ctrl.Manager, metricForw
 		}))
 	}
 	or := reconcile.AsReconciler[*datadoghqv1alpha1.DatadogMonitor](r.Client, r)
-	if err := builder.For(&datadoghqv1alpha1.DatadogMonitor{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).Complete(or); err != nil {
+	if err := builder.For(&datadoghqv1alpha1.DatadogMonitor{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).WithOptions(ctrlcontroller.Options{
+		MaxConcurrentReconciles: r.Options.MaxConcurrentReconciles,
+	}).Complete(or); err != nil {
 		return err
 	}
 

--- a/internal/controller/datadogmonitor_controller.go
+++ b/internal/controller/datadogmonitor_controller.go
@@ -71,6 +71,10 @@ func (r *DatadogMonitorReconciler) SetupWithManager(mgr ctrl.Manager, metricForw
 		}))
 	}
 	or := reconcile.AsReconciler[*datadoghqv1alpha1.DatadogMonitor](r.Client, r)
+	// Keep informer events at the default priority, including the initial list
+	// delivered after controller startup. This ensures that every existing
+	// DatadogMonitor is reconciled promptly; only controller-scheduled
+	// background requeues are assigned low priority by the internal reconciler.
 	if err := builder.For(&datadoghqv1alpha1.DatadogMonitor{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).WithOptions(ctrlcontroller.Options{
 		MaxConcurrentReconciles: r.Options.MaxConcurrentReconciles,
 	}).Complete(or); err != nil {

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -42,6 +42,8 @@ type SetupOptions struct {
 	CredsManager                      *config.CredentialManager
 	DatadogAgentEnabled               bool
 	DatadogMonitorEnabled             bool
+	DatadogMonitorMaxWorkers          int
+	DatadogMonitorRequeue             time.Duration
 	DatadogSLOEnabled                 bool
 	OperatorMetricsEnabled            bool
 	V2APIEnabled                      bool
@@ -197,6 +199,10 @@ func startDatadogMonitor(logger logr.Logger, mgr manager.Manager, pInfo kubernet
 		Scheme:                 mgr.GetScheme(),
 		Recorder:               mgr.GetEventRecorderFor(monitorControllerName),
 		operatorMetricsEnabled: options.OperatorMetricsEnabled,
+		Options: DatadogMonitorReconcilerOptions{
+			MaxConcurrentReconciles: options.DatadogMonitorMaxWorkers,
+			RequeuePeriod:           options.DatadogMonitorRequeue,
+		},
 	}
 
 	return monitorReconciler.SetupWithManager(mgr, metricForwardersMgr)


### PR DESCRIPTION
### What does this PR do?

- Adds configurable DatadogMonitor concurrency and status-polling cadence: c6af8bf36105d9d5e58b0ca146fc499aa879ee18
- Makes scheduled status polling low priority, keeping create/update/delete work ahead of it: af9c7d5002392b54e8273ca3c58bb144471cdf15
- Addresses review findings around retry timing and scheduled reconciliation: 42b8d62fd639389049c1bff5bf825d956c96b655
- Documents reconciliation priority and retry behavior inline: 5779096b204e648e95b094b822d7f949dca12933

### Motivation

Large monitor collections can accumulate polling work and delay lifecycle operations.

> [!WARNING]
> For large DatadogMonitor fleets, we recommend disabling direct operator telemetry with `--operatorMetricsEnabled=false` (`DD_OPERATOR_METRICS_ENABLED=false`) for better performance. When enabled (default), every DatadogMonitor starts one metrics-forwarder goroutine.
>
> Reconciliation and Kubernetes Events continue to work, but direct Datadog operator metrics `datadog.operator.reconcile.success`, `datadog.operator.<resource>.custom_resource.count`, etc.) and events for DatadogAgent, DatadogAgentInternal, and DatadogMonitor resources are disabled. **THESE DO NOT AFFECT Agent telemetry, this is purely self-telemetry from the operator**
>
> If operator own telemetry must remain enabled, raise the `--maximumGoroutines` (`DD_MAXIMUM_GOROUTINES`) health-check threshold above the expected total goroutine count; its default is 500 and it is not a runtime goroutine limit.

### QA

Manual scale and priority check:

1. Deploy the operator with DatadogMonitor enabled and `--datadogMonitorMaxConcurrentReconciles=10` (as well as `operatorMetricsEnabled=false` or `maximumGoroutines=10000`)
2. Create 1,000 monitors at once with the helper below and verify they receive Datadog monitor IDs.
3. Restart with `--datadogMonitorMaxConcurrentReconciles=1` to accumulate scheduled status-polling work.
4. Create one additional monitor and verify it is reconciled ahead of the polling backlog.
5. Restore the worker count and delete the load-test monitors.

<details>
<summary>DatadogMonitor bulk load helper</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

ACTION="${1:-}"
COUNT="${2:-}"
NAMESPACE="${NAMESPACE:-default}"
PREFIX="${PREFIX:-datadogmonitor-load}"

if [[ "$ACTION" != create && "$ACTION" != delete ]] || ! [[ "$COUNT" =~ ^[1-9][0-9]*$ ]]; then
  echo "usage: NAMESPACE=default PREFIX=datadogmonitor-load $0 {create|delete} <count>" >&2
  exit 1
fi

render() {
  local i name
  for ((i = 1; i <= COUNT; i++)); do
    name="${PREFIX}-${i}"
    cat <<EOF
---
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMonitor
metadata:
  name: ${name}
spec:
  name: ${name}
  type: metric alert
  query: avg(last_5m):avg:system.load.1{*} > 100000
  message: DatadogMonitor controller load test
  tags:
    - generated:kubernetes
    - test:datadogmonitor-load
EOF
  done
}

case "$ACTION" in
  create) render | kubectl --namespace "$NAMESPACE" create --filename - ;;
  delete) render | kubectl --namespace "$NAMESPACE" delete --filename - --ignore-not-found ;;
esac
```

```console
./datadogmonitor-load.sh create 1000
./datadogmonitor-load.sh delete 1000
```

The full batch is sent through one `kubectl create` or `kubectl delete` invocation.

</details>