### PR TITLE
Fix concurrent access to enabled features in metrics forwarder

### DIFF
--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"os"
 	"strings"
 	"sync"
@@ -438,7 +439,7 @@ func (mf *metricsForwarder) forwardMetrics() error {
 	}
 
 	// send feature metrics
-	for _, featuresList := range mf.EnabledFeatures {
+	for _, featuresList := range mf.snapshotEnabledFeatures() {
 		for _, feature := range featuresList {
 			mf.sendFeatureMetric(ctx, feature)
 		}
@@ -447,6 +448,12 @@ func (mf *metricsForwarder) forwardMetrics() error {
 	mf.sendResourceCountMetric(ctx)
 
 	return nil
+}
+
+func (mf *metricsForwarder) snapshotEnabledFeatures() map[string][]string {
+	mf.RLock()
+	defer mf.RUnlock()
+	return maps.Clone(mf.EnabledFeatures)
 }
 
 // processReconcileError updates lastReconcileErr


### PR DESCRIPTION
### What does this PR do?

The metrics forwarding loop could iterate over `EnabledFeatures` while a reconciliation updated the map, causing a fatal concurrent map iteration and map write error.

This commit clones the map under a read lock and makes the existing code iterate over the snapshot, avoiding concurrent access without holding the lock while sending metrics.

### Motivation

Observed `concurrent map iteration and map write` errors causing the operator to crash.

### Additional Notes

This fix doesn't fix the potential of map value slices concurrent modifications, however, that scenario is currently not present in the code as the values are set as whole slices and guarded by the `setEnabledFeatures(..)` function.

While browsing the code, I noticed that the `EnabledFeatures` map only holds one key, which is the `id` of this forwarder. This id is set only at creation time and the no longer changed. This creates an opportunity for simplification here, by turning `EnabledFeatures` into a slice instead.

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits