### PR TITLE
Private Action Runner split mode support

### DIFF
--- a/examples/datadogagent/datadog-agent-with-private-action-runner.yaml
+++ b/examples/datadogagent/datadog-agent-with-private-action-runner.yaml
@@ -13,6 +13,8 @@ metadata:
   annotations:
     # Enable Private Action Runner for Node Agent
     agent.datadoghq.com/private-action-runner-enabled: "true"
+    # Opt into split mode (Agent 7.84+)
+    agent.datadoghq.com/private-action-runner-split-enabled: "false"
     # Grant PAR access to host systemd and select persistent, volatile, or both journal stores
     agent.datadoghq.com/private-action-runner-systemd-enabled: "true"
     agent.datadoghq.com/private-action-runner-systemd-journal-storage: "persistent"

--- a/examples/datadogagent/datadog-agent-with-private-action-runner.yaml
+++ b/examples/datadogagent/datadog-agent-with-private-action-runner.yaml
@@ -13,8 +13,6 @@ metadata:
   annotations:
     # Enable Private Action Runner for Node Agent
     agent.datadoghq.com/private-action-runner-enabled: "true"
-    # Opt into split mode (Agent 7.84+)
-    agent.datadoghq.com/private-action-runner-split-enabled: "false"
     # Grant PAR access to host systemd and select persistent, volatile, or both journal stores
     agent.datadoghq.com/private-action-runner-systemd-enabled: "true"
     agent.datadoghq.com/private-action-runner-systemd-journal-storage: "persistent"

--- a/internal/controller/datadogagent/feature/privateactionrunner/const.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/const.go
@@ -8,6 +8,14 @@ package privateactionrunner
 const (
 	PrivateActionRunnerConfigPath = "/etc/datadog-agent/privateactionrunner.yaml"
 
+	privateActionRunnerSplitMinVersion = "7.84.0-0"
+	privateActionRunnerEntrypoint      = "/opt/entrypoints/privateactionrunner"
+	privateActionRunnerProbe           = "/par-probe.sh"
+	privateActionRunnerRunPath         = "/opt/datadog-agent/run"
+	privateActionRunnerSocketPath      = privateActionRunnerRunPath + "/dd-procmgrd.sock"
+	privateActionRunnerRunVolumeName   = "private-action-runner-run"
+	privateActionRunnerGracePeriod     = int64(190)
+
 	privateActionRunnerVolumeNameSuffix = "privateactionrunner-config"
 	privateActionRunnerFileName         = "privateactionrunner.yaml"
 	privateActionRunnerSuffix           = "private-action-runner"

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -74,7 +73,7 @@ func (f *privateActionRunnerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 			if pkgutils.IsAboveMinVersion(version, privateActionRunnerSplitMinVersion, nil) {
 				f.splitEnabled = true
 			} else {
-				f.splitConfigErr = fmt.Errorf("Private Action Runner split mode requires Agent >= %s, got %s", privateActionRunnerSplitMinVersion, version)
+				f.splitConfigErr = fmt.Errorf("private action runner split mode requires Agent >= %s, got %s", privateActionRunnerSplitMinVersion, version)
 			}
 		}
 
@@ -306,7 +305,7 @@ func (f *privateActionRunnerFeature) ManageNodeAgent(managers feature.PodTemplat
 
 		podTemplate := managers.PodTemplateSpec()
 		if podTemplate.Spec.TerminationGracePeriodSeconds == nil || *podTemplate.Spec.TerminationGracePeriodSeconds < privateActionRunnerGracePeriod {
-			podTemplate.Spec.TerminationGracePeriodSeconds = ptr.To(privateActionRunnerGracePeriod)
+			podTemplate.Spec.TerminationGracePeriodSeconds = new(privateActionRunnerGracePeriod)
 		}
 		for i := range podTemplate.Spec.Containers {
 			if podTemplate.Spec.Containers[i].Name == string(apicommon.PrivateActionRunnerContainerName) {

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -15,10 +15,12 @@ import (
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	featureutils "github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/utils"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
+	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 	pkgutils "github.com/DataDog/datadog-operator/pkg/utils"
 )
@@ -69,7 +71,12 @@ func (f *privateActionRunnerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 		f.nodeEnabled = true
 		f.systemdConfig, f.systemdConfigErr = systemdHostConfigFromAnnotations(dda.GetAnnotations())
 		if featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnablePrivateActionRunnerSplitAnnotation) {
-			version := common.GetComponentVersion(dda, v2alpha1.NodeAgentComponentName)
+			image := images.GetLatestAgentImage()
+			if override := ddaSpec.Override[v2alpha1.NodeAgentComponentName]; override != nil && override.Image != nil {
+				image = images.OverrideAgentImage(image, override.Image)
+			}
+			image, _ = experimental.ResolveImageOverride(dda, string(apicommon.PrivateActionRunnerContainerName), image)
+			version := common.GetAgentVersionFromImage(v2alpha1.AgentImageConfig{Name: image})
 			if pkgutils.IsAboveMinVersion(version, privateActionRunnerSplitMinVersion, new(false)) {
 				f.splitEnabled = true
 			} else {

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -70,7 +70,7 @@ func (f *privateActionRunnerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 		f.systemdConfig, f.systemdConfigErr = systemdHostConfigFromAnnotations(dda.GetAnnotations())
 		if featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnablePrivateActionRunnerSplitAnnotation) {
 			version := common.GetComponentVersion(dda, v2alpha1.NodeAgentComponentName)
-			if pkgutils.IsAboveMinVersion(version, privateActionRunnerSplitMinVersion, nil) {
+			if pkgutils.IsAboveMinVersion(version, privateActionRunnerSplitMinVersion, new(false)) {
 				f.splitEnabled = true
 			} else {
 				f.splitConfigErr = fmt.Errorf("private action runner split mode requires Agent >= %s, got %s", privateActionRunnerSplitMinVersion, version)

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
@@ -20,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/object/volume"
 	"github.com/DataDog/datadog-operator/pkg/constants"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	pkgutils "github.com/DataDog/datadog-operator/pkg/utils"
 )
 
 func init() {
@@ -42,6 +44,8 @@ type privateActionRunnerFeature struct {
 	logger                    logr.Logger
 	nodeEnabled               bool
 	nodeConfigData            string
+	splitEnabled              bool
+	splitConfigErr            error
 	systemdConfig             systemdHostConfig
 	systemdConfigErr          error
 	clusterConfig             *PrivateActionRunnerConfig
@@ -65,6 +69,14 @@ func (f *privateActionRunnerFeature) Configure(dda metav1.Object, ddaSpec *v2alp
 	if featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnablePrivateActionRunnerAnnotation) {
 		f.nodeEnabled = true
 		f.systemdConfig, f.systemdConfigErr = systemdHostConfigFromAnnotations(dda.GetAnnotations())
+		if featureutils.HasFeatureEnableAnnotation(dda, featureutils.EnablePrivateActionRunnerSplitAnnotation) {
+			version := common.GetComponentVersion(dda, v2alpha1.NodeAgentComponentName)
+			if pkgutils.IsAboveMinVersion(version, privateActionRunnerSplitMinVersion, nil) {
+				f.splitEnabled = true
+			} else {
+				f.splitConfigErr = fmt.Errorf("Private Action Runner split mode requires Agent >= %s, got %s", privateActionRunnerSplitMinVersion, version)
+			}
+		}
 
 		// Use config data from annotation directly, or fall back to default
 		if configData, ok := featureutils.GetFeatureConfigAnnotation(dda, featureutils.PrivateActionRunnerConfigDataAnnotation); ok {
@@ -250,6 +262,9 @@ func (f *privateActionRunnerFeature) ManageNodeAgent(managers feature.PodTemplat
 	if f.systemdConfigErr != nil {
 		return fmt.Errorf("invalid Private Action Runner systemd configuration: %w", f.systemdConfigErr)
 	}
+	if f.splitConfigErr != nil {
+		return f.splitConfigErr
+	}
 
 	configMapName := f.getConfigMapName()
 
@@ -267,6 +282,45 @@ func (f *privateActionRunnerFeature) ManageNodeAgent(managers feature.PodTemplat
 		ReadOnly:  true,
 	}
 	managers.VolumeMount().AddVolumeMountToContainer(&volMount, apicommon.PrivateActionRunnerContainerName)
+
+	if f.splitEnabled {
+		runVolume := corev1.Volume{
+			Name: privateActionRunnerRunVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}
+		managers.Volume().AddVolume(&runVolume)
+		managers.VolumeMount().AddVolumeMountToContainer(&corev1.VolumeMount{
+			Name:      privateActionRunnerRunVolumeName,
+			MountPath: privateActionRunnerRunPath,
+		}, apicommon.PrivateActionRunnerContainerName)
+
+		for _, env := range []*corev1.EnvVar{
+			{Name: "DD_PRIVATE_ACTION_RUNNER_SPLIT_ENABLED", Value: "true"},
+			{Name: "DD_PRIVATE_ACTION_RUNNER_EXTRA_CONFIG_PATH", Value: PrivateActionRunnerConfigPath},
+			{Name: "DD_PM_SOCKET_PATH", Value: privateActionRunnerSocketPath},
+		} {
+			managers.EnvVar().AddEnvVarToContainer(apicommon.PrivateActionRunnerContainerName, env)
+		}
+
+		podTemplate := managers.PodTemplateSpec()
+		if podTemplate.Spec.TerminationGracePeriodSeconds == nil || *podTemplate.Spec.TerminationGracePeriodSeconds < privateActionRunnerGracePeriod {
+			podTemplate.Spec.TerminationGracePeriodSeconds = ptr.To(privateActionRunnerGracePeriod)
+		}
+		for i := range podTemplate.Spec.Containers {
+			if podTemplate.Spec.Containers[i].Name == string(apicommon.PrivateActionRunnerContainerName) {
+				podTemplate.Spec.Containers[i].Command = []string{privateActionRunnerEntrypoint}
+				podTemplate.Spec.Containers[i].Args = nil
+				podTemplate.Spec.Containers[i].ReadinessProbe = &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{Command: []string{privateActionRunnerProbe}},
+					},
+				}
+				break
+			}
+		}
+	}
 
 	// procdir volume mount
 	procdirVol, procdirVolMount := volume.GetVolumes(common.ProcdirVolumeName, common.ProcdirHostPath, common.ProcdirMountPath, true)

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
@@ -151,6 +151,139 @@ func Test_privateActionRunnerFeature_ManageNodeAgent(t *testing.T) {
 	assert.Empty(t, managers.AnnotationMgr.Annotations)
 }
 
+func Test_privateActionRunnerFeature_ManageNodeAgentSplitMode(t *testing.T) {
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dda",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"agent.datadoghq.com/private-action-runner-enabled":       "true",
+				"agent.datadoghq.com/private-action-runner-split-enabled": "true",
+			},
+		},
+		Spec: v2alpha1.DatadogAgentSpec{
+			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+				v2alpha1.NodeAgentComponentName: {
+					Image: &v2alpha1.AgentImageConfig{Tag: "7.84.0"},
+				},
+			},
+		},
+	}
+	f := buildPrivateActionRunnerFeature(nil)
+	f.Configure(dda, &dda.Spec, nil)
+
+	gracePeriod := int64(30)
+	managers := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: &gracePeriod,
+			Containers: []corev1.Container{
+				{
+					Name:    string(apicommon.PrivateActionRunnerContainerName),
+					Command: []string{"privateactionrunner", "run"},
+					Args:    []string{"-c=/etc/datadog-agent/datadog.yaml"},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, f.ManageNodeAgent(managers))
+
+	parContainer := managers.PodTemplateSpec().Spec.Containers[0]
+	assert.Equal(t, []string{privateActionRunnerEntrypoint}, parContainer.Command)
+	assert.Empty(t, parContainer.Args)
+	require.NotNil(t, parContainer.ReadinessProbe)
+	require.NotNil(t, parContainer.ReadinessProbe.Exec)
+	assert.Equal(t, []string{privateActionRunnerProbe}, parContainer.ReadinessProbe.Exec.Command)
+	assert.Equal(t, privateActionRunnerGracePeriod, *managers.PodTemplateSpec().Spec.TerminationGracePeriodSeconds)
+
+	var runVolumeFound bool
+	for _, volume := range managers.VolumeMgr.Volumes {
+		if volume.Name == privateActionRunnerRunVolumeName {
+			runVolumeFound = true
+			require.NotNil(t, volume.EmptyDir)
+		}
+	}
+	assert.True(t, runVolumeFound)
+
+	var runMountFound bool
+	for _, mount := range managers.VolumeMountMgr.VolumeMountsByC[apicommon.PrivateActionRunnerContainerName] {
+		if mount.Name == privateActionRunnerRunVolumeName {
+			runMountFound = true
+			assert.Equal(t, privateActionRunnerRunPath, mount.MountPath)
+		}
+	}
+	assert.True(t, runMountFound)
+
+	envs := managers.EnvVarMgr.EnvVarsByC[apicommon.PrivateActionRunnerContainerName]
+	assert.Contains(t, envs, &corev1.EnvVar{Name: "DD_PRIVATE_ACTION_RUNNER_SPLIT_ENABLED", Value: "true"})
+	assert.Contains(t, envs, &corev1.EnvVar{Name: "DD_PRIVATE_ACTION_RUNNER_EXTRA_CONFIG_PATH", Value: PrivateActionRunnerConfigPath})
+	assert.Contains(t, envs, &corev1.EnvVar{Name: "DD_PM_SOCKET_PATH", Value: privateActionRunnerSocketPath})
+}
+
+func Test_privateActionRunnerFeature_ManageNodeAgentMonolithicMode(t *testing.T) {
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dda",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"agent.datadoghq.com/private-action-runner-enabled":       "true",
+				"agent.datadoghq.com/private-action-runner-split-enabled": "false",
+			},
+		},
+	}
+	f := buildPrivateActionRunnerFeature(nil)
+	f.Configure(dda, &dda.Spec, nil)
+
+	command := []string{"privateactionrunner", "run"}
+	args := []string{"-c=/etc/datadog-agent/datadog.yaml"}
+	gracePeriod := int64(30)
+	managers := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: &gracePeriod,
+			Containers: []corev1.Container{{
+				Name:    string(apicommon.PrivateActionRunnerContainerName),
+				Command: command,
+				Args:    args,
+			}},
+		},
+	})
+
+	require.NoError(t, f.ManageNodeAgent(managers))
+
+	parContainer := managers.PodTemplateSpec().Spec.Containers[0]
+	assert.Equal(t, command, parContainer.Command)
+	assert.Equal(t, args, parContainer.Args)
+	assert.Nil(t, parContainer.ReadinessProbe)
+	assert.Equal(t, gracePeriod, *managers.PodTemplateSpec().Spec.TerminationGracePeriodSeconds)
+	assert.Empty(t, managers.EnvVarMgr.EnvVarsByC[apicommon.PrivateActionRunnerContainerName])
+	for _, volume := range managers.VolumeMgr.Volumes {
+		assert.NotEqual(t, privateActionRunnerRunVolumeName, volume.Name)
+	}
+}
+
+func Test_privateActionRunnerFeature_RejectsSplitModeOnOldAgent(t *testing.T) {
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"agent.datadoghq.com/private-action-runner-enabled":       "true",
+				"agent.datadoghq.com/private-action-runner-split-enabled": "true",
+			},
+		},
+		Spec: v2alpha1.DatadogAgentSpec{
+			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+				v2alpha1.NodeAgentComponentName: {
+					Image: &v2alpha1.AgentImageConfig{Tag: "7.83.0"},
+				},
+			},
+		},
+	}
+	f := buildPrivateActionRunnerFeature(nil)
+	f.Configure(dda, &dda.Spec, nil)
+
+	err := f.ManageNodeAgent(fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{}))
+	require.ErrorContains(t, err, "split mode requires Agent >= 7.84.0-0")
+}
+
 // Test_privateActionRunnerFeature_ProfileDDAI_ConfigMapNames verifies that when PAR is
 // enabled on a profile DDAI (whose name differs from the parent DDA), the ConfigMaps are
 // named after the DDA (not the DDAI) so all profile DDAIs share the same ConfigMap.

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
@@ -8,6 +8,7 @@ package privateactionrunner
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -17,10 +18,13 @@ import (
 	apicommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/common"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/experimental"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/store"
+	"github.com/DataDog/datadog-operator/pkg/images"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
+	pkgutils "github.com/DataDog/datadog-operator/pkg/utils"
 )
 
 func Test_privateActionRunnerFeature_Configure(t *testing.T) {
@@ -285,7 +289,6 @@ func Test_privateActionRunnerFeature_RejectsSplitModeOnOldAgent(t *testing.T) {
 }
 
 func Test_privateActionRunnerFeature_RejectsSplitModeOnUnknownAgentVersion(t *testing.T) {
-	pullPolicy := corev1.PullAlways
 	dda := &v2alpha1.DatadogAgent{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -296,7 +299,7 @@ func Test_privateActionRunnerFeature_RejectsSplitModeOnUnknownAgentVersion(t *te
 		Spec: v2alpha1.DatadogAgentSpec{
 			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
 				v2alpha1.NodeAgentComponentName: {
-					Image: &v2alpha1.AgentImageConfig{PullPolicy: &pullPolicy},
+					Image: &v2alpha1.AgentImageConfig{Tag: "dev"},
 				},
 			},
 		},
@@ -306,6 +309,113 @@ func Test_privateActionRunnerFeature_RejectsSplitModeOnUnknownAgentVersion(t *te
 
 	err := f.ManageNodeAgent(fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{}))
 	require.ErrorContains(t, err, "split mode requires Agent >= 7.84.0-0")
+}
+
+func Test_privateActionRunnerFeature_SplitModeImageOverrides(t *testing.T) {
+	tests := []struct {
+		name         string
+		image        v2alpha1.AgentImageConfig
+		experimental string
+		wantVersion  string
+		wantError    bool
+	}{
+		{
+			name:         "older PAR override",
+			image:        v2alpha1.AgentImageConfig{Tag: "7.84.0"},
+			experimental: `{"private-action-runner":{"tag":"7.83.0"}}`,
+			wantVersion:  "7.83.0", wantError: true,
+		},
+		{
+			name:         "newer PAR override",
+			image:        v2alpha1.AgentImageConfig{Tag: "7.83.0"},
+			experimental: `{"private-action-runner":{"tag":"7.84.0"}}`,
+			wantVersion:  "7.84.0",
+		},
+		{
+			name:         "full image name takes precedence over tag",
+			image:        v2alpha1.AgentImageConfig{Tag: "7.84.0"},
+			experimental: `{"private-action-runner":{"name":"example.com/agent:7.83.0","tag":"7.84.0"}}`,
+			wantVersion:  "7.83.0", wantError: true,
+		},
+		{
+			name:         "name-only override inherits component tag",
+			image:        v2alpha1.AgentImageConfig{Tag: "7.84.0"},
+			experimental: `{"private-action-runner":{"name":"custom-agent"}}`,
+			wantVersion:  "7.84.0",
+		},
+		{
+			name:         "unrelated container override",
+			image:        v2alpha1.AgentImageConfig{Tag: "7.83.0"},
+			experimental: `{"agent":{"tag":"7.84.0"}}`,
+			wantVersion:  "7.83.0", wantError: true,
+		},
+		{
+			name:         "malformed override is ignored",
+			image:        v2alpha1.AgentImageConfig{Tag: "7.84.0"},
+			experimental: `not-json`,
+			wantVersion:  "7.84.0",
+		},
+		{
+			name:         "unknown PAR version is rejected",
+			image:        v2alpha1.AgentImageConfig{Tag: "7.84.0"},
+			experimental: `{"private-action-runner":{"tag":"dev"}}`,
+			wantVersion:  "dev", wantError: true,
+		},
+		{
+			name:        "partial component override inherits default version",
+			image:       v2alpha1.AgentImageConfig{PullPolicy: new(corev1.PullAlways)},
+			wantVersion: images.AgentLatestVersion,
+			wantError:   !pkgutils.IsAboveMinVersion(images.AgentLatestVersion, privateActionRunnerSplitMinVersion, new(false)),
+		},
+		{
+			name:         "partial component override with newer PAR",
+			image:        v2alpha1.AgentImageConfig{PullPolicy: new(corev1.PullAlways)},
+			experimental: `{"private-action-runner":{"tag":"7.84.0"}}`,
+			wantVersion:  "7.84.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dda := &v2alpha1.DatadogAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-dda",
+					Annotations: map[string]string{
+						"agent.datadoghq.com/private-action-runner-enabled":       "true",
+						"agent.datadoghq.com/private-action-runner-split-enabled": "true",
+						"experimental.agent.datadoghq.com/image-override-config":  tt.experimental,
+					},
+				},
+				Spec: v2alpha1.DatadogAgentSpec{
+					Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+						v2alpha1.NodeAgentComponentName: {Image: &tt.image},
+					},
+				},
+			}
+			f := buildPrivateActionRunnerFeature(nil)
+			f.Configure(dda, &dda.Spec, nil)
+			managers := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:  string(apicommon.PrivateActionRunnerContainerName),
+					Image: images.GetLatestAgentImage(),
+				}}},
+			})
+
+			err := f.ManageNodeAgent(managers)
+			if tt.wantError {
+				require.ErrorContains(t, err, "split mode requires Agent >= 7.84.0-0")
+				require.ErrorContains(t, err, "got "+tt.wantVersion)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, []string{privateActionRunnerEntrypoint}, managers.PodTemplateSpec().Spec.Containers[0].Command)
+			}
+
+			container := &managers.PodTemplateSpec().Spec.Containers[0]
+			container.Image = images.OverrideAgentImage(container.Image, &tt.image)
+			experimental.ApplyExperimentalOverrides(logr.Discard(), dda, managers)
+			assert.Equal(t, tt.wantVersion, common.GetAgentVersionFromImage(v2alpha1.AgentImageConfig{Name: container.Image}))
+		})
+	}
 }
 
 // Test_privateActionRunnerFeature_ProfileDDAI_ConfigMapNames verifies that when PAR is

--- a/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
+++ b/internal/controller/datadogagent/feature/privateactionrunner/feature_test.go
@@ -284,6 +284,30 @@ func Test_privateActionRunnerFeature_RejectsSplitModeOnOldAgent(t *testing.T) {
 	require.ErrorContains(t, err, "split mode requires Agent >= 7.84.0-0")
 }
 
+func Test_privateActionRunnerFeature_RejectsSplitModeOnUnknownAgentVersion(t *testing.T) {
+	pullPolicy := corev1.PullAlways
+	dda := &v2alpha1.DatadogAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"agent.datadoghq.com/private-action-runner-enabled":       "true",
+				"agent.datadoghq.com/private-action-runner-split-enabled": "true",
+			},
+		},
+		Spec: v2alpha1.DatadogAgentSpec{
+			Override: map[v2alpha1.ComponentName]*v2alpha1.DatadogAgentComponentOverride{
+				v2alpha1.NodeAgentComponentName: {
+					Image: &v2alpha1.AgentImageConfig{PullPolicy: &pullPolicy},
+				},
+			},
+		},
+	}
+	f := buildPrivateActionRunnerFeature(nil)
+	f.Configure(dda, &dda.Spec, nil)
+
+	err := f.ManageNodeAgent(fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{}))
+	require.ErrorContains(t, err, "split mode requires Agent >= 7.84.0-0")
+}
+
 // Test_privateActionRunnerFeature_ProfileDDAI_ConfigMapNames verifies that when PAR is
 // enabled on a profile DDAI (whose name differs from the parent DDA), the ConfigMaps are
 // named after the DDA (not the DDAI) so all profile DDAIs share the same ConfigMap.

--- a/internal/controller/datadogagent/feature/utils/utils.go
+++ b/internal/controller/datadogagent/feature/utils/utils.go
@@ -46,6 +46,7 @@ const (
 	EnableNetworkCRDsAnnotation    = "agent.datadoghq.com/network-crds-enabled"
 
 	EnablePrivateActionRunnerAnnotation                     = "agent.datadoghq.com/private-action-runner-enabled"
+	EnablePrivateActionRunnerSplitAnnotation                = "agent.datadoghq.com/private-action-runner-split-enabled"
 	PrivateActionRunnerConfigDataAnnotation                 = "agent.datadoghq.com/private-action-runner-configdata"
 	EnablePrivateActionRunnerSystemdAnnotation              = "agent.datadoghq.com/private-action-runner-systemd-enabled"
 	PrivateActionRunnerSystemdJournalStorageAnnotation      = "agent.datadoghq.com/private-action-runner-systemd-journal-storage"


### PR DESCRIPTION
### What does this PR do?

Adds opt-in to PAR split mode via `agent.datadoghq.com/private-action-runner-split-enabled` annotation.

### Motivation

This lets us dogfood PAR split mode.

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: v7.84.0
* Cluster Agent: not applicable

### Checklist

- [x] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [x] PR has a milestone or the `qa/skip-qa` label
- [x] All commits are signed (see: [signing commits])
