### PR TITLE
feat(orchestrator): grant KServe collection RBAC

### DIFF
--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
@@ -142,6 +142,23 @@ func getRBACPolicyRules(logger logr.Logger, crs []string, collectKubernetesNetwo
 			APIGroups: []string{rbac.EKSAPIGroup},
 			Resources: []string{rbac.Wildcard},
 		},
+		{
+			APIGroups: []string{rbac.KServeAPIGroup},
+			Resources: []string{
+				rbac.ClusterStorageContainersResource,
+				rbac.LLMInferenceServiceConfigsResource,
+				rbac.LLMInferenceServicesResource,
+				rbac.LocalModelCachesResource,
+				rbac.LocalModelNamespaceCachesResource,
+				rbac.LocalModelNodeGroupsResource,
+				rbac.LocalModelNodesResource,
+				rbac.ClusterServingRuntimesResource,
+				rbac.InferenceGraphsResource,
+				rbac.InferenceServicesResource,
+				rbac.ServingRuntimesResource,
+				rbac.TrainedModelsResource,
+			},
+		},
 	}
 
 	if collectKubernetesNetworkResources {

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
@@ -41,6 +41,24 @@ func TestGetRBACPolicyRules(t *testing.T) {
 			Resources: []string{rbac.Wildcard},
 			Verbs:     []string{rbac.ListVerb, rbac.WatchVerb},
 		},
+		{
+			APIGroups: []string{rbac.KServeAPIGroup},
+			Resources: []string{
+				rbac.ClusterStorageContainersResource,
+				rbac.LLMInferenceServiceConfigsResource,
+				rbac.LLMInferenceServicesResource,
+				rbac.LocalModelCachesResource,
+				rbac.LocalModelNamespaceCachesResource,
+				rbac.LocalModelNodeGroupsResource,
+				rbac.LocalModelNodesResource,
+				rbac.ClusterServingRuntimesResource,
+				rbac.InferenceGraphsResource,
+				rbac.InferenceServicesResource,
+				rbac.ServingRuntimesResource,
+				rbac.TrainedModelsResource,
+			},
+			Verbs: []string{rbac.ListVerb, rbac.WatchVerb},
+		},
 	}
 
 	tests := []struct {

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -391,6 +391,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -391,6 +391,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -391,6 +391,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -391,6 +391,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -372,6 +372,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
@@ -372,6 +372,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -372,6 +372,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
@@ -372,6 +372,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -372,6 +372,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
@@ -372,6 +372,24 @@ rules:
   - list
   - watch
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterservingruntimes
+  - clusterstoragecontainers
+  - inferencegraphs
+  - inferenceservices
+  - llminferenceserviceconfigs
+  - llminferenceservices
+  - localmodelcaches
+  - localmodelnamespacecaches
+  - localmodelnodegroups
+  - localmodelnodes
+  - servingruntimes
+  - trainedmodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - source.toolkit.fluxcd.io
   resources:
   - buckets

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -41,6 +41,7 @@ const (
 	KarpenterAPIGroup            = "karpenter.sh"
 	KarpenterAWSAPIGroup         = "karpenter.k8s.aws"
 	KarpenterAzureAPIGroup       = "karpenter.azure.com"
+	KServeAPIGroup               = "serving.kserve.io"
 
 	// Service Mesh API groups
 	IstioNetworkingAPIGroup = "networking.istio.io"
@@ -126,6 +127,18 @@ const (
 	Helmrepositories                                  = "helmrepositories"
 	Ocirepositories                                   = "ocirepositories"
 	Kustomizations                                    = "kustomizations"
+	ClusterStorageContainersResource                  = "clusterstoragecontainers"
+	LLMInferenceServiceConfigsResource                = "llminferenceserviceconfigs"
+	LLMInferenceServicesResource                      = "llminferenceservices"
+	LocalModelCachesResource                          = "localmodelcaches"
+	LocalModelNamespaceCachesResource                 = "localmodelnamespacecaches"
+	LocalModelNodeGroupsResource                      = "localmodelnodegroups"
+	LocalModelNodesResource                           = "localmodelnodes"
+	ClusterServingRuntimesResource                    = "clusterservingruntimes"
+	InferenceGraphsResource                           = "inferencegraphs"
+	InferenceServicesResource                         = "inferenceservices"
+	ServingRuntimesResource                           = "servingruntimes"
+	TrainedModelsResource                             = "trainedmodels"
 
 	// Gateway API resources
 	GatewaysResource     = "gateways"


### PR DESCRIPTION
### What does this PR do?

Grants list/watch permissions for the 12 `serving.kserve.io` resources collected out of the box by the orchestrator explorer.

### Motivation

Companion to DataDog/datadog-agent#55699. Operator-managed Agent installations need these permissions to collect KServe resources without custom RBAC configuration.

### Additional Notes

DataDog/helm-charts#2890 grants the same permissions for Helm-managed installations.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: A version containing DataDog/datadog-agent#55699

### Describe your test plan

- `go test ./internal/controller/datadogagent/feature/orchestratorexplorer ./pkg/kubernetes/rbac`
- `make lint`