### PR TITLE
[orchestrator] Grant networkpolicies to the orchestrator-explorer  ClusterRole

### DIFF
--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
@@ -77,7 +77,7 @@ func getRBACPolicyRules(logger logr.Logger, crs []string, collectKubernetesNetwo
 		},
 		{
 			APIGroups: []string{rbac.NetworkingAPIGroup},
-			Resources: []string{rbac.IngressesResource},
+			Resources: []string{rbac.IngressesResource, rbac.NetworkPolicyResource},
 		},
 		{
 			APIGroups: []string{rbac.AutoscalingK8sIoAPIGroup},

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -369,6 +369,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -369,6 +369,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -369,6 +369,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -369,6 +369,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -350,6 +350,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
@@ -350,6 +350,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -350,6 +350,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
@@ -350,6 +350,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -350,6 +350,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
@@ -350,6 +350,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - list
   - watch


### PR DESCRIPTION
## What

Add `networkpolicies` to the `networking.k8s.io` rule in the orchestrator-explorer feature's ClusterRole (used by the cluster-checks runner / cluster-agent when it runs the orchestrator check).

## Why — this is a bug

The orchestrator check already lists `networkpolicies` as a collected resource, but the operator-generated ClusterRole only grants `ingresses` under `networking.k8s.io`. 

The public Datadog Helm chart already grants this exact permission to the cluster-agent for orchestrator-explorer, confirming this is a gap on the operator side:

https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/cluster-agent-rbac.yaml#L239-L243

```yaml
- apiGroups:
  - networking.k8s.io
  resources:
  - networkpolicies
  verbs:
  - list
```

## Change

One line in `internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go`:

```go
- Resources: []string{rbac.IngressesResource},
+ Resources: []string{rbac.IngressesResource, rbac.NetworkPolicyResource},
```

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./internal/controller/datadogagent/feature/orchestratorexplorer/...` — passes
- [x] `go test ./internal/controller/datadogagent/...` — passes (all features + controller + override + store + global + merger + object)
- [ ] Post-merge, in an operator-managed cluster, confirm the generated `*-orch-exp-ccr` ClusterRole includes `networkpolicies` and that the orchestrator check (DCA or CCR) no longer logs the RBAC-denied error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CAP-3428]: https://datadoghq.atlassian.net/browse/CAP-3428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