### PR TITLE
fix(cspm): set compliance config env vars on all node agent containers

### DIFF
--- a/internal/controller/datadogagent/feature/cspm/feature.go
+++ b/internal/controller/datadogagent/feature/cspm/feature.go
@@ -313,12 +313,17 @@ func (f *cspmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) erro
 	VolMgr.AddVolume(&groupVol)
 
 	// env vars
+	// The compliance settings are added to every container of the pod, not only to the one
+	// actually running the checks. When config streaming is enabled, the consumer container
+	// drops its own env layer and replays the Core Agent's config snapshot; if the Core Agent
+	// doesn't carry these settings, they silently revert to their default values.
 	enabledEnvVar := &corev1.EnvVar{
 		Name:  DDComplianceConfigEnabled,
 		Value: "true",
 	}
 	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, targetContainer}, enabledEnvVar)
 
+	// HOST_ROOT is not a config setting, it only makes sense where the host root volume is mounted.
 	hostRootEnvVar := &corev1.EnvVar{
 		Name:  common.DDHostRootEnvVar,
 		Value: common.HostRootMountPath,
@@ -330,20 +335,20 @@ func (f *cspmFeature) ManageNodeAgent(managers feature.PodTemplateManagers) erro
 			Name:  DDComplianceConfigCheckInterval,
 			Value: f.checkInterval,
 		}
-		managers.EnvVar().AddEnvVarToContainer(targetContainer, intervalEnvVar)
+		managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, targetContainer}, intervalEnvVar)
 	}
 
 	hostBenchmarksEnabledEnvVar := &corev1.EnvVar{
 		Name:  DDComplianceHostBenchmarksEnabled,
 		Value: apiutils.BoolToString(&f.hostBenchmarksEnabled),
 	}
-	managers.EnvVar().AddEnvVarToContainer(targetContainer, hostBenchmarksEnabledEnvVar)
+	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, targetContainer}, hostBenchmarksEnabledEnvVar)
 
 	runInSystemProbeEnvVar := &corev1.EnvVar{
 		Name:  DDComplianceConfigRunInSystemProbe,
 		Value: apiutils.BoolToString(&f.runInSystemProbe),
 	}
-	managers.EnvVar().AddEnvVarToContainer(targetContainer, runInSystemProbeEnvVar)
+	managers.EnvVar().AddEnvVarToContainers([]apicommon.AgentContainerName{apicommon.CoreAgentContainerName, targetContainer}, runInSystemProbeEnvVar)
 
 	return nil
 }

--- a/internal/controller/datadogagent/feature/cspm/feature_test.go
+++ b/internal/controller/datadogagent/feature/cspm/feature_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
+	mergerfake "github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger/fake"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -163,14 +164,12 @@ func cspmAgentNodeWantFunc(runInSystemProbe bool) *test.ComponentTest {
 				targetContainer = apicommon.SystemProbeContainerName
 			}
 
-			want := []*corev1.EnvVar{
+			// The compliance settings are added to all the containers of the pod so that the
+			// Core Agent config snapshot carries them when config streaming is enabled.
+			wantAllContainers := []*corev1.EnvVar{
 				{
 					Name:  DDComplianceConfigEnabled,
 					Value: "true",
-				},
-				{
-					Name:  common.DDHostRootEnvVar,
-					Value: common.HostRootMountPath,
 				},
 				{
 					Name:  DDComplianceConfigCheckInterval,
@@ -186,8 +185,20 @@ func cspmAgentNodeWantFunc(runInSystemProbe bool) *test.ComponentTest {
 				},
 			}
 
+			allContainersEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
+			assert.True(t, apiutils.IsEqualStruct(allContainersEnvVars, wantAllContainers), "Agent envvars \ndiff = %s", cmp.Diff(allContainersEnvVars, wantAllContainers))
+
+			// HOST_ROOT is only set on the container running the checks, since it is where the
+			// host root volume is mounted.
+			wantTargetContainer := []*corev1.EnvVar{
+				{
+					Name:  common.DDHostRootEnvVar,
+					Value: common.HostRootMountPath,
+				},
+			}
+
 			targetContainerEnvVars := mgr.EnvVarMgr.EnvVarsByC[targetContainer]
-			assert.True(t, apiutils.IsEqualStruct(targetContainerEnvVars, want), "Agent envvars \ndiff = %s", cmp.Diff(targetContainerEnvVars, want))
+			assert.True(t, apiutils.IsEqualStruct(targetContainerEnvVars, wantTargetContainer), "Agent envvars \ndiff = %s", cmp.Diff(targetContainerEnvVars, wantTargetContainer))
 
 			// check volume mounts
 			wantVolumeMounts := []corev1.VolumeMount{

--- a/internal/controller/datadogagent/feature/cspm/feature_test.go
+++ b/internal/controller/datadogagent/feature/cspm/feature_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/test"
-	mergerfake "github.com/DataDog/datadog-operator/internal/controller/datadogagent/merger/fake"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -164,9 +163,9 @@ func cspmAgentNodeWantFunc(runInSystemProbe bool) *test.ComponentTest {
 				targetContainer = apicommon.SystemProbeContainerName
 			}
 
-			// The compliance settings are added to all the containers of the pod so that the
-			// Core Agent config snapshot carries them when config streaming is enabled.
-			wantAllContainers := []*corev1.EnvVar{
+			// The compliance settings are also added to the Core Agent container so that its
+			// config snapshot carries them when config streaming is enabled.
+			wantCoreAgent := []*corev1.EnvVar{
 				{
 					Name:  DDComplianceConfigEnabled,
 					Value: "true",
@@ -185,15 +184,31 @@ func cspmAgentNodeWantFunc(runInSystemProbe bool) *test.ComponentTest {
 				},
 			}
 
-			allContainersEnvVars := mgr.EnvVarMgr.EnvVarsByC[mergerfake.AllContainers]
-			assert.True(t, apiutils.IsEqualStruct(allContainersEnvVars, wantAllContainers), "Agent envvars \ndiff = %s", cmp.Diff(allContainersEnvVars, wantAllContainers))
+			coreAgentEnvVars := mgr.EnvVarMgr.EnvVarsByC[apicommon.CoreAgentContainerName]
+			assert.True(t, apiutils.IsEqualStruct(coreAgentEnvVars, wantCoreAgent), "Core Agent envvars \ndiff = %s", cmp.Diff(coreAgentEnvVars, wantCoreAgent))
 
 			// HOST_ROOT is only set on the container running the checks, since it is where the
 			// host root volume is mounted.
 			wantTargetContainer := []*corev1.EnvVar{
 				{
+					Name:  DDComplianceConfigEnabled,
+					Value: "true",
+				},
+				{
 					Name:  common.DDHostRootEnvVar,
 					Value: common.HostRootMountPath,
+				},
+				{
+					Name:  DDComplianceConfigCheckInterval,
+					Value: "1200000000000",
+				},
+				{
+					Name:  DDComplianceHostBenchmarksEnabled,
+					Value: "true",
+				},
+				{
+					Name:  DDComplianceConfigRunInSystemProbe,
+					Value: apiutils.BoolToString(&runInSystemProbe),
 				},
 			}
 


### PR DESCRIPTION
### What does this PR do?

Add DD_COMPLIANCE_CONFIG_ENABLED, DD_COMPLIANCE_CONFIG_CHECK_INTERVAL, DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED and
DD_COMPLIANCE_CONFIG_RUN_IN_SYSTEM_PROBE to every container of the pod so that the Core Agent snapshot carries the real values.

HOST_ROOT stays on the target container only: it is not a DD_ config setting, so config streaming never touches it, and it is only meaningful where the host root volume is mounted.

### Motivation

When config streaming is enabled, the consumer container drops its own env layer and replays the Core Agent's config snapshot. The CSPM feature only set the compliance settings on the container actually running the checks, so the Core Agent's snapshot carried the defaults and streamed them back: compliance_config.run_in_system_probe reverted to false, system-probe skipped StartCompliance, and every datadog.security_agent.compliance.* metric disappeared without any error being logged.

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits