### PR TITLE
Revert "move CI to ddoghq/images instead of DataDog/images (#3446)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -833,7 +833,7 @@ trigger_internal_operator_image:
     - if: $CI_COMMIT_TAG
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -857,7 +857,7 @@ trigger_internal_operator_check_image:
     - if: $CI_COMMIT_TAG
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -875,7 +875,7 @@ trigger_internal_operator_image_rc_latest:
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/'
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -902,7 +902,7 @@ trigger_internal_operator_image_latest:
     - if: $CI_COMMIT_TAG
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -927,7 +927,7 @@ trigger_internal_operator_nightly_image:
       when: on_success
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -945,7 +945,7 @@ trigger_internal_operator_check_nightly_image:
       when: on_success
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -964,7 +964,7 @@ trigger_custom_operator_image_staging:
       when: manual
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -982,7 +982,7 @@ trigger_custom_operator_image_fips_staging:
       when: manual
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:
@@ -1000,7 +1000,7 @@ trigger_custom_operator_check_image_staging:
       when: manual
     - when: never
   trigger:
-    project: ddoghq/images
+    project: DataDog/images
     branch: master
     strategy: depend
   variables:


### PR DESCRIPTION
### What does this PR do?

This reverts commit 1549c937352d369c18e024b6bb32ee6c59e61acf.

### Motivation

Migration was postponed to 16th september -> #incident-61308

### Additional Notes

Anything else we should know when reviewing?

### Minimum Agent Versions

Are there minimum versions of the Datadog Agent and/or Cluster Agent required?

* Agent: vX.Y.Z
* Cluster Agent: vX.Y.Z

### Describe your test plan

Write there any instructions and details you may have to test your PR.

### Checklist

- [ ] PR has at least one valid label: `bug`, `enhancement`, `refactoring`, `documentation`, `tooling`, and/or `dependencies`
- [ ] PR has a milestone or the `qa/skip-qa` label
- [ ] All commits are signed (see: [signing commits][1])

[1]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits