### PR TITLE
Fix E2E lint for local module replacements

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -110,6 +110,12 @@ paths = [
   'examples$'
 ]
 
+# The E2E module runs with GOWORK=off to isolate its Kubernetes dependencies,
+# so its local replacements are required to test the current checkout.
+[[linters.exclusions.rules]]
+path = '^test/e2e/go\.mod$'
+linters = ['gomoddirectives']
+
 [issues]
 max-issues-per-linter = 0
 max-same-issues = 0


### PR DESCRIPTION
## Summary
- document why the E2E module uses local replacements
- scope the gomoddirectives exclusion to test/e2e/go.mod

## Tests
- make lint-e2e
- make lint
- golangci-lint config verify
- git diff --check