### PR TITLE
test: use Operator defaults in ADP fixtures

### DIFF
--- a/docs/gke_autopilot/external.md
+++ b/docs/gke_autopilot/external.md
@@ -82,7 +82,7 @@ By default, the Operator uses the built-in default allowlist version. To pin ano
 metadata:
   annotations:
     agent.datadoghq.com/cluster-provider: gke-autopilot
-    experimental.agent.datadoghq.com/autopilot-allowlist-version: "v1.0.5"
+    experimental.agent.datadoghq.com/autopilot-allowlist-version: "v1.0.6"
 ```
 
 The value must use the `vX.Y.Z` format. Malformed values are ignored and the default version is used.

--- a/internal/controller/datadogagent/experimental/autopilot.go
+++ b/internal/controller/datadogagent/experimental/autopilot.go
@@ -39,16 +39,29 @@ func IsAutopilotEnabled(obj metav1.Object) bool {
 }
 
 // applyExperimentalAutopilotOverrides creates the GKE Autopilot WorkloadAllowlist
-// synchronizer when Autopilot is enabled. Pod-template mutations are handled by
-// the provider-capabilities framework (see IsAutopilotEnabled doc).
-func applyExperimentalAutopilotOverrides(dda metav1.Object, _ feature.PodTemplateManagers) {
-	if IsAutopilotEnabled(dda) {
-		allowlistsynchronizer.CreateAllowlistSynchronizer(
-			getExperimentalAnnotation(dda, ExperimentalAutopilotAllowlistVersionSubkey),
-			object.NewPartOfLabelValue(dda).String(),
-			commonLabelsFromObject(dda),
-		)
+// synchronizer and selects its resolved allowlist on the node Agent pod template.
+// Other Autopilot pod-template mutations are handled by the provider-capabilities
+// framework (see IsAutopilotEnabled doc).
+func applyExperimentalAutopilotOverrides(dda metav1.Object, manager feature.PodTemplateManagers) {
+	if !IsAutopilotEnabled(dda) {
+		return
 	}
+
+	version := getExperimentalAnnotation(dda, ExperimentalAutopilotAllowlistVersionSubkey)
+	applyAutopilotWorkloadAllowlistLabel(manager, version)
+	allowlistsynchronizer.CreateAllowlistSynchronizer(
+		version,
+		object.NewPartOfLabelValue(dda).String(),
+		commonLabelsFromObject(dda),
+	)
+}
+
+func applyAutopilotWorkloadAllowlistLabel(manager feature.PodTemplateManagers, version string) {
+	template := manager.PodTemplateSpec()
+	if template.Labels == nil {
+		template.Labels = map[string]string{}
+	}
+	template.Labels["cloud.google.com/matching-allowlist"] = allowlistsynchronizer.WorkloadAllowlistName(version)
 }
 
 // CreateDatadogCSIAllowlistSynchronizer creates the Datadog CSI driver

--- a/internal/controller/datadogagent/experimental/autopilot_test.go
+++ b/internal/controller/datadogagent/experimental/autopilot_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-operator/api/datadoghq/v2alpha1"
+	"github.com/DataDog/datadog-operator/internal/controller/datadogagent/feature/fake"
 	"github.com/DataDog/datadog-operator/pkg/kubernetes"
 )
 
@@ -64,6 +66,28 @@ func TestGetAutopilotAllowlistVersionAnnotation(t *testing.T) {
 			}
 			got := getExperimentalAnnotation(dda, ExperimentalAutopilotAllowlistVersionSubkey)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyAutopilotWorkloadAllowlistLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "default version", want: "datadog-datadog-daemonset-exemption-v1.0.6"},
+		{name: "allowlist version override", version: "v1.2.3", want: "datadog-datadog-daemonset-exemption-v1.2.3"},
+		{name: "malformed version falls back to default", version: "invalid", want: "datadog-datadog-daemonset-exemption-v1.0.6"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := fake.NewPodTemplateManagers(t, corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"existing": "label"}}})
+
+			applyAutopilotWorkloadAllowlistLabel(manager, tt.version)
+
+			assert.Equal(t, tt.want, manager.PodTemplateSpec().Labels["cloud.google.com/matching-allowlist"])
+			assert.Equal(t, "label", manager.PodTemplateSpec().Labels["existing"])
 		})
 	}
 }

--- a/internal/controller/datadogagent/feature/dataplane/feature_test.go
+++ b/internal/controller/datadogagent/feature/dataplane/feature_test.go
@@ -60,7 +60,6 @@ func Test_dataPlaneFeature(t *testing.T) {
 		{
 			Name: "data plane enabled by feature default",
 			DDA: testutils.NewDatadogAgentBuilder().
-				WithNodeAgentImage("agent:7.83.0-rc.5").
 				BuildWithDefaults(),
 			FeatureOptions: &feature.Options{
 				DefaultDataPlaneEnabled: true,
@@ -76,7 +75,7 @@ func Test_dataPlaneFeature(t *testing.T) {
 					assert.Contains(t, adpEnvVars, dataPlaneRemoteAgentEnabledEnvVar, "DD_DATA_PLANE_REMOTE_AGENT_ENABLED should be set on Agent Data Plane when Data Plane is enabled by the feature default")
 					assert.Contains(t, adpEnvVars, dataPlaneUseNewConfigStreamEndpointEnvVar, "DD_DATA_PLANE_USE_NEW_CONFIG_STREAM_ENDPOINT should be set on Agent Data Plane when Data Plane is enabled by the feature default")
 
-					dda := testutils.NewDatadogAgentBuilder().WithNodeAgentImage("agent:7.83.0-rc.5").BuildWithDefaults()
+					dda := testutils.NewDatadogAgentBuilder().BuildWithDefaults()
 					requiredComponents := buildDataPlaneFeature(&feature.Options{DefaultDataPlaneEnabled: true}).Configure(dda, &dda.Spec, dda.Status.RemoteConfigConfiguration)
 					assert.Contains(t, requiredComponents.Agent.Containers, apicommon.AgentDataPlaneContainerName, "Agent Data Plane should be a required Agent component when Data Plane is enabled by the feature default")
 				},
@@ -87,7 +86,6 @@ func Test_dataPlaneFeature(t *testing.T) {
 			DDA: testutils.NewDatadogAgentBuilder().
 				WithSingleContainerStrategy(true).
 				WithDataPlaneDogstatsdEnabled(true).
-				WithNodeAgentImage("agent:7.83.0-rc.5").
 				BuildWithDefaults(),
 			FeatureOptions: &feature.Options{
 				DefaultDataPlaneEnabled: true,

--- a/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
+++ b/internal/controller/datadogagent/feature/dogstatsd/feature_test.go
@@ -511,7 +511,6 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 			Name: "data plane feature default routes DogStatsD UDP host port to ADP",
 			DDA: testutils.NewDefaultDatadogAgentBuilder().
 				WithDogstatsdHostPortEnabled(true).
-				WithNodeAgentImage("agent:7.83.0-rc.5").
 				BuildWithDefaults(),
 			FeatureOptions: &feature.Options{
 				DefaultDataPlaneEnabled: true,
@@ -535,7 +534,6 @@ func Test_DogstatsdFeature_Configure(t *testing.T) {
 				WithSingleContainerStrategy(true).
 				WithDataPlaneDogstatsdEnabled(true).
 				WithDogstatsdHostPortEnabled(true).
-				WithNodeAgentImage("agent:7.83.0-rc.5").
 				BuildWithDefaults(),
 			FeatureOptions: &feature.Options{
 				DefaultDataPlaneEnabled: true,

--- a/internal/controller/datadogagent/feature/test/factory_test.go
+++ b/internal/controller/datadogagent/feature/test/factory_test.go
@@ -71,7 +71,6 @@ func TestBuilder(t *testing.T) {
 			name: "Data Plane enabled by feature options with single container strategy, 1 single container",
 			dda: testutils.NewDatadogAgentBuilder().
 				WithSingleContainerStrategy(true).
-				WithNodeAgentImage("agent:7.83.0-rc.5").
 				BuildWithDefaults(),
 			featureOptions: feature.Options{
 				DefaultDataPlaneEnabled: true,

--- a/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/comprehensive-autopilot.golden.yaml
@@ -1412,7 +1412,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 3d559495a5d61788e11fc24c7cc24829
+    agent.datadoghq.com/agentspechash: cced2f02a06805faed3105a0ad7e904b
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1423,6 +1423,7 @@ metadata:
     app.kubernetes.io/name: datadog-agent-deployment
     app.kubernetes.io/part-of: -datadog--agent
     app.kubernetes.io/version: ""
+    cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
     env.datadoghq.com/kind: gke-autopilot
   name: datadog-agent-agent
   ownerReferences:
@@ -1453,6 +1454,7 @@ spec:
         app.kubernetes.io/name: datadog-agent-deployment
         app.kubernetes.io/part-of: -datadog--agent
         app.kubernetes.io/version: ""
+        cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
         env.datadoghq.com/kind: gke-autopilot
     spec:
       containers:

--- a/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/minimal-autopilot.golden.yaml
@@ -1275,7 +1275,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: a7ecd949579bc5e539f172707c537607
+    agent.datadoghq.com/agentspechash: 8ae26412c3f59a8ff3bcc683bfb42b67
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1286,6 +1286,7 @@ metadata:
     app.kubernetes.io/name: datadog-agent-deployment
     app.kubernetes.io/part-of: -datadog--agent
     app.kubernetes.io/version: ""
+    cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
     env.datadoghq.com/kind: gke-autopilot
   name: datadog-agent-agent
   ownerReferences:
@@ -1316,6 +1317,7 @@ spec:
         app.kubernetes.io/name: datadog-agent-deployment
         app.kubernetes.io/part-of: -datadog--agent
         app.kubernetes.io/version: ""
+        cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
         env.datadoghq.com/kind: gke-autopilot
     spec:
       containers:

--- a/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/override-autopilot.golden.yaml
@@ -1292,7 +1292,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: 46a80d21a4e52d3b5438144fe2bdda0e
+    agent.datadoghq.com/agentspechash: de96c7c38c5be0a1d57893375c99d748
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1303,6 +1303,7 @@ metadata:
     app.kubernetes.io/name: datadog-agent-deployment
     app.kubernetes.io/part-of: -datadog--agent
     app.kubernetes.io/version: ""
+    cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
     env.datadoghq.com/kind: gke-autopilot
   name: datadog-agent-agent
   ownerReferences:
@@ -1333,6 +1334,7 @@ spec:
         app.kubernetes.io/name: datadog-agent-deployment
         app.kubernetes.io/part-of: -datadog--agent
         app.kubernetes.io/version: ""
+        cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
         env.datadoghq.com/kind: gke-autopilot
     spec:
       containers:

--- a/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
+++ b/internal/controller/testutils/renderer/testdata/golden/suppression-autopilot.golden.yaml
@@ -1291,7 +1291,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    agent.datadoghq.com/agentspechash: f3c1afb98f9d3ba167f0ef89f856ffb6
+    agent.datadoghq.com/agentspechash: 743de55519381637569dc162696f3de5
   labels:
     admission.datadoghq.com/enabled: "false"
     agent.datadoghq.com/component: agent
@@ -1302,6 +1302,7 @@ metadata:
     app.kubernetes.io/name: datadog-agent-deployment
     app.kubernetes.io/part-of: -datadog--agent
     app.kubernetes.io/version: ""
+    cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
     env.datadoghq.com/kind: gke-autopilot
   name: datadog-agent-agent
   ownerReferences:
@@ -1333,6 +1334,7 @@ spec:
         app.kubernetes.io/name: datadog-agent-deployment
         app.kubernetes.io/part-of: -datadog--agent
         app.kubernetes.io/version: ""
+        cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.6
         env.datadoghq.com/kind: gke-autopilot
     spec:
       containers:

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer.go
@@ -86,6 +86,13 @@ func resolveCSIWorkloadAllowlistVersion(version string) string {
 	return resolveWorkloadAllowlistVersionWithDefault(version, DefaultCSIWorkloadAllowlistVersion)
 }
 
+// WorkloadAllowlistName returns the GKE WorkloadAllowlist resource name for a
+// requested Agent allowlist version. Empty or malformed versions resolve to the
+// Operator default.
+func WorkloadAllowlistName(version string) string {
+	return fmt.Sprintf("datadog-datadog-daemonset-exemption-%s", resolveWorkloadAllowlistVersion(version))
+}
+
 func resolveWorkloadAllowlistVersionWithDefault(version, defaultVersion string) string {
 	if version == "" {
 		return defaultVersion
@@ -103,7 +110,7 @@ func applyAllowlistSynchronizerResource(k8sClient client.Client, version, partOf
 		k8sClient,
 		agentAllowlistSynchronizerName,
 		agentAllowlistAppNameLabel,
-		[]string{fmt.Sprintf("Datadog/datadog/datadog-datadog-daemonset-exemption-%s.yaml", version)},
+		[]string{fmt.Sprintf("Datadog/datadog/%s.yaml", WorkloadAllowlistName(version))},
 		partOfLabel,
 		commonLabels,
 	)

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer.go
@@ -18,9 +18,9 @@ import (
 )
 
 // DefaultWorkloadAllowlistVersion is the default version of the Datadog
-// daemonset WorkloadAllowlist. v1.0.5 includes the system-probe / NPM
+// daemonset WorkloadAllowlist. v1.0.6 includes the system-probe / NPM
 // exemptions required by the NPM feature on GKE Autopilot.
-const DefaultWorkloadAllowlistVersion = "v1.0.5"
+const DefaultWorkloadAllowlistVersion = "v1.0.6"
 
 // DefaultCSIWorkloadAllowlistVersion is the default version of the Datadog CSI
 // driver daemonset WorkloadAllowlist. v1.1.1 allows the registrar image from

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
@@ -60,6 +60,23 @@ func TestDefaultWorkloadAllowlistVersion(t *testing.T) {
 	assert.Equal(t, "v1.0.6", DefaultWorkloadAllowlistVersion)
 }
 
+func TestWorkloadAllowlistName(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "default version", want: "datadog-datadog-daemonset-exemption-v1.0.6"},
+		{name: "valid override", version: "v1.2.3", want: "datadog-datadog-daemonset-exemption-v1.2.3"},
+		{name: "malformed override falls back to default", version: "not-a-version", want: "datadog-datadog-daemonset-exemption-v1.0.6"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, WorkloadAllowlistName(tt.version))
+		})
+	}
+}
+
 func TestDefaultCSIWorkloadAllowlistVersion(t *testing.T) {
 	// Sanity check — locks the default to a known value so a silent bump is caught.
 	assert.Equal(t, "v1.1.1", DefaultCSIWorkloadAllowlistVersion)

--- a/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
+++ b/pkg/allowlistsynchronizer/allowlistsynchronizer_test.go
@@ -27,8 +27,8 @@ func TestResolveWorkloadAllowlistVersion(t *testing.T) {
 	}{
 		{name: "empty falls back to default", input: "", expected: DefaultWorkloadAllowlistVersion},
 		{name: "well-formed override is preserved", input: "v2.5.0", expected: "v2.5.0"},
-		{name: "malformed falls back to default (no v prefix)", input: "1.0.5", expected: DefaultWorkloadAllowlistVersion},
-		{name: "malformed falls back to default (extra suffix)", input: "v1.0.5-alpha", expected: DefaultWorkloadAllowlistVersion},
+		{name: "malformed falls back to default (no v prefix)", input: "1.0.6", expected: DefaultWorkloadAllowlistVersion},
+		{name: "malformed falls back to default (extra suffix)", input: "v1.0.6-alpha", expected: DefaultWorkloadAllowlistVersion},
 		{name: "malformed falls back to default (random)", input: "garbage", expected: DefaultWorkloadAllowlistVersion},
 	}
 	for _, tt := range tests {
@@ -57,7 +57,7 @@ func TestResolveCSIWorkloadAllowlistVersion(t *testing.T) {
 
 func TestDefaultWorkloadAllowlistVersion(t *testing.T) {
 	// Sanity check — locks the default to a known value so a silent bump is caught.
-	assert.Equal(t, "v1.0.5", DefaultWorkloadAllowlistVersion)
+	assert.Equal(t, "v1.0.6", DefaultWorkloadAllowlistVersion)
 }
 
 func TestDefaultCSIWorkloadAllowlistVersion(t *testing.T) {
@@ -77,7 +77,7 @@ func TestApplyAllowlistSynchronizerResource_AllowlistPath(t *testing.T) {
 		{
 			name:       "default version",
 			version:    DefaultWorkloadAllowlistVersion,
-			expectPath: "Datadog/datadog/datadog-datadog-daemonset-exemption-v1.0.5.yaml",
+			expectPath: "Datadog/datadog/datadog-datadog-daemonset-exemption-v1.0.6.yaml",
 		},
 		{
 			name:       "user override",
@@ -177,12 +177,12 @@ func TestApplyAllowlistSynchronizerResource_UpdatesExistingResource(t *testing.T
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
 
-	require.NoError(t, applyAllowlistSynchronizerResource(c, "v1.0.5", "default-foo", nil))
+	require.NoError(t, applyAllowlistSynchronizerResource(c, "v1.0.6", "default-foo", nil))
 
 	got := &AllowlistSynchronizer{}
 	require.NoError(t, c.Get(context.TODO(), client.ObjectKey{Name: "datadog-synchronizer"}, got))
 	require.Len(t, got.Spec.AllowlistPaths, 1)
-	assert.Equal(t, "Datadog/datadog/datadog-datadog-daemonset-exemption-v1.0.5.yaml", got.Spec.AllowlistPaths[0])
+	assert.Equal(t, "Datadog/datadog/datadog-datadog-daemonset-exemption-v1.0.6.yaml", got.Spec.AllowlistPaths[0])
 	assert.Equal(t, "default-foo", got.Labels[kubernetes.AppKubernetesPartOfLabelKey])
 	assert.Equal(t, "datadog-operator", got.Labels[kubernetes.AppKubernetesManageByLabelKey])
 	assert.Equal(t, "datadog-allowlist-synchronizer", got.Labels[kubernetes.AppKubernetesNameLabelKey])
@@ -233,7 +233,7 @@ func TestApplyAllowlistSynchronizerResource_CommonLabels(t *testing.T) {
 		"team":        "platform",
 		"cost-center": "ops",
 	}
-	require.NoError(t, applyAllowlistSynchronizerResource(c, "v1.0.5", "default-foo", commonLabels))
+	require.NoError(t, applyAllowlistSynchronizerResource(c, "v1.0.6", "default-foo", commonLabels))
 
 	got := &AllowlistSynchronizer{}
 	require.NoError(t, c.Get(context.TODO(), client.ObjectKey{Name: agentAllowlistSynchronizerName}, got))
@@ -254,7 +254,7 @@ func TestApplyAllowlistSynchronizerResource_CommonLabels_CannotOverrideOperatorK
 		kubernetes.AppKubernetesManageByLabelKey: "my-operator", // attempt override
 		"team":                                   "platform",
 	}
-	require.NoError(t, applyAllowlistSynchronizerResource(c, "v1.0.5", "default-foo", commonLabels))
+	require.NoError(t, applyAllowlistSynchronizerResource(c, "v1.0.6", "default-foo", commonLabels))
 
 	got := &AllowlistSynchronizer{}
 	require.NoError(t, c.Get(context.TODO(), client.ObjectKey{Name: agentAllowlistSynchronizerName}, got))

--- a/test/e2e/manifests/datadog-agent-gke-autopilot.yaml
+++ b/test/e2e/manifests/datadog-agent-gke-autopilot.yaml
@@ -8,12 +8,6 @@ metadata:
   annotations:
     experimental.agent.datadoghq.com/autopilot: "true"
 spec:
-  override:
-    nodeAgent:
-      labels:
-        cloud.google.com/matching-allowlist: datadog-datadog-daemonset-exemption-v1.0.5
-      image:
-        tag: 7.83.0-rc.5
   features:
     logCollection:
       enabled: true

--- a/test/e2e/manifests/datadog-agent-gke-autopilot.yaml
+++ b/test/e2e/manifests/datadog-agent-gke-autopilot.yaml
@@ -9,6 +9,8 @@ metadata:
     experimental.agent.datadoghq.com/autopilot: "true"
 spec:
   features:
+    dataPlane:
+      enabled: true
     logCollection:
       enabled: true
       containerCollectAll: true

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-single-adp-default.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-single-adp-default.yaml
@@ -10,10 +10,6 @@ spec:
     registry: public.ecr.aws/datadog
     kubelet:
       tlsVerify: false
-  override:
-    nodeAgent:
-      image:
-        tag: 7.83.0-rc.5
   features:
     # Service Discovery requires the privileged System Probe container, which is incompatible with this strategy.
     serviceDiscovery:

--- a/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-single-adp.yaml
+++ b/test/e2e/manifests/dogstatsd/datadog-agent-dsd-udp-single-adp.yaml
@@ -3,7 +3,7 @@ kind: DatadogAgent
 metadata:
   namespace: e2e-operator
   labels:
-    agent.datadoghq.com/e2e-test: datadog-agent-dsd-udp-single-adp-default
+    agent.datadoghq.com/e2e-test: datadog-agent-dsd-udp-single-adp
 spec:
   global:
     containerStrategy: single
@@ -11,6 +11,8 @@ spec:
     kubelet:
       tlsVerify: false
   features:
+    dataPlane:
+      enabled: true
     # Service Discovery requires the privileged System Probe container, which is incompatible with this strategy.
     serviceDiscovery:
       enabled: false

--- a/test/e2e/tests/k8s_suite/gke_autopilot_test.go
+++ b/test/e2e/tests/k8s_suite/gke_autopilot_test.go
@@ -49,9 +49,6 @@ rbac:
 serviceAccount:
   create: false
   name: datadog-operator-e2e-controller-manager
-env:
-  - name: DD_DEFAULT_DATA_PLANE_LINUX_ENABLED
-    value: "true"
 `),
 	}
 

