### PR TITLE
[CONTP-2021] Support Software Catalog entities (service definitions) in DatadogGenericResource

### DIFF
--- a/api/datadoghq/v1alpha1/datadoggenericresource_types.go
+++ b/api/datadoghq/v1alpha1/datadoggenericresource_types.go
@@ -20,6 +20,7 @@ const (
 	Notebook                SupportedResourcesType = "notebook"
 	SLO                     SupportedResourcesType = "slo"
 	SLOCorrection           SupportedResourcesType = "slo_correction"
+	SoftwareCatalogEntity   SupportedResourcesType = "software_catalog_entity"
 	SyntheticsAPITest       SupportedResourcesType = "synthetics_api_test"
 	SyntheticsBrowserTest   SupportedResourcesType = "synthetics_browser_test"
 )
@@ -28,7 +29,7 @@ const (
 // +k8s:openapi-gen=true
 type DatadogGenericResourceSpec struct {
 	// Type is the type of the API object
-	// +kubebuilder:validation:Enum=dashboard;downtime;monitor;monitor_notification_rule;notebook;slo;slo_correction;synthetics_api_test;synthetics_browser_test
+	// +kubebuilder:validation:Enum=dashboard;downtime;monitor;monitor_notification_rule;notebook;slo;slo_correction;software_catalog_entity;synthetics_api_test;synthetics_browser_test
 	Type SupportedResourcesType `json:"type"`
 	// JsonSpec is the specification of the API object
 	// +kubebuilder:validation:MinLength=1

--- a/config/crd/bases/v1/datadoghq.com_datadoggenericresources.yaml
+++ b/config/crd/bases/v1/datadoghq.com_datadoggenericresources.yaml
@@ -72,6 +72,7 @@ spec:
                     - notebook
                     - slo
                     - slo_correction
+                    - software_catalog_entity
                     - synthetics_api_test
                     - synthetics_browser_test
                   type: string

--- a/config/crd/bases/v1/datadoghq.com_datadoggenericresources_v1alpha1.json
+++ b/config/crd/bases/v1/datadoghq.com_datadoggenericresources_v1alpha1.json
@@ -32,6 +32,7 @@
             "notebook",
             "slo",
             "slo_correction",
+            "software_catalog_entity",
             "synthetics_api_test",
             "synthetics_browser_test"
           ],

--- a/docs/datadoggenericresource/datadog_generic_resource.md
+++ b/docs/datadoggenericresource/datadog_generic_resource.md
@@ -56,6 +56,7 @@ A `DatadogGenericResource` object has two fields:
 | `slo`                     | v1.28.0          | https://docs.datadoghq.com/api/latest/service-level-objectives/#create-an-slo-object  | [SLO manifest](../../examples/datadoggenericresource/slo-sample.yaml)                   |
 | `monitor_notification_rule` | v1.30.0        | https://docs.datadoghq.com/api/latest/monitors/create-a-monitor-notification-rule/    | [Notification rule manifest](../../examples/datadoggenericresource/notification-rule-sample.yaml) |
 | `slo_correction`          | v1.31.0          | https://docs.datadoghq.com/api/latest/service-level-objective-corrections/#create-an-slo-correction | [SLO correction manifest](../../examples/datadoggenericresource/slo-correction-sample.yaml) |
+| `software_catalog_entity` | v1.32.0          | https://docs.datadoghq.com/api/latest/software-catalog/#create-or-update-entity      | [Software Catalog entity manifest](../../examples/datadoggenericresource/software-catalog-entity-sample.yaml) |
 
 ## Prerequisites
 

--- a/examples/datadoggenericresource/software-catalog-entity-sample.yaml
+++ b/examples/datadoggenericresource/software-catalog-entity-sample.yaml
@@ -1,0 +1,29 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogGenericResource
+metadata:
+  name: ddgr-software-catalog-entity-sample
+spec:
+  type: software_catalog_entity
+  # This example registers a "service" entity in Software Catalog. jsonSpec follows
+  # the Entity V3 schema directly (apiVersion/kind/metadata/spec), not a JSON:API
+  # envelope. The Software Catalog API is upsert-shaped: re-applying this manifest
+  # after editing jsonSpec updates the same entity, keyed by kind/namespace/name.
+  jsonSpec: |-
+    {
+      "apiVersion": "v3",
+      "kind": "service",
+      "metadata": {
+        "name": "example-service",
+        "displayName": "Example Service",
+        "description": "Example service entity set by Datadog Generic Resource",
+        "owner": "my-team",
+        "tags": [
+          "env:prod"
+        ]
+      },
+      "spec": {
+        "lifecycle": "production",
+        "tier": "1",
+        "type": "web"
+      }
+    }

--- a/internal/controller/datadoggenericresource/software_catalog_entities.go
+++ b/internal/controller/datadoggenericresource/software_catalog_entities.go
@@ -84,7 +84,7 @@ func (h *SoftwareCatalogEntityHandler) updateResource(auth context.Context, inst
 		// Not a live API error, but treated as one of the same shape (permanent, 400-equivalent) so the
 		// reconciler backs off to forceSyncPeriod instead of retrying every few seconds forever: this
 		// condition never resolves on its own until the user edits the spec back or deletes the CR.
-		immutableErr := fmt.Errorf("cannot update software catalog entity: identity fields kind/metadata.name/metadata.namespace are immutable (was %s/%s/%s, spec now has %s/%s/%s); delete and recreate the resource instead",
+		immutableErr := fmt.Errorf("cannot update software catalog entity: identity fields metadata.namespace/kind/metadata.name are immutable (was %s/%s/%s, spec now has %s/%s/%s); delete and recreate the resource instead",
 			currentAttrs.GetNamespace(), currentAttrs.GetKind(), currentAttrs.GetName(), newIdentity.namespace, newIdentity.kind, newIdentity.name)
 		return ctrutils.NewAPIError(immutableErr, &http.Response{StatusCode: http.StatusBadRequest})
 	}

--- a/internal/controller/datadoggenericresource/software_catalog_entities.go
+++ b/internal/controller/datadoggenericresource/software_catalog_entities.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadoggenericresource
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+)
+
+// SoftwareCatalogEntityHandler manages Software Catalog entities (services,
+// datastores, queues, systems, APIs) through the DDGR CRD.
+//
+// The Software Catalog API is upsert-shaped: UpsertCatalogEntity handles both
+// creation and update of an entity, keyed by its kind/namespace/name rather
+// than by a client-supplied ID. createResource and updateResource both call
+// the same upsertSoftwareCatalogEntity helper; status.id is populated from
+// the ID Datadog assigns in the upsert response and is then used as the
+// stable identifier for get/delete calls. There is no dedicated get-by-id
+// endpoint, so getResource uses ListCatalogEntity filtered by that ID.
+type SoftwareCatalogEntityHandler struct {
+	client *datadogV2.SoftwareCatalogApi
+}
+
+func (h *SoftwareCatalogEntityHandler) createResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) (CreateResult, error) {
+	upserted, err := upsertSoftwareCatalogEntity(auth, h.client, instance)
+	if err != nil {
+		return CreateResult{}, err
+	}
+
+	if len(upserted.Data) == 0 {
+		return CreateResult{}, errors.New("cannot create software catalog entity: upsert response contained no entity data")
+	}
+	entity := upserted.Data[0]
+
+	var createdTime *metav1.Time
+	if entity.Meta != nil && entity.Meta.CreatedAt != nil {
+		if parsed, err := time.Parse(time.RFC3339, *entity.Meta.CreatedAt); err == nil {
+			ct := metav1.NewTime(parsed)
+			createdTime = &ct
+		}
+	}
+
+	return CreateResult{
+		ID:          entity.GetId(),
+		CreatedTime: createdTime,
+	}, nil
+}
+
+func (h *SoftwareCatalogEntityHandler) getResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := getSoftwareCatalogEntity(auth, h.client, instance.Status.Id)
+	return err
+}
+
+func (h *SoftwareCatalogEntityHandler) updateResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {
+	_, err := upsertSoftwareCatalogEntity(auth, h.client, instance)
+	return err
+}
+
+func (h *SoftwareCatalogEntityHandler) deleteResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {
+	return deleteSoftwareCatalogEntity(auth, h.client, instance.Status.Id)
+}
+
+func (h *SoftwareCatalogEntityHandler) refreshState(_ context.Context, _ *v1alpha1.DatadogGenericResource) (*string, error) {
+	return nil, nil
+}
+
+func getSoftwareCatalogEntity(auth context.Context, client *datadogV2.SoftwareCatalogApi, entityID string) (datadogV2.EntityData, error) {
+	if entityID == "" {
+		return datadogV2.EntityData{}, fmt.Errorf("cannot get software catalog entity: entityID is empty")
+	}
+
+	params := datadogV2.NewListCatalogEntityOptionalParameters().WithFilterId(entityID)
+	resp, httpResp, err := client.ListCatalogEntity(auth, *params)
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.EntityData{}, translateClientError(err, httpResp, "error getting software catalog entity")
+	}
+
+	if len(resp.Data) == 0 {
+		return datadogV2.EntityData{}, translateClientError(errors.New("404 Not Found"), &http.Response{StatusCode: http.StatusNotFound}, "error getting software catalog entity")
+	}
+
+	return resp.Data[0], nil
+}
+
+func deleteSoftwareCatalogEntity(auth context.Context, client *datadogV2.SoftwareCatalogApi, entityID string) error {
+	if entityID == "" {
+		return fmt.Errorf("cannot delete software catalog entity: entityID is empty")
+	}
+	httpResponse, err := client.DeleteCatalogEntity(auth, entityID)
+	if httpResponse != nil {
+		defer httpResponse.Body.Close()
+	}
+	if err != nil {
+		if httpResponse != nil && httpResponse.StatusCode == 404 {
+			return nil
+		}
+		return translateClientError(err, httpResponse, "error deleting software catalog entity")
+	}
+	return nil
+}
+
+func upsertSoftwareCatalogEntity(auth context.Context, client *datadogV2.SoftwareCatalogApi, instance *v1alpha1.DatadogGenericResource) (datadogV2.UpsertCatalogEntityResponse, error) {
+	if instance.Spec.JsonSpec == "" {
+		return datadogV2.UpsertCatalogEntityResponse{}, fmt.Errorf("cannot upsert software catalog entity: spec.jsonSpec is empty")
+	}
+
+	body := &datadogV2.UpsertCatalogEntityRequest{}
+	if err := json.Unmarshal([]byte(instance.Spec.JsonSpec), body); err != nil {
+		return datadogV2.UpsertCatalogEntityResponse{}, translateUnmarshalError(err, "error unmarshalling software catalog entity spec")
+	}
+
+	upserted, httpResp, err := client.UpsertCatalogEntity(auth, *body)
+	if httpResp != nil {
+		defer httpResp.Body.Close()
+	}
+	if err != nil {
+		return datadogV2.UpsertCatalogEntityResponse{}, translateClientError(err, httpResp, "error upserting software catalog entity")
+	}
+	return upserted, nil
+}

