### PR TITLE
[CASCL-1386] Document the autoscaling cluster sub-commands

### DIFF
--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -167,7 +167,7 @@ Flags:
 
 Migrates a cluster off the node groups Datadog does not manage — EC2 Auto Scaling groups, EKS managed node groups, user Karpenter NodePools and standalone EC2 instances — so that their workloads end up on the Datadog-managed Karpenter NodePools. It scales down the `cluster-autoscaler` if there is one, then cordons and drains each target's nodes and scales the target down to zero, one target at a time.
 
-Select the targets with `--all` or with one or more `--target`, and preview a run with `--dry-run`. The command displays its plan and asks for confirmation before touching anything. It is re-runnable: a node that fails to drain keeps its workloads and its instance is never terminated, so a later run can pick up where this one stopped.
+Select the targets with `--all` or with one or more `--target`, and preview a run with `--dry-run`. The command displays its plan and asks for confirmation before any destructive step. One write does precede the prompt: the cluster-info ConfigMap snapshot is refreshed first, so declining still leaves that snapshot updated — `--dry-run` skips the write altogether. It is re-runnable: a node that fails to drain keeps its workloads and its instance is never terminated, so a later run can pick up where this one stopped.
 
 The migration is one-way — the plugin does not restore the previous capacity, nor scale the `cluster-autoscaler` back up. Note also that a user Karpenter NodePool is only drained, not disabled, so Karpenter may provision new nodes from it unless you retire it yourself.
 

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -106,16 +106,11 @@ Available Commands:
 
 Installs Karpenter on an EKS cluster and configures it for use with Datadog Cluster Autoscaling. The command:
 
-1. Creates two AWS CloudFormation stacks: one carrying the node role, the controller IAM policies and the interruption-handling resources Karpenter needs, and one carrying the mode-specific authentication resources described below.
-2. Configures how the Karpenter controller authenticates and where it runs, depending on `--install-mode`:
-   - `fargate` (default): registers the cluster OIDC provider, creates an IRSA role for the controller, and creates a Fargate profile on the cluster private subnets (auto-discovered unless `--fargate-subnets` is set), so that Karpenter never runs on the nodes it manages.
-   - `existing-nodes`: ensures the EKS Pod Identity agent addon is available and configures a Pod Identity association for the controller.
+1. Creates two AWS CloudFormation stacks holding the IAM roles, permissions and AWS-side plumbing Karpenter needs.
+2. Installs Karpenter via Helm from the OCI registry. By default the controller runs on dedicated Fargate nodes, so that it never runs on the nodes it manages; pass `--install-mode=existing-nodes` to run it on the cluster's own nodes instead.
+3. Optionally creates `EC2NodeClass` and `NodePool` Karpenter resources, inferred from existing cluster nodes or EKS node groups.
 
-   In both modes, an EKS access entry is created for the Karpenter node role on clusters whose authentication mode supports access entries (`API` or `API_AND_CONFIG_MAP`), and that role is also mapped in the `aws-auth` ConfigMap when that ConfigMap is present.
-3. Installs Karpenter via Helm from the OCI registry.
-4. Optionally creates `EC2NodeClass` and `NodePool` Karpenter resources, inferred from existing cluster nodes or EKS node groups.
-
-The command installs nothing and exits successfully with an explanatory message when EKS auto-mode is active, or when a Karpenter installation it did not create, or one in a different namespace, is already present on the cluster.
+If something goes wrong, those CloudFormation stacks and that Helm release are the two places to look. The command installs nothing and exits successfully with an explanatory message when EKS auto-mode is active, or when Karpenter is already installed on the cluster.
 
 ```console
 $ kubectl datadog autoscaling cluster install --help
@@ -170,25 +165,11 @@ Flags:
 
 #### `autoscaling cluster evict-legacy-nodes`
 
-Drains the node groups that Datadog does not manage, with the goal of having their workloads rescheduled onto the Datadog-managed Karpenter NodePools. It covers EC2 Auto Scaling groups, EKS managed node groups, user-managed Karpenter NodePools and standalone EC2 instances. Fargate profiles, and nodes whose provider cannot be identified, are out of scope and are left in place.
+Migrates a cluster off the node groups Datadog does not manage — EC2 Auto Scaling groups, EKS managed node groups, user Karpenter NodePools and standalone EC2 instances — so that their workloads end up on the Datadog-managed Karpenter NodePools. It scales down the `cluster-autoscaler` if there is one, then cordons and drains each target's nodes and scales the target down to zero, one target at a time.
 
-Before anything destructive, the command verifies its preconditions — Karpenter is installed, the cluster does not run EKS auto-mode, and at least one Datadog-managed `NodePool` exists to receive the evicted pods — then displays the eviction plan and asks for confirmation. It also warns when a user `NodePool` has a `spec.weight` greater than or equal to the Datadog ones, since evicted pods could land back on it.
+Select the targets with `--all` or with one or more `--target`, and preview a run with `--dry-run`. The command displays its plan and asks for confirmation before touching anything. It is re-runnable: a node that fails to drain keeps its workloads and its instance is never terminated, so a later run can pick up where this one stopped.
 
-Audit your PodDisruptionBudgets first: a workload whose own PDB never allows a disruption (`maxUnavailable: 0`, or `minAvailable` equal to its replica count) cannot be evicted, and its node will only fail once the timeouts have elapsed.
-
-Once confirmed:
-
-1. The `cluster-autoscaler` Deployment, when the cluster runs one, is scaled down to 0 replicas, so that it cannot provision new legacy nodes mid-migration (skip with `--skip-cluster-autoscaler`). The command waits for it to reach 0 replicas and aborts before any drain if it does not. It is never scaled back up — re-enabling it afterwards is manual.
-2. Temporary PodDisruptionBudgets (`maxUnavailable: 1`) are created for the Deployments, StatefulSets and standalone ReplicaSets running on the targeted nodes that no PDB already covers, and removed at the end (enabled by default, disable with `--ensure-pdbs=false`). Pods owned by anything else — Jobs, CronJobs, DaemonSets, custom controllers — or by nothing at all get none.
-3. Targets are processed one at a time. Each target's nodes are cordoned and drained through the Eviction API, then its capacity is retired:
-   - **EC2 Auto Scaling group**: `AZRebalance` is suspended and `MinSize` set to 0 up front, each drained instance is terminated individually, and the group is finally locked at `min=max=desired=0`.
-   - **EKS managed node group**: scaled to `min=desired=0`, `max` preserved, then the command waits for the group's nodes to disappear from the cluster. Raise `--node-timeout` for large node groups: it bounds that wait as a whole.
-   - **Standalone EC2 instance**: terminated.
-   - **User Karpenter NodePool**: its nodes are drained, but the NodePool itself is left untouched. The command does not disable it, so Karpenter may provision fresh nodes from it for the pods just evicted — lower its `spec.weight` or set its limits yourself to retire it for good.
-
-None of this is reversible by the plugin: the previous scaling configuration is not recorded, so restoring legacy capacity is manual.
-
-Exactly one of `--all` or `--target` is required. The command is re-runnable rather than transactional: a node that fails to drain keeps its workloads and is never terminated, and its node group is not scaled to zero — but everything already applied stays applied, so a later run resumes from there.
+The migration is one-way — the plugin does not restore the previous capacity, nor scale the `cluster-autoscaler` back up. Note also that a user Karpenter NodePool is only drained, not disabled, so Karpenter may provision new nodes from it unless you retire it yourself.
 
 ```console
 $ kubectl datadog autoscaling cluster evict-legacy-nodes --help
@@ -225,14 +206,9 @@ Flags:
 
 #### `autoscaling cluster uninstall`
 
-Removes the `kubectl-datadog`-managed autoscaling resources from an EKS cluster. The command:
+Removes Karpenter and the associated resources from an EKS cluster. Deletes the `NodePool` and `EC2NodeClass` resources it created, waits for the corresponding EC2 instances to terminate, uninstalls the Karpenter Helm release, cleans up IAM, and removes the CloudFormation stacks.
 
-1. Deletes the `NodePool` and `EC2NodeClass` resources it created, then waits for the corresponding EC2 instances to terminate. Every node Karpenter provisioned from them is drained and terminated, so make sure the cluster has other capacity first — in particular after `evict-legacy-nodes`, which leaves the legacy node groups scaled to zero. NodePools created by other Datadog products, or by hand, are left in place.
-2. Uninstalls the Helm release named `karpenter`.
-3. Removes the Karpenter node role mapping from the `aws-auth` ConfigMap when that ConfigMap is present, and deletes the instance profiles attached to that role.
-4. Deletes the CloudFormation stacks, and with them the IAM roles.
-
-Each step is independent and best-effort, so that a run interrupted halfway can simply be re-run: `uninstall` deliberately skips the ownership pre-checks `install` and `update` perform, since the resources they key off may already be gone. Point `--karpenter-namespace` at the installation to remove. The cluster OIDC provider registered by a Fargate-mode install is left in place.
+Every node Karpenter provisioned is drained and terminated in the process, so make sure the cluster has other capacity first. Each step is independent and best-effort, so an interrupted run can simply be re-run.
 
 ```console
 $ kubectl datadog autoscaling cluster uninstall --help

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -88,14 +88,34 @@ Available Commands:
 
 These commands install and configure [Karpenter](https://karpenter.sh/) on an EKS cluster so that Datadog can manage cluster autoscaling.
 
+```console
+$ kubectl datadog autoscaling cluster --help
+Manage cluster autoscaling
+
+Usage:
+  datadog autoscaling cluster [command]
+
+Available Commands:
+  evict-legacy-nodes Drain workloads from non-Datadog node groups onto Datadog-managed Karpenter NodePools
+  install            Install autoscaling on an EKS cluster
+  uninstall          Uninstall autoscaling from an EKS cluster
+  update             Update an existing autoscaling installation on an EKS cluster
+```
+
 #### `autoscaling cluster install`
 
 Installs Karpenter on an EKS cluster and configures it for use with Datadog Cluster Autoscaling. The command:
 
-1. Creates the required AWS CloudFormation stacks.
-2. Configures EKS authentication (aws-auth ConfigMap, EKS Pod Identity, or API-based access entries depending on the cluster).
+1. Creates two AWS CloudFormation stacks: one carrying the node role, the controller IAM policies and the interruption-handling resources Karpenter needs, and one carrying the mode-specific authentication resources described below.
+2. Configures how the Karpenter controller authenticates and where it runs, depending on `--install-mode`:
+   - `fargate` (default): registers the cluster OIDC provider, creates an IRSA role for the controller, and creates a Fargate profile on the cluster private subnets (auto-discovered unless `--fargate-subnets` is set), so that Karpenter never runs on the nodes it manages.
+   - `existing-nodes`: ensures the EKS Pod Identity agent addon is available and configures a Pod Identity association for the controller.
+
+   In both modes, an EKS access entry is created for the Karpenter node role on clusters whose authentication mode supports access entries (`API` or `API_AND_CONFIG_MAP`), and that role is also mapped in the `aws-auth` ConfigMap when that ConfigMap is present.
 3. Installs Karpenter via Helm from the OCI registry.
 4. Optionally creates `EC2NodeClass` and `NodePool` Karpenter resources, inferred from existing cluster nodes or EKS node groups.
+
+The command installs nothing and exits successfully with an explanatory message when EKS auto-mode is active, or when a Karpenter installation it did not create, or one in a different namespace, is already present on the cluster.
 
 ```console
 $ kubectl datadog autoscaling cluster install --help
@@ -113,14 +133,106 @@ Flags:
       --cluster-name string                                   Name of the EKS cluster
       --create-karpenter-resources CreateKarpenterResources   Which Karpenter resources to create: none, ec2nodeclass, all (default: all) (default all)
       --debug                                                 Enable debug logs
+      --fargate-subnets strings                               Override auto-discovery of private subnets for the Fargate profile (comma-separated subnet IDs). Only used when --install-mode=fargate.
       --inference-method InferenceMethod                      Method to infer EC2NodeClass and NodePool properties: nodes, nodegroups (default nodegroups)
+      --install-mode InstallMode                              How to run the Karpenter controller: fargate (on dedicated Fargate nodes, default) or existing-nodes (on existing cluster nodes) (default fargate)
       --karpenter-namespace string                            Name of the Kubernetes namespace to deploy Karpenter into (default "dd-karpenter")
       --karpenter-version string                              Version of Karpenter to install (default to latest)
 ```
 
+#### `autoscaling cluster update`
+
+Refreshes an autoscaling installation previously created by `kubectl datadog`: it updates the CloudFormation stacks and upgrades the Karpenter Helm release in place. The command refuses to touch a Karpenter installation it did not create.
+
+The parameters that cannot change after the initial install — Karpenter namespace, install mode, and Fargate subnets — are read back from the CloudFormation stack `install` created, and are therefore not exposed as flags.
+
+Unlike `install`, `--create-karpenter-resources` defaults to `none`, so that manual edits to the `EC2NodeClass` and `NodePool` resources survive an update. Pass `ec2nodeclass` to regenerate the `EC2NodeClass` alone, or `all` to regenerate both.
+
+```console
+$ kubectl datadog autoscaling cluster update --help
+Update an existing autoscaling installation on an EKS cluster
+
+Usage:
+  datadog autoscaling cluster update [flags]
+
+Examples:
+
+  # update a previously installed kubectl-datadog Karpenter deployment
+  kubectl datadog autoscaling cluster update
+
+Flags:
+      --cluster-name string                                   Name of the EKS cluster
+      --create-karpenter-resources CreateKarpenterResources   Which Karpenter resources to (re-)create: none (default), ec2nodeclass, all (default none)
+      --debug                                                 Enable debug logs
+      --inference-method InferenceMethod                      Method to infer EC2NodeClass and NodePool properties when --create-karpenter-resources is set: nodes, nodegroups (default nodegroups)
+      --karpenter-version string                              Version of Karpenter to upgrade to (default to latest)
+```
+
+#### `autoscaling cluster evict-legacy-nodes`
+
+Drains the node groups that Datadog does not manage, with the goal of having their workloads rescheduled onto the Datadog-managed Karpenter NodePools. It covers EC2 Auto Scaling groups, EKS managed node groups, user-managed Karpenter NodePools and standalone EC2 instances. Fargate profiles, and nodes whose provider cannot be identified, are out of scope and are left in place.
+
+Before anything destructive, the command verifies its preconditions — Karpenter is installed, the cluster does not run EKS auto-mode, and at least one Datadog-managed `NodePool` exists to receive the evicted pods — then displays the eviction plan and asks for confirmation. It also warns when a user `NodePool` has a `spec.weight` greater than or equal to the Datadog ones, since evicted pods could land back on it.
+
+Audit your PodDisruptionBudgets first: a workload whose own PDB never allows a disruption (`maxUnavailable: 0`, or `minAvailable` equal to its replica count) cannot be evicted, and its node will only fail once the timeouts have elapsed.
+
+Once confirmed:
+
+1. The `cluster-autoscaler` Deployment, when the cluster runs one, is scaled down to 0 replicas, so that it cannot provision new legacy nodes mid-migration (skip with `--skip-cluster-autoscaler`). The command waits for it to reach 0 replicas and aborts before any drain if it does not. It is never scaled back up — re-enabling it afterwards is manual.
+2. Temporary PodDisruptionBudgets (`maxUnavailable: 1`) are created for the Deployments, StatefulSets and standalone ReplicaSets running on the targeted nodes that no PDB already covers, and removed at the end (enabled by default, disable with `--ensure-pdbs=false`). Pods owned by anything else — Jobs, CronJobs, DaemonSets, custom controllers — or by nothing at all get none.
+3. Targets are processed one at a time. Each target's nodes are cordoned and drained through the Eviction API, then its capacity is retired:
+   - **EC2 Auto Scaling group**: `AZRebalance` is suspended and `MinSize` set to 0 up front, each drained instance is terminated individually, and the group is finally locked at `min=max=desired=0`.
+   - **EKS managed node group**: scaled to `min=desired=0`, `max` preserved, then the command waits for the group's nodes to disappear from the cluster. Raise `--node-timeout` for large node groups: it bounds that wait as a whole.
+   - **Standalone EC2 instance**: terminated.
+   - **User Karpenter NodePool**: its nodes are drained, but the NodePool itself is left untouched. The command does not disable it, so Karpenter may provision fresh nodes from it for the pods just evicted — lower its `spec.weight` or set its limits yourself to retire it for good.
+
+None of this is reversible by the plugin: the previous scaling configuration is not recorded, so restoring legacy capacity is manual.
+
+Exactly one of `--all` or `--target` is required. The command is re-runnable rather than transactional: a node that fails to drain keeps its workloads and is never terminated, and its node group is not scaled to zero — but everything already applied stays applied, so a later run resumes from there.
+
+```console
+$ kubectl datadog autoscaling cluster evict-legacy-nodes --help
+Drain workloads from non-Datadog node groups onto Datadog-managed Karpenter NodePools
+
+Usage:
+  datadog autoscaling cluster evict-legacy-nodes [flags]
+
+Examples:
+
+  # evict every node group that is not Datadog-managed (cluster-autoscaler ASGs,
+  # EKS managed node groups, user Karpenter NodePools, standalone EC2)
+  kubectl datadog autoscaling cluster evict-legacy-nodes --all
+
+  # evict a single ASG by name
+  kubectl datadog autoscaling cluster evict-legacy-nodes --target=asg/my-legacy-asg
+
+  # preview the actions without performing them
+  kubectl datadog autoscaling cluster evict-legacy-nodes --all --dry-run
+
+Flags:
+      --all                          Evict every node group that is not managed by Datadog
+      --cluster-name string          Name of the EKS cluster
+      --debug                        Enable debug logs
+      --dry-run                      Log the actions that would be taken without performing them
+      --ensure-pdbs                  Create temporary PodDisruptionBudgets (maxUnavailable: 1) for workloads without one, and remove them at the end (default true)
+      --eviction-timeout duration    Time budget per pod for the Eviction API to succeed before giving up (PDB-blocked pods) (default 5m0s)
+      --karpenter-namespace string   Namespace where Karpenter is deployed (auto-detected when empty)
+      --node-timeout duration        Time budget per node for it to become empty after pods have been evicted (default 15m0s)
+      --skip-cluster-autoscaler      Do not scale the cluster-autoscaler Deployment to 0 replicas as step 1
+      --target standalone            Target a specific node group: <manager>/<name>, with <manager> one of asg, eksManagedNodeGroup, karpenter. Use standalone (no name) for standalone EC2 instances. Repeatable. Mutually exclusive with --all.
+      --yes                          Skip the confirmation prompt
+```
+
 #### `autoscaling cluster uninstall`
 
-Removes Karpenter and all associated resources from an EKS cluster. Deletes `NodePool` and `EC2NodeClass` resources, waits for the corresponding EC2 instances to terminate, uninstalls the Karpenter Helm release, cleans up IAM roles, and removes the CloudFormation stacks. Only resources originally created by `kubectl datadog` are affected.
+Removes the `kubectl-datadog`-managed autoscaling resources from an EKS cluster. The command:
+
+1. Deletes the `NodePool` and `EC2NodeClass` resources it created, then waits for the corresponding EC2 instances to terminate. Every node Karpenter provisioned from them is drained and terminated, so make sure the cluster has other capacity first — in particular after `evict-legacy-nodes`, which leaves the legacy node groups scaled to zero. NodePools created by other Datadog products, or by hand, are left in place.
+2. Uninstalls the Helm release named `karpenter`.
+3. Removes the Karpenter node role mapping from the `aws-auth` ConfigMap when that ConfigMap is present, and deletes the instance profiles attached to that role.
+4. Deletes the CloudFormation stacks, and with them the IAM roles.
+
+Each step is independent and best-effort, so that a run interrupted halfway can simply be re-run: `uninstall` deliberately skips the ownership pre-checks `install` and `update` perform, since the resources they key off may already be gone. Point `--karpenter-namespace` at the installation to remove. The cluster OIDC provider registered by a Fargate-mode install is left in place.
 
 ```console
 $ kubectl datadog autoscaling cluster uninstall --help
@@ -135,9 +247,9 @@ Examples:
   kubectl datadog autoscaling cluster uninstall
 
 Flags:
-      --cluster-name string        Name of the EKS cluster
-      --karpenter-namespace string  Name of the Kubernetes namespace where Karpenter is deployed (default "dd-karpenter")
-      --yes                        Skip confirmation prompt
+      --cluster-name string          Name of the EKS cluster
+      --karpenter-namespace string   Name of the Kubernetes namespace where Karpenter is deployed (default "dd-karpenter")
+      --yes                          Skip confirmation prompt
 ```
 
 [1]: https://github.com/DataDog/helm-charts/tree/main/charts/datadog

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -110,7 +110,7 @@ Installs Karpenter on an EKS cluster and configures it for use with Datadog Clus
 2. Installs Karpenter via Helm from the OCI registry. By default the controller runs on dedicated Fargate nodes, so that it never runs on the nodes it manages; pass `--install-mode=existing-nodes` to run it on the cluster's own nodes instead.
 3. Optionally creates `EC2NodeClass` and `NodePool` Karpenter resources, inferred from existing cluster nodes or EKS node groups.
 
-If something goes wrong, those CloudFormation stacks and that Helm release are the two places to look. The command installs nothing and exits successfully with an explanatory message when EKS auto-mode is active, or when the cluster already runs a Karpenter installation that `kubectl-datadog` does not manage — including one it manages but in a namespace other than the requested one. Re-running `install` against an installation it does manage in that namespace is *not* a no-op: it converges the CloudFormation stacks, upgrades the Helm release, and, with the default `--create-karpenter-resources=all`, re-creates the `EC2NodeClass` and `NodePool` resources, discarding any manual edits to them.
+If something goes wrong, those CloudFormation stacks and that Helm release are the two places to look. The command installs nothing and exits with an explanatory message when EKS auto-mode is active, or when the cluster already runs a Karpenter installation `kubectl-datadog` does not manage in the requested namespace. Re-running it over its own installation is not a no-op: with the default `--create-karpenter-resources=all` it re-creates the `EC2NodeClass` and `NodePool`, discarding manual edits — use `update` for that.
 
 ```console
 $ kubectl datadog autoscaling cluster install --help
@@ -167,7 +167,7 @@ Flags:
 
 Migrates a cluster off the node groups Datadog does not manage — EC2 Auto Scaling groups, EKS managed node groups, user Karpenter NodePools and standalone EC2 instances — so that their workloads end up on the Datadog-managed Karpenter NodePools. It scales down the `cluster-autoscaler` if there is one, then cordons and drains each target's nodes and scales the target down to zero, one target at a time.
 
-Select the targets with `--all` or with one or more `--target`, and preview a run with `--dry-run`. The command displays its plan and asks for confirmation before any destructive step. One write does precede the prompt: the cluster-info ConfigMap snapshot is refreshed first, so declining still leaves that snapshot updated — `--dry-run` skips the write altogether. It is re-runnable: a node that fails to drain keeps its workloads and its instance is never terminated, so a later run can pick up where this one stopped.
+Select the targets with `--all` or with one or more `--target`, and preview a run with `--dry-run`. The command displays its plan and asks for confirmation before draining anything. It is re-runnable: a node that fails to drain keeps its workloads and its instance is never terminated, so a later run can pick up where this one stopped.
 
 The migration is one-way — the plugin does not restore the previous capacity, nor scale the `cluster-autoscaler` back up. Note also that a user Karpenter NodePool is only drained, not disabled, so Karpenter may provision new nodes from it unless you retire it yourself.
 
@@ -208,7 +208,7 @@ Flags:
 
 Removes Karpenter and the associated resources from an EKS cluster. Deletes the `NodePool` and `EC2NodeClass` resources it created, waits for the corresponding EC2 instances to terminate, uninstalls the Karpenter Helm release, cleans up IAM, and removes the CloudFormation stacks.
 
-Nodes provisioned from the `NodePool` resources this command created are drained and terminated in the process, so make sure the cluster has other capacity first. Hand-created and third-party `NodePool` resources are not selected, so they and their nodes are left running. Each step is independent and best-effort, so an interrupted run can simply be re-run.
+The nodes provisioned from the `NodePool` resources it created are drained and terminated in the process, so make sure the cluster has other capacity first; hand-created and third-party NodePools are left alone. Each step is independent and best-effort, so an interrupted run can simply be re-run.
 
 ```console
 $ kubectl datadog autoscaling cluster uninstall --help

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -110,7 +110,7 @@ Installs Karpenter on an EKS cluster and configures it for use with Datadog Clus
 2. Installs Karpenter via Helm from the OCI registry. By default the controller runs on dedicated Fargate nodes, so that it never runs on the nodes it manages; pass `--install-mode=existing-nodes` to run it on the cluster's own nodes instead.
 3. Optionally creates `EC2NodeClass` and `NodePool` Karpenter resources, inferred from existing cluster nodes or EKS node groups.
 
-If something goes wrong, those CloudFormation stacks and that Helm release are the two places to look. The command installs nothing and exits successfully with an explanatory message when EKS auto-mode is active, or when Karpenter is already installed on the cluster.
+If something goes wrong, those CloudFormation stacks and that Helm release are the two places to look. The command installs nothing and exits successfully with an explanatory message when EKS auto-mode is active, or when the cluster already runs a Karpenter installation that `kubectl-datadog` does not manage — including one it manages but in a namespace other than the requested one. Re-running `install` against an installation it does manage in that namespace is *not* a no-op: it converges the CloudFormation stacks, upgrades the Helm release, and, with the default `--create-karpenter-resources=all`, re-creates the `EC2NodeClass` and `NodePool` resources, discarding any manual edits to them.
 
 ```console
 $ kubectl datadog autoscaling cluster install --help
@@ -208,7 +208,7 @@ Flags:
 
 Removes Karpenter and the associated resources from an EKS cluster. Deletes the `NodePool` and `EC2NodeClass` resources it created, waits for the corresponding EC2 instances to terminate, uninstalls the Karpenter Helm release, cleans up IAM, and removes the CloudFormation stacks.
 
-Every node Karpenter provisioned is drained and terminated in the process, so make sure the cluster has other capacity first. Each step is independent and best-effort, so an interrupted run can simply be re-run.
+Nodes provisioned from the `NodePool` resources this command created are drained and terminated in the process, so make sure the cluster has other capacity first. Hand-created and third-party `NodePool` resources are not selected, so they and their nodes are left running. Each step is independent and best-effort, so an interrupted run can simply be re-run.
 
 ```console
 $ kubectl datadog autoscaling cluster uninstall --help

--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -165,7 +165,7 @@ Flags:
 
 #### `autoscaling cluster evict-legacy-nodes`
 
-Migrates a cluster off the node groups Datadog does not manage — EC2 Auto Scaling groups, EKS managed node groups, user Karpenter NodePools and standalone EC2 instances — so that their workloads end up on the Datadog-managed Karpenter NodePools. It scales down the `cluster-autoscaler` if there is one, then cordons and drains each target's nodes and scales the target down to zero, one target at a time.
+Migrates a cluster off the node groups Datadog does not manage — EC2 Auto Scaling groups, EKS managed node groups, user Karpenter NodePools and standalone EC2 instances — so that their workloads can reschedule onto the Datadog-managed Karpenter NodePools. It scales down the `cluster-autoscaler` if there is one, then cordons and drains each target's nodes and scales the target down to zero, one target at a time.
 
 Select the targets with `--all` or with one or more `--target`, and preview a run with `--dry-run`. The command displays its plan and asks for confirmation before draining anything. It is re-runnable: a node that fails to drain keeps its workloads and its instance is never terminated, so a later run can pick up where this one stopped.
 


### PR DESCRIPTION
### What does this PR do?

Documents the `kubectl datadog autoscaling cluster` sub-commands that were missing from `docs/kubectl-plugin.md`, and refreshes the ones that had drifted from the implementation.

- Adds the `autoscaling cluster --help` listing to the section header, so the four sub-commands are discoverable.
- Documents **`evict-legacy-nodes`**: what it migrates, how targets are selected, and the two things worth knowing before running it (the migration is one-way, and a user Karpenter NodePool is drained but not disabled).
- Documents **`update`**, which was already implemented but never documented: the parameters read back from the CloudFormation stack instead of being exposed as flags, and why `--create-karpenter-resources` defaults to `none`.
- **`install`**: adds the missing `--install-mode` and `--fargate-subnets` flags, and points at the CloudFormation stacks and the Helm release as the places to look when an install misbehaves.
- **`uninstall`**: notes that Karpenter-provisioned nodes are drained and terminated, and that an interrupted run can simply be re-run.

The descriptions stay deliberately short — enough for a user to know what the command does and what to inspect when it does not, without restating the implementation. All four `console` blocks were regenerated from the built plugin and match `--help` verbatim, minus the global kubeconfig flags that the file already omits by convention.

### Motivation

`evict-legacy-nodes` was implemented across #3160-#3164, #3172-#3178 and #3207 (the split of #3026) but never documented. Reviewing the surrounding sections surfaced that `update` was undocumented too, and that the `install` section predated the Fargate install mode.

### Additional Notes

Two stale strings remain in `cmd/kubectl-datadog/autoscaling/cluster/evict/evict.go` and are reproduced verbatim in the `--help` excerpt, so they are not fixed here:

- the `--all` example calls the ASG targets "cluster-autoscaler ASGs", but `resolveASGs` buckets a node under `asg` whenever it belongs to *any* Auto Scaling group;
- `--node-timeout` is described as a per-node budget, yet `waitEKSNodegroupEmpty` applies the same value to a whole managed node group.

Both are code changes and would be worth a follow-up.

### Minimum Agent Versions

None — documentation only.

### Describe your test plan

Documentation-only change; no code touched. Verified by diffing every `console` block against the real output of the built plugin:

```shell
make kubectl-datadog
for c in install update evict-legacy-nodes uninstall; do
  ./bin/kubectl-datadog autoscaling cluster "$c" --help
done
```

Every claim left in the prose was checked against the implementation under `cmd/kubectl-datadog/autoscaling/cluster/`.

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