--- a/test/e2e/tests/k8s_suite/k8s_suite_test.go
+++ b/test/e2e/tests/k8s_suite/k8s_suite_test.go
@@ -477,39 +477,33 @@ serviceAccount:
 		}, 3*time.Minute, 10*time.Second, "DSD UDP with ADP: metrics not received by fakeintake")
 	})
 
-	// --- Subtest: DSD UDP, single-container ADP enabled by the Operator default ---
-	s.T().Run("Single-container DSD UDP uses the Operator ADP default", func(t *testing.T) {
-		ddaConfigPath, err := common.GetAbsPath(filepath.Join(common.ManifestsPath, "dogstatsd", "datadog-agent-dsd-udp-single-adp-default.yaml"))
+	// --- Subtest: DSD UDP with explicitly enabled ADP, single-container strategy ---
+	s.T().Run("Single-container DSD UDP with ADP", func(t *testing.T) {
+		ddaConfigPath, err := common.GetAbsPath(filepath.Join(common.ManifestsPath, "dogstatsd", "datadog-agent-dsd-udp-single-adp.yaml"))
 		assert.NoError(s.T(), err)
 		senderPath, err := common.GetAbsPath(filepath.Join(common.ManifestsPath, "dogstatsd", "dsd-udp-sender.yaml"))
 		assert.NoError(s.T(), err)
 
 		ddaOpts := append([]agentwithoperatorparams.Option{
 			agentwithoperatorparams.WithDDAConfig(agentwithoperatorparams.DDAConfig{
-				Name:         "dda-dsd-udp-single-adp-default",
+				Name:         "dda-dsd-udp-single-adp",
 				YamlFilePath: ddaConfigPath,
 			}),
 		}, defaultDDAOpts...)
 
-		operatorOpts := append([]operatorparams.Option{}, defaultOperatorOpts...)
-		operatorOpts = append(operatorOpts, operatorparams.WithHelmValues(`env:
-  - name: DD_DEFAULT_DATA_PLANE_LINUX_ENABLED
-    value: "true"
-`))
-
 		provisionerOpts := []provisioners.KubernetesProvisionerOption{
-			provisioners.WithTestName("e2e-operator-dsd-udp-single-adp-default"),
-			provisioners.WithOperatorOptions(operatorOpts...),
+			provisioners.WithTestName("e2e-operator-dsd-udp-single-adp"),
+			provisioners.WithOperatorOptions(defaultOperatorOpts...),
 			provisioners.WithDDAOptions(ddaOpts...),
 			provisioners.WithYAMLWorkload(provisioners.YAMLWorkload{Name: "dsd-udp-sender", Path: senderPath}),
 			provisioners.WithLocal(s.local),
 		}
-		applyDDA("e2e-operator-dsd-udp-single-adp-default", provisionerOpts)
+		applyDDA("e2e-operator-dsd-udp-single-adp", provisionerOpts)
 
 		err = s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 		s.Assert().NoError(err)
 
-		agentSelector := common.NodeAgentSelector + ",agent.datadoghq.com/name=dda-dsd-udp-single-adp-default"
+		agentSelector := common.NodeAgentSelector + ",agent.datadoghq.com/name=dda-dsd-udp-single-adp"
 
 		s.Assert().EventuallyWithTf(func(c *assert.CollectT) {
 			utils.VerifyAgentPods(s.T(), c, common.NamespaceName, s.Env().KubernetesCluster.Client(), agentSelector)
@@ -520,11 +514,11 @@ serviceAccount:
 				return
 			}
 			s.assertSingleContainerADPRuntime(c, pods.Items[0])
-		}, 5*time.Minute, 15*time.Second, "single-container DSD UDP ADP default runtime verification failed")
+		}, 5*time.Minute, 15*time.Second, "single-container DSD UDP ADP runtime verification failed")
 
 		s.Assert().EventuallyWithTf(func(c *assert.CollectT) {
 			s.verifyDSDMetrics(c, "e2e.dsd.udp.counter")
-		}, 3*time.Minute, 10*time.Second, "single-container DSD UDP ADP default metrics not received by fakeintake")
+		}, 3*time.Minute, 10*time.Second, "single-container DSD UDP ADP metrics not received by fakeintake")
 	})
 
 	// --- Subtest: DSD UDS, ADP disabled ---


### PR DESCRIPTION
## Summary
- Update the Operator-managed GKE WorkloadAllowlist default and override documentation to `v1.0.6`.
- Remove the fixed GKE WorkloadAllowlist selector so the Autopilot fixture follows that Operator-managed default.
- Remove obsolete 7.83 release-candidate Agent image pins from ADP E2E and unit fixtures.
- Explicitly enable ADP in the Autopilot and single-container DogStatsD DatadogAgent fixtures instead of overriding the Operator default through E2E Helm environment variables.
- Keep production ADP defaults and CI rules unchanged.

## Test Plan
- [x] `go test ./...`
- [x] `go test ./pkg/allowlistsynchronizer`
- [x] `make lint`
- [x] `make lint-e2e`
- [x] `GOWORK=off go test -C test/e2e ./tests/k8s_suite -run '^$' --tags=e2e -count=1`
- [ ] GKE Autopilot E2E (will run after the current PR image is available)
