### PR TITLE
feat(orchestrator): grant KubeAI collection RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -449,6 +449,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac.go
@@ -152,6 +152,10 @@ func getRBACPolicyRules(logger logr.Logger, crs []string, collectKubernetesNetwo
 			},
 		},
 		{
+			APIGroups: []string{rbac.KubeAIAPIGroup},
+			Resources: []string{rbac.KubeAIModelsResource},
+		},
+		{
 			APIGroups: []string{rbac.DynamoAPIGroup},
 			Resources: []string{
 				rbac.DynamoCheckpointsResource,

--- a/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
+++ b/internal/controller/datadogagent/feature/orchestratorexplorer/rbac_test.go
@@ -52,6 +52,11 @@ func TestGetRBACPolicyRules(t *testing.T) {
 			Verbs: []string{rbac.ListVerb, rbac.WatchVerb},
 		},
 		{
+			APIGroups: []string{rbac.KubeAIAPIGroup},
+			Resources: []string{rbac.KubeAIModelsResource},
+			Verbs:     []string{rbac.ListVerb, rbac.WatchVerb},
+		},
+		{
 			APIGroups: []string{rbac.DynamoAPIGroup},
 			Resources: []string{
 				rbac.DynamoCheckpointsResource,

--- a/internal/controller/datadogagent_controller.go
+++ b/internal/controller/datadogagent_controller.go
@@ -228,6 +228,7 @@ type DatadogAgentReconciler struct {
 // +kubebuilder:rbac:groups=karpenter.azure.com,resources="*",verbs=list;watch
 // +kubebuilder:rbac:groups=eks.amazonaws.com,resources="*",verbs=get;list;watch
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters;raycronjobs;rayjobs;rayservices,verbs=list;watch
+// +kubebuilder:rbac:groups=kubeai.org,resources=models,verbs=list;watch
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamocheckpoints;dynamocomponentdeployments;dynamographdeploymentrequests;dynamographdeployments;dynamographdeploymentscalingadapters;dynamomodels;dynamoworkermetadatas,verbs=list;watch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=clusterstoragecontainers;llminferenceserviceconfigs;llminferenceservices;localmodelcaches;localmodelnamespacecaches;localmodelnodegroups;localmodelnodes;clusterservingruntimes;inferencegraphs;inferenceservices;servingruntimes;trainedmodels,verbs=list;watch
 

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-aks.golden.yaml
@@ -390,6 +390,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -390,6 +390,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-baseline.golden.yaml
@@ -390,6 +390,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-eks-hostname-from-file.golden.yaml
@@ -390,6 +390,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -371,6 +371,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-baseline.golden.yaml
@@ -371,6 +371,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -371,6 +371,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-baseline.golden.yaml
@@ -371,6 +371,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -371,6 +371,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-baseline.golden.yaml
@@ -371,6 +371,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - kubeai.org
+  resources:
+  - models
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - kustomize.toolkit.fluxcd.io
   resources:
   - kustomizations

--- a/pkg/kubernetes/rbac/const.go
+++ b/pkg/kubernetes/rbac/const.go
@@ -45,6 +45,7 @@ const (
 	KarpenterAWSAPIGroup          = "karpenter.k8s.aws"
 	KarpenterAzureAPIGroup        = "karpenter.azure.com"
 	KubeRayAPIGroup               = "ray.io"
+	KubeAIAPIGroup                = "kubeai.org"
 	DynamoAPIGroup                = "nvidia.com"
 	KServeAPIGroup                = "serving.kserve.io"
 
@@ -136,6 +137,7 @@ const (
 	RayCronJobsResource                               = "raycronjobs"
 	RayJobsResource                                   = "rayjobs"
 	RayServicesResource                               = "rayservices"
+	KubeAIModelsResource                              = "models"
 	DynamoCheckpointsResource                         = "dynamocheckpoints"
 	DynamoComponentDeploymentsResource                = "dynamocomponentdeployments"
 	DynamoGraphDeploymentRequestsResource             = "dynamographdeploymentrequests"


### PR DESCRIPTION
### What does this PR do?

Grants `list` and `watch` access to `kubeai.org/models` in Cluster Agent roles generated by the Datadog Operator and in the operator's own RBAC role.

### Motivation

Make KubeAI model manifests collectable by the Cluster Agent without manual RBAC changes. The operator itself needs the same access so it can create the generated Cluster Agent roles.

### Additional Notes

- Agent collection: https://github.com/DataDog/datadog-agent/pull/55892
- Datadog Helm chart RBAC: https://github.com/DataDog/helm-charts/pull/2899
- Internal Datadog Operator chart RBAC: https://github.com/DataDog/k8s-datadog-agent-ops/pull/9650

### Minimum Agent Versions

* Agent: N/A
* Cluster Agent: v7.84.0

### Describe your test plan

- `make generate`
- `make golden-update`
- `go test ./internal/controller/datadogagent/feature/orchestratorexplorer ./pkg/kubernetes/rbac`

### Checklist

- [x] PR has the `enhancement` label
- [x] PR has milestone `v1.31.0`
- [x] All commits are signed
