### PR TITLE
fix(ci): forward image merge strategy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -469,7 +469,43 @@ go_e2e_deps:
       if [[ -n "${IMG_DESTINATIONS_REGEX_REPL:-}" ]]; then args+=(--regex-replacement "${IMG_DESTINATIONS_REGEX_REPL}"); fi
       if [[ -n "${IMG_TAG_REFERENCE:-}" ]]; then args+=(--tag-reference "${IMG_TAG_REFERENCE}"); fi
       if [[ -n "${IMG_NEW_TAGS:-}" ]]; then args+=(--new-tags "${IMG_NEW_TAGS}"); fi
+      if [[ -n "${IMG_MERGE_STRATEGY:-}" ]]; then args+=(--merge-strategy "${IMG_MERGE_STRATEGY}"); fi
       dd-pkg "${args[@]}"
+
+# Exercise the shared argument builder without contacting a registry.
+test_publish_image_merge_strategy:
+  stage: test
+  extends: .docker_publish_job_definition
+  needs: []
+  rules:
+    - if: '$DDR == "true"'
+      when: never
+    - changes:
+        paths:
+          - .gitlab-ci.yml
+        compare_to: refs/heads/main
+    - when: never
+  variables:
+    IMG_MERGE_STRATEGY: "index_oci"
+  before_script:
+    - |
+      dd-pkg() {
+        if [[ "${1:-}" == "version" ]]; then
+          return 0
+        fi
+
+        local args=("$@")
+        local i
+        for ((i = 0; i < ${#args[@]} - 1; i++)); do
+          if [[ "${args[$i]}" == "--merge-strategy" && "${args[$((i + 1))]}" == "${IMG_MERGE_STRATEGY}" ]]; then
+            echo "merge strategy argument forwarded successfully"
+            return 0
+          fi
+        done
+
+        echo "missing --merge-strategy ${IMG_MERGE_STRATEGY} argument" >&2
+        return 1
+      }
 
 trigger_e2e_operator_image:
   stage: e2e


### PR DESCRIPTION
## Summary

- forward `IMG_MERGE_STRATEGY` to `dd-pkg publish-image`
- add a focused CI regression test for the shared argument builder

## Root cause

`publish_redhat_public_tag` in pipeline `135374301` failed because the `dd-pkg` migration stopped forwarding the configured `IMG_MERGE_STRATEGY=index_oci` value.

With the value missing, the downstream publisher used its default strategy and produced a Docker manifest list containing OCI child manifests. Red Hat Quay rejected that mixed manifest as `MANIFEST_INVALID`. All three downstream attempts failed identically, so the failure was deterministic rather than transient.

This PR restores the missing `--merge-strategy index_oci` argument.

## Verification

The focused regression test shadows `dd-pkg` and verifies that the inherited publishing script passes `--merge-strategy index_oci`. It does not contact a registry.

The fix was also tested end-to-end using the exact `v1.30.0-rc.3` amd64 and arm64 source images from the failed release. Red Hat Quay accepted the image in the private partner repository, and an authenticated read-back verified the stored manifest:

`quay.io/redhat-isv-containers/5e7c8ebc1c86a3163d1a69be:merge-strategy-135414526-7525534a`

- [Successful Red Hat publish job](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/2014887820)
- [Successful authenticated manifest verification](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/2014887841)

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:dbc814e11f020034fad42263da89c7ad16d7753fea6ae7b93458d4b7027caeaf",
      "platform": {"architecture": "amd64", "os": "linux"}
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:15b8f106ee96d9529540436cf573256830fba72df5f29fe0ff9eac087cd46e25",
      "platform": {"architecture": "arm64", "os": "linux"}
    }
  ]
}
```

Additional checks:

- local positive test observed `--merge-strategy index_oci`
- negative control without the forwarding line failed as expected
- GitLab CI lint API accepted the configuration

The temporary end-to-end test PR was used only to gather this evidence and was closed without merging.
