### PR TITLE
Document Host Profiler Annotations

### DIFF
--- a/docs/host_profiler.md
+++ b/docs/host_profiler.md
@@ -1,0 +1,27 @@
+# Host Profiler
+
+Host Profiler is an experimental, annotation-based feature in Preview. It can
+be enabled and configured through annotations on a `DatadogAgent`.
+
+## Annotations
+
+| Annotation | Default | Description |
+| --------- | ------- | ----------- |
+| `agent.datadoghq.com/host-profiler-enabled` | `false` | Enables Host Profiler when set to `"true"`. |
+| `agent.datadoghq.com/host-profiler-seccomp-enabled` | `true` | Enables the Host Profiler seccomp profile and its setup init container. Set to `"false"` to disable both. |
+| `agent.datadoghq.com/host-profiler-logging-seccomp-enabled` | `false` | Enables the logging seccomp profile. Has no effect when the Host Profiler seccomp profile is disabled. |
+| `agent.datadoghq.com/host-profiler-non-root-enabled` | `false` | Runs the Host Profiler container as UID/GID `100` with `runAsNonRoot: true` when set to `"true"`. |
+| `agent.datadoghq.com/host-profiler-selinux-type` | `spc_t` | Sets the SELinux type for the Host Profiler container and its setup init container. |
+
+## Example
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+  annotations:
+    agent.datadoghq.com/host-profiler-enabled: "true"
+    agent.datadoghq.com/host-profiler-non-root-enabled: "true"
+    agent.datadoghq.com/host-profiler-selinux-type: "custom_t"
+```


### PR DESCRIPTION
### What does this PR do?

Adds Host Profiler annotations to docs

### Motivation

We're finding ourselves documenting these on our own public docs (https://github.com/DataDog/datadog-agent/pull/54257), that would mean needing to pair each operator PR touching on annotations with another agent-side PR.

### Additional Notes

I inferred where the annotation documentations lived, so they definitely could be misplaced. I'm happy to put them somewhere else if needed!

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits