### PR TITLE
[Backport v1.30] Update default Agent to `7.83.0` (#3426)

### DIFF
--- a/internal/controller/datadogagent/global/global_test.go
+++ b/internal/controller/datadogagent/global/global_test.go
@@ -140,6 +140,7 @@ func TestNodeAgentComponenGlobalSettings(t *testing.T) {
 			dda: func() *v2alpha1.DatadogAgent {
 				dda := testutils.NewDatadogAgentBuilder().
 					WithCredentials("apiKey", "appKey").
+					WithNodeAgentImage("agent:7.81.1").
 					BuildWithDefaults()
 				dda.Spec.Global.UseVSock = ptr.To(true)
 				return dda

--- a/internal/controller/testutils/renderer/render_e2e_test.go
+++ b/internal/controller/testutils/renderer/render_e2e_test.go
@@ -16,13 +16,15 @@ import (
 )
 
 // baseKindCounts is the expected resource inventory for a minimal DatadogAgent
-// with no extra features enabled. The three Services are the Cluster Agent,
-// the admission controller, and the node Agent local service (rendered because
-// the simulated Kubernetes version is >= 1.22).
+// with no explicitly enabled features. Instrumentation CRD is enabled by
+// default because the default Agent versions meet its minimum version. The
+// three Services are the Cluster Agent, the admission controller, and the node
+// Agent local service (rendered because the simulated Kubernetes version is >=
+// 1.22).
 var baseKindCounts = map[string]int{
 	"ServiceAccount":       2,
-	"ClusterRole":          5,
-	"ClusterRoleBinding":   5,
+	"ClusterRole":          6,
+	"ClusterRoleBinding":   6,
 	"Role":                 1,
 	"RoleBinding":          1,
 	"Secret":               1,
@@ -37,8 +39,8 @@ var baseKindCounts = map[string]int{
 // reflecting the dependency-aware sort in kindOrder.
 var baseKindSeq = []string{
 	"ServiceAccount", "ServiceAccount",
-	"ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole",
-	"ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding",
+	"ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole",
+	"ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding",
 	"Role",
 	"RoleBinding",
 	"Secret",
@@ -93,8 +95,8 @@ func TestRender_WithDAP(t *testing.T) {
 
 	assert.Equal(t, map[string]int{
 		"ServiceAccount":       2,
-		"ClusterRole":          5,
-		"ClusterRoleBinding":   5,
+		"ClusterRole":          6,
+		"ClusterRoleBinding":   6,
 		"Role":                 1,
 		"RoleBinding":          1,
 		"Secret":               1,
@@ -109,8 +111,8 @@ func TestRender_WithDAP(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"ServiceAccount", "ServiceAccount",
-		"ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole",
-		"ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding",
+		"ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole", "ClusterRole",
+		"ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding", "ClusterRoleBinding",
 		"Role",
 		"RoleBinding",
 		"Secret",

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -2168,7 +2168,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 9f9cc18615463016b51e37676cc4b72a
+    agent.datadoghq.com/agentspechash: 5d1b372f994c9fd5b7eab5961a295c4d
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2288,7 +2288,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.81.1
+        image: registry.datadoghq.com/agent:7.83.0
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2343,7 +2343,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.81.1
+        image: registry.datadoghq.com/agent:7.83.0
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -2133,7 +2133,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 9bb3d4e42d99fde0ef482717a4d139d7
+    agent.datadoghq.com/agentspechash: f3023a12307441636a01837d679f81df
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2257,7 +2257,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: gcr.io/datadoghq/agent:7.81.1
+        image: gcr.io/datadoghq/agent:7.83.0
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2312,7 +2312,7 @@ spec:
         command:
         - bash
         - -c
-        image: gcr.io/datadoghq/agent:7.81.1
+        image: gcr.io/datadoghq/agent:7.83.0
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -2165,7 +2165,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 9f9cc18615463016b51e37676cc4b72a
+    agent.datadoghq.com/agentspechash: 5d1b372f994c9fd5b7eab5961a295c4d
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2285,7 +2285,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.81.1
+        image: registry.datadoghq.com/agent:7.83.0
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2340,7 +2340,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.81.1
+        image: registry.datadoghq.com/agent:7.83.0
         name: init-config
         resources: {}
         volumeMounts:

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -2187,7 +2187,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 9f9cc18615463016b51e37676cc4b72a
+    agent.datadoghq.com/agentspechash: 5d1b372f994c9fd5b7eab5961a295c4d
   labels:
     agent.datadoghq.com/component: cluster-checks-runner
     agent.datadoghq.com/name: datadog-agent
@@ -2307,7 +2307,7 @@ spec:
           value: "true"
         - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
           value: "true"
-        image: registry.datadoghq.com/agent:7.81.1
+        image: registry.datadoghq.com/agent:7.83.0
         livenessProbe:
           failureThreshold: 6
           httpGet:
@@ -2362,7 +2362,7 @@ spec:
         command:
         - bash
         - -c
-        image: registry.datadoghq.com/agent:7.81.1
+        image: registry.datadoghq.com/agent:7.83.0
         name: init-config
         resources: {}
         volumeMounts:

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -16,11 +16,11 @@ import (
 
 const (
 	// AgentLatestVersion corresponds to the latest stable agent release
-	AgentLatestVersion = "7.81.1"
+	AgentLatestVersion = "7.83.0"
 	// ClusterAgentLatestVersion corresponds to the latest stable cluster-agent release
-	ClusterAgentLatestVersion = "7.81.1"
+	ClusterAgentLatestVersion = "7.83.0"
 	// DdotCollectorLatestVersion corresponds to the latest stable ddot-collector release
-	DdotCollectorLatestVersion = "7.81.1"
+	DdotCollectorLatestVersion = "7.83.0"
 	// FIPSProxyLatestVersion corresponds to the latest stable fips-proxy release
 	FIPSProxyLatestVersion = "1.1.29"
 	// DDOTFIPSMinimumVersion is the minimum version at which ddot-collector publishes a -fips variant.


### PR DESCRIPTION
* Update golden tests

* test: account for Agent 7.83.0 feature gates

Pin the VSock regression case below the 7.83.0 Remote Agent Registry VSock threshold so it continues to validate the compatibility override.

Update renderer resource expectations because the 7.83.0 defaults satisfy the Instrumentation CRD minimum of 7.82.0, enabling its ClusterRole and ClusterRoleBinding by default.

* test(appsec): update GKE default-version gate test for 7.83.0

images.AgentLatestVersion is now 7.83.0, which is above ClusterAgentGKEMinVersion (7.82.0), so an unpinned cluster-agent no longer gates GKE support off by default. Invert the assertions to match, per the test's own "only means something while below 7.82.0" comment.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits