### PR TITLE
Enable additional golangci-lint checks

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -15,16 +15,12 @@ custom-order = true
 [linters]
 default = 'all'
 disable = [
-  'bodyclose',
-  'containedctx',
   'contextcheck',
   'cyclop',
   'dupl',
-  'dupword',
   'embeddedstructfieldcheck',
   'err113',
   'errcheck',
-  'errchkjson',
   'exhaustive',
   'exhaustruct',
   'forcetypeassert',
@@ -39,7 +35,6 @@ disable = [
   'godoclint',
   'godot',
   'godox',
-  'gomoddirectives',
   'gosec',
   'inamedparam',
   'interfacebloat',
@@ -49,27 +44,21 @@ disable = [
   'maintidx',
   'misspell',
   'mnd',
-  'musttag',
   'nakedret',
   'nestif',
   'nilnil',
   'nlreturn',
-  'nolintlint',
   'noinlineerr',
   'nonamedreturns',
   'paralleltest',
   'perfsprint',
   'revive',
-  'rowserrcheck',
-  'sqlclosecheck',
-  'staticcheck',
   'tagliatelle',
   'testpackage',
   'thelper',
   'unparam',
   'usestdlibvars',
   'varnamelen',
-  'wastedassign',
   'whitespace',
   'wrapcheck',
   'wsl',
@@ -108,6 +97,10 @@ enable = [
 [linters.settings.misspell]
 locale = 'US'
 
+[linters.settings.staticcheck]
+# Keep correctness checks while deferring the existing style and dependency-deprecation backlog.
+checks = ['all', '-QF*', '-ST*', '-SA1019']
+
 [linters.exclusions]
 generated = 'lax'
 paths = [
@@ -118,8 +111,5 @@ paths = [
 ]
 
 [issues]
-exclude-use-default = false
-max-per-linter = 0
+max-issues-per-linter = 0
 max-same-issues = 0
-exclude = []
-

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -98,8 +98,8 @@ enable = [
 locale = 'US'
 
 [linters.settings.staticcheck]
-# Keep correctness checks while deferring the existing style and dependency-deprecation backlog.
-checks = ['all', '-QF*', '-ST*', '-SA1019']
+# Keep correctness and quick-fix checks while deferring the existing style and dependency-deprecation backlog.
+checks = ['all', '-ST*', '-SA1019']
 
 [linters.exclusions]
 generated = 'lax'

--- a/api/datadoghq/v2alpha1/datadogagent_types.go
+++ b/api/datadoghq/v2alpha1/datadogagent_types.go
@@ -1129,7 +1129,7 @@ type MetricMeta struct {
 	// LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
 	// +optional
 	LabelsFromPath map[string][]string `json:"labelsFromPath,omitempty" yaml:"labelsFromPath,omitempty"`
-	// Path is the path to to generate metric(s) for.
+	// Path is the path to generate metric(s) for.
 	Path []string `json:"path" yaml:"path"`
 }
 

--- a/cmd/kubectl-datadog/agent/check/check.go
+++ b/cmd/kubectl-datadog/agent/check/check.go
@@ -289,7 +289,7 @@ func findErrors(statusJSON string) ([]string, bool, error) {
 	for _, check := range status.RunnerStats.Checks {
 		for checkName, stat := range check {
 			if stat.LastError != "" {
-				errMessage := ""
+				var errMessage string
 				lastError := []Error{}
 				err := json.Unmarshal([]byte(stat.LastError), &lastError)
 				if err != nil {

--- a/cmd/kubectl-datadog/autoscaling/cluster/common/helm/helm.go
+++ b/cmd/kubectl-datadog/autoscaling/cluster/common/helm/helm.go
@@ -57,7 +57,7 @@ func install(ctx context.Context, ac *action.Configuration, releaseName, namespa
 	installAction.ReleaseName = releaseName
 	installAction.CreateNamespace = true
 	installAction.Namespace = namespace
-	installAction.ChartPathOptions.Version = version
+	installAction.Version = version
 	installAction.Wait = true
 	installAction.WaitForJobs = true
 	installAction.Timeout = 30 * time.Minute
@@ -65,7 +65,7 @@ func install(ctx context.Context, ac *action.Configuration, releaseName, namespa
 	settings := cli.New()
 	settings.SetNamespace(namespace)
 
-	chartPath, err := installAction.ChartPathOptions.LocateChart(chartRef, settings)
+	chartPath, err := installAction.LocateChart(chartRef, settings)
 	if err != nil {
 		return fmt.Errorf("failed to locate chart %s: %w", chartRef, err)
 	}
@@ -97,7 +97,7 @@ func upgrade(ctx context.Context, ac *action.Configuration, releaseName, namespa
 
 	upgradeAction := action.NewUpgrade(ac)
 	upgradeAction.Namespace = namespace
-	upgradeAction.ChartPathOptions.Version = version
+	upgradeAction.Version = version
 	upgradeAction.Wait = true
 	upgradeAction.WaitForJobs = true
 	upgradeAction.Timeout = 30 * time.Minute
@@ -105,7 +105,7 @@ func upgrade(ctx context.Context, ac *action.Configuration, releaseName, namespa
 	settings := cli.New()
 	settings.SetNamespace(namespace)
 
-	chartPath, err := upgradeAction.ChartPathOptions.LocateChart(chartRef, settings)
+	chartPath, err := upgradeAction.LocateChart(chartRef, settings)
 	if err != nil {
 		return fmt.Errorf("failed to locate chart %s: %w", chartRef, err)
 	}

--- a/cmd/kubectl-datadog/clusteragent/leader/leader.go
+++ b/cmd/kubectl-datadog/clusteragent/leader/leader.go
@@ -109,16 +109,16 @@ func (o *options) run(cmd *cobra.Command) error {
 
 	// Try to get leader from lease if supported
 	if useLease {
-		fmt.Fprintln(o.IOStreams.Out, "Using lease for leader election")
+		fmt.Fprintln(o.Out, "Using lease for leader election")
 		leaderName, err = o.getLeaderFromLease(objKey)
 	}
 
 	// Fall back to ConfigMap if lease is not supported or failed
 	if !useLease || err != nil {
 		if err != nil {
-			fmt.Fprintln(o.IOStreams.Out, "Lease lookup failed, falling back to ConfigMap")
+			fmt.Fprintln(o.Out, "Lease lookup failed, falling back to ConfigMap")
 		}
-		fmt.Fprintln(o.IOStreams.Out, "Using ConfigMap for leader election")
+		fmt.Fprintln(o.Out, "Using ConfigMap for leader election")
 		leaderName, err = o.getLeaderFromConfigMap(objKey)
 	}
 

--- a/cmd/kubectl-datadog/flare/flare.go
+++ b/cmd/kubectl-datadog/flare/flare.go
@@ -254,7 +254,8 @@ func (o *options) createCRFiles(dir string, cmd *cobra.Command) error {
 	}
 
 	// Get custom resources yaml
-	template, err := yaml.Marshal(ddList.Items)
+	// Kubernetes API types use JSON tags, which this YAML marshaler honors.
+	template, err := yaml.Marshal(ddList.Items) //nolint:musttag
 	if err != nil {
 		return err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,7 +58,7 @@ import (
 	"github.com/DataDog/datadog-operator/pkg/version"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	// nolint:gci
+	//nolint:gci // Keep the scaffold marker in its own import section.
 	// +kubebuilder:scaffold:imports
 )
 
@@ -187,7 +187,7 @@ func (opts *options) Parse() {
 	flag.BoolVar(&opts.untaintControllerWaitForCSIDriver, "untaintControllerWaitForCSIDriver", false,
 		"When true (requires --untaintControllerEnabled), the Untaint controller removes the startup taint only after both the node Agent and Datadog CSI node-server pods are Ready. Requires Pod watch coverage of CSI namespaces (DD_CSIDRIVER_WATCH_NAMESPACE).")
 	flag.BoolVar(&opts.rolloutOnConfigMapChangeEnabled, "rolloutOnConfigMapChangeEnabled", true,
-		"Automatically roll out Agent/Cluster Agent/Cluster Check Runner/OTel Agent Gateway workloads when a ConfigMap referenced by their pod template changes content out-of-band")
+		"Automatically roll out Agent, Cluster Agent, Cluster Check Runner, and OTel Agent Gateway workloads when a ConfigMap referenced by their pod template changes content out-of-band")
 
 	// DatadogAgentInternal
 	flag.BoolVar(&opts.createControllerRevisions, "createControllerRevisions", false, "Enable creation of ControllerRevision snapshots on each DDA spec change")

--- a/cmd/yaml-mapper/mapper/map_processors.go
+++ b/cmd/yaml-mapper/mapper/map_processors.go
@@ -282,8 +282,8 @@ var mapOverrideType = MappingProcessor{
 					utils.MergeOrSet(interim, newPath, string(newPathVal))
 
 				case newType == "int":
-					switch {
-					case pathValType == "string":
+					switch pathValType {
+					case "string":
 						convertedInt, convErr := strconv.Atoi(pathVal.(string))
 						if convErr != nil {
 							slog.Error("failed to convert string to int", "error", convErr)

--- a/cmd/yaml-mapper/mapper/mapper.go
+++ b/cmd/yaml-mapper/mapper/mapper.go
@@ -197,7 +197,7 @@ func (m *Mapper) mapValues(sourceValues chartutil.Values, mappingValues chartuti
 
 	// Map values.yaml => DDA
 	for _, sourceKey := range mappingKeys {
-		destKey, _ := mappingValues[sourceKey]
+		destKey := mappingValues[sourceKey]
 		// Only copy a whole table if none of its sub-keys are mapped separately
 		// (e.g. agents.podSecurity.seLinuxContext.rule has its own mapping entry,
 		// so seLinuxContext itself shouldn't be copied as one big table).

--- a/cmd/yaml-mapper/mapper/mapper.go
+++ b/cmd/yaml-mapper/mapper/mapper.go
@@ -113,7 +113,7 @@ func (m *Mapper) loadInputs() (mappingValues chartutil.Values, sourceValues char
 		if err != nil {
 			return nil, nil, err
 		}
-		m.MapConfig.SourcePath = tmpSourcePath
+		m.SourcePath = tmpSourcePath
 
 	}
 
@@ -124,11 +124,11 @@ func (m *Mapper) loadInputs() (mappingValues chartutil.Values, sourceValues char
 
 		// Ignore error so we can fall back on embedded mapping
 		tmpMappingPath, _ = utils.FetchYAMLFile(defaultDDAMapUrl, tmpFile.Name())
-		m.MapConfig.MappingPath = tmpMappingPath
+		m.MappingPath = tmpMappingPath
 	}
 
 	// Read mapping file
-	mapping, err := os.ReadFile(m.MapConfig.MappingPath)
+	mapping, err := os.ReadFile(m.MappingPath)
 	if err != nil {
 		// Fall back on embedded default mapping
 		mapping = defaultDDAMap
@@ -139,7 +139,7 @@ func (m *Mapper) loadInputs() (mappingValues chartutil.Values, sourceValues char
 	}
 
 	// Read source yaml file
-	source, err := os.ReadFile(m.MapConfig.SourcePath)
+	source, err := os.ReadFile(m.SourcePath)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -166,18 +166,18 @@ func (m *Mapper) loadInputs() (mappingValues chartutil.Values, sourceValues char
 // mapValues maps the Helm source Values to a DDA custom resource based on the provided mapping Values.
 func (m *Mapper) mapValues(sourceValues chartutil.Values, mappingValues chartutil.Values) (map[string]any, int) {
 	var errorCount int
-	var ddaName = m.MapConfig.DDAName
+	var ddaName = m.DDAName
 	var interim = map[string]any{}
 
-	if m.MapConfig.HeaderPath == "" {
+	if m.HeaderPath == "" {
 		interim = newDefaultFileHeader()
 		if ddaName == "" {
 			ddaName = "datadog"
 		}
 		utils.MergeOrSet(interim, "metadata.name", ddaName)
 
-		if m.MapConfig.Namespace != "" {
-			utils.MergeOrSet(interim, "metadata.namespace", m.MapConfig.Namespace)
+		if m.Namespace != "" {
+			utils.MergeOrSet(interim, "metadata.namespace", m.Namespace)
 		}
 	}
 
@@ -370,22 +370,22 @@ func (m *Mapper) updateMapping(sourceValues chartutil.Values, mappingValues char
 	if e != nil {
 		return e
 	}
-	if strings.HasPrefix(m.MapConfig.MappingPath, constants.DefaultDDAMappingPath) {
+	if strings.HasPrefix(m.MappingPath, constants.DefaultDDAMappingPath) {
 		newMapYaml = `# This file maps keys from the Datadog Helm chart (YAML) to the DatadogAgent CustomResource spec (YAML).
 ` + newMapYaml
 	}
 
-	if m.MapConfig.PrintOutput {
+	if m.PrintOutput {
 		os.Stdout.WriteString("\nUpdated mapping file:\n" + newMapYaml)
 	}
 
-	e = os.WriteFile(m.MapConfig.MappingPath, []byte(newMapYaml), 0660)
+	e = os.WriteFile(m.MappingPath, []byte(newMapYaml), 0660)
 	if e != nil {
 		slog.Error("failed to update mapping yaml", "error", e)
 		return e
 	}
 
-	slog.Info("mapping file successfully updated", "path", m.MapConfig.MappingPath)
+	slog.Info("mapping file successfully updated", "path", m.MappingPath)
 
 	return nil
 }

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals.yaml
@@ -1804,7 +1804,7 @@ spec:
                                               description: NilIsZero indicates that if a value is nil it will be treated as zero value.
                                               type: boolean
                                             path:
-                                              description: Path is the path to to generate metric(s) for.
+                                              description: Path is the path to generate metric(s) for.
                                               items:
                                                 type: string
                                               type: array
@@ -1830,7 +1830,7 @@ spec:
                                               description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
                                               type: object
                                             path:
-                                              description: Path is the path to to generate metric(s) for.
+                                              description: Path is the path to generate metric(s) for.
                                               items:
                                                 type: string
                                               type: array
@@ -1856,7 +1856,7 @@ spec:
                                                 type: string
                                               type: array
                                             path:
-                                              description: Path is the path to to generate metric(s) for.
+                                              description: Path is the path to generate metric(s) for.
                                               items:
                                                 type: string
                                               type: array
@@ -10612,7 +10612,7 @@ spec:
                                                   description: NilIsZero indicates that if a value is nil it will be treated as zero value.
                                                   type: boolean
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10638,7 +10638,7 @@ spec:
                                                   description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
                                                   type: object
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10664,7 +10664,7 @@ spec:
                                                     type: string
                                                   type: array
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array

--- a/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentinternals_v1alpha1.json
@@ -1821,7 +1821,7 @@
                                       "type": "boolean"
                                     },
                                     "path": {
-                                      "description": "Path is the path to to generate metric(s) for.",
+                                      "description": "Path is the path to generate metric(s) for.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -1859,7 +1859,7 @@
                                       "type": "object"
                                     },
                                     "path": {
-                                      "description": "Path is the path to to generate metric(s) for.",
+                                      "description": "Path is the path to generate metric(s) for.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -1897,7 +1897,7 @@
                                       "type": "array"
                                     },
                                     "path": {
-                                      "description": "Path is the path to to generate metric(s) for.",
+                                      "description": "Path is the path to generate metric(s) for.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -10310,7 +10310,7 @@
                                           "type": "boolean"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -10348,7 +10348,7 @@
                                           "type": "object"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -10386,7 +10386,7 @@
                                           "type": "array"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles.yaml
@@ -1804,7 +1804,7 @@ spec:
                                                   description: NilIsZero indicates that if a value is nil it will be treated as zero value.
                                                   type: boolean
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1830,7 +1830,7 @@ spec:
                                                   description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
                                                   type: object
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1856,7 +1856,7 @@ spec:
                                                     type: string
                                                   type: array
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array

--- a/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagentprofiles_v1alpha1.json
@@ -1825,7 +1825,7 @@
                                           "type": "boolean"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -1863,7 +1863,7 @@
                                           "type": "object"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -1901,7 +1901,7 @@
                                           "type": "array"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },

--- a/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents.yaml
@@ -1808,7 +1808,7 @@ spec:
                                               description: NilIsZero indicates that if a value is nil it will be treated as zero value.
                                               type: boolean
                                             path:
-                                              description: Path is the path to to generate metric(s) for.
+                                              description: Path is the path to generate metric(s) for.
                                               items:
                                                 type: string
                                               type: array
@@ -1834,7 +1834,7 @@ spec:
                                               description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
                                               type: object
                                             path:
-                                              description: Path is the path to to generate metric(s) for.
+                                              description: Path is the path to generate metric(s) for.
                                               items:
                                                 type: string
                                               type: array
@@ -1860,7 +1860,7 @@ spec:
                                                 type: string
                                               type: array
                                             path:
-                                              description: Path is the path to to generate metric(s) for.
+                                              description: Path is the path to generate metric(s) for.
                                               items:
                                                 type: string
                                               type: array
@@ -10711,7 +10711,7 @@ spec:
                                                   description: NilIsZero indicates that if a value is nil it will be treated as zero value.
                                                   type: boolean
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10737,7 +10737,7 @@ spec:
                                                   description: LabelsFromPath adds additional labels where the value of the label is taken from a field under Path.
                                                   type: object
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array
@@ -10763,7 +10763,7 @@ spec:
                                                     type: string
                                                   type: array
                                                 path:
-                                                  description: Path is the path to to generate metric(s) for.
+                                                  description: Path is the path to generate metric(s) for.
                                                   items:
                                                     type: string
                                                   type: array

--- a/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadogagents_v2alpha1.json
@@ -1821,7 +1821,7 @@
                                       "type": "boolean"
                                     },
                                     "path": {
-                                      "description": "Path is the path to to generate metric(s) for.",
+                                      "description": "Path is the path to generate metric(s) for.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -1859,7 +1859,7 @@
                                       "type": "object"
                                     },
                                     "path": {
-                                      "description": "Path is the path to to generate metric(s) for.",
+                                      "description": "Path is the path to generate metric(s) for.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -1897,7 +1897,7 @@
                                       "type": "array"
                                     },
                                     "path": {
-                                      "description": "Path is the path to to generate metric(s) for.",
+                                      "description": "Path is the path to generate metric(s) for.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -10413,7 +10413,7 @@
                                           "type": "boolean"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -10451,7 +10451,7 @@
                                           "type": "object"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },
@@ -10489,7 +10489,7 @@
                                           "type": "array"
                                         },
                                         "path": {
-                                          "description": "Path is the path to to generate metric(s) for.",
+                                          "description": "Path is the path to generate metric(s) for.",
                                           "items": {
                                             "type": "string"
                                           },

--- a/hack/e2e-test-output/main.go
+++ b/hack/e2e-test-output/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 type testEvent struct {
-	Output string
+	Output string `json:"Output"`
 }
 
 func main() {

--- a/internal/controller/datadogagent/experimental/utils.go
+++ b/internal/controller/datadogagent/experimental/utils.go
@@ -27,7 +27,7 @@ func getExperimentalAnnotation(dda metav1.Object, annotationSubkey string) strin
 	return ""
 }
 
-// ApplyExperimentalOverrides applies any configured experimental overrides for the the given DatadogAgent resource.
+// ApplyExperimentalOverrides applies any configured experimental overrides for the given DatadogAgent resource.
 func ApplyExperimentalOverrides(logger logr.Logger, dda metav1.Object, manager feature.PodTemplateManagers) {
 	elogger := logger.WithName("ExperimentalOverrides")
 	elogger.V(2).Info("Applying experimental overrides")

--- a/internal/controller/datadogagent/feature/apm/feature.go
+++ b/internal/controller/datadogagent/feature/apm/feature.go
@@ -586,7 +586,7 @@ func (f *apmFeature) manageNodeAgent(agentContainerName apicommon.AgentContainer
 		})
 		socketVol, socketVolMount := volume.GetVolumes(apmSocketVolumeName, udsHostFolder, apmSocketVolumeLocalPath, false)
 		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
-		socketVol.VolumeSource.HostPath.Type = &volType
+		socketVol.HostPath.Type = &volType
 		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, agentContainerName, merger.OverrideCurrentVolumeMountMergeFunction)
 		managers.Volume().AddVolume(&socketVol)
 	}

--- a/internal/controller/datadogagent/feature/controlplanemonitoring/configmap.go
+++ b/internal/controller/datadogagent/feature/controlplanemonitoring/configmap.go
@@ -14,7 +14,8 @@ import (
 
 func (f *controlPlaneMonitoringFeature) buildControlPlaneMonitoringConfigMap(provider string, configMapName string) (*corev1.ConfigMap, error) {
 	var configMap *corev1.ConfigMap
-	if provider == kubernetes.OpenShiftProviderLabel {
+	switch provider {
+	case kubernetes.OpenShiftProviderLabel:
 		configMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configMapName,
@@ -70,7 +71,7 @@ instances:
     tls_private_key: "/etc/etcd-certs/tls.key"`,
 			},
 		}
-	} else if provider == kubernetes.EKSProviderLabel {
+	case kubernetes.EKSProviderLabel:
 		configMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configMapName,
@@ -114,7 +115,7 @@ instances:
     tls_ca_cert: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"`,
 			},
 		}
-	} else { // Default provider
+	default: // Default provider
 		configMap = nil
 	}
 	return configMap, nil

--- a/internal/controller/datadogagent/feature/dogstatsd/feature.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature.go
@@ -286,7 +286,7 @@ func (f *dogstatsdFeature) manageNodeAgent(containerName apicommon.AgentContaine
 		socketVol, socketVolMount := volume.GetVolumes(common.DogstatsdSocketVolumeName, udsHostFolder, common.DogstatsdSocketLocalPath, false)
 		volType := corev1.HostPathDirectoryOrCreate // We need to create the directory on the host if it does not exist.
 
-		socketVol.VolumeSource.HostPath.Type = &volType
+		socketVol.HostPath.Type = &volType
 		managers.VolumeMount().AddVolumeMountToContainerWithMergeFunc(&socketVolMount, containerName, merger.OverrideCurrentVolumeMountMergeFunction)
 		managers.Volume().AddVolume(&socketVol)
 		managers.EnvVar().AddEnvVar(&corev1.EnvVar{

--- a/internal/controller/datadogagent/feature/gpu/feature.go
+++ b/internal/controller/datadogagent/feature/gpu/feature.go
@@ -54,7 +54,7 @@ func (f *gpuFeature) NodeAgentProviderCapabilities() providercaps.ProviderCapabi
 	}
 
 	vol, volMount := volume.GetVolumes(gkeCOSNVIDIADriverLib64VolumeName, gkeCOSNVIDIADriverLib64HostPath, gkeCOSNVIDIADriverLib64MountPath, true)
-	vol.VolumeSource.HostPath.Type = ptr.To(corev1.HostPathDirectoryOrCreate)
+	vol.HostPath.Type = ptr.To(corev1.HostPathDirectoryOrCreate)
 
 	return providercaps.ProviderCapabilityMap{
 		kubernetes.GKECosProvider: {

--- a/internal/controller/datadogagent/feature/helmcheck/configmap.go
+++ b/internal/controller/datadogagent/feature/helmcheck/configmap.go
@@ -44,17 +44,17 @@ func helmCheckConfig(clusterCheck bool, collectEvents bool, valuesAsTags map[str
 	collectEventsVal := strconv.FormatBool(collectEvents)
 	sortedTagsKeys := sortTagsKeys(valuesAsTags)
 	var config strings.Builder
-	config.WriteString(fmt.Sprintf(`---
+	fmt.Fprintf(&config, `---
 cluster_check: %s
 init_config:
 instances:
   - collect_events: %s
-`, clusterChecksVal, collectEventsVal))
+`, clusterChecksVal, collectEventsVal)
 
 	if len(valuesAsTags) > 0 {
 		config.WriteString("    helm_values_as_tags:\n")
 		for _, key := range sortedTagsKeys {
-			config.WriteString(fmt.Sprintf("      %s: %s\n", key, valuesAsTags[key]))
+			fmt.Fprintf(&config, "      %s: %s\n", key, valuesAsTags[key])
 		}
 	}
 

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/envvar.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/envvar.go
@@ -42,7 +42,7 @@ func (f *orchestratorExplorerFeature) getEnvVars() []*corev1.EnvVar {
 	}
 
 	if len(f.extraTags) > 0 {
-		tags, _ := json.Marshal(f.extraTags)
+		tags, _ := json.Marshal(f.extraTags) //nolint:errchkjson // A string slice cannot fail JSON marshaling.
 		envVarsList = append(envVarsList, &corev1.EnvVar{
 			Name:  DDOrchestratorExplorerExtraTags,
 			Value: string(tags),

--- a/internal/controller/datadogagent/global/global.go
+++ b/internal/controller/datadogagent/global/global.go
@@ -315,9 +315,8 @@ func applyGlobalSettings(logger logr.Logger, manager feature.PodTemplateManagers
 }
 
 func updateContainerImages(config *v2alpha1.GlobalConfig, podTemplateManager feature.PodTemplateManagers) {
-	image := &images.Image{}
 	for i, container := range podTemplateManager.PodTemplateSpec().Spec.Containers {
-		image = images.FromString(container.Image).
+		image := images.FromString(container.Image).
 			WithRegistry(*config.Registry).
 			WithFIPS(*config.UseFIPSAgent)
 		// Note: if an image tag override is configured, this image tag will be overwritten
@@ -325,7 +324,7 @@ func updateContainerImages(config *v2alpha1.GlobalConfig, podTemplateManager fea
 	}
 
 	for i, container := range podTemplateManager.PodTemplateSpec().Spec.InitContainers {
-		image = images.FromString(container.Image).
+		image := images.FromString(container.Image).
 			WithRegistry(*config.Registry).
 			WithFIPS(*config.UseFIPSAgent)
 		// Note: if an image tag override is configured, this image tag will be overwritten

--- a/internal/controller/datadogagent/store/store.go
+++ b/internal/controller/datadogagent/store/store.go
@@ -361,7 +361,7 @@ func (ds *Store) DeleteAll(ctx context.Context, k8sClient client.Client) []error
 						gvk = gvks[0]
 					}
 				}
-				partialObj.TypeMeta.SetGroupVersionKind(gvk)
+				partialObj.SetGroupVersionKind(gvk)
 				objsToDelete = append(objsToDelete, partialObj)
 			}
 		}
@@ -420,7 +420,7 @@ func (ds *Store) listObjectToDelete(kind kubernetes.ObjectKind, objList client.O
 						}
 					}
 
-					partialObj.TypeMeta.SetGroupVersionKind(gvk)
+					partialObj.SetGroupVersionKind(gvk)
 					objsToDelete = append(objsToDelete, partialObj)
 				}
 			}

--- a/internal/controller/datadogagentinternal/reconcile_helpers.go
+++ b/internal/controller/datadogagentinternal/reconcile_helpers.go
@@ -13,7 +13,6 @@ import (
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
-	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv2alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/component"
 	componentccr "github.com/DataDog/datadog-operator/internal/controller/datadogagent/component/clusterchecksrunner"
@@ -31,7 +30,7 @@ import (
 // STEP 2 of the reconcile loop: reconcile 3 components
 
 // setupDependencies initializes the store and resource managers.
-func (r *Reconciler) setupDependencies(ctx context.Context, instance *datadoghqv1alpha1.DatadogAgentInternal) (*store.Store, feature.ResourceManagers) {
+func (r *Reconciler) setupDependencies(ctx context.Context, instance *v1alpha1.DatadogAgentInternal) (*store.Store, feature.ResourceManagers) {
 	storeOptions := &store.StoreOptions{
 		SupportCilium: r.options.SupportCilium,
 		PlatformInfo:  r.platformInfo,
@@ -44,7 +43,7 @@ func (r *Reconciler) setupDependencies(ctx context.Context, instance *datadoghqv
 }
 
 // manageGlobalDependencies manages the global dependencies for a component.
-func (r *Reconciler) manageGlobalDependencies(ctx context.Context, ddai *datadoghqv1alpha1.DatadogAgentInternal, resourceManagers feature.ResourceManagers, requiredComponents feature.RequiredComponents) error {
+func (r *Reconciler) manageGlobalDependencies(ctx context.Context, ddai *v1alpha1.DatadogAgentInternal, resourceManagers feature.ResourceManagers, requiredComponents feature.RequiredComponents) error {
 	logger := ctrl.LoggerFrom(ctx)
 	var errs []error
 	// Non component specific dependencies
@@ -87,7 +86,7 @@ func (r *Reconciler) manageFeatureDependencies(features []feature.Feature, resou
 }
 
 // overrideDependencies wraps the dependency override logic.
-func (r *Reconciler) overrideDependencies(ctx context.Context, resourceManagers feature.ResourceManagers, instance *datadoghqv1alpha1.DatadogAgentInternal) error {
+func (r *Reconciler) overrideDependencies(ctx context.Context, resourceManagers feature.ResourceManagers, instance *v1alpha1.DatadogAgentInternal) error {
 	errs := override.Dependencies(ctrl.LoggerFrom(ctx), resourceManagers, instance.GetObjectMeta(), &instance.Spec)
 	if len(errs) > 0 {
 		return errors.NewAggregate(errs)
@@ -100,7 +99,7 @@ func (r *Reconciler) overrideDependencies(ctx context.Context, resourceManagers 
 // *************************************
 
 // cleanupExtraneousResources groups the cleanup calls for old components.
-func (r *Reconciler) cleanupExtraneousResources(ctx context.Context, instance *datadoghqv1alpha1.DatadogAgentInternal, newStatus *datadoghqv1alpha1.DatadogAgentInternalStatus, resourceManagers feature.ResourceManagers) error {
+func (r *Reconciler) cleanupExtraneousResources(ctx context.Context, instance *v1alpha1.DatadogAgentInternal, newStatus *v1alpha1.DatadogAgentInternalStatus, resourceManagers feature.ResourceManagers) error {
 	logger := ctrl.LoggerFrom(ctx)
 	var errs []error
 	// Cleanup old DaemonSets, DCA and CCR deployments.

--- a/internal/controller/datadogagentinternal_controller.go
+++ b/internal/controller/datadogagentinternal_controller.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
-	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagentinternal"
 	"github.com/DataDog/datadog-operator/pkg/controller/utils/datadog"
@@ -98,7 +97,7 @@ func (r *DatadogAgentInternalReconciler) SetupWithManager(mgr ctrl.Manager, metr
 	}
 
 	or := reconcile.AsReconciler[*v1alpha1.DatadogAgentInternal](r.Client, r)
-	if err := builder.For(&datadoghqv1alpha1.DatadogAgentInternal{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).Complete(or); err != nil {
+	if err := builder.For(&v1alpha1.DatadogAgentInternal{}, builderOptions...).WithEventFilter(predicate.GenerationChangedPredicate{}).Complete(or); err != nil {
 		return err
 	}
 

--- a/internal/controller/datadoggenericresource/controller.go
+++ b/internal/controller/datadoggenericresource/controller.go
@@ -200,6 +200,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, instance *v1alpha1.DatadogGe
 	}
 
 	// If reconcile was successful and uneventful, requeue with the configured period.
+	// Requeue is needed here to distinguish an immediate requeue requested by the finalizer.
 	if !result.Requeue && result.RequeueAfter == 0 {
 		result.RequeueAfter = r.requeuePeriod
 	}

--- a/internal/controller/datadoggenericresource/downtimes.go
+++ b/internal/controller/datadoggenericresource/downtimes.go
@@ -123,8 +123,8 @@ func updateDowntime(auth context.Context, client *datadogV2.DowntimesApi, instan
 	// ID is retrieved from the status and type is always downtime
 	var specData struct {
 		Data struct {
-			Attributes *datadogV2.DowntimeUpdateRequestAttributes
-		}
+			Attributes *datadogV2.DowntimeUpdateRequestAttributes `json:"attributes"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(instance.Spec.JsonSpec), &specData); err != nil {
 		return datadogV2.DowntimeResponse{}, translateClientError(err, "error unmarshalling downtime spec")

--- a/internal/controller/datadoggenericresource/monitor_notification_rules.go
+++ b/internal/controller/datadoggenericresource/monitor_notification_rules.go
@@ -126,8 +126,8 @@ func updateMonitorNotificationRule(auth context.Context, client *datadogV2.Monit
 
 	var specData struct {
 		Data struct {
-			Attributes *datadogV2.MonitorNotificationRuleAttributes
-		}
+			Attributes *datadogV2.MonitorNotificationRuleAttributes `json:"attributes"`
+		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(instance.Spec.JsonSpec), &specData); err != nil {
 		return datadogV2.MonitorNotificationRuleResponse{}, translateClientError(err, "error unmarshalling monitor notification rule spec")

--- a/internal/controller/untaint_controller.go
+++ b/internal/controller/untaint_controller.go
@@ -450,7 +450,7 @@ func latestPodStartTime(pods []corev1.Pod) (time.Time, bool) {
 		if st == nil {
 			continue
 		}
-		if !found || st.Time.After(latest) {
+		if !found || st.After(latest) {
 			latest = st.Time
 			found = true
 		}

--- a/pkg/agentprofile/agent_profile.go
+++ b/pkg/agentprofile/agent_profile.go
@@ -77,7 +77,7 @@ func AssignNodesToProfile(profile metav1.ObjectMeta, profileRequirements []*labe
 		profilesByNode[node.Name] = profileNSName
 		if CreateStrategyEnabled() {
 			profileLabelValue, labelExists := node.Labels[constants.ProfileLabelKey]
-			needsLabel := !(labelExists && profileLabelValue == profile.Name)
+			needsLabel := !labelExists || profileLabelValue != profile.Name
 			if needsLabel {
 				csInfo[profileNSName].nodesNeedingLabel = append(csInfo[profileNSName].nodesNeedingLabel, node.Name)
 			} else {
@@ -230,7 +230,7 @@ func SortProfiles(profiles []v1alpha1.DatadogAgentProfile) []v1alpha1.DatadogAge
 // compareProfiles compares two profiles first by creation time, then by name.
 func compareProfiles(a, b v1alpha1.DatadogAgentProfile) int {
 	return cmp.Or(
-		a.CreationTimestamp.Time.Compare(b.CreationTimestamp.Time),
+		a.CreationTimestamp.Compare(b.CreationTimestamp.Time),
 		cmp.Compare(a.Name, b.Name),
 	)
 }

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -192,7 +192,7 @@ func UpdateDeploymentStatus(dep *appsv1.Deployment, depStatus *v2alpha1.Deployme
 
 	depStatus.State = fmt.Sprintf("%v", deploymentState)
 	depStatus.Status = fmt.Sprintf("%v (%d/%d/%d)", deploymentState, depStatus.Replicas, depStatus.ReadyReplicas, depStatus.UpdatedReplicas)
-	depStatus.DeploymentName = dep.ObjectMeta.Name
+	depStatus.DeploymentName = dep.Name
 	return depStatus
 }
 
@@ -212,7 +212,7 @@ func UpdateDaemonSetStatusDDAI(dsName string, ds *appsv1.DaemonSet, dsStatus *v2
 		dsStatus.Ready = ds.Status.NumberReady
 		dsStatus.Available = ds.Status.NumberAvailable
 		dsStatus.UpToDate = ds.Status.UpdatedNumberScheduled
-		dsStatus.DaemonsetName = ds.ObjectMeta.Name
+		dsStatus.DaemonsetName = ds.Name
 		if updateTime != nil {
 			dsStatus.LastUpdate = updateTime
 		}

--- a/pkg/config/creds.go
+++ b/pkg/config/creds.go
@@ -445,8 +445,8 @@ func (cm *CredentialManager) getCredentialsFromDDA(dda *v2alpha1.DatadogAgent) (
 
 	defaultSecretName := secrets.GetDefaultCredentialsSecretName(dda)
 
-	apiKey := ""
-	err := error(nil)
+	var apiKey string
+	var err error
 	if dda.Spec.Global != nil && dda.Spec.Global.Credentials != nil && dda.Spec.Global.Credentials.APIKey != nil && *dda.Spec.Global.Credentials.APIKey != "" {
 		apiKey = *dda.Spec.Global.Credentials.APIKey
 	} else {

--- a/pkg/controller/utils/datadog/forwarders_manager.go
+++ b/pkg/controller/utils/datadog/forwarders_manager.go
@@ -67,7 +67,7 @@ func (f *ForwardersManager) Start(stop <-chan struct{}) error {
 func (f *ForwardersManager) Register(obj client.Object) {
 	f.Lock()
 	defer f.Unlock()
-	id := getObjID(obj) // nolint: ifshort
+	id := getObjID(obj)
 	if _, found := f.metricsForwarders[id]; !found {
 		f.metricsForwarders[id] = newMetricsForwarder(f.k8sClient, f.decryptor, obj, f.platformInfo, f.credsManager)
 		f.wg.Add(1)

--- a/pkg/controller/utils/datadog/metrics_forwarder.go
+++ b/pkg/controller/utils/datadog/metrics_forwarder.go
@@ -694,8 +694,8 @@ func (mf *metricsForwarder) getCredentialsFromDDA(dda *v2alpha1.DatadogAgent) (s
 
 	defaultSecretName := secrets.GetDefaultCredentialsSecretName(dda)
 
+	var apiKey string
 	var err error
-	apiKey := ""
 
 	if dda.Spec.Global != nil && dda.Spec.Global.Credentials != nil && dda.Spec.Global.Credentials.APIKey != nil && *dda.Spec.Global.Credentials.APIKey != "" {
 		apiKey = *dda.Spec.Global.Credentials.APIKey
@@ -715,16 +715,12 @@ func (mf *metricsForwarder) getCredentialsFromDDA(dda *v2alpha1.DatadogAgent) (s
 }
 
 // getCredentialsFromDDAI retrieves the API key configured in the DatadogAgentInternal
-// DatadogAgentInternal are always stored in a secret, so we don't need to resolve secrets
+// credentials are always stored in a secret, so we don't need to resolve secrets.
 func (mf *metricsForwarder) getCredentialsFromDDAI(ddai *v1alpha1.DatadogAgentInternal) (string, error) {
-
-	var err error
-	apiKey := ""
-
 	defaultSecretName := secrets.GetDefaultCredentialsSecretName(ddai)
 
 	_, secretName, secretKeyName := secrets.GetAPIKeySecret(ddai.Spec.Global.Credentials, defaultSecretName)
-	apiKey, err = mf.getKeyFromSecret(ddai.Namespace, secretName, secretKeyName)
+	apiKey, err := mf.getKeyFromSecret(ddai.Namespace, secretName, secretKeyName)
 	if err != nil {
 		return "", err
 	}
@@ -922,7 +918,7 @@ func (mf *metricsForwarder) setUpDatadogAPIClient() {
 	mf.datadogEventsApi = datadogV1.NewEventsApi(apiClient) // Initialize events API
 }
 
-// API key set here. This and Get API from etc. etc.
+// generateDatadogContext configures the API key and endpoint used by API calls.
 func (mf *metricsForwarder) generateDatadogContext() context.Context {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, datadogapi.ContextAPIKeys,

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -182,7 +182,7 @@ func splitProviderSuffix(provider string) (string, string) {
 // GetAgentNameWithProvider returns the agent name based on the ds name and provider
 func GetAgentNameWithProvider(overrideDSName, provider string) string {
 	if provider != "" && overrideDSName != "" {
-		return overrideDSName + "-" + strings.Replace(provider, "_", "-", -1)
+		return overrideDSName + "-" + strings.ReplaceAll(provider, "_", "-")
 	}
 	return overrideDSName
 }

--- a/pkg/testutils/builder.go
+++ b/pkg/testutils/builder.go
@@ -76,7 +76,7 @@ func (builder *DatadogAgentBuilder) WithName(name string) *DatadogAgentBuilder {
 }
 
 func (builder *DatadogAgentBuilder) WithAnnotations(annotations map[string]string) *DatadogAgentBuilder {
-	builder.datadogAgent.ObjectMeta.Annotations = annotations
+	builder.datadogAgent.Annotations = annotations
 	return builder
 }
 

--- a/pkg/testutils/ddai_builder.go
+++ b/pkg/testutils/ddai_builder.go
@@ -76,7 +76,7 @@ func (builder *DatadogAgentInternalBuilder) WithName(name string) *DatadogAgentI
 }
 
 func (builder *DatadogAgentInternalBuilder) WithAnnotations(annotations map[string]string) *DatadogAgentInternalBuilder {
-	builder.datadogAgentInternal.ObjectMeta.Annotations = annotations
+	builder.datadogAgentInternal.Annotations = annotations
 	return builder
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,7 +43,8 @@ func newVersionJSON() []byte {
 		Error:     "",
 	})
 	if err != nil {
-		bytes, _ = json.Marshal(JSON{Error: fmt.Sprintf("cannot get version: %v", err)})
+		// JSON contains only string fields, so marshaling this fallback cannot fail.
+		bytes, _ = json.Marshal(JSON{Error: fmt.Sprintf("cannot get version: %v", err)}) //nolint:errchkjson
 	}
 
 	return bytes


### PR DESCRIPTION
### What does this PR do?

Enables eleven low-churn golangci-lint checks:

- `bodyclose`, `containedctx`, `dupword`, `errchkjson`, `gomoddirectives`
- `musttag`, `nolintlint`, `rowserrcheck`, `sqlclosecheck`, `staticcheck`, `wastedassign`

It also enables the Staticcheck correctness and quick-fix analyzers, fixes the resulting findings, and updates legacy golangci-lint v2 configuration keys.

### Motivation

Several useful correctness, resource-safety, and configuration checks were disabled globally. Enabling the clean or tractable checks prevents new violations while keeping the initial rollout reviewable.

### Additional Notes

This is the base of a two-PR branch stack. Follow-up #3416 enables the actionable Staticcheck style checks.

Next linters and analyzer groups to evaluate:

- `errcheck` (50+ existing findings), prioritizing meaningful unchecked returns over output/cleanup noise
- `gosec` (50+ findings), with a security-focused review of each suppression
- `contextcheck` (62 findings), which requires context propagation through controller call chains
- `forcetypeassert` (24 findings) and `exhaustive` (19 findings), both requiring behavioral decisions
- `SA1019`, after planning controller-runtime typed-apply and event-recorder migrations

### Minimum Agent Versions

No minimum Datadog Agent or Cluster Agent version is required.

### Describe your test plan

- `make generate && make manifests`
- `go test ./...`
- `make fmt`
- `make lint`
- `golangci-lint config verify`

### Checklist

- [x] PR has at least one valid label: `enhancement`
- [x] PR has milestone `v1.31.0` and label `qa/skip-qa`
- [x] All commits are signed
