### PR TITLE
[PROF-15646] selinux annotation on install-seccomp

### DIFF
--- a/internal/controller/datadogagent/feature/hostprofiler/feature.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature.go
@@ -158,7 +158,7 @@ func (o *hostProfilerFeature) ManageNodeAgent(managers feature.PodTemplateManage
 
 		// Init container: copy seccomp profile JSON to the kubelet seccomp directory on the host.
 		// Appended after the base init containers (init-volume, init-config) added by default.go.
-		initContainer := buildSeccompSetupInitContainer(hostProfilerImage, o.loggingSeccomp)
+		initContainer := buildSeccompSetupInitContainer(hostProfilerImage, o.loggingSeccomp, o.selinuxType)
 		managers.PodTemplateSpec().Spec.InitContainers = append(managers.PodTemplateSpec().Spec.InitContainers, initContainer)
 	} else {
 		sc.SeccompProfile = &corev1.SeccompProfile{

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -264,6 +264,9 @@ func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expected
 				assert.NotNil(t, setupContainer, "host-profiler-seccomp-setup init container should be present")
 				if setupContainer != nil {
 					assert.Equal(t, hostProfilerImage, setupContainer.Image)
+					assert.NotNil(t, setupContainer.SecurityContext)
+					assert.NotNil(t, setupContainer.SecurityContext.SELinuxOptions)
+					assert.Equal(t, "spc_t", setupContainer.SecurityContext.SELinuxOptions.Type)
 					assert.Contains(t, setupContainer.Command, seccompSourcePath, "cp source should be the in-image seccomp path")
 					expectedDst := common.SeccompRootVolumePath + "/" + seccompProfileName(hostProfilerImage, false)
 					assert.Contains(t, setupContainer.Command, expectedDst, "cp command should target the kubelet seccomp path")

--- a/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/feature_test.go
@@ -176,6 +176,18 @@ func Test_hostProfilerFeature_SELinuxTypeAnnotation(t *testing.T) {
 	// The selinux-type annotation overrides the spc_t default.
 	require.NotNil(t, hpContainer.SecurityContext.SELinuxOptions)
 	assert.Equal(t, "custom_t", hpContainer.SecurityContext.SELinuxOptions.Type)
+
+	var setupContainer *corev1.Container
+	for i := range manager.Tpl.Spec.InitContainers {
+		if manager.Tpl.Spec.InitContainers[i].Name == string(apicommon.HostProfilerSeccompSetupContainerName) {
+			setupContainer = &manager.Tpl.Spec.InitContainers[i]
+			break
+		}
+	}
+	require.NotNil(t, setupContainer)
+	require.NotNil(t, setupContainer.SecurityContext)
+	require.NotNil(t, setupContainer.SecurityContext.SELinuxOptions)
+	assert.Equal(t, "custom_t", setupContainer.SecurityContext.SELinuxOptions.Type)
 }
 
 func testExpectedAgent(agentContainerName apicommon.AgentContainerName, expectedVolumeMount []corev1.VolumeMount) *test.ComponentTest {

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -46,7 +46,7 @@ func defaultCapabilities() []corev1.Capability {
 	}
 }
 
-func buildSeccompSetupInitContainer(image string, loggingSeccomp bool) corev1.Container {
+func buildSeccompSetupInitContainer(image string, loggingSeccomp bool, selinuxType string) corev1.Container {
 	dst := fmt.Sprintf("%s/%s", common.SeccompRootVolumePath, seccompProfileName(image, loggingSeccomp))
 	var command []string
 	if loggingSeccomp {
@@ -64,7 +64,7 @@ func buildSeccompSetupInitContainer(image string, loggingSeccomp bool) corev1.Co
 		Image:   image,
 		Command: command,
 		SecurityContext: &corev1.SecurityContext{
-			SELinuxOptions: &corev1.SELinuxOptions{Type: defaultSELinuxType},
+			SELinuxOptions: &corev1.SELinuxOptions{Type: selinuxType},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			common.GetVolumeMountForSeccomp(),

--- a/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
+++ b/internal/controller/datadogagent/feature/hostprofiler/seccomp.go
@@ -63,6 +63,9 @@ func buildSeccompSetupInitContainer(image string, loggingSeccomp bool) corev1.Co
 		Name:    string(apicommon.HostProfilerSeccompSetupContainerName),
 		Image:   image,
 		Command: command,
+		SecurityContext: &corev1.SecurityContext{
+			SELinuxOptions: &corev1.SELinuxOptions{Type: defaultSELinuxType},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			common.GetVolumeMountForSeccomp(),
 		},


### PR DESCRIPTION
### What does this PR do?

On SELinux setups with containerd integration, `/host/var/lib/kubelet/seccomp/` gets a `var_lib_t` label and denies operations to unprivileged containers.
On these setups, the host profiler's initcontainer fails as it was running under the default selinux profile.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits