### PR TITLE
test(ci): verify published OCI index manifest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -507,6 +507,55 @@ test_publish_image_merge_strategy:
         return 1
       }
 
+# Integration coverage for the stacked test PR only. The destination is the
+# private Red Hat partner repository and the tag is unique to this pipeline.
+publish_merge_strategy_test_image:
+  stage: e2e
+  extends: .docker_publish_job_definition
+  needs: []
+  rules:
+    - if: '$DDR == "true"'
+      when: never
+    - changes:
+        paths:
+          - .gitlab-ci.yml
+        compare_to: refs/heads/main
+    - when: never
+  variables:
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v1.30.0-rc.3-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:v1.30.0-rc.3-arm64
+    IMG_DESTINATIONS: $RH_PARTNER_PROJECT_ID:merge-strategy-${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_REGISTRIES: redhat-operator
+    IMG_SIGNING: "false"
+    IMG_MERGE_STRATEGY: "index_oci"
+
+verify_merge_strategy_test_manifest:
+  stage: release
+  image: $JOB_DOCKER_IMAGE
+  tags: ["arch:amd64"]
+  needs:
+    - publish_merge_strategy_test_image
+  rules:
+    - if: '$DDR == "true"'
+      when: never
+    - changes:
+        paths:
+          - .gitlab-ci.yml
+        compare_to: refs/heads/main
+    - when: never
+  before_script:
+    - aws ssm get-parameter --region us-east-1 --name ci.datadog-operator.$RH_PARTNER_REGISTRY_KEY_SSM_KEY --with-decryption --query "Parameter.Value" --out text | crane auth login "${RH_PARTNER_REGISTRY%%/*}" --username "$RH_PARTNER_REGISTRY_USER" --password-stdin
+  script:
+    - |
+      image="${RH_PARTNER_REGISTRY}/${RH_PARTNER_PROJECT_ID}:merge-strategy-${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+      manifest=$(crane manifest "$image")
+      echo "$manifest" | jq .
+      echo "$manifest" | jq -e '
+        .mediaType == "application/vnd.oci.image.index.v1+json" and
+        all(.manifests[]; .mediaType == "application/vnd.oci.image.manifest.v1+json") and
+        ([.manifests[].platform.architecture] | index("amd64") != null) and
+        ([.manifests[].platform.architecture] | index("arm64") != null)
+      '
+
 trigger_e2e_operator_image:
   stage: e2e
   rules: !reference [.on_run_e2e_base]


### PR DESCRIPTION
### What does this PR do?

Adds a test-only integration layer on top of #3434. It publishes a multi-architecture image with `IMG_MERGE_STRATEGY=index_oci` directly to the private Red Hat partner repository, retrieves the raw manifest from Quay, and verifies its media types.

This PR exists to validate #3434 and is not intended to be merged afterward.

### Motivation

The focused test in #3434 proves that the CLI flag is present. This stacked PR proves that the artifact gateway and public-images pipeline produce a manifest that Red Hat Quay accepts, fixing the reported `MANIFEST_INVALID` failure.

### Additional Notes

The destination is the private Red Hat partner repository. The `merge-strategy-<pipeline>-<sha>` tag is unique to the test pipeline; no release, `latest`, or certification-submission job is used.

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: N/A

### Describe your test plan

DDCI runs two additional jobs:

1. `publish_merge_strategy_test_image` republishes the exact `v1.30.0-rc.3` amd64 and arm64 source images to the Red Hat partner repository using `index_oci`.
2. `verify_merge_strategy_test_manifest` authenticates to Quay, prints the stored raw manifest, and asserts:
   - top-level media type is `application/vnd.oci.image.index.v1+json`
   - all child descriptors use `application/vnd.oci.image.manifest.v1+json`
   - both amd64 and arm64 are present

### Observed result

Red Hat Quay accepted the push and the authenticated read-back passed:

`quay.io/redhat-isv-containers/5e7c8ebc1c86a3163d1a69be:merge-strategy-135414526-7525534a`

- [Successful Red Hat publish job](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/2014887820)
- [Successful Quay manifest verification job](https://gitlab.ddbuild.io/DataDog/datadog-operator/-/jobs/2014887841)

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 1627,
      "digest": "sha256:dbc814e11f020034fad42263da89c7ad16d7753fea6ae7b93458d4b7027caeaf",
      "platform": {"architecture": "amd64", "os": "linux"}
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 1627,
      "digest": "sha256:15b8f106ee96d9529540436cf573256830fba72df5f29fe0ff9eac087cd46e25",
      "platform": {"architecture": "arm64", "os": "linux"}
    }
  ]
}
```

### Checklist

- [x] Test-only stacked PR; production change is isolated in #3434
- [x] No public release or mutable tag is created
- [x] Red Hat Quay accepted the image
- [x] Authenticated manifest read-back passed
- [x] All commits are signed
