### PR TITLE
[publish-community-bundles] Do everything except create PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1069,15 +1069,23 @@ publish_community_operators:
       aud: dd-octo-sts
   before_script:
     - make install-tools
-  script:
-    # Set version
-    - export VERSION=${CI_COMMIT_TAG:1} # vX.Y.Z => X.Y.Z
     # Install github-cli and skopeo deps
     - curl -fsSL "https://cli.github.com/packages/githubcli-archive-keyring.gpg" -o /usr/share/keyrings/githubcli-archive-keyring.gpg
     - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
     - apt-get update -y
     - apt-get install -y gh libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config
     - rm -rf /var/lib/apt/lists/*
+
+    # Setup github token for pushing to community operators
+    - dd-octo-sts version
+    - dd-octo-sts debug --scope DataDog --policy datadog-operator.publish-community-bundles
+    - dd-octo-sts token --scope DataDog --policy datadog-operator.publish-community-bundles > token.txt
+    - export GITHUB_TOKEN=$(cat token.txt)
+    - git config --global user.email $GITLAB_USER_EMAIL
+    - gh auth setup-git
+  script:
+    # Set version
+    - export VERSION=${CI_COMMIT_TAG:1} # vX.Y.Z => X.Y.Z
     # Build skopeo and install (needed for make bundle-redhat)
     # Note: skopeo apt package is only available in for ubuntu 20.10+
     # https://github.com/containers/skopeo/blob/main/install.md#ubuntu
@@ -1092,17 +1100,10 @@ publish_community_operators:
       ci.datadog-operator.redhat-registry-token --with-decryption --query "Parameter.Value" --out text > ~/.redhat/auths.json
     - cd $CI_PROJECT_DIR
     - make bundle-redhat
-
-    # Configure github-cli
-    - git config --global user.email $GITLAB_USER_EMAIL
-    # Use dd-octo-sts to get GitHub token
-    - dd-octo-sts version
-    - dd-octo-sts debug --scope DataDog --policy datadog-operator.publish-community-bundles
-    - dd-octo-sts token --scope DataDog --policy datadog-operator.publish-community-bundles > token.txt
-    - export GITHUB_TOKEN=$(cat token.txt)
-    - gh auth login --with-token < token.txt
-    - gh auth setup-git
-    # create pull request for each marketplace repo
+    # push the updated bundle branches to the DataDog forks for each marketplace repo.
+    # PRs against the upstream repos are not created here since our token only has
+    # perms scoped to the DataDog org; open those manually with CREATE_PR=true locally
+    # (see hack/publish-community-bundles.sh), or set CREATE_PR=true here once perms allow it.
     - make publish-community-bundles
   after_script:
     # Revoke the token after usage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1083,9 +1083,6 @@ publish_community_operators:
     - export GITHUB_TOKEN=$(cat token.txt)
     - git config --global user.email $GITLAB_USER_EMAIL
     - gh auth setup-git
-  script:
-    # Set version
-    - export VERSION=${CI_COMMIT_TAG:1} # vX.Y.Z => X.Y.Z
     # Build skopeo and install (needed for make bundle-redhat)
     # Note: skopeo apt package is only available in for ubuntu 20.10+
     # https://github.com/containers/skopeo/blob/main/install.md#ubuntu
@@ -1094,11 +1091,14 @@ publish_community_operators:
     - cd /tmp/skopeo && DISABLE_DOCS=1 make bin/skopeo
     - DISABLE_DOCS=1 make install
     - skopeo --version
+    - cd $CI_PROJECT_DIR
+  script:
+    # Set version
+    - export VERSION=${CI_COMMIT_TAG:1} # vX.Y.Z => X.Y.Z
     # Set up redhat registry access to generate bundle-redhat
     - mkdir ~/.redhat
     - aws ssm get-parameter --region us-east-1 --name
       ci.datadog-operator.redhat-registry-token --with-decryption --query "Parameter.Value" --out text > ~/.redhat/auths.json
-    - cd $CI_PROJECT_DIR
     - make bundle-redhat
     # push the updated bundle branches to the DataDog forks for each marketplace repo.
     # PRs against the upstream repos are not created here since our token only has

--- a/Makefile
+++ b/Makefile
@@ -400,9 +400,11 @@ yaml-mapper: fmt lint
 check-operator: fmt lint
 	go build -ldflags '${LDFLAGS}' -o bin/check-operator ./cmd/check-operator/main.go
 
+CREATE_PR ?= false
+
 .PHONY: publish-community-bundles
-publish-community-bundles: ## Publish bundles to community repositories
-	hack/publish-community-bundles.sh
+publish-community-bundles: ## Publish bundles to community repositories (set CREATE_PR=true to also open PRs upstream)
+	CREATE_PR=$(CREATE_PR) hack/publish-community-bundles.sh
 
 .PHONY: annotate-gcp-manifest
 annotate-gcp-manifest: ## Annotate manifest for GCP marketplace

--- a/hack/publish-community-bundles.sh
+++ b/hack/publish-community-bundles.sh
@@ -5,6 +5,7 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+CREATE_PR="${CREATE_PR:-false}"
 OPERATOR_SUBPATH="datadog-operator"
 BUNDLE_NAME="bundle"
 WORKING_DIR=$PWD
@@ -37,13 +38,18 @@ update_bundle() {
   cp -R "$CI_PROJECT_DIR"/$BUNDLE_NAME/* "$dest_path"
 }
 
+push_branch() {
+  echo "Pushing branch $PR_BRANCH_NAME to DataDog/$repo"
+  message="operator $OPERATOR_SUBPATH ($VERSION)"
+  git add -A
+  git commit -s -m "$message"
+  git push -f --set-upstream origin "$PR_BRANCH_NAME"
+}
+
 create_pr() {
   echo "Creating pull request for repo: $ORG/$repo"
   message="operator $OPERATOR_SUBPATH ($VERSION)"
   body="Update operator $OPERATOR_SUBPATH ($VERSION).<br><br>Pull request triggered by $GITLAB_USER_EMAIL."
-  git add -A
-  git commit -s -m "$message"
-  git push -f --set-upstream origin "$PR_BRANCH_NAME"
   curl -L \
     -X POST \
     -H "Accept: application/vnd.github+json" \
@@ -84,7 +90,13 @@ do
 
   clone_and_sync_fork
   update_bundle
-  create_pr
+  push_branch
+
+  if [ "$CREATE_PR" = "true" ]; then
+    create_pr
+  else
+    echo "Skipping PR creation for $ORG/$repo (CREATE_PR=$CREATE_PR)."
+  fi
 
 done
 


### PR DESCRIPTION
## Summary
- Gate upstream PR creation behind `CREATE_PR` (default false) — CI just pushes branches to the DataDog forks now, since our token isn't scoped outside the DataDog org.
- Fix the CI job's GitHub auth flow: drop the broken `gh auth login --with-token` call, move token setup into `before_script`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)