### PR TITLE
Gate managed Agent installation on workload readiness

### DIFF
--- a/internal/controller/datadogagent/reconcile_common.go
+++ b/internal/controller/datadogagent/reconcile_common.go
@@ -201,6 +201,7 @@ func (r *Reconciler) addDDAIStatusToDDAStatus(status *v2alpha1.DatadogAgentStatu
 	status.Agent = condition.CombineDaemonSetStatus(status.Agent, currentDDAI.Status.Agent)
 	status.ClusterAgent = condition.CombineDeploymentStatus(status.ClusterAgent, currentDDAI.Status.ClusterAgent)
 	status.ClusterChecksRunner = condition.CombineDeploymentStatus(status.ClusterChecksRunner, currentDDAI.Status.ClusterChecksRunner)
+	status.OtelAgentGateway = condition.CombineDeploymentStatus(status.OtelAgentGateway, currentDDAI.Status.OtelAgentGateway)
 
 	// Only the default DDAI runs dependency management (e.g. RBAC-gated
 	// resources), so it's the only DDAI whose reconcile error is surfaced on
@@ -319,7 +320,8 @@ func IsEqualStatus(current *v2alpha1.DatadogAgentStatus, newStatus *v2alpha1.Dat
 	}
 
 	if !condition.IsEqualDeploymentStatus(current.ClusterAgent, newStatus.ClusterAgent) ||
-		!condition.IsEqualDeploymentStatus(current.ClusterChecksRunner, newStatus.ClusterChecksRunner) {
+		!condition.IsEqualDeploymentStatus(current.ClusterChecksRunner, newStatus.ClusterChecksRunner) ||
+		!condition.IsEqualDeploymentStatus(current.OtelAgentGateway, newStatus.OtelAgentGateway) {
 		return false
 	}
 

--- a/internal/controller/datadogagent/reconcile_common_test.go
+++ b/internal/controller/datadogagent/reconcile_common_test.go
@@ -72,6 +72,12 @@ func Test_addDDAIStatusToDDAStatus(t *testing.T) {
 					ClusterChecksRunner: &v2alpha1.DeploymentStatus{
 						CurrentHash: "foo",
 					},
+					OtelAgentGateway: &v2alpha1.DeploymentStatus{
+						Replicas:          int32(1),
+						UpdatedReplicas:   int32(1),
+						ReadyReplicas:     int32(1),
+						AvailableReplicas: int32(1),
+					},
 					RemoteConfigConfiguration: &v2alpha1.RemoteConfigConfiguration{
 						Features: &v2alpha1.DatadogFeatures{
 							CWS: &v2alpha1.CWSFeatureConfig{
@@ -93,6 +99,12 @@ func Test_addDDAIStatusToDDAStatus(t *testing.T) {
 				},
 				ClusterChecksRunner: &v2alpha1.DeploymentStatus{
 					CurrentHash: "foo",
+				},
+				OtelAgentGateway: &v2alpha1.DeploymentStatus{
+					Replicas:          int32(1),
+					UpdatedReplicas:   int32(1),
+					ReadyReplicas:     int32(1),
+					AvailableReplicas: int32(1),
 				},
 			},
 		},
@@ -167,4 +179,19 @@ func Test_addDDAIStatusToDDAStatus(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, tt.status)
 		})
 	}
+}
+
+func TestIsEqualStatusIncludesOtelAgentGateway(t *testing.T) {
+	current := &v2alpha1.DatadogAgentStatus{
+		OtelAgentGateway: &v2alpha1.DeploymentStatus{
+			Replicas:          1,
+			UpdatedReplicas:   1,
+			ReadyReplicas:     1,
+			AvailableReplicas: 1,
+		},
+	}
+	updated := current.DeepCopy()
+	updated.OtelAgentGateway.ReadyReplicas = 0
+
+	assert.False(t, IsEqualStatus(current, updated))
 }

--- a/pkg/fleet/managed_agent_installation.go
+++ b/pkg/fleet/managed_agent_installation.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,8 +30,10 @@ import (
 
 	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -55,6 +58,8 @@ const (
 
 var managedAgentInstallationDeletePollInterval = time.Second
 var managedAgentInstallationDeleteTimeout = 3 * time.Minute
+var managedAgentInstallationReadinessTimeout = 10 * time.Minute
+var managedAgentInstallationReadinessRetryInterval = 5 * time.Second
 
 var allowedManagedAgentInstallationSites = map[string]struct{}{
 	"datadoghq.com":     {},
@@ -75,6 +80,22 @@ type managedAgentInstallationCredentialNotReadyError struct {
 }
 
 func (e *managedAgentInstallationCredentialNotReadyError) Error() string {
+	return e.msg
+}
+
+type managedAgentInstallationWorkloadsNotReadyError struct {
+	msg string
+}
+
+func (e *managedAgentInstallationWorkloadsNotReadyError) Error() string {
+	return e.msg
+}
+
+type managedAgentInstallationReadinessTimeoutError struct {
+	msg string
+}
+
+func (e *managedAgentInstallationReadinessTimeoutError) Error() string {
 	return e.msg
 }
 
@@ -114,6 +135,9 @@ func (d *Daemon) installDatadogAgent(ctx context.Context, command managedAgentIn
 		d.setPackageConfigVersions(packageDatadogOperator, fleetPartialConfigVersionPrefix+liveConfigID, "")
 		if err := d.ensureManagedAgentInstallationWindowsProfile(ctx, existing); err != nil {
 			return d.retainFleetDatadogAgentPartial(ctx, existing.UID, err)
+		}
+		if err := d.validateManagedAgentInstallationWorkloadsReady(ctx, target, existing.UID); err != nil {
+			return err
 		}
 		if err := d.markFleetDatadogAgentReady(ctx, target, existing.UID, configID); err != nil {
 			return d.retainFleetDatadogAgentPartial(ctx, existing.UID, fmt.Errorf("create DatadogAgent: mark managed Agent installation ready: %w", err))
@@ -202,6 +226,9 @@ func (d *Daemon) installDatadogAgent(ctx context.Context, command managedAgentIn
 	}
 	if err := d.ensureManagedAgentInstallationWindowsProfile(ctx, dda); err != nil {
 		return d.retainFleetDatadogAgentPartial(ctx, dda.UID, err)
+	}
+	if err := d.validateManagedAgentInstallationWorkloadsReady(ctx, target, dda.UID); err != nil {
+		return err
 	}
 	if err := d.markFleetDatadogAgentReady(ctx, target, dda.UID, configID); err != nil {
 		return fmt.Errorf("create DatadogAgent: mark managed Agent installation ready: %w", err)
@@ -693,6 +720,111 @@ func validateFleetDatadogAgentInstallCompletion(dda *v2alpha1.DatadogAgent, uid 
 		return &stateDoesntMatchError{msg: fmt.Sprintf("DatadogAgent %s/%s is not ready at install completion", dda.Namespace, dda.Name)}
 	}
 	return nil
+}
+
+func (d *Daemon) validateManagedAgentInstallationWorkloadsReady(ctx context.Context, target types.NamespacedName, uid types.UID) error {
+	dda, err := d.validateManagedAgentInstallationTarget(ctx, target)
+	if err != nil {
+		return d.retainFleetDatadogAgentPartial(ctx, uid, err)
+	}
+	return validateFleetDatadogAgentWorkloadsReady(dda, time.Now())
+}
+
+func managedAgentInstallationComponentDisabled(dda *v2alpha1.DatadogAgent, component v2alpha1.ComponentName) bool {
+	override := dda.Spec.Override[component]
+	return override != nil && override.Disabled != nil && *override.Disabled
+}
+
+func managedAgentInstallationOptionalComponentEnabled(dda *v2alpha1.DatadogAgent, component v2alpha1.ComponentName) bool {
+	if managedAgentInstallationComponentDisabled(dda, component) || dda.Spec.Features == nil {
+		return false
+	}
+	switch component {
+	case v2alpha1.ClusterChecksRunnerComponentName:
+		return constants.IsClusterChecksEnabled(&dda.Spec) && constants.IsCCREnabled(&dda.Spec)
+	case v2alpha1.OtelAgentGatewayComponentName:
+		feature := dda.Spec.Features.OtelAgentGateway
+		return feature != nil && feature.Enabled != nil && *feature.Enabled
+	default:
+		return false
+	}
+}
+
+func managedAgentInstallationDeploymentReadinessDetail(name string, status *v2alpha1.DeploymentStatus) string {
+	if status == nil {
+		return name + " status is unavailable"
+	}
+	if status.Replicas == 0 || status.UpdatedReplicas != status.Replicas || status.ReadyReplicas != status.Replicas ||
+		status.AvailableReplicas != status.Replicas || status.UnavailableReplicas != 0 {
+		return fmt.Sprintf(
+			"%s is not ready (replicas=%d updated=%d ready=%d available=%d unavailable=%d)",
+			name, status.Replicas, status.UpdatedReplicas, status.ReadyReplicas, status.AvailableReplicas, status.UnavailableReplicas,
+		)
+	}
+	return ""
+}
+
+func validateFleetDatadogAgentWorkloadsReady(dda *v2alpha1.DatadogAgent, now time.Time) error {
+	if dda == nil {
+		return &managedAgentInstallationWorkloadsNotReadyError{msg: "Fleet-managed DatadogAgent is pending workload readiness: resource is unavailable"}
+	}
+
+	var details []string
+	for _, conditionType := range []string{
+		common.DatadogAgentReconcileErrorConditionType,
+		common.DatadogAgentInternalReconcileErrorConditionType,
+	} {
+		if condition := meta.FindStatusCondition(dda.Status.Conditions, conditionType); condition != nil && condition.Status == metav1.ConditionTrue {
+			detail := condition.Type
+			if condition.Message != "" {
+				detail += ": " + condition.Message
+			}
+			details = append(details, detail)
+		}
+	}
+
+	agent := dda.Status.Agent
+	if !managedAgentInstallationComponentDisabled(dda, v2alpha1.NodeAgentComponentName) && (agent == nil || agent.Desired == 0 || agent.Current != agent.Desired || agent.Ready != agent.Desired || agent.Available != agent.Desired || agent.UpToDate != agent.Desired) {
+		if agent == nil {
+			details = append(details, "Agent status is unavailable")
+		} else {
+			details = append(details, fmt.Sprintf(
+				"Agent is not ready (desired=%d current=%d ready=%d available=%d upToDate=%d)",
+				agent.Desired, agent.Current, agent.Ready, agent.Available, agent.UpToDate,
+			))
+		}
+	}
+
+	if !managedAgentInstallationComponentDisabled(dda, v2alpha1.ClusterAgentComponentName) {
+		if detail := managedAgentInstallationDeploymentReadinessDetail("Cluster Agent", dda.Status.ClusterAgent); detail != "" {
+			details = append(details, detail)
+		}
+	}
+	if managedAgentInstallationOptionalComponentEnabled(dda, v2alpha1.ClusterChecksRunnerComponentName) {
+		if detail := managedAgentInstallationDeploymentReadinessDetail("Cluster Checks Runner", dda.Status.ClusterChecksRunner); detail != "" {
+			details = append(details, detail)
+		}
+	}
+	if managedAgentInstallationOptionalComponentEnabled(dda, v2alpha1.OtelAgentGatewayComponentName) {
+		if detail := managedAgentInstallationDeploymentReadinessDetail("OTel Agent Gateway", dda.Status.OtelAgentGateway); detail != "" {
+			details = append(details, detail)
+		}
+	}
+
+	if len(details) == 0 {
+		return nil
+	}
+
+	if !now.Before(dda.CreationTimestamp.Add(managedAgentInstallationReadinessTimeout)) {
+		return &managedAgentInstallationReadinessTimeoutError{msg: fmt.Sprintf(
+			"DatadogAgent %s/%s did not become ready within %s: %s",
+			dda.Namespace, dda.Name, managedAgentInstallationReadinessTimeout, strings.Join(details, "; "),
+		)}
+	}
+	return &managedAgentInstallationWorkloadsNotReadyError{msg: fmt.Sprintf(
+		"DatadogAgent %s/%s is pending managed installation readiness: %s",
+		dda.Namespace, dda.Name, strings.Join(details, "; "),
+	)}
 }
 
 func (d *Daemon) waitForManagedAgentInstallationResourcesAbsent(ctx context.Context, target types.NamespacedName, deletedUID types.UID) error {

--- a/pkg/fleet/managed_agent_installation.go
+++ b/pkg/fleet/managed_agent_installation.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -736,7 +737,66 @@ func (d *Daemon) validateManagedAgentInstallationWorkloadsReady(ctx context.Cont
 	if err != nil {
 		return d.retainFleetDatadogAgentPartial(ctx, uid, err)
 	}
-	return validateFleetDatadogAgentWorkloadsReady(dda, time.Now())
+	windowsDetails, err := d.managedAgentInstallationWindowsReadinessDetails(ctx)
+	if err != nil {
+		return d.retainFleetDatadogAgentPartial(ctx, uid, err)
+	}
+	return validateFleetDatadogAgentWorkloadsReady(dda, time.Now(), windowsDetails...)
+}
+
+func (d *Daemon) managedAgentInstallationWindowsReadinessDetails(ctx context.Context) ([]string, error) {
+	key := d.managedAgentInstallationWindowsProfileKey()
+	ddai := &v1alpha1.DatadogAgentInternal{}
+	if err := d.managedAgentInstallationReader().Get(ctx, key, ddai); err != nil {
+		if apierrors.IsNotFound(err) {
+			return []string{fmt.Sprintf("Windows Agent status is unavailable: DatadogAgentInternal %s/%s was not found", key.Namespace, key.Name)}, nil
+		}
+		return nil, fmt.Errorf("read Windows DatadogAgentInternal %s/%s for managed installation readiness: %w", key.Namespace, key.Name, err)
+	}
+
+	var details []string
+	if condition := meta.FindStatusCondition(ddai.Status.Conditions, common.DatadogAgentReconcileErrorConditionType); condition != nil && condition.Status == metav1.ConditionTrue {
+		detail := "Windows Agent " + condition.Type
+		if condition.Message != "" {
+			detail += ": " + condition.Message
+		}
+		details = append(details, detail)
+	}
+	detail, err := d.managedAgentInstallationWindowsAgentReadinessDetail(ctx, ddai.Status.Agent)
+	if err != nil {
+		return nil, err
+	}
+	if detail != "" {
+		details = append(details, detail)
+	}
+	return details, nil
+}
+
+func (d *Daemon) managedAgentInstallationWindowsAgentReadinessDetail(ctx context.Context, status *v2alpha1.DaemonSetStatus) (string, error) {
+	detail := managedAgentInstallationDaemonSetReadinessDetail("Windows Agent", status)
+	if status == nil || status.LastUpdate == nil || status.DaemonsetName == "" || status.Desired != 0 || status.Current != 0 || status.Ready != 0 || status.Available != 0 || status.UpToDate != 0 {
+		return detail, nil
+	}
+
+	key := types.NamespacedName{Namespace: d.managedAgentInstallationWindowsProfileKey().Namespace, Name: status.DaemonsetName}
+	daemonSet := &appsv1.DaemonSet{}
+	if err := d.managedAgentInstallationReader().Get(ctx, key, daemonSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Sprintf("Windows Agent DaemonSet %s/%s is unavailable", key.Namespace, key.Name), nil
+		}
+		return "", fmt.Errorf("read Windows Agent DaemonSet %s/%s for managed installation readiness: %w", key.Namespace, key.Name, err)
+	}
+	if daemonSet.Generation <= 0 || daemonSet.Status.ObservedGeneration < daemonSet.Generation {
+		return fmt.Sprintf("Windows Agent DaemonSet %s/%s has not been observed by the workload controller", key.Namespace, key.Name), nil
+	}
+	if daemonSet.Status.DesiredNumberScheduled != 0 || daemonSet.Status.CurrentNumberScheduled != 0 ||
+		daemonSet.Status.NumberReady != 0 || daemonSet.Status.NumberAvailable != 0 || daemonSet.Status.UpdatedNumberScheduled != 0 {
+		return fmt.Sprintf(
+			"Windows Agent DaemonSet %s/%s status is newer than the DatadogAgent status",
+			key.Namespace, key.Name,
+		), nil
+	}
+	return "", nil
 }
 
 func managedAgentInstallationComponentDisabled(dda *v2alpha1.DatadogAgent, component v2alpha1.ComponentName) bool {
@@ -763,6 +823,9 @@ func managedAgentInstallationDaemonSetReadinessDetail(name string, status *v2alp
 	if status == nil {
 		return name + " status is unavailable"
 	}
+	if status.LastUpdate == nil {
+		return name + " status has not been observed"
+	}
 	if status.Desired == 0 || status.Current != status.Desired || status.Ready != status.Desired ||
 		status.Available != status.Desired || status.UpToDate != status.Desired {
 		return fmt.Sprintf(
@@ -777,6 +840,9 @@ func managedAgentInstallationDeploymentReadinessDetail(name string, status *v2al
 	if status == nil {
 		return name + " status is unavailable"
 	}
+	if status.LastUpdate == nil {
+		return name + " status has not been observed"
+	}
 	if status.Replicas == 0 || status.UpdatedReplicas != status.Replicas || status.ReadyReplicas != status.Replicas ||
 		status.AvailableReplicas != status.Replicas || status.UnavailableReplicas != 0 {
 		return fmt.Sprintf(
@@ -787,12 +853,12 @@ func managedAgentInstallationDeploymentReadinessDetail(name string, status *v2al
 	return ""
 }
 
-func validateFleetDatadogAgentWorkloadsReady(dda *v2alpha1.DatadogAgent, now time.Time) error {
+func validateFleetDatadogAgentWorkloadsReady(dda *v2alpha1.DatadogAgent, now time.Time, additionalDetails ...string) error {
 	if dda == nil {
 		return &managedAgentInstallationWorkloadsNotReadyError{msg: "Fleet-managed DatadogAgent is pending workload readiness: resource is unavailable"}
 	}
 
-	var details []string
+	details := append([]string(nil), additionalDetails...)
 	for _, conditionType := range []string{
 		common.DatadogAgentReconcileErrorConditionType,
 		common.DatadogAgentInternalReconcileErrorConditionType,

--- a/pkg/fleet/managed_agent_installation.go
+++ b/pkg/fleet/managed_agent_installation.go
@@ -46,6 +46,7 @@ const (
 	fleetTargetIDLabel                         = "fleet.datadoghq.com/target-id"
 	fleetConfigHashAnnotation                  = "fleet.datadoghq.com/config-hash"
 	fleetCreateTaskIDAnnotation                = "fleet.datadoghq.com/create-task-id"
+	fleetReadinessStartedAtAnnotation          = "fleet.datadoghq.com/readiness-started-at"
 	fleetManagedByValue                        = "fleet-automation"
 	fleetManagedAgentInstallationStatePartial  = "partial"
 	fleetManagedAgentInstallationStateReady    = "ready"
@@ -178,8 +179,9 @@ func (d *Daemon) installDatadogAgent(ctx context.Context, command managedAgentIn
 				fleetTargetIDLabel:                         d.managedAgentInstallationIdentity.TargetID(),
 			},
 			Annotations: map[string]string{
-				fleetConfigHashAnnotation:   configHash,
-				fleetCreateTaskIDAnnotation: command.Intent.OperationID,
+				fleetConfigHashAnnotation:         configHash,
+				fleetCreateTaskIDAnnotation:       command.Intent.OperationID,
+				fleetReadinessStartedAtAnnotation: time.Now().UTC().Format(time.RFC3339Nano),
 			},
 		},
 		Spec: *spec,
@@ -540,7 +542,7 @@ func (d *Daemon) markFleetDatadogAgentReady(ctx context.Context, nsn types.Names
 		if err := validateFleetDatadogAgentAcceptedSpec(dda); err != nil {
 			return err
 		}
-		if dda.Labels[fleetManagedAgentInstallationStateLabel] == fleetManagedAgentInstallationStateReady {
+		if dda.Labels[fleetManagedAgentInstallationStateLabel] == fleetManagedAgentInstallationStateReady && dda.Annotations[fleetReadinessStartedAtAnnotation] == "" {
 			return nil
 		}
 		base := dda.DeepCopy()
@@ -548,6 +550,7 @@ func (d *Daemon) markFleetDatadogAgentReady(ctx context.Context, nsn types.Names
 			dda.Labels = make(map[string]string)
 		}
 		dda.Labels[fleetManagedAgentInstallationStateLabel] = fleetManagedAgentInstallationStateReady
+		delete(dda.Annotations, fleetReadinessStartedAtAnnotation)
 		return d.client.Patch(
 			ctx,
 			dda,
@@ -574,11 +577,17 @@ func (d *Daemon) markFleetDatadogAgentPartial(ctx context.Context, nsn types.Nam
 			return err
 		}
 		configID = dda.Labels[fleetConfigIDLabel]
-		if dda.Labels[fleetManagedAgentInstallationStateLabel] == fleetManagedAgentInstallationStatePartial {
+		if dda.Labels[fleetManagedAgentInstallationStateLabel] == fleetManagedAgentInstallationStatePartial && dda.Annotations[fleetReadinessStartedAtAnnotation] != "" {
 			return nil
 		}
 		base := dda.DeepCopy()
 		dda.Labels[fleetManagedAgentInstallationStateLabel] = fleetManagedAgentInstallationStatePartial
+		if dda.Annotations == nil {
+			dda.Annotations = make(map[string]string)
+		}
+		if dda.Annotations[fleetReadinessStartedAtAnnotation] == "" {
+			dda.Annotations[fleetReadinessStartedAtAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+		}
 		return d.client.Patch(
 			ctx,
 			dda,
@@ -750,6 +759,20 @@ func managedAgentInstallationOptionalComponentEnabled(dda *v2alpha1.DatadogAgent
 	}
 }
 
+func managedAgentInstallationDaemonSetReadinessDetail(name string, status *v2alpha1.DaemonSetStatus) string {
+	if status == nil {
+		return name + " status is unavailable"
+	}
+	if status.Desired == 0 || status.Current != status.Desired || status.Ready != status.Desired ||
+		status.Available != status.Desired || status.UpToDate != status.Desired {
+		return fmt.Sprintf(
+			"%s is not ready (desired=%d current=%d ready=%d available=%d upToDate=%d)",
+			name, status.Desired, status.Current, status.Ready, status.Available, status.UpToDate,
+		)
+	}
+	return ""
+}
+
 func managedAgentInstallationDeploymentReadinessDetail(name string, status *v2alpha1.DeploymentStatus) string {
 	if status == nil {
 		return name + " status is unavailable"
@@ -783,30 +806,26 @@ func validateFleetDatadogAgentWorkloadsReady(dda *v2alpha1.DatadogAgent, now tim
 		}
 	}
 
-	agent := dda.Status.Agent
-	if !managedAgentInstallationComponentDisabled(dda, v2alpha1.NodeAgentComponentName) && (agent == nil || agent.Desired == 0 || agent.Current != agent.Desired || agent.Ready != agent.Desired || agent.Available != agent.Desired || agent.UpToDate != agent.Desired) {
-		if agent == nil {
-			details = append(details, "Agent status is unavailable")
-		} else {
-			details = append(details, fmt.Sprintf(
-				"Agent is not ready (desired=%d current=%d ready=%d available=%d upToDate=%d)",
-				agent.Desired, agent.Current, agent.Ready, agent.Available, agent.UpToDate,
-			))
+	if !managedAgentInstallationComponentDisabled(dda, v2alpha1.NodeAgentComponentName) {
+		if detail := managedAgentInstallationDaemonSetReadinessDetail("Agent", dda.Status.Agent); detail != "" {
+			details = append(details, detail)
 		}
 	}
 
-	if !managedAgentInstallationComponentDisabled(dda, v2alpha1.ClusterAgentComponentName) {
-		if detail := managedAgentInstallationDeploymentReadinessDetail("Cluster Agent", dda.Status.ClusterAgent); detail != "" {
-			details = append(details, detail)
-		}
+	deploymentWorkloads := []struct {
+		name    string
+		enabled bool
+		status  *v2alpha1.DeploymentStatus
+	}{
+		{name: "Cluster Agent", enabled: !managedAgentInstallationComponentDisabled(dda, v2alpha1.ClusterAgentComponentName), status: dda.Status.ClusterAgent},
+		{name: "Cluster Checks Runner", enabled: managedAgentInstallationOptionalComponentEnabled(dda, v2alpha1.ClusterChecksRunnerComponentName), status: dda.Status.ClusterChecksRunner},
+		{name: "OTel Agent Gateway", enabled: managedAgentInstallationOptionalComponentEnabled(dda, v2alpha1.OtelAgentGatewayComponentName), status: dda.Status.OtelAgentGateway},
 	}
-	if managedAgentInstallationOptionalComponentEnabled(dda, v2alpha1.ClusterChecksRunnerComponentName) {
-		if detail := managedAgentInstallationDeploymentReadinessDetail("Cluster Checks Runner", dda.Status.ClusterChecksRunner); detail != "" {
-			details = append(details, detail)
+	for _, workload := range deploymentWorkloads {
+		if !workload.enabled {
+			continue
 		}
-	}
-	if managedAgentInstallationOptionalComponentEnabled(dda, v2alpha1.OtelAgentGatewayComponentName) {
-		if detail := managedAgentInstallationDeploymentReadinessDetail("OTel Agent Gateway", dda.Status.OtelAgentGateway); detail != "" {
+		if detail := managedAgentInstallationDeploymentReadinessDetail(workload.name, workload.status); detail != "" {
 			details = append(details, detail)
 		}
 	}
@@ -815,7 +834,13 @@ func validateFleetDatadogAgentWorkloadsReady(dda *v2alpha1.DatadogAgent, now tim
 		return nil
 	}
 
-	if !now.Before(dda.CreationTimestamp.Add(managedAgentInstallationReadinessTimeout)) {
+	readinessStartedAt, err := time.Parse(time.RFC3339Nano, dda.Annotations[fleetReadinessStartedAtAnnotation])
+	if err != nil {
+		return &stateDoesntMatchError{msg: fmt.Sprintf(
+			"DatadogAgent %s/%s has invalid managed installation readiness start time", dda.Namespace, dda.Name,
+		)}
+	}
+	if !now.Before(readinessStartedAt.Add(managedAgentInstallationReadinessTimeout)) {
 		return &managedAgentInstallationReadinessTimeoutError{msg: fmt.Sprintf(
 			"DatadogAgent %s/%s did not become ready within %s: %s",
 			dda.Namespace, dda.Name, managedAgentInstallationReadinessTimeout, strings.Join(details, "; "),

--- a/pkg/fleet/managed_agent_installation_command.go
+++ b/pkg/fleet/managed_agent_installation_command.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -132,12 +133,14 @@ func (d *Daemon) executeManagedAgentInstallationCommand(ctx context.Context, com
 			return err
 		}
 		var stateErr *stateDoesntMatchError
-		if !errors.As(err, &stateErr) && ctx.Err() == nil && isRetryable(err) {
+		var terminalErr *managedAgentInstallationReadinessTimeoutError
+		if !errors.As(err, &stateErr) && !errors.As(err, &terminalErr) && ctx.Err() == nil && isRetryable(err) {
+			retryDelay := managedAgentInstallationRetryDelay(err)
 			if persistErr := d.recordManagedAgentInstallationResult(ctx, command, pbgo.TaskState_RUNNING, err); persistErr != nil {
-				d.requestManagedAgentInstallationRetryAfter()
+				d.requestManagedAgentInstallationRetryAfterDelay(retryDelay)
 				return errors.Join(err, persistErr)
 			}
-			d.requestManagedAgentInstallationRetryAfter()
+			d.requestManagedAgentInstallationRetryAfterDelay(retryDelay)
 			return err
 		}
 		resultState := pbgo.TaskState_ERROR
@@ -170,6 +173,14 @@ func (d *Daemon) executeManagedAgentInstallationCommand(ctx context.Context, com
 	d.taskMu.Unlock()
 	d.emitManagedAgentInstallationCompletedEvent(ctx, command)
 	return nil
+}
+
+func managedAgentInstallationRetryDelay(err error) time.Duration {
+	var workloadsNotReadyErr *managedAgentInstallationWorkloadsNotReadyError
+	if errors.As(err, &workloadsNotReadyErr) {
+		return managedAgentInstallationReadinessRetryInterval
+	}
+	return managedAgentInstallationRetryInterval
 }
 
 func (d *Daemon) managedAgentInstallationShouldWaitForFleet(ctx context.Context, desiredState managedAgentInstallationDesiredState) (bool, error) {

--- a/pkg/fleet/managed_agent_installation_intent_test.go
+++ b/pkg/fleet/managed_agent_installation_intent_test.go
@@ -262,6 +262,7 @@ func TestManagedAgentInstallationIntentInstallAndUninstall(t *testing.T) {
 		testFleetCredentialSecret(),
 		unrelated,
 	)
+	kubeClient.(*managedAgentInstallationTestClient).workloadsReadyOnCreate = false
 
 	install := managedAgentInstallationIntentSnapshot{raw: testManagedAgentInstallationIntent(
 		t,
@@ -269,9 +270,18 @@ func TestManagedAgentInstallationIntentInstallAndUninstall(t *testing.T) {
 		managedAgentInstallationDesiredStateInstalled,
 	)}
 	putManagedAgentInstallationIntentConfigMap(t, kubeClient, install.raw)
-	require.NoError(t, daemon.handleManagedAgentInstallationIntent(ctx, install))
+	err := daemon.handleManagedAgentInstallationIntent(ctx, install)
+	require.ErrorContains(t, err, "pending managed installation readiness")
+	require.Len(t, rcClient.state, 1)
+	assert.Equal(t, pbgo.TaskState_RUNNING, rcClient.state[0].GetTask().GetState())
+	assert.Equal(t, fleetPartialConfigVersionPrefix+testAddonInstallOperationID, rcClient.state[0].GetStableConfigVersion())
 
 	dda := &v2alpha1.DatadogAgent{}
+	require.NoError(t, kubeClient.Get(ctx, testDDANSN, dda))
+	assert.Equal(t, fleetManagedAgentInstallationStatePartial, dda.Labels[fleetManagedAgentInstallationStateLabel])
+	setTestManagedAgentInstallationWorkloadsReady(dda)
+	require.NoError(t, kubeClient.Status().Update(ctx, dda))
+	require.NoError(t, daemon.handleManagedAgentInstallationIntent(ctx, install))
 	require.NoError(t, kubeClient.Get(ctx, testDDANSN, dda))
 	assert.Equal(t, testAddonInstallOperationID, dda.Labels[fleetConfigIDLabel])
 	assert.Equal(t, string(testManagedAgentInstallationIdentity.Provider()), dda.Labels[fleetManagedAgentInstallationProviderLabel])
@@ -332,7 +342,7 @@ func TestManagedAgentInstallationIntentInstallAndUninstall(t *testing.T) {
 	require.NoError(t, daemon.handleManagedAgentInstallationIntent(ctx, uninstall))
 	assert.True(t, reservedDuringUninstallRefresh)
 
-	err := kubeClient.Get(ctx, testDDANSN, &v2alpha1.DatadogAgent{})
+	err = kubeClient.Get(ctx, testDDANSN, &v2alpha1.DatadogAgent{})
 	require.True(t, apierrors.IsNotFound(err))
 	require.NoError(t, kubeClient.Get(ctx, client.ObjectKeyFromObject(unrelated), &v2alpha1.DatadogAgent{}))
 	assert.Equal(t, testAddonUninstallOperationID, rcClient.state[0].GetTask().GetId())
@@ -644,6 +654,57 @@ func TestManagedAgentInstallationCommandReportsTerminalFailures(t *testing.T) {
 			assert.False(t, daemon.managedAgentInstallationTaskReserved)
 		})
 	}
+}
+
+func TestManagedAgentInstallationPendingReadinessSchedulesConfiguredRetry(t *testing.T) {
+	ctx := context.Background()
+	previousInterval := managedAgentInstallationReadinessRetryInterval
+	managedAgentInstallationReadinessRetryInterval = 10 * time.Millisecond
+	t.Cleanup(func() { managedAgentInstallationReadinessRetryInterval = previousInterval })
+
+	daemon, kubeClient, _ := testManagedAgentInstallationDaemon(
+		[]*pbgo.PackageState{{Package: packageDatadogOperator}},
+		testFleetCredentialSecret(),
+	)
+	daemon.managedAgentInstallationUpdates = make(chan struct{}, 1)
+	kubeClient.(*managedAgentInstallationTestClient).workloadsReadyOnCreate = false
+	raw := testManagedAgentInstallationIntent(t, testAddonInstallOperationID, managedAgentInstallationDesiredStateInstalled)
+	putManagedAgentInstallationIntentConfigMap(t, kubeClient, raw)
+	command := testManagedAgentInstallationCommand(t, testAddonInstallOperationID, managedAgentInstallationDesiredStateInstalled)
+
+	err := daemon.handleManagedAgentInstallationCommand(ctx, command)
+	require.ErrorContains(t, err, "pending managed installation readiness")
+	select {
+	case <-daemon.managedAgentInstallationUpdates:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("pending workload readiness did not schedule the configured retry")
+	}
+}
+
+func TestManagedAgentInstallationReadinessTimeoutReportsTerminalError(t *testing.T) {
+	ctx := context.Background()
+	previousTimeout := managedAgentInstallationReadinessTimeout
+	managedAgentInstallationReadinessTimeout = 0
+	t.Cleanup(func() { managedAgentInstallationReadinessTimeout = previousTimeout })
+
+	daemon, kubeClient, rcClient := testManagedAgentInstallationDaemon(
+		[]*pbgo.PackageState{{Package: packageDatadogOperator}},
+		testFleetCredentialSecret(),
+	)
+	kubeClient.(*managedAgentInstallationTestClient).workloadsReadyOnCreate = false
+	raw := testManagedAgentInstallationIntent(t, testAddonInstallOperationID, managedAgentInstallationDesiredStateInstalled)
+	putManagedAgentInstallationIntentConfigMap(t, kubeClient, raw)
+	command := testManagedAgentInstallationCommand(t, testAddonInstallOperationID, managedAgentInstallationDesiredStateInstalled)
+
+	err := daemon.handleManagedAgentInstallationCommand(ctx, command)
+	require.ErrorContains(t, err, "did not become ready within 0s")
+	persisted, readErr := daemon.readManagedAgentInstallationState(ctx)
+	require.NoError(t, readErr)
+	require.NotNil(t, persisted)
+	assert.Equal(t, pbgo.TaskState_ERROR, persisted.TaskState)
+	require.Len(t, rcClient.state, 1)
+	assert.Equal(t, pbgo.TaskState_ERROR, rcClient.state[0].GetTask().GetState())
+	assert.False(t, daemon.managedAgentInstallationTaskReserved)
 }
 
 func TestManagedAgentInstallationCommandRejectsConcurrentOperation(t *testing.T) {

--- a/pkg/fleet/managed_agent_installation_intent_test.go
+++ b/pkg/fleet/managed_agent_installation_intent_test.go
@@ -1572,6 +1572,39 @@ func TestManagedAgentInstallationReadinessTagsRejectsIncompleteState(t *testing.
 	require.ErrorContains(t, err, "target is absent")
 }
 
+func TestManagedAgentInstallationStateWritesAreDeduplicated(t *testing.T) {
+	ctx := context.Background()
+	daemon, kubeClient, _ := testManagedAgentInstallationDaemon(nil)
+	raw := testManagedAgentInstallationIntent(t, testAddonInstallOperationID, managedAgentInstallationDesiredStateInstalled)
+	putManagedAgentInstallationIntentConfigMap(t, kubeClient, raw)
+	command := testManagedAgentInstallationCommand(t, testAddonInstallOperationID, managedAgentInstallationDesiredStateInstalled)
+	pending := managedAgentInstallationStateFromCommand(command, pbgo.TaskState_RUNNING, errors.New("workloads are pending"))
+	require.NoError(t, daemon.writeManagedAgentInstallationState(ctx, pending))
+
+	patchCalls := 0
+	daemon.client = &managedAgentInstallationFaultClient{
+		Client: kubeClient,
+		patchError: func(client.Object) error {
+			patchCalls++
+			return nil
+		},
+	}
+
+	accepted := managedAgentInstallationStateFromCommand(command, pbgo.TaskState_RUNNING, nil)
+	require.NoError(t, daemon.writeManagedAgentInstallationState(ctx, accepted))
+	state, err := daemon.readManagedAgentInstallationState(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, pending.Error, state.Error)
+	assert.Zero(t, patchCalls)
+
+	changed := pending
+	changed.Error = "workloads are still pending"
+	require.NoError(t, daemon.writeManagedAgentInstallationResult(ctx, changed))
+	require.NoError(t, daemon.writeManagedAgentInstallationResult(ctx, changed))
+	assert.Equal(t, 1, patchCalls)
+}
+
 func TestManagedAgentInstallationPersistedStateFailures(t *testing.T) {
 	ctx := context.Background()
 	newDaemonWithIntent := func(t *testing.T) (*Daemon, client.Client, managedAgentInstallationPersistedState) {

--- a/pkg/fleet/managed_agent_installation_intent_test.go
+++ b/pkg/fleet/managed_agent_installation_intent_test.go
@@ -279,11 +279,14 @@ func TestManagedAgentInstallationIntentInstallAndUninstall(t *testing.T) {
 	dda := &v2alpha1.DatadogAgent{}
 	require.NoError(t, kubeClient.Get(ctx, testDDANSN, dda))
 	assert.Equal(t, fleetManagedAgentInstallationStatePartial, dda.Labels[fleetManagedAgentInstallationStateLabel])
+	_, readinessStartedAtErr := time.Parse(time.RFC3339Nano, dda.Annotations[fleetReadinessStartedAtAnnotation])
+	require.NoError(t, readinessStartedAtErr)
 	setTestManagedAgentInstallationWorkloadsReady(dda)
 	require.NoError(t, kubeClient.Status().Update(ctx, dda))
 	require.NoError(t, daemon.handleManagedAgentInstallationIntent(ctx, install))
 	require.NoError(t, kubeClient.Get(ctx, testDDANSN, dda))
 	assert.Equal(t, testAddonInstallOperationID, dda.Labels[fleetConfigIDLabel])
+	assert.NotContains(t, dda.Annotations, fleetReadinessStartedAtAnnotation)
 	assert.Equal(t, string(testManagedAgentInstallationIdentity.Provider()), dda.Labels[fleetManagedAgentInstallationProviderLabel])
 	assert.Equal(t, testManagedAgentInstallationIdentity.InstallationID(), dda.Labels[fleetInstallationIDLabel])
 	assert.Equal(t, testManagedAgentInstallationIdentity.TargetID(), dda.Labels[fleetTargetIDLabel])
@@ -654,6 +657,35 @@ func TestManagedAgentInstallationCommandReportsTerminalFailures(t *testing.T) {
 			assert.False(t, daemon.managedAgentInstallationTaskReserved)
 		})
 	}
+}
+
+func TestManagedAgentInstallationCompletedInstallStartsFreshReadinessDeadline(t *testing.T) {
+	ctx := context.Background()
+	daemon, kubeClient, _ := testManagedAgentInstallationDaemon(
+		[]*pbgo.PackageState{{Package: packageDatadogOperator}},
+		testFleetCredentialSecret(),
+	)
+	raw := testManagedAgentInstallationIntent(t, testAddonInstallOperationID, managedAgentInstallationDesiredStateInstalled)
+	putManagedAgentInstallationIntentConfigMap(t, kubeClient, raw)
+	snapshot := managedAgentInstallationIntentSnapshot{raw: raw}
+	require.NoError(t, daemon.handleManagedAgentInstallationIntent(ctx, snapshot))
+
+	dda := &v2alpha1.DatadogAgent{}
+	require.NoError(t, kubeClient.Get(ctx, managedAgentInstallationTarget, dda))
+	dda.CreationTimestamp = metav1.NewTime(time.Now().Add(-24 * time.Hour))
+	require.NoError(t, kubeClient.Update(ctx, dda))
+	require.NoError(t, kubeClient.Get(ctx, managedAgentInstallationTarget, dda))
+	dda.Status.Agent.Ready = 0
+	require.NoError(t, kubeClient.Status().Update(ctx, dda))
+
+	err := daemon.handleManagedAgentInstallationIntent(ctx, snapshot)
+	require.ErrorContains(t, err, "pending managed installation readiness")
+	var terminalErr *managedAgentInstallationReadinessTimeoutError
+	require.NotErrorAs(t, err, &terminalErr)
+	require.NoError(t, kubeClient.Get(ctx, managedAgentInstallationTarget, dda))
+	readinessStartedAt, parseErr := time.Parse(time.RFC3339Nano, dda.Annotations[fleetReadinessStartedAtAnnotation])
+	require.NoError(t, parseErr)
+	assert.WithinDuration(t, time.Now(), readinessStartedAt, time.Second)
 }
 
 func TestManagedAgentInstallationPendingReadinessSchedulesConfiguredRetry(t *testing.T) {

--- a/pkg/fleet/managed_agent_installation_state.go
+++ b/pkg/fleet/managed_agent_installation_state.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
@@ -179,8 +180,20 @@ func (d *Daemon) writeManagedAgentInstallationStateForOperation(ctx context.Cont
 		if expectedOperationID != "" && current.Data[managedAgentInstallationStateOperationIDKey] != expectedOperationID {
 			return nil
 		}
+
+		desiredData := managedAgentInstallationStateData(state)
+		if expectedOperationID == "" &&
+			state.TaskState == pbgo.TaskState_RUNNING &&
+			state.Error == "" &&
+			current.Data[managedAgentInstallationStateOperationIDKey] == state.OperationID &&
+			current.Data[managedAgentInstallationStateTaskStateKey] == pbgo.TaskState_RUNNING.String() {
+			desiredData[managedAgentInstallationStateErrorKey] = current.Data[managedAgentInstallationStateErrorKey]
+		}
+		if maps.Equal(current.Data, desiredData) {
+			return nil
+		}
 		base := current.DeepCopy()
-		current.Data = managedAgentInstallationStateData(state)
+		current.Data = desiredData
 		return d.client.Patch(ctx, current, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{}), client.FieldOwner("fleet-daemon"))
 	})
 }

--- a/pkg/fleet/managed_agent_installation_test.go
+++ b/pkg/fleet/managed_agent_installation_test.go
@@ -161,7 +161,10 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 	ready := &v2alpha1.DatadogAgent{ObjectMeta: metav1.ObjectMeta{
 		Namespace:         managedAgentInstallationTarget.Namespace,
 		Name:              managedAgentInstallationTarget.Name,
-		CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+		CreationTimestamp: metav1.NewTime(now.Add(-24 * time.Hour)),
+		Annotations: map[string]string{
+			fleetReadinessStartedAtAnnotation: now.Add(-time.Minute).Format(time.RFC3339Nano),
+		},
 	}}
 	setTestManagedAgentInstallationWorkloadsReady(ready)
 	require.NoError(t, validateFleetDatadogAgentWorkloadsReady(ready, now))
@@ -238,9 +241,8 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 	} {
 		t.Run(test.name+" may be disabled", func(t *testing.T) {
 			dda := ready.DeepCopy()
-			disabled := true
 			dda.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
-				test.component: {Disabled: &disabled},
+				test.component: {Disabled: new(true)},
 			}
 			test.disable(dda)
 			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
@@ -251,31 +253,29 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 		name      string
 		component v2alpha1.ComponentName
 		enable    func(*v2alpha1.DatadogAgent)
-		status    func(*v2alpha1.DatadogAgent) **v2alpha1.DeploymentStatus
+		setStatus func(*v2alpha1.DatadogAgent, *v2alpha1.DeploymentStatus)
 	}{
 		{
 			name:      "Cluster Checks Runner",
 			component: v2alpha1.ClusterChecksRunnerComponentName,
 			enable: func(dda *v2alpha1.DatadogAgent) {
-				enabled := true
 				dda.Spec.Features = &v2alpha1.DatadogFeatures{ClusterChecks: &v2alpha1.ClusterChecksFeatureConfig{
-					Enabled:                 &enabled,
-					UseClusterChecksRunners: &enabled,
+					Enabled:                 new(true),
+					UseClusterChecksRunners: new(true),
 				}}
 			},
-			status: func(dda *v2alpha1.DatadogAgent) **v2alpha1.DeploymentStatus {
-				return &dda.Status.ClusterChecksRunner
+			setStatus: func(dda *v2alpha1.DatadogAgent, status *v2alpha1.DeploymentStatus) {
+				dda.Status.ClusterChecksRunner = status
 			},
 		},
 		{
 			name:      "OTel Agent Gateway",
 			component: v2alpha1.OtelAgentGatewayComponentName,
 			enable: func(dda *v2alpha1.DatadogAgent) {
-				enabled := true
-				dda.Spec.Features = &v2alpha1.DatadogFeatures{OtelAgentGateway: &v2alpha1.OtelAgentGatewayFeatureConfig{Enabled: &enabled}}
+				dda.Spec.Features = &v2alpha1.DatadogFeatures{OtelAgentGateway: &v2alpha1.OtelAgentGatewayFeatureConfig{Enabled: new(true)}}
 			},
-			status: func(dda *v2alpha1.DatadogAgent) **v2alpha1.DeploymentStatus {
-				return &dda.Status.OtelAgentGateway
+			setStatus: func(dda *v2alpha1.DatadogAgent, status *v2alpha1.DeploymentStatus) {
+				dda.Status.OtelAgentGateway = status
 			},
 		},
 	} {
@@ -284,23 +284,22 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 			test.enable(dda)
 
 			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), test.name+" status is unavailable")
-			*test.status(dda) = &v2alpha1.DeploymentStatus{Replicas: 1}
+			test.setStatus(dda, &v2alpha1.DeploymentStatus{Replicas: 1})
 			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), test.name+" is not ready")
-			*test.status(dda) = testManagedAgentInstallationDeploymentReady()
+			test.setStatus(dda, testManagedAgentInstallationDeploymentReady())
 			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
 
-			disabled := true
 			dda.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
-				test.component: {Disabled: &disabled},
+				test.component: {Disabled: new(true)},
 			}
-			*test.status(dda) = nil
+			test.setStatus(dda, nil)
 			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
 		})
 	}
 
 	t.Run("deadline returns terminal error with details", func(t *testing.T) {
 		dda := ready.DeepCopy()
-		dda.CreationTimestamp = metav1.NewTime(now.Add(-managedAgentInstallationReadinessTimeout))
+		dda.Annotations[fleetReadinessStartedAtAnnotation] = now.Add(-managedAgentInstallationReadinessTimeout).Format(time.RFC3339Nano)
 		dda.Status.Agent.Ready = 0
 		err := validateFleetDatadogAgentWorkloadsReady(dda, now)
 		var terminalErr *managedAgentInstallationReadinessTimeoutError

--- a/pkg/fleet/managed_agent_installation_test.go
+++ b/pkg/fleet/managed_agent_installation_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ import (
 
 	v1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	v2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -38,6 +40,7 @@ var testManagedAgentInstallationIdentity = NewEKSManagedAgentInstallationIdentit
 
 type managedAgentInstallationTestClient struct {
 	client.Client
+	workloadsReadyOnCreate bool
 }
 
 type rejectManagedAgentInstallationTargetCreateClient struct {
@@ -125,8 +128,16 @@ func (c *rejectManagedAgentInstallationTargetDeleteClient) Delete(ctx context.Co
 }
 
 func (c *managedAgentInstallationTestClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if dda, ok := obj.(*v2alpha1.DatadogAgent); ok && dda.UID == "" {
-		dda.UID = types.UID("created-dda-uid")
+	if dda, ok := obj.(*v2alpha1.DatadogAgent); ok {
+		if dda.UID == "" {
+			dda.UID = types.UID("created-dda-uid")
+		}
+		if dda.CreationTimestamp.IsZero() {
+			dda.CreationTimestamp = metav1.Now()
+		}
+		if c.workloadsReadyOnCreate {
+			setTestManagedAgentInstallationWorkloadsReady(dda)
+		}
 	}
 	return c.Client.Create(ctx, obj, opts...)
 }
@@ -143,6 +154,160 @@ func (c *managedAgentInstallationTestClient) Delete(ctx context.Context, obj cli
 		}
 	}
 	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	ready := &v2alpha1.DatadogAgent{ObjectMeta: metav1.ObjectMeta{
+		Namespace:         managedAgentInstallationTarget.Namespace,
+		Name:              managedAgentInstallationTarget.Name,
+		CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+	}}
+	setTestManagedAgentInstallationWorkloadsReady(ready)
+	require.NoError(t, validateFleetDatadogAgentWorkloadsReady(ready, now))
+
+	t.Run("pending status", func(t *testing.T) {
+		dda := ready.DeepCopy()
+		dda.Status = v2alpha1.DatadogAgentStatus{}
+		err := validateFleetDatadogAgentWorkloadsReady(dda, now)
+		require.ErrorContains(t, err, "Agent status is unavailable")
+		require.ErrorContains(t, err, "Cluster Agent status is unavailable")
+		var notReadyErr *managedAgentInstallationWorkloadsNotReadyError
+		require.ErrorAs(t, err, &notReadyErr)
+		assert.Equal(t, managedAgentInstallationReadinessRetryInterval, managedAgentInstallationRetryDelay(err))
+		assert.Equal(t, managedAgentInstallationRetryInterval, managedAgentInstallationRetryDelay(errors.New("retryable error")))
+	})
+
+	for _, conditionType := range []string{
+		common.DatadogAgentReconcileErrorConditionType,
+		common.DatadogAgentInternalReconcileErrorConditionType,
+	} {
+		t.Run("active "+conditionType, func(t *testing.T) {
+			dda := ready.DeepCopy()
+			dda.Status.Conditions = []metav1.Condition{{
+				Type:    conditionType,
+				Status:  metav1.ConditionTrue,
+				Message: "RBAC reconciliation failed",
+			}}
+			err := validateFleetDatadogAgentWorkloadsReady(dda, now)
+			require.ErrorContains(t, err, "RBAC reconciliation failed")
+			var notReadyErr *managedAgentInstallationWorkloadsNotReadyError
+			require.ErrorAs(t, err, &notReadyErr)
+		})
+	}
+
+	t.Run("inactive reconciliation error does not block readiness", func(t *testing.T) {
+		dda := ready.DeepCopy()
+		dda.Status.Conditions = []metav1.Condition{{
+			Type:   common.DatadogAgentReconcileErrorConditionType,
+			Status: metav1.ConditionFalse,
+		}}
+		require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
+	})
+
+	readinessChecks := []struct {
+		name   string
+		mutate func(*v2alpha1.DatadogAgent)
+	}{
+		{name: "Agent desired", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent = &v2alpha1.DaemonSetStatus{} }},
+		{name: "Agent current", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.Current = 0 }},
+		{name: "Agent ready", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.Ready = 0 }},
+		{name: "Agent available", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.Available = 0 }},
+		{name: "Agent up to date", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.UpToDate = 0 }},
+		{name: "Cluster Agent replicas", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent = &v2alpha1.DeploymentStatus{} }},
+		{name: "Cluster Agent updated", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent.UpdatedReplicas = 0 }},
+		{name: "Cluster Agent ready", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent.ReadyReplicas = 0 }},
+		{name: "Cluster Agent available", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent.AvailableReplicas = 0 }},
+		{name: "Cluster Agent unavailable", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent.UnavailableReplicas = 1 }},
+	}
+	for _, test := range readinessChecks {
+		t.Run(test.name, func(t *testing.T) {
+			dda := ready.DeepCopy()
+			test.mutate(dda)
+			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), "is not ready")
+		})
+	}
+
+	for _, test := range []struct {
+		name      string
+		component v2alpha1.ComponentName
+		disable   func(*v2alpha1.DatadogAgent)
+	}{
+		{name: "Node Agent", component: v2alpha1.NodeAgentComponentName, disable: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent = nil }},
+		{name: "Cluster Agent", component: v2alpha1.ClusterAgentComponentName, disable: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent = nil }},
+	} {
+		t.Run(test.name+" may be disabled", func(t *testing.T) {
+			dda := ready.DeepCopy()
+			disabled := true
+			dda.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+				test.component: {Disabled: &disabled},
+			}
+			test.disable(dda)
+			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
+		})
+	}
+
+	for _, test := range []struct {
+		name      string
+		component v2alpha1.ComponentName
+		enable    func(*v2alpha1.DatadogAgent)
+		status    func(*v2alpha1.DatadogAgent) **v2alpha1.DeploymentStatus
+	}{
+		{
+			name:      "Cluster Checks Runner",
+			component: v2alpha1.ClusterChecksRunnerComponentName,
+			enable: func(dda *v2alpha1.DatadogAgent) {
+				enabled := true
+				dda.Spec.Features = &v2alpha1.DatadogFeatures{ClusterChecks: &v2alpha1.ClusterChecksFeatureConfig{
+					Enabled:                 &enabled,
+					UseClusterChecksRunners: &enabled,
+				}}
+			},
+			status: func(dda *v2alpha1.DatadogAgent) **v2alpha1.DeploymentStatus {
+				return &dda.Status.ClusterChecksRunner
+			},
+		},
+		{
+			name:      "OTel Agent Gateway",
+			component: v2alpha1.OtelAgentGatewayComponentName,
+			enable: func(dda *v2alpha1.DatadogAgent) {
+				enabled := true
+				dda.Spec.Features = &v2alpha1.DatadogFeatures{OtelAgentGateway: &v2alpha1.OtelAgentGatewayFeatureConfig{Enabled: &enabled}}
+			},
+			status: func(dda *v2alpha1.DatadogAgent) **v2alpha1.DeploymentStatus {
+				return &dda.Status.OtelAgentGateway
+			},
+		},
+	} {
+		t.Run(test.name+" readiness", func(t *testing.T) {
+			dda := ready.DeepCopy()
+			test.enable(dda)
+
+			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), test.name+" status is unavailable")
+			*test.status(dda) = &v2alpha1.DeploymentStatus{Replicas: 1}
+			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), test.name+" is not ready")
+			*test.status(dda) = testManagedAgentInstallationDeploymentReady()
+			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
+
+			disabled := true
+			dda.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+				test.component: {Disabled: &disabled},
+			}
+			*test.status(dda) = nil
+			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
+		})
+	}
+
+	t.Run("deadline returns terminal error with details", func(t *testing.T) {
+		dda := ready.DeepCopy()
+		dda.CreationTimestamp = metav1.NewTime(now.Add(-managedAgentInstallationReadinessTimeout))
+		dda.Status.Agent.Ready = 0
+		err := validateFleetDatadogAgentWorkloadsReady(dda, now)
+		var terminalErr *managedAgentInstallationReadinessTimeoutError
+		require.ErrorAs(t, err, &terminalErr)
+		require.ErrorContains(t, err, "did not become ready within 10m0s")
+		require.ErrorContains(t, err, "ready=0")
+	})
 }
 
 func TestManagedAgentInstallationKeysUseConfiguredNamespace(t *testing.T) {
@@ -1173,9 +1338,31 @@ func TestValidateFleetCredentialSecretReadFailure(t *testing.T) {
 	require.ErrorContains(t, daemon.validateFleetCredentialSecret(context.Background()), "Secret read failed")
 }
 
+func setTestManagedAgentInstallationWorkloadsReady(dda *v2alpha1.DatadogAgent) {
+	dda.Status.Agent = &v2alpha1.DaemonSetStatus{
+		Desired:   1,
+		Current:   1,
+		Ready:     1,
+		Available: 1,
+		UpToDate:  1,
+	}
+	dda.Status.ClusterAgent = testManagedAgentInstallationDeploymentReady()
+}
+
+func testManagedAgentInstallationDeploymentReady() *v2alpha1.DeploymentStatus {
+	return &v2alpha1.DeploymentStatus{
+		Replicas:          1,
+		UpdatedReplicas:   1,
+		ReadyReplicas:     1,
+		AvailableReplicas: 1,
+	}
+}
+
 func testFleetManagedDatadogAgent(t testing.TB, phase v2alpha1.ExperimentPhase, configID string) *v2alpha1.DatadogAgent {
 	t.Helper()
 	dda := testDDAObject(phase)
+	dda.CreationTimestamp = metav1.Now()
+	setTestManagedAgentInstallationWorkloadsReady(dda)
 	dda.UID = types.UID("managed-dda-uid")
 	dda.Labels = map[string]string{
 		fleetManagedByLabel:                        fleetManagedByValue,
@@ -1213,7 +1400,7 @@ func testManagedAgentInstallationDaemon(rcState []*pbgo.PackageState, objects ..
 		WithStatusSubresource(&v2alpha1.DatadogAgent{}).
 		WithObjects(objects...).
 		Build()
-	kubeClient := &managedAgentInstallationTestClient{Client: baseClient}
+	kubeClient := &managedAgentInstallationTestClient{Client: baseClient, workloadsReadyOnCreate: true}
 	rcClient := &mockRCClient{state: rcState}
 	daemon := &Daemon{
 		rcClient:                             rcClient,

--- a/pkg/fleet/managed_agent_installation_test.go
+++ b/pkg/fleet/managed_agent_installation_test.go
@@ -15,6 +15,7 @@ import (
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -212,12 +213,10 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 		name   string
 		mutate func(*v2alpha1.DatadogAgent)
 	}{
-		{name: "Agent desired", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent = &v2alpha1.DaemonSetStatus{} }},
 		{name: "Agent current", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.Current = 0 }},
 		{name: "Agent ready", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.Ready = 0 }},
 		{name: "Agent available", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.Available = 0 }},
 		{name: "Agent up to date", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.Agent.UpToDate = 0 }},
-		{name: "Cluster Agent replicas", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent = &v2alpha1.DeploymentStatus{} }},
 		{name: "Cluster Agent updated", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent.UpdatedReplicas = 0 }},
 		{name: "Cluster Agent ready", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent.ReadyReplicas = 0 }},
 		{name: "Cluster Agent available", mutate: func(dda *v2alpha1.DatadogAgent) { dda.Status.ClusterAgent.AvailableReplicas = 0 }},
@@ -230,6 +229,23 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), "is not ready")
 		})
 	}
+
+	t.Run("unobserved zero status is pending", func(t *testing.T) {
+		dda := ready.DeepCopy()
+		dda.Status.Agent = &v2alpha1.DaemonSetStatus{}
+		dda.Status.ClusterAgent = &v2alpha1.DeploymentStatus{}
+		err := validateFleetDatadogAgentWorkloadsReady(dda, now)
+		require.ErrorContains(t, err, "Agent status has not been observed")
+		require.ErrorContains(t, err, "Cluster Agent status has not been observed")
+	})
+
+	t.Run("summarized zero-target status remains pending", func(t *testing.T) {
+		dda := ready.DeepCopy()
+		observedAt := metav1.NewTime(now)
+		dda.Status.Agent = &v2alpha1.DaemonSetStatus{LastUpdate: &observedAt}
+		dda.Status.ClusterAgent = &v2alpha1.DeploymentStatus{LastUpdate: &observedAt}
+		require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), "is not ready")
+	})
 
 	for _, test := range []struct {
 		name      string
@@ -248,6 +264,16 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
 		})
 	}
+
+	t.Run("profile readiness blocks when the parent Agent is disabled", func(t *testing.T) {
+		dda := ready.DeepCopy()
+		dda.Spec.Override = map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+			v2alpha1.NodeAgentComponentName: {Disabled: new(true)},
+		}
+		dda.Status.Agent = nil
+		err := validateFleetDatadogAgentWorkloadsReady(dda, now, "Windows Agent status has not been observed")
+		require.ErrorContains(t, err, "Windows Agent status has not been observed")
+	})
 
 	for _, test := range []struct {
 		name      string
@@ -284,7 +310,8 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 			test.enable(dda)
 
 			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), test.name+" status is unavailable")
-			test.setStatus(dda, &v2alpha1.DeploymentStatus{Replicas: 1})
+			observedAt := metav1.NewTime(now)
+			test.setStatus(dda, &v2alpha1.DeploymentStatus{Replicas: 1, LastUpdate: &observedAt})
 			require.ErrorContains(t, validateFleetDatadogAgentWorkloadsReady(dda, now), test.name+" is not ready")
 			test.setStatus(dda, testManagedAgentInstallationDeploymentReady())
 			require.NoError(t, validateFleetDatadogAgentWorkloadsReady(dda, now))
@@ -307,6 +334,77 @@ func TestManagedAgentInstallationWorkloadReadiness(t *testing.T) {
 		require.ErrorContains(t, err, "did not become ready within 10m0s")
 		require.ErrorContains(t, err, "ready=0")
 	})
+}
+
+func TestManagedAgentInstallationWindowsReadinessDetails(t *testing.T) {
+	ctx := context.Background()
+	daemon, kubeClient, _ := testManagedAgentInstallationDaemon(nil)
+
+	details, err := daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, details)
+
+	daemonSet := &appsv1.DaemonSet{}
+	require.NoError(t, kubeClient.Get(ctx, types.NamespacedName{Namespace: managedAgentInstallationWindowsProfileKey.Namespace, Name: "datadog-agent-windows-agent"}, daemonSet))
+	daemonSet.Status.ObservedGeneration = 0
+	require.NoError(t, kubeClient.Status().Update(ctx, daemonSet))
+	details, err = daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.NoError(t, err)
+	require.Len(t, details, 1)
+	assert.Contains(t, details[0], "has not been observed by the workload controller")
+
+	daemonSet.Status.ObservedGeneration = 1
+	daemonSet.Status.DesiredNumberScheduled = 1
+	require.NoError(t, kubeClient.Status().Update(ctx, daemonSet))
+	details, err = daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.NoError(t, err)
+	require.Len(t, details, 1)
+	assert.Contains(t, details[0], "status is newer than the DatadogAgent status")
+
+	daemonSet.Status.DesiredNumberScheduled = 0
+	require.NoError(t, kubeClient.Status().Update(ctx, daemonSet))
+	details, err = daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, details)
+
+	ddai := &v1alpha1.DatadogAgentInternal{}
+	require.NoError(t, kubeClient.Get(ctx, managedAgentInstallationWindowsProfileKey, ddai))
+	ddai.Status.Agent = nil
+	require.NoError(t, kubeClient.Update(ctx, ddai))
+	details, err = daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.NoError(t, err)
+	require.Len(t, details, 1)
+	assert.Contains(t, details[0], "Windows Agent status is unavailable")
+
+	observedAt := metav1.Now()
+	ddai.Status.Agent = &v2alpha1.DaemonSetStatus{LastUpdate: &observedAt}
+	ddai.Status.Conditions = []metav1.Condition{{
+		Type:    common.DatadogAgentReconcileErrorConditionType,
+		Status:  metav1.ConditionTrue,
+		Message: "RBAC reconciliation failed",
+	}}
+	require.NoError(t, kubeClient.Update(ctx, ddai))
+	details, err = daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, details, "Windows Agent "+common.DatadogAgentReconcileErrorConditionType+": RBAC reconciliation failed")
+
+	require.NoError(t, kubeClient.Delete(ctx, ddai))
+	details, err = daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.NoError(t, err)
+	require.Len(t, details, 1)
+	assert.Contains(t, details[0], "Windows Agent status is unavailable")
+
+	daemon.apiReader = &managedAgentInstallationFaultClient{
+		Client: kubeClient,
+		getError: func(key client.ObjectKey, _ client.Object) error {
+			if key == managedAgentInstallationWindowsProfileKey {
+				return errors.New("Windows DDAI read failed")
+			}
+			return nil
+		},
+	}
+	_, err = daemon.managedAgentInstallationWindowsReadinessDetails(ctx)
+	require.ErrorContains(t, err, "Windows DDAI read failed")
 }
 
 func TestManagedAgentInstallationKeysUseConfiguredNamespace(t *testing.T) {
@@ -1338,22 +1436,26 @@ func TestValidateFleetCredentialSecretReadFailure(t *testing.T) {
 }
 
 func setTestManagedAgentInstallationWorkloadsReady(dda *v2alpha1.DatadogAgent) {
+	now := metav1.Now()
 	dda.Status.Agent = &v2alpha1.DaemonSetStatus{
-		Desired:   1,
-		Current:   1,
-		Ready:     1,
-		Available: 1,
-		UpToDate:  1,
+		Desired:    1,
+		Current:    1,
+		Ready:      1,
+		Available:  1,
+		UpToDate:   1,
+		LastUpdate: &now,
 	}
 	dda.Status.ClusterAgent = testManagedAgentInstallationDeploymentReady()
 }
 
 func testManagedAgentInstallationDeploymentReady() *v2alpha1.DeploymentStatus {
+	now := metav1.Now()
 	return &v2alpha1.DeploymentStatus{
 		Replicas:          1,
 		UpdatedReplicas:   1,
 		ReadyReplicas:     1,
 		AvailableReplicas: 1,
+		LastUpdate:        &now,
 	}
 }
 
@@ -1388,8 +1490,34 @@ func testManagedAgentInstallationCommand(t *testing.T, operationID string, desir
 	return newManagedAgentInstallationCommand(intent, config, digest)
 }
 
+func testManagedAgentInstallationWindowsDDAIReady() *v1alpha1.DatadogAgentInternal {
+	now := metav1.Now()
+	return &v1alpha1.DatadogAgentInternal{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: managedAgentInstallationWindowsProfileKey.Namespace,
+			Name:      managedAgentInstallationWindowsProfileKey.Name,
+		},
+		Status: v1alpha1.DatadogAgentInternalStatus{
+			Agent: &v2alpha1.DaemonSetStatus{LastUpdate: &now, DaemonsetName: "datadog-agent-windows-agent"},
+		},
+	}
+}
+
+func testManagedAgentInstallationWindowsDaemonSetObserved() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  managedAgentInstallationWindowsProfileKey.Namespace,
+			Name:       "datadog-agent-windows-agent",
+			Generation: 1,
+		},
+		Status: appsv1.DaemonSetStatus{ObservedGeneration: 1},
+	}
+}
+
 func testManagedAgentInstallationDaemon(rcState []*pbgo.PackageState, objects ...client.Object) (*Daemon, client.Client, *mockRCClient) {
+	objects = append(objects, testManagedAgentInstallationWindowsDDAIReady(), testManagedAgentInstallationWindowsDaemonSetObserved())
 	scheme := testFleetScheme()
+	_ = appsv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
 	_ = apiregistrationv1.AddToScheme(scheme)


### PR DESCRIPTION
### What does this PR do?

Prevents managed Agent installation from reporting success until the DatadogAgent has reconciled and every enabled workload is ready.

The installation remains RUNNING and the DatadogAgent remains marked partial while readiness is pending. The Fleet daemon retries readiness checks every five seconds and reports a terminal error after ten minutes. The readiness start time is persisted on the DatadogAgent so restarting the operator does not reset the deadline.

Readiness requires:

- no active DatadogAgent or DatadogAgentInternal reconciliation errors
- the Linux Agent and Cluster Agent workloads to be ready unless explicitly disabled
- the Cluster Checks Runner and OTel Agent Gateway workloads to be ready when their features are enabled
- the managed Windows-profile DatadogAgentInternal to reconcile successfully and its Agent workload to be ready

Fresh, unobserved all-zero workload statuses remain pending. A Windows Agent workload with a legitimate desired count of zero is accepted only after its DaemonSet generation has been observed and its native status also reports zero workloads.

The DatadogAgent status now aggregates OTel Agent Gateway status from DatadogAgentInternal profiles and detects changes to that status. Repeated RUNNING state writes are also deduplicated without discarding the current pending-readiness error.

### Motivation

The EKS managed add-on installation could report success immediately after creating the DatadogAgent resource, before its controllers had reconciled or its workloads were available.

https://datadoghq.atlassian.net/browse/TON-833

### Additional Notes

Explicitly disabled components are skipped. Optional components are checked only when enabled by the accepted DatadogAgent spec.

### Minimum Agent Versions

No new minimum versions.

* Agent: unchanged
* Cluster Agent: unchanged

### Describe your test plan

- Run `CGO_ENABLED=0 go test ./... -count=1`
- Run `make lint`
- Verify pending or unobserved workloads keep the installation RUNNING and partial
- Verify all enabled Linux and optional workloads becoming ready transitions the installation to DONE
- Verify Windows readiness for pending, ready, and legitimate desired-zero DaemonSets
- Verify active DatadogAgent and DatadogAgentInternal reconciliation errors block completion
- Verify the persisted ten-minute readiness deadline produces a terminal ERROR and survives retries
- Verify explicitly disabled components are skipped
- Verify repeated RUNNING state updates preserve the pending error without unnecessary ConfigMap patches

### Checklist

- [x] PR has at least one valid label: bug
- [ ] PR has a milestone or the qa/skip-qa label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits