### PR TITLE
[Backport v1.30] Update Golang to 1.26.7 (#3392)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 env:
-  GO_VERSION: 1.26.6
+  GO_VERSION: 1.26.7
 on:
   push:
 # Permission forced by repo-level setting; only elevate on job-level

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.26.6
+  GO_VERSION: 1.26.7
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
   # packages: read
 env:
-  GO_VERSION: 1.26.6
+  GO_VERSION: 1.26.7
 jobs:
   build-linux-binary:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/yaml-mapper.yml
+++ b/.github/workflows/yaml-mapper.yml
@@ -12,7 +12,7 @@ permissions:
   # packages: read
 env:
   PROJECTNAME: "datadog-operator"
-  GO_VERSION: 1.26.6
+  GO_VERSION: 1.26.7
 jobs:
   yaml-mapper-test:
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.ddbuild.io/images/mirror/library/golang:1.26.6
+image: registry.ddbuild.io/images/mirror/library/golang:1.26.7
 variables:
   NIGHTLY_BUILD_CONDUCTOR_NAME: "operator-nightly-build"
   PROJECTNAME: "datadog-operator"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG FIPS_ENABLED=false
 
 # Build the manager binary
-FROM golang:1.26.6 AS builder
+FROM golang:1.26.7 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/DataDog/datadog-operator/api
 
 go 1.26.0
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.56.0

--- a/check-operator.Dockerfile
+++ b/check-operator.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.6 AS builder
+FROM golang:1.26.7 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-operator
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.63.0-rc.1 // indirect

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.26.6
+go 1.26.7
 
-toolchain go1.26.6
+toolchain go1.26.7
 
 use (
 	.

--- a/go.work.sum
+++ b/go.work.sum
@@ -1644,6 +1644,7 @@ golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZ
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
 golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
+golang.org/x/telemetry v0.0.0-20260811182544-a038080d80e5/go.mod h1:LVehoXe41cL5SCVQilsV7Gg6BNG+Js6P9PhSbYTIUkQ=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-operator/test/e2e
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/DataDog/datadog-agent/test/e2e-framework v0.81.0-devel.0.20260604205353-3e3ae70e791b


### PR DESCRIPTION
Backport of ae9eacd4b388aad8e2f46f5749e5fd32e8a88b78. Tests: make ci-test.