### PR TITLE
Add code-review-action workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,29 @@
+---
+name: "Code review"
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+    branches:
+      - main
+      - "v[0-9]+.[0-9]+"
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  review:
+    if: ${{ github.event_name != 'pull_request' || (!contains(github.event.pull_request.user.login, '[bot]') && github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'no-draft-review'))) }}
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    uses: DataDog/code-review-action/.github/workflows/code-review.yml@b4f43b4ac7a96b9ecc3484d77aa04ad41c07b420 # v1.3.0
+    with:
+      provider: codex
+      # Review PRs when they are opened or transition out of draft. Use on_demand for issue_comments
+      trigger_mode: ${{ github.event_name == 'pull_request' && 'always' || 'on_demand' }}
+      review_event: COMMENT_ONLY
+    secrets:
+      openai_api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Adds the DataDog/code-review-action reusable workflow as the default PR review workflow, replacing codex.

- provider: `codex`, requires `OPENAI_API_KEY` secret (not yet provisioned)
- telemetry disabled for now (no dd-sts policy set up yet)
- triggers on `main` and `vN.N` release branches, plus `/dd-review` PR comments

Jira: https://datadoghq.atlassian.net/browse/ACIX-1829