--- a/internal/controller/datadoggenericresource/software_catalog_entities.go
+++ b/internal/controller/datadoggenericresource/software_catalog_entities.go
@@ -84,9 +84,9 @@ func (h *SoftwareCatalogEntityHandler) updateResource(auth context.Context, inst
 		// Not a live API error, but treated as one of the same shape (permanent, 400-equivalent) so the
 		// reconciler backs off to forceSyncPeriod instead of retrying every few seconds forever: this
 		// condition never resolves on its own until the user edits the spec back or deletes the CR.
-		err := fmt.Errorf("cannot update software catalog entity: identity fields kind/metadata.name/metadata.namespace are immutable (was %s/%s/%s, spec now has %s/%s/%s); delete and recreate the resource instead",
+		immutableErr := fmt.Errorf("cannot update software catalog entity: identity fields kind/metadata.name/metadata.namespace are immutable (was %s/%s/%s, spec now has %s/%s/%s); delete and recreate the resource instead",
 			currentAttrs.GetNamespace(), currentAttrs.GetKind(), currentAttrs.GetName(), newIdentity.namespace, newIdentity.kind, newIdentity.name)
-		return ctrutils.NewAPIError(err, &http.Response{StatusCode: http.StatusBadRequest})
+		return ctrutils.NewAPIError(immutableErr, &http.Response{StatusCode: http.StatusBadRequest})
 	}
 
 	_, err = upsertSoftwareCatalogEntity(auth, h.client, instance)

--- a/internal/controller/datadoggenericresource/software_catalog_entities.go
+++ b/internal/controller/datadoggenericresource/software_catalog_entities.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	ctrutils "github.com/DataDog/datadog-operator/pkg/controller/utils"
 )
 
 // SoftwareCatalogEntityHandler manages Software Catalog entities (services,
@@ -64,8 +65,60 @@ func (h *SoftwareCatalogEntityHandler) getResource(auth context.Context, instanc
 }
 
 func (h *SoftwareCatalogEntityHandler) updateResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {
-	_, err := upsertSoftwareCatalogEntity(auth, h.client, instance)
+	// UpsertCatalogEntity is keyed by kind/namespace/name, not by instance.Status.Id: if the
+	// spec's identity fields changed, the upsert would create a second entity under the new
+	// identity rather than update the one we're tracking, orphaning the old entity and leaving
+	// the new one unmanaged. Reject identity changes instead of silently leaking a duplicate.
+	current, err := getSoftwareCatalogEntity(auth, h.client, instance.Status.Id)
+	if err != nil {
+		return err
+	}
+
+	newIdentity, err := parseEntityIdentity(instance.Spec.JsonSpec)
+	if err != nil {
+		return translateUnmarshalError(err, "error parsing software catalog entity identity")
+	}
+
+	currentAttrs := current.GetAttributes()
+	if newIdentity.kind != currentAttrs.GetKind() || newIdentity.name != currentAttrs.GetName() || newIdentity.namespace != currentAttrs.GetNamespace() {
+		// Not a live API error, but treated as one of the same shape (permanent, 400-equivalent) so the
+		// reconciler backs off to forceSyncPeriod instead of retrying every few seconds forever: this
+		// condition never resolves on its own until the user edits the spec back or deletes the CR.
+		err := fmt.Errorf("cannot update software catalog entity: identity fields kind/metadata.name/metadata.namespace are immutable (was %s/%s/%s, spec now has %s/%s/%s); delete and recreate the resource instead",
+			currentAttrs.GetNamespace(), currentAttrs.GetKind(), currentAttrs.GetName(), newIdentity.namespace, newIdentity.kind, newIdentity.name)
+		return ctrutils.NewAPIError(err, &http.Response{StatusCode: http.StatusBadRequest})
+	}
+
+	_, err = upsertSoftwareCatalogEntity(auth, h.client, instance)
 	return err
+}
+
+// entityIdentity is the kind/namespace/name tuple that UpsertCatalogEntity uses to key an
+// entity; it is read generically off spec.jsonSpec since Entity V3's oneOf kinds (service,
+// datastore, queue, system, api) all share this same top-level shape.
+type entityIdentity struct {
+	kind      string
+	name      string
+	namespace string
+}
+
+func parseEntityIdentity(jsonSpec string) (entityIdentity, error) {
+	var parsed struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(jsonSpec), &parsed); err != nil {
+		return entityIdentity{}, err
+	}
+
+	namespace := parsed.Metadata.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+	return entityIdentity{kind: parsed.Kind, name: parsed.Metadata.Name, namespace: namespace}, nil
 }
 
 func (h *SoftwareCatalogEntityHandler) deleteResource(auth context.Context, instance *v1alpha1.DatadogGenericResource) error {

--- a/internal/controller/datadoggenericresource/software_catalog_entities_test.go
+++ b/internal/controller/datadoggenericresource/software_catalog_entities_test.go
@@ -1,0 +1,190 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package datadoggenericresource
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	datadogapi "github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+)
+
+func Test_upsertSoftwareCatalogEntity_marshalling(t *testing.T) {
+	tests := []struct {
+		name      string
+		jsonSpec  string
+		wantErr   bool
+		wantName  string
+		wantOwner string
+	}{
+		{
+			name: "valid service entity",
+			jsonSpec: `{
+				"apiVersion": "v3",
+				"kind": "service",
+				"metadata": {
+					"name": "test-service",
+					"owner": "test-team"
+				},
+				"spec": {
+					"tier": "1"
+				}
+			}`,
+			wantName:  "test-service",
+			wantOwner: "test-team",
+		},
+		{name: "empty jsonSpec", jsonSpec: "", wantErr: true},
+		{name: "invalid JSON", jsonSpec: `{invalid`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				capturedBody, err = io.ReadAll(r.Body)
+				require.NoError(t, err)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"data":[{"id":"entity-abc","type":"entity","attributes":{"kind":"service","name":"test-service"},"meta":{"createdAt":"2026-01-01T00:00:00Z"}}]}`))
+			}))
+			defer server.Close()
+
+			cfg := datadogapi.NewConfiguration()
+			cfg.HTTPClient = server.Client()
+			client := datadogV2.NewSoftwareCatalogApi(datadogapi.NewAPIClient(cfg))
+			auth := setupTestAuth(server.URL)
+
+			instance := &v1alpha1.DatadogGenericResource{
+				Spec: v1alpha1.DatadogGenericResourceSpec{JsonSpec: tt.jsonSpec},
+			}
+
+			_, err := upsertSoftwareCatalogEntity(auth, client, instance)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			var sent datadogV2.EntityV3
+			require.NoError(t, json.Unmarshal(capturedBody, &sent))
+			require.NotNil(t, sent.EntityV3Service)
+			assert.Equal(t, tt.wantName, sent.EntityV3Service.Metadata.Name)
+			assert.Equal(t, tt.wantOwner, sent.EntityV3Service.Metadata.GetOwner())
+		})
+	}
+}
+
+func Test_createResource_populatesIDAndCreatedTime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[{"id":"entity-abc","type":"entity","attributes":{"kind":"service","name":"test-service"},"meta":{"createdAt":"2026-01-01T00:00:00Z"}}]}`))
+	}))
+	defer server.Close()
+
+	cfg := datadogapi.NewConfiguration()
+	cfg.HTTPClient = server.Client()
+	client := datadogV2.NewSoftwareCatalogApi(datadogapi.NewAPIClient(cfg))
+	auth := setupTestAuth(server.URL)
+
+	handler := &SoftwareCatalogEntityHandler{client: client}
+	instance := &v1alpha1.DatadogGenericResource{
+		Spec: v1alpha1.DatadogGenericResourceSpec{
+			JsonSpec: `{"apiVersion":"v3","kind":"service","metadata":{"name":"test-service"}}`,
+		},
+	}
+
+	result, err := handler.createResource(auth, instance)
+	require.NoError(t, err)
+	assert.Equal(t, "entity-abc", result.ID)
+	require.NotNil(t, result.CreatedTime)
+	assert.Equal(t, 2026, result.CreatedTime.Year())
+}
+
+func Test_getSoftwareCatalogEntity(t *testing.T) {
+	tests := []struct {
+		name       string
+		entityID   string
+		statusCode int
+		body       string
+		wantErr    bool
+	}{
+		{
+			name:       "entity found",
+			entityID:   "entity-abc",
+			statusCode: http.StatusOK,
+			body:       `{"data":[{"id":"entity-abc","type":"entity","attributes":{"kind":"service","name":"test-service"}}]}`,
+		},
+		{
+			name:       "entity not found (empty data)",
+			entityID:   "entity-missing",
+			statusCode: http.StatusOK,
+			body:       `{"data":[]}`,
+			wantErr:    true,
+		},
+		{
+			name:     "empty entityID",
+			entityID: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newTestHTTPServer(tt.statusCode, tt.body)
+			defer server.Close()
+
+			cfg := datadogapi.NewConfiguration()
+			cfg.HTTPClient = server.Client()
+			client := datadogV2.NewSoftwareCatalogApi(datadogapi.NewAPIClient(cfg))
+			auth := setupTestAuth(server.URL)
+
+			_, err := getSoftwareCatalogEntity(auth, client, tt.entityID)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_deleteSoftwareCatalogEntity_idempotent(t *testing.T) {
+	for _, tc := range defaultDeleteCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestHTTPServer(tc.statusCode, tc.body)
+			defer server.Close()
+
+			cfg := datadogapi.NewConfiguration()
+			cfg.HTTPClient = server.Client()
+			client := datadogV2.NewSoftwareCatalogApi(datadogapi.NewAPIClient(cfg))
+			auth := setupTestAuth(server.URL)
+
+			err := deleteSoftwareCatalogEntity(auth, client, "entity-123")
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_softwareCatalogEntityHandler_refreshState(t *testing.T) {
+	handler := &SoftwareCatalogEntityHandler{}
+	state, err := handler.refreshState(nil, &v1alpha1.DatadogGenericResource{})
+	assert.NoError(t, err)
+	assert.Nil(t, state)
+}

--- a/internal/controller/datadoggenericresource/software_catalog_entities_test.go
+++ b/internal/controller/datadoggenericresource/software_catalog_entities_test.go
@@ -182,6 +182,66 @@ func Test_deleteSoftwareCatalogEntity_idempotent(t *testing.T) {
 	}
 }
 
+func Test_updateResource_rejectsIdentityChange(t *testing.T) {
+	tests := []struct {
+		name        string
+		newJsonSpec string
+		wantErr     bool
+	}{
+		{
+			name:        "same identity, update proceeds",
+			newJsonSpec: `{"apiVersion":"v3","kind":"service","metadata":{"name":"test-service","namespace":"default","owner":"new-team"}}`,
+		},
+		{
+			name:        "name changed, rejected",
+			newJsonSpec: `{"apiVersion":"v3","kind":"service","metadata":{"name":"renamed-service","namespace":"default"}}`,
+			wantErr:     true,
+		},
+		{
+			name:        "kind changed, rejected",
+			newJsonSpec: `{"apiVersion":"v3","kind":"datastore","metadata":{"name":"test-service","namespace":"default"}}`,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var upsertCalled bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				if r.Method == http.MethodGet {
+					_, _ = w.Write([]byte(`{"data":[{"id":"entity-abc","type":"entity","attributes":{"kind":"service","name":"test-service","namespace":"default"}}]}`))
+					return
+				}
+				upsertCalled = true
+				_, _ = w.Write([]byte(`{"data":[{"id":"entity-abc","type":"entity","attributes":{"kind":"service","name":"test-service","namespace":"default"}}]}`))
+			}))
+			defer server.Close()
+
+			cfg := datadogapi.NewConfiguration()
+			cfg.HTTPClient = server.Client()
+			client := datadogV2.NewSoftwareCatalogApi(datadogapi.NewAPIClient(cfg))
+			auth := setupTestAuth(server.URL)
+
+			handler := &SoftwareCatalogEntityHandler{client: client}
+			instance := &v1alpha1.DatadogGenericResource{
+				Spec:   v1alpha1.DatadogGenericResourceSpec{JsonSpec: tt.newJsonSpec},
+				Status: v1alpha1.DatadogGenericResourceStatus{Id: "entity-abc"},
+			}
+
+			err := handler.updateResource(auth, instance)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.False(t, upsertCalled, "upsert must not be called when the identity would change")
+				return
+			}
+			assert.NoError(t, err)
+			assert.True(t, upsertCalled)
+		})
+	}
+}
+
 func Test_softwareCatalogEntityHandler_refreshState(t *testing.T) {
 	handler := &SoftwareCatalogEntityHandler{}
 	state, err := handler.refreshState(nil, &v1alpha1.DatadogGenericResource{})

--- a/internal/controller/datadoggenericresource/utils.go
+++ b/internal/controller/datadoggenericresource/utils.go
@@ -25,6 +25,7 @@ func buildHandlers(clients *datadogclient.GenericClients) map[v1alpha1.Supported
 		v1alpha1.Notebook:                &NotebookHandler{client: clients.NotebooksClient},
 		v1alpha1.SLO:                     &SLOHandler{client: clients.SLOsClient},
 		v1alpha1.SLOCorrection:           &SLOCorrectionHandler{client: clients.SLOCorrectionsClient},
+		v1alpha1.SoftwareCatalogEntity:   &SoftwareCatalogEntityHandler{client: clients.SoftwareCatalogClient},
 		v1alpha1.SyntheticsAPITest:       &SyntheticsAPITestHandler{client: clients.SyntheticsClient},
 		v1alpha1.SyntheticsBrowserTest:   &SyntheticsBrowserTestHandler{client: clients.SyntheticsClient},
 	}

--- a/pkg/datadogclient/client.go
+++ b/pkg/datadogclient/client.go
@@ -42,6 +42,7 @@ type GenericClients struct {
 	SLOCorrectionsClient           *datadogV1.ServiceLevelObjectiveCorrectionsApi
 	DowntimesClient                *datadogV2.DowntimesApi
 	MonitorNotificationRulesClient *datadogV2.MonitorsApi
+	SoftwareCatalogClient          *datadogV2.SoftwareCatalogApi
 }
 
 // InitGenericClients creates stateless Datadog API clients for generic resource operations.
@@ -57,5 +58,6 @@ func InitGenericClients() *GenericClients {
 		SLOCorrectionsClient:           datadogV1.NewServiceLevelObjectiveCorrectionsApi(apiClient),
 		DowntimesClient:                datadogV2.NewDowntimesApi(apiClient),
 		MonitorNotificationRulesClient: datadogV2.NewMonitorsApi(apiClient),
+		SoftwareCatalogClient:          datadogV2.NewSoftwareCatalogApi(apiClient),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Support managing Service Catalog entities via `DatadogGenericResources`

### Motivation

Provide a way to customers to manage service/entity metadata declaratively alongside the rest of their Operator-managed Datadog resources.

### Additional Notes

This implementation is scoped to the Software Catalog entity surface. It does not implement the same support for the legacy service definition schema v1 / v2 / v2.1 / v2.2.

### Describe your test plan

Added unit tests.

Manual testing is advised:

#### Setup
Deploy the operator with `-datadogGenericResourceEnabled=true`


#### Creation

Apply the sample manifest.

```
kubectl apply -f examples/datadoggenericresource/software-catalog-entity-sample.yaml
kubectl get datadoggenericresource ddgr-software-catalog-entity-sample -o yaml
```

Verify: `status.id` is set, `status.syncStatus` is `OK`, and the entity shows up in Software Catalog in the Datadog UI.

#### Update


Edit `tier` (or any field) in `spec.jsonSpec`, then re-apply.
```
kubectl apply -f examples/datadoggenericresource/software-catalog-entity-sample.yaml
kubectl get datadoggenericresource ddgr-software-catalog-entity-sample -o yaml
```
Verify: `status.id` is unchanged (same entity updated, not a duplicate) and the entity's `modifiedAt` in the catalog is newer.

#### Delete

```
kubectl delete -f examples/datadoggenericresource/software-catalog-entity-sample.yaml
```

Verify: the CR is removed and the finalizer clears (no hang), and the entity is gone from Software Catalog.

#### Delete idempotency (404 handling)

Delete the entity directly from the Datadog UI (or via the API) first, then delete the CR:
```
kubectl delete -f examples/datadoggenericresource/software-catalog-entity-sample.yaml
```
Verify: the finalizer still clears cleanly even though the entity is already gone (no stuck CR, no error loop).



### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits