### PR TITLE
feat(orchestrator): grant Ray and Dynamo collection RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -498,6 +498,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
@@ -516,6 +529,16 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
+  verbs:
+  - list
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
@@ -142,6 +142,27 @@ func getRBACPolicyRules(logger logr.Logger, crs []string, collectKubernetesNetwo
 			APIGroups: []string{rbac.EKSAPIGroup},
 			Resources: []string{rbac.Wildcard},
 		},
+		{
+			APIGroups: []string{rbac.KubeRayAPIGroup},
+			Resources: []string{
+				rbac.RayClustersResource,
+				rbac.RayCronJobsResource,
+				rbac.RayJobsResource,
+				rbac.RayServicesResource,
+			},
+		},
+		{
+			APIGroups: []string{rbac.DynamoAPIGroup},
+			Resources: []string{
+				rbac.DynamoCheckpointsResource,
+				rbac.DynamoComponentDeploymentsResource,
+				rbac.DynamoGraphDeploymentRequestsResource,
+				rbac.DynamoGraphDeploymentsResource,
+				rbac.DynamoGraphDeploymentScalingAdaptersResource,
+				rbac.DynamoModelsResource,
+				rbac.DynamoWorkerMetadatasResource,
+			},
+		},
 	}
 
 	if collectKubernetesNetworkResources {

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
@@ -41,6 +41,29 @@ func TestGetRBACPolicyRules(t *testing.T) {
 			Resources: []string{rbac.Wildcard},
 			Verbs:     []string{rbac.ListVerb, rbac.WatchVerb},
 		},
+		{
+			APIGroups: []string{rbac.KubeRayAPIGroup},
+			Resources: []string{
+				rbac.RayClustersResource,
+				rbac.RayCronJobsResource,
+				rbac.RayJobsResource,
+				rbac.RayServicesResource,
+			},
+			Verbs: []string{rbac.ListVerb, rbac.WatchVerb},
+		},
+		{
+			APIGroups: []string{rbac.DynamoAPIGroup},
+			Resources: []string{
+				rbac.DynamoCheckpointsResource,
+				rbac.DynamoComponentDeploymentsResource,
+				rbac.DynamoGraphDeploymentRequestsResource,
+				rbac.DynamoGraphDeploymentsResource,
+				rbac.DynamoGraphDeploymentScalingAdaptersResource,
+				rbac.DynamoModelsResource,
+				rbac.DynamoWorkerMetadatasResource,
+			},
+			Verbs: []string{rbac.ListVerb, rbac.WatchVerb},
+		},
 	}
 
 	tests := []struct {

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -224,6 +224,8 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=karpenter.k8s.aws,resources="*",verbs=get;list;watch
 // +kubebuilder:rbac:groups=karpenter.azure.com,resources="*",verbs=list;watch
 // +kubebuilder:rbac:groups=eks.amazonaws.com,resources="*",verbs=get;list;watch
+// +kubebuilder:rbac:groups=ray.io,resources=rayclusters;raycronjobs;rayjobs;rayservices,verbs=list;watch
+// +kubebuilder:rbac:groups=nvidia.com,resources=dynamocheckpoints;dynamocomponentdeployments;dynamographdeploymentrequests;dynamographdeployments;dynamographdeploymentscalingadapters;dynamomodels;dynamoworkermetadatas,verbs=list;watch
 
 // Kubernetes_state_core
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -374,9 +374,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -374,9 +374,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -374,9 +374,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -374,9 +374,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -355,9 +355,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
@@ -355,9 +355,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -355,9 +355,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
@@ -355,9 +355,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -355,9 +355,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
@@ -355,9 +355,32 @@ rules:
   - list
   - watch
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  - dynamocomponentdeployments
+  - dynamographdeploymentrequests
+  - dynamographdeployments
+  - dynamographdeploymentscalingadapters
+  - dynamomodels
+  - dynamoworkermetadatas
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  - raycronjobs
+  - rayjobs
+  - rayservices
   verbs:
   - list
   - watch

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -41,6 +41,8 @@ const (
 	KarpenterAPIGroup            = "karpenter.sh"
 	KarpenterAWSAPIGroup         = "karpenter.k8s.aws"
 	KarpenterAzureAPIGroup       = "karpenter.azure.com"
+	KubeRayAPIGroup              = "ray.io"
+	DynamoAPIGroup               = "nvidia.com"
 
 	// Service Mesh API groups
 	IstioNetworkingAPIGroup = "networking.istio.io"
@@ -126,6 +128,17 @@ const (
 	Helmrepositories                                  = "helmrepositories"
 	Ocirepositories                                   = "ocirepositories"
 	Kustomizations                                    = "kustomizations"
+	RayClustersResource                               = "rayclusters"
+	RayCronJobsResource                               = "raycronjobs"
+	RayJobsResource                                   = "rayjobs"
+	RayServicesResource                               = "rayservices"
+	DynamoCheckpointsResource                         = "dynamocheckpoints"
+	DynamoComponentDeploymentsResource                = "dynamocomponentdeployments"
+	DynamoGraphDeploymentRequestsResource             = "dynamographdeploymentrequests"
+	DynamoGraphDeploymentsResource                    = "dynamographdeployments"
+	DynamoGraphDeploymentScalingAdaptersResource      = "dynamographdeploymentscalingadapters"
+	DynamoModelsResource                              = "dynamomodels"
+	DynamoWorkerMetadatasResource                     = "dynamoworkermetadatas"
 
 	// Gateway API resources
 	GatewaysResource     = "gateways"


### PR DESCRIPTION
CAP-3932

### What does this PR do?

Grants list/watch permissions for the KubeRay `ray.io` and NVIDIA Dynamo `nvidia.com` resources collected out of the box by the orchestrator explorer. It also grants the Operator those permissions through kubebuilder RBAC markers so it can create the Cluster Agent role.

### Motivation

Companion to DataDog/datadog-agent#55684 and DataDog/datadog-agent#55685. Operator-managed Agent installations need these permissions to collect Ray and Dynamo resources without custom RBAC configuration.

### Additional Notes

DataDog/helm-charts#2892 grants the same permissions for Helm-managed installations.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: A version containing DataDog/datadog-agent#55684 and DataDog/datadog-agent#55685

### Describe your test plan

- `make generate`
- `go test ./internal/controller/testutils/renderer/ -run TestRender_Golden`
- `go test ./internal/controller/datadogagent/feature/orchestratorexplorer ./pkg/kubernetes/rbac`
- `make lint`
- Verify the clusterrole for orchestrator explorer grants permissions for these resources